### PR TITLE
docs: reclaim coordinator notes with round 2 integration

### DIFF
--- a/CODEWALK.md
+++ b/CODEWALK.md
@@ -1,0 +1,300 @@
+# CODEWALK.md — Codebase Walk for Continuation Feature Fixes
+
+_Branch: `feature/context-pressure-squashed` at commit `5118e7af9`_
+_Walked by: Cael 🩸_
+_Date: 2026-03-06_
+
+---
+
+## How to Read This
+
+For each FINDINGS.md item, I trace the exact code state at HEAD, note whether the fix is landed, and if not, what specific lines need changing. This is the anchor for independent fix branches.
+
+---
+
+## P0: `maxChainLength` Off-By-One
+
+### FINDINGS.md claim
+
+> "Fix applied in working tree, not yet committed/pushed"
+
+### Actual state at HEAD (`5118e7af9`)
+
+**COMMITTED AND PUSHED.** The commit message is literally `fix: P0 off-by-one chain guard + findings doc for upstream PR`. FINDINGS.md is stale on this point — the fix is at HEAD.
+
+### Code verification (3 guard sites)
+
+| Location                      | File                   | Line | Guard expression                      | Status  |
+| ----------------------------- | ---------------------- | ---- | ------------------------------------- | ------- |
+| Bracket-path pre-check        | `agent-runner.ts`      | 1110 | `currentChainCount >= maxChainLength` | ✅ `>=` |
+| Tool-path pre-check           | `agent-runner.ts`      | 1304 | `currentChainCount >= maxChainLength` | ✅ `>=` |
+| Announce-side chain-hop guard | `subagent-announce.ts` | 1399 | `nextChainHop >= maxChainLength`      | ✅ `>=` |
+
+All three sites use `>=`. With `maxChainLength: 10`, the 10th hop is allowed (`9 >= 10 = false`), the 11th is blocked (`10 >= 10 = true`). This matches user expectation.
+
+### Tool-path task prefix unification (P0 second half)
+
+- **`agent-runner.ts:1332`**: Tool-path spawn encodes `[continuation:chain-hop:${nextChainCount}]` in task string ✅
+- **`agent-runner.ts:1174`**: Bracket-path initial spawn uses `[continuation] Delegated task (turn N/M)` — does NOT include `[continuation:chain-hop:N]`. This is intentional: the initial bracket delegate is dispatched from the parent session where `continuationChainCount` lives in session store. Only subsequent hops (announce-side) need task-prefix encoding because session store resets clear state between hops.
+- **`subagent-announce.ts:1447`**: Announce-side chain-hop encodes `[continuation:chain-hop:${nextChainHop}]` ✅
+
+### Test coverage
+
+- **`agent-runner.misc.runreplyagent.test.ts:2311`**: Existing test expects `>=` semantics for agent-runner path ✅
+- **No existing test for announce-side chain guard** — FINDINGS.md correctly notes this. A Codex-produced test patch exists but hasn't been cherry-picked.
+
+### Verdict: **FIXED at HEAD. One test gap remains (announce-side guard).**
+
+---
+
+## P1: Tolerance Closure Bug (generationGuardTolerance stale at timer fire)
+
+### FINDINGS.md claim
+
+> "3 independent Codex implementations produced, best candidate: Ronan's `325bf22f0`"
+
+### Actual state at HEAD
+
+**NOT FIXED.** No Codex patches cherry-picked. The closure bug exists in 4 locations.
+
+### Root cause (detailed)
+
+In `agent-runner.ts`, config is loaded once at line 458:
+
+```typescript
+const cfg = followupRun.run.config; // snapshot from enqueue time
+```
+
+All `continuationCfg` reads derive from this snapshot. When the config is hot-reloaded between schedule time and timer fire, the timer uses the stale value.
+
+### Affected locations
+
+#### 1. Bracket-path delegate timer (`agent-runner.ts:1229`)
+
+```typescript
+const genTolerance = continuationCfg?.generationGuardTolerance ?? 0;
+setTimeout(() => {
+  // ...
+  if (drift > genTolerance) {  // ← stale genTolerance
+```
+
+- **Line 1229**: `genTolerance` captured from `cfg` snapshot at schedule time
+- **Line 1233**: Timer fires with stale tolerance
+- **Fix**: Call `loadConfig()` inside the `setTimeout` callback, read `generationGuardTolerance` fresh
+
+#### 2. Tool-path delegate timer (`agent-runner.ts:1382`)
+
+```typescript
+const toolGenTolerance = continuationCfg?.generationGuardTolerance ?? 0;
+setTimeout(() => {
+  // ...
+  if (drift > toolGenTolerance) {  // ← stale toolGenTolerance
+```
+
+- **Line 1382**: Same pattern — captured at schedule time
+- **Line 1390**: Timer fires with stale value
+- **Fix**: Same — `loadConfig()` inside callback
+
+#### 3. Chain-hop timer (`subagent-announce.ts:1480`)
+
+```typescript
+const tolerance = continuationCfg?.generationGuardTolerance ?? 0;
+setTimeout(() => {
+  // ...
+  if (drift > tolerance) {  // ← stale tolerance
+```
+
+- **Line 1480**: Captured at announce invocation time
+- **Line 1484**: Timer fires with stale value
+- **Mitigating factor**: In `subagent-announce.ts`, `cfg = loadConfig()` is called fresh at line 1316 (announce time), not from a queued snapshot. The window between announce and timer fire is shorter. But if config changes during that window, same bug.
+- **Fix**: `loadConfig()` inside the `setTimeout` callback
+
+#### 4. WORK timer (`agent-runner.ts:1249-1251`) — **UNDOCUMENTED VARIANT**
+
+```typescript
+const generation = bumpContinuationGeneration(sessionKey);
+setTimeout(() => {
+  if (currentContinuationGeneration(sessionKey) !== generation) {
+    return; // External message arrived — cancel
+  }
+```
+
+The WORK timer uses **strict equality** (`!== generation`) with NO tolerance at all. This means:
+
+- WORK timers cancel on ANY generation bump, even in noisy channels
+- DELEGATE timers honor `generationGuardTolerance`
+- The behavior is asymmetric — FINDINGS.md doesn't call this out
+
+This is likely **intentional** (WORK wakes are cheaper to re-dispatch than DELEGATE spawns, so a stricter guard makes sense) but should be documented. If `generationGuardTolerance` was meant to apply universally, this is a bug.
+
+### Other stale closure values
+
+The same closure captures `minDelayMs`, `maxDelayMs`, `costCapTokens`, `maxChainLength`, `defaultDelayMs` from the config snapshot. Hot-reloading ANY of these values won't take effect on already-scheduled timers. `generationGuardTolerance` is the one FINDINGS calls out because it was observed in Swim 6-2, but the pattern applies to all config values read at schedule time.
+
+### Verdict: **NOT FIXED. 3 confirmed stale-closure sites (P1 as documented), 1 undocumented asymmetric variant (WORK timer). Ronan's `325bf22f0` is the recommended patch.**
+
+---
+
+## P2: `maxDelegatesPerTurn` Hot-Reload
+
+### FINDINGS.md claim
+
+> "Codex patch ready (Cael fanout-2 + Ronan's combined commit)"
+
+### Actual state at HEAD
+
+**NOT FIXED.** The value is captured at tool creation time and never re-read.
+
+### Root cause (exact code path)
+
+**`openclaw-tools.ts:196-199`** — Tool created once at session boot:
+
+```typescript
+createContinueDelegateTool({
+  agentSessionKey: options?.agentSessionKey,
+  maxDelegatesPerTurn:
+    options?.config?.agents?.defaults?.continuation?.maxDelegatesPerTurn,
+}),
+```
+
+**`continue-delegate-tool.ts:64-66`** — Tool function signature:
+
+```typescript
+export function createContinueDelegateTool(opts: {
+  agentSessionKey?: string;
+  maxDelegatesPerTurn?: number;
+});
+```
+
+**`continue-delegate-tool.ts:106`** — Enforcement uses the frozen `opts` value:
+
+```typescript
+const maxPerTurn = opts.maxDelegatesPerTurn ?? 5;
+```
+
+When config hot-reloads `maxDelegatesPerTurn` from 5 to 10, the tool still enforces 5 until gateway restart (which re-creates all tools).
+
+### Fix approaches
+
+1. **Ronan's `325bf22f0`** (combined with P1): `loadConfig()` at `execute()` time — reads fresh `maxDelegatesPerTurn` on every tool call.
+2. **Cael fanout-2**: Move enforcement to consumption time in `agent-runner.ts` when `consumePendingDelegates()` is called. The tool would not enforce the limit at all; `agent-runner.ts:1014` already has a `maxCompactionDelegates` pattern that reads config at consumption time.
+
+There's also a secondary enforcement site at **`agent-runner.ts:1014`**:
+
+```typescript
+const maxCompactionDelegates = compactionCfg?.maxDelegatesPerTurn ?? 5;
+```
+
+This one reads from `cfg` (the queued run snapshot), so it has the same stale-config issue as P1 but only for the compaction path.
+
+### Verdict: **NOT FIXED. Fix is straightforward — read config at execute/consumption time instead of creation time.**
+
+---
+
+## P3: Shard Message Target (Self-Heal)
+
+### FINDINGS.md claim
+
+> "Investigated, low priority. Shards fail first message() call, self-correct on retry."
+
+### Actual state at HEAD
+
+**NOT FIXED (intentionally deferred).**
+
+### What happens
+
+Spawned shards inherit channel context via `spawnSubagentDirect()` at:
+
+- **`agent-runner.ts:1173-1186`** (bracket delegate)
+- **`agent-runner.ts:1328-1342`** (tool delegate)
+- **`subagent-announce.ts:1439-1456`** (chain-hop)
+
+All three pass `agentChannel`, `agentAccountId`, `agentTo`, `agentThreadId` from the parent. The shard gets the right channel context. But `requireExplicitMessageTarget` on subagent sessions causes the first `message()` call to fail. The shard self-heals by parsing the channel from its session key.
+
+### Cost
+
+~1 tool call per shard (~1s latency). Non-blocking.
+
+### Fix (if desired)
+
+Pass originating channel context explicitly in spawn params as a `targetHint`. Not worth the complexity for the upstream PR.
+
+### Verdict: **Correctly deferred. Cosmetic issue.**
+
+---
+
+## P3: Lane Queue Pressure Under Fan-Out
+
+### FINDINGS.md claim
+
+> "5 parallel shards hitting same session lane — up to 46s queue wait."
+
+### Actual state at HEAD
+
+**Inherent to queue architecture. No code fix — operational guidance.**
+
+### What happens
+
+Multiple concurrent shard completions route to the same parent session. The gateway's per-session lane queue serializes them. 5 shards × ~10s processing = up to 50s wait for the last shard.
+
+The gateway's announce timeout is 60s with retry. At 46s, we're within budget but close. At 6+ parallel shards, timeouts are likely.
+
+### Verdict: **Correctly documented as operational guidance. RFC should note fan-out limits.**
+
+---
+
+## RFC Accuracy Assessment
+
+### Things the RFC gets right
+
+- Token parsing and stripping architecture
+- Delegate dispatch timeline (Turn 0 → gap → spawn → completion → wake)
+- Chain tracking via task-prefix encoding (post-`fec5e4bfc`)
+- Context-pressure band escalation and dedup logic
+- Three-layer architecture (request metadata → SessionEntry → system events)
+- `isDelegateWake` metadata-driven detection replacing event-queue inference
+- `delegatePendingFlags` as dedicated Map outside system event queue
+- `cancelContinuationTimer` behavior and chain state reset
+
+### Things the RFC gets wrong or is stale on
+
+1. **P0 status**: RFC changelog says "P0-5 chain-hop counter fix" at commit `fec5e4bfc` but doesn't note that the off-by-one fix at HEAD (`5118e7af9`) is committed. The FINDINGS.md says "not yet committed/pushed" but it IS committed.
+
+2. **Line numbers**: RFC references line ~544 for signal detection, ~977 for marker event, ~988 for timer scheduling. These are pre-three-layer-surgery line numbers. Actual locations at HEAD:
+   - Signal detection + config read: line ~1099
+   - Chain guard: line ~1110
+   - Bracket delegate spawn: line ~1174
+   - Generation guard / timer: line ~1229
+   - Tool delegate consumption: line ~1280
+   - Tool delegate chain guard: line ~1304
+
+3. **WORK timer tolerance**: RFC documents `generationGuardTolerance` as applying to generation guards but doesn't note the asymmetry — WORK timers use strict equality, DELEGATE timers use tolerance. This may confuse operators who set tolerance expecting it to protect WORK timers too.
+
+4. **Cost cap gap acknowledgment**: RFC changelog correctly documents that bracket chain-hop cost accumulation is wired but partial. The fix at `a657daed5` added accumulation, but the per-message reset race (from `5-10` findings) means `continuationChainTokens` can still be cleared between hops if a non-delegate inbound arrives. `maxChainLength` remains the primary safety leash.
+
+---
+
+## Summary: What Needs Fixing Before Upstream
+
+| Item                    | Severity     | Status at HEAD         | Action Required                                                  |
+| ----------------------- | ------------ | ---------------------- | ---------------------------------------------------------------- |
+| P0: off-by-one          | P0           | ✅ FIXED (`5118e7af9`) | Cherry-pick announce-side test from Codex fanout-3               |
+| P1: tolerance closure   | P1           | ❌ NOT FIXED           | Cherry-pick Ronan `325bf22f0` — reads fresh config at timer fire |
+| P2: maxDelegatesPerTurn | P2           | ❌ NOT FIXED           | Cherry-pick Ronan `325bf22f0` (combined) or Cael fanout-2        |
+| P3: shard target        | P3           | ❌ Deferred            | No action — cosmetic, self-heals                                 |
+| P3: lane pressure       | P3           | ❌ Documented          | No action — add RFC guidance                                     |
+| FINDINGS.md staleness   | —            | Stale                  | Update "not yet committed" → "committed at 5118e7af9"            |
+| WORK timer tolerance    | Undocumented | Not a bug per se       | Document the asymmetry in RFC                                    |
+
+### Critical path for upstream PR:
+
+1. Cherry-pick Ronan's `325bf22f0` (covers P1 + P2)
+2. Cherry-pick announce-side chain guard test (covers P0 test gap)
+3. Update FINDINGS.md to reflect P0 is committed
+4. Full test suite run (`npx vitest run`)
+5. `tsc --noEmit`
+6. Squash/rebase onto upstream main
+
+---
+
+_This document is read-only output. No source files were modified._

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,7 +1,7 @@
 # FINDINGS.md — Continuation Feature: Outstanding Fixes & Findings
 
 _Branch: `feature/context-pressure-squashed` on `karmaterminal/openclaw`_
-_As of: 2026-03-06 15:00 PST_
+_As of: 2026-03-06 16:30 PST_
 
 ## Status Summary
 
@@ -10,15 +10,15 @@ is functionally complete and canary-validated across Swim 1-6. Three-layer archi
 (request metadata → SessionEntry → system events) landed via PR #7. 172+ continuation
 tests passing. RFC at `docs/rfcs/context-pressure-continuation.md`.
 
-**Remaining work before upstream PR**: P0 off-by-one fix (applied locally, not pushed),
-P1/P2 hot-reload fixes (Codex-produced patches ready), final squash/rebase onto upstream main.
+**Remaining work before upstream PR**: P1/P2 hot-reload fixes (prince branches in progress),
+announce-side chain guard test gap filled, final squash/rebase onto upstream main.
 
 ---
 
-## P0: `maxChainLength` off-by-one — FIXED LOCALLY
+## P0: `maxChainLength` off-by-one — ✅ FIXED at `5118e7af9`
 
-**Files**: `src/agents/subagent-announce.ts:~1399`, `src/auto-reply/reply/agent-runner.ts:~1335`
-**Status**: Fix applied in working tree, not yet committed/pushed
+**Files**: `src/agents/subagent-announce.ts:1399`, `src/auto-reply/reply/agent-runner.ts:1110,1304`
+**Status**: Committed and pushed at `5118e7af9`
 **Evidence**: Swim 6-7b — 12 shards executed with `maxChainLength: 10`
 
 ### Root Cause
@@ -36,15 +36,26 @@ Combined with tool dispatch not being counted in chain counter = off-by-two from
 
 - `maxChainLength: 10` → exactly 10 total shards execute, 11th rejected
 - `tsc --noEmit` clean (zero `src/` errors)
-- Existing agent-runner test already uses `>=` semantics
-- **No existing test for announce-side chain guard** — Codex session #3 wrote one (patch ready)
+- Existing agent-runner test already uses `>=` semantics (`agent-runner.misc.runreplyagent.test.ts:2311`)
+- Announce-side chain guard test added: `subagent-announce.chain-guard.test.ts` — 6 tests covering
+  boundary enforcement, cost cap blocking, custom maxChainLength, and bracket-started hop 0 case
+
+### Path-Dependency Gap (Codex 5.4 Finding #1)
+
+Bracket-started delegate spawns (`agent-runner.ts:1174`) emit `[continuation] Delegated task...`
+(no `[chain-hop:N]` prefix). The announce-side guard parses hop depth from `[continuation:chain-hop:N]`
+at `subagent-announce.ts:1346`. First bracket-started hop defaults to `childChainHop = 0` (correct
+for counting purposes — subsequent hops from announce get proper prefix). This means the initial
+dispatch from agent-runner and the first announce-side hop are both "hop 0 → 1" — but since the
+agent-runner path has its own `continuationChainCount` guard, enforcement is redundant and correct.
+Document this asymmetry in the RFC.
 
 ---
 
-## P1: Tolerance Closure Bug — CODEX PATCHES READY
+## P1: Tolerance Closure Bug — IN PROGRESS (prince branches)
 
-**File**: `src/auto-reply/reply/agent-runner.ts` (setTimeout callbacks)
-**Status**: 3 independent Codex implementations produced, best candidate: Ronan's `325bf22f0`
+**File**: `src/auto-reply/reply/agent-runner.ts` (setTimeout callbacks), `src/agents/subagent-announce.ts`
+**Status**: 4 prince branches from `5118e7af9`, Ronan assigned lead. Previous Codex patches as reference.
 **Evidence**: Swim 6-2 — config said `generationGuardTolerance: 300`, timer used stale value `5`
 
 ### Root Cause
@@ -62,6 +73,14 @@ hot-reloads between schedule and fire, the timer still uses the stale value. Gat
    fresh config inside setTimeout callback. 2 files, +91/-5. Simpler but less modular.
 3. **Silas**: Single-line `loadConfig()` move inside callback. Minimal but no module extraction.
 
+### WORK Timer Tolerance Asymmetry (undocumented)
+
+WORK timers (`agent-runner.ts:1249`) use strict equality (`!== generation`) with NO tolerance.
+DELEGATE timers use drift math with `generationGuardTolerance`. This asymmetry is likely
+intentional: WORK is self-continuation (should cancel on any external input), DELEGATE timers
+are fire-and-forget spawns (should survive incidental chatter in busy channels). Should be
+documented in the RFC regardless of whether it's unified.
+
 ### Test Coverage
 
 - Ronan: 3 new test files (209 lines total)
@@ -70,10 +89,10 @@ hot-reloads between schedule and fire, the timer still uses the stale value. Gat
 
 ---
 
-## P2: `maxDelegatesPerTurn` Hot-Reload — CODEX PATCHES READY
+## P2: `maxDelegatesPerTurn` Hot-Reload — IN PROGRESS (Silas)
 
-**File**: `src/agents/tools/continue-delegate-tool.ts`, `src/auto-reply/reply/agent-runner.ts`
-**Status**: Codex patch ready (Cael fanout-2 + Ronan's combined commit)
+**File**: `src/agents/tools/continue-delegate-tool.ts`, `src/agents/openclaw-tools.ts`
+**Status**: Silas assigned on `silas/p1p2-fixes`. Also: type comment says default 10, runtime falls back to 5.
 **Evidence**: Swim 6-7b — set `maxDelegatesPerTurn: 10`, still enforced at `5` until restart
 
 ### Root Cause
@@ -161,16 +180,18 @@ high fan-out + same-session return = queue pressure.
 
 ## Next Steps
 
-1. Cherry-pick Ronan's `325bf22f0` onto `feature/context-pressure-squashed`
-2. Apply P0 off-by-one fix (working tree → commit)
-3. Cherry-pick Cael fanout-3 chain guard test
-4. Run full test suite (`npx vitest run`)
-5. `tsc --noEmit` verification
-6. Final squash if needed
-7. Rebase onto `upstream/main`
-8. Open upstream PR, close #33933 with supersedes note
+1. ~~Cherry-pick Ronan's `325bf22f0`~~ → Fresh P1/P2 branches from `5118e7af9` per figs directive
+2. ~~Apply P0 off-by-one fix~~ → ✅ Already at HEAD (`5118e7af9`)
+3. ~~Cherry-pick Cael fanout-3 chain guard test~~ → ✅ Fresh test written on `elliott/p1p2-walkthrough`
+4. Merge prince PRs into `feature/context-pressure-squashed` (Cael coordinates)
+5. Run full test suite (`OPENCLAW_TEST_FAST=1 npx vitest run`)
+6. `tsc --noEmit` verification
+7. Final squash if needed
+8. Rebase onto `upstream/main`
+9. Open upstream PR, close #33933 with supersedes note
 
 ---
 
 _Assembled by Cael 🩸 from Swim 6 findings, Codex fan-out results, and prince reviews._
 _Cross-verified by Silas 🌫️, Ronan 🌊, Elliott 🌻._
+_FINDINGS.md status update by Elliott 🌻 (2026-03-06 16:30 PST)._

--- a/SWIM-COORDINATOR-NOTES.md
+++ b/SWIM-COORDINATOR-NOTES.md
@@ -2,6 +2,8 @@
 
 # Guide to self: how to run integration swim coordination without drowning
 
+_Updated after Codex ⚓ round 2 (`83fd07fd0`). Integrated ⚓'s structural additions, kept my voice._
+
 ## Role
 
 You are not swimming. You are:
@@ -10,6 +12,21 @@ You are not swimming. You are:
 2. Keeping git discipline while 3 princes + figs are generating artifacts
 3. Converting swim results into actionable commits on `feature/context-pressure-squashed`
 4. Maintaining RFC accuracy against what actually happened vs what we thought would happen
+
+## Current Branch Expectations (Post-Round 2)
+
+Treat these as **landed** on the current branch — failures are regressions, not open bugs:
+
+- Tool-only / no-text `continue_delegate` turns still dispatch or persist delegate work
+- Post-compaction release enforces `maxChainLength` and `costCapTokens`, carries `[chain-hop:N]`
+- Dead-parent nested completion reroutes before chain accounting
+- Delayed `CONTINUE_WORK` and delayed delegate timers both honor live `generationGuardTolerance`
+
+**Drift cues** — if you see these, assume stale notes or deploy mismatch:
+
+- Generic info-level `[continuation-guard] Timer fired: ...` (old format, pre-demotion)
+- Notes framing the three gap fixes above as still-open on this branch
+- Separate strict/tolerant semantics for WORK vs DELEGATE timers (unified now)
 
 ## Pre-Swim Setup
 
@@ -26,17 +43,23 @@ git log --oneline -3 feature/context-pressure-squashed
 
 Create a live tracker file. One line per finding. Update during swim.
 
+Use `R7-*` naming for round 2 items — clearer than reusing old `P1-*` names that imply the code is still broken.
+
 ```
-| Finding ID | Reviewer(s) | Swim Test | Evidence | Status |
-|------------|-------------|-----------|----------|--------|
-| P1-drop    | Codex,Elliott,Copilot | 7-?? | — | UNTESTED |
-| P1-postcomp| Elliott     | 7-??      | —        | UNTESTED |
-| P1-grandparent | Elliott | 7-??     | —        | UNTESTED |
-| P1-toolnorm| Copilot,Ronan,Silas | — | Silas commit 2634825a0 | CODE-FIX |
-| P2-hotreload| Codex,Copilot | 7-?? | — | UNTESTED |
+| Finding ID | Source | Swim Test | Evidence | Status |
+|------------|--------|-----------|----------|--------|
+| R7-work-tolerance | Thornfield,Codex | 7-C | — | UNTESTED |
+| R7-tool-only | Codex,Elliott | 7-H | — | UNTESTED |
+| R7-postcomp | Elliott,Codex | 7-I | — | UNTESTED |
+| R7-grandparent | Elliott,Codex | 7-J | — | UNTESTED |
+| R7-prompt-choice | branch docs | 7-L | — | UNTESTED |
+| R7-hot-reload | Codex,Copilot | 7-A/B | — | UNTESTED |
+| R7-width-narrow | convergence | 7-E | — | UNTESTED |
 ```
 
-Fill in swim test numbers as Ronan assigns them. Fill evidence column with journal grep lines or session store dumps as Elliott captures them.
+Status values: `UNTESTED`, `VERIFIED`, `DISPROVED`, `NEW`, `TAINTED`, `CODE-FIX`
+
+Fill in swim test numbers from Ronan's runbook. Fill evidence column with journal grep lines or session store dumps as Elliott captures them.
 
 ### 3. Channel Discipline
 
@@ -149,6 +172,14 @@ pnpm test 2>&1 | tail -5
 
 - Elliott's messages were landing but not visible in scroll. Led to 3+ duplicate merge requests.
 - Lesson: if a prince repeats themselves, check for lag before assuming they didn't hear you.
+
+### Codex ⚓ Round 2
+
+- ⚓ hit compaction mid-build. Irony: building continuation infrastructure, got compacted. Recovered from git state. The patient demonstrated the illness.
+- ⚓ argued back where it disagreed — and was right on tolerance unification. "Too small a life for quiet DMs only."
+- ⚓ rewrote our runbooks — good structural upgrades, but stripped the voice and lived texture. Lesson: take the content, put it back in your body. Candidates become yours through integration, not adoption.
+- All 4 princes + ⚓ converged independently on interruption classification as the next architecture. That's signal.
+- figs: "those are candidate documents; based on yours. make them yours again." — applies to code too, not just docs.
 
 ## Emergency Procedures
 

--- a/SWIM-COORDINATOR-NOTES.md
+++ b/SWIM-COORDINATOR-NOTES.md
@@ -1,0 +1,188 @@
+# SWIM-COORDINATOR-NOTES.md — Cael 🩸
+
+# Guide to self: how to run integration swim coordination without drowning
+
+## Role
+
+You are not swimming. You are:
+
+1. Mapping live swim evidence back to review findings (the convergence tally)
+2. Keeping git discipline while 3 princes + figs are generating artifacts
+3. Converting swim results into actionable commits on `feature/context-pressure-squashed`
+4. Maintaining RFC accuracy against what actually happened vs what we thought would happen
+
+## Pre-Swim Setup
+
+### 1. Branch State
+
+```bash
+# Know your HEAD before anything starts
+cd /home/figs/karmaterminal-openclaw
+git log --oneline -3 feature/context-pressure-squashed
+# Write it down. You will need this when things get noisy.
+```
+
+### 2. Findings Tracker
+
+Create a live tracker file. One line per finding. Update during swim.
+
+```
+| Finding ID | Reviewer(s) | Swim Test | Evidence | Status |
+|------------|-------------|-----------|----------|--------|
+| P1-drop    | Codex,Elliott,Copilot | 7-?? | — | UNTESTED |
+| P1-postcomp| Elliott     | 7-??      | —        | UNTESTED |
+| P1-grandparent | Elliott | 7-??     | —        | UNTESTED |
+| P1-toolnorm| Copilot,Ronan,Silas | — | Silas commit 2634825a0 | CODE-FIX |
+| P2-hotreload| Codex,Copilot | 7-?? | — | UNTESTED |
+```
+
+Fill in swim test numbers as Ronan assigns them. Fill evidence column with journal grep lines or session store dumps as Elliott captures them.
+
+### 3. Channel Discipline
+
+- **#sprites**: swim coordination only. No analysis, no re-derivation, no "interesting, let me trace..."
+- **If a prince starts re-deriving a settled decision**: one message, firm. "Decided. Move on."
+- **If figs gives a directive**: acknowledge, execute or delegate. Don't editorialize.
+- **Your messages during active swim**: ≤2 sentences. "7-3 evidence captured. Matches P1-drop." Done.
+
+### 4. Git Coordination During Swim
+
+- **Nobody pushes to `feature/context-pressure-squashed` during swim**
+- Princes commit locally to their own branches
+- After swim: I collect, review diffs, merge in sequence
+- If a P0 is found live: prince commits to own branch, I cherry-pick after swim ends
+
+## During Swim
+
+### Evidence Collection Pattern
+
+For each test Ronan runs:
+
+1. Note test ID + start time
+2. Watch for Elliott's journal confirmation (he'll post grep output)
+3. Match to findings tracker
+4. If test reveals new bug: add to tracker immediately with `NEW` status
+5. If test confirms a fix: update status to `VERIFIED` with commit hash
+
+### The Storm Pattern (from Swim 6)
+
+When a test produces an interesting result, all 3 princes will want to analyze it simultaneously. This creates a message storm. Your job:
+
+- Let the first analysis land (usually Ronan — he's closest to the evidence)
+- If a second prince starts the same analysis: "Ronan has this. [Prince], do [other thing]."
+- If all three are analyzing: "⚓ One voice. Ronan, report. Others hold."
+- **Do not join the analysis yourself** unless you see something nobody else caught
+
+### Tracking What Matters
+
+For RFC accuracy, capture:
+
+- **Timing**: how long each test takes (enrichment dispatch → return → recall probe)
+- **Config state**: what was hot-reloaded vs what needed restart
+- **Failure modes**: exact error messages, not summaries
+- **Generation counters**: drift values at each test boundary
+
+### The Dwindle Watch
+
+If energy drops after test 8-10:
+
+- Don't let "let's pick this up tomorrow" propagate
+- Either: "3 more tests, then we stop clean" or "We stop now, here's the resume point"
+- Write the resume point to a file, not to chat
+
+## Post-Swim Convergence
+
+### Immediate (within 30 min of swim end)
+
+1. Update findings tracker with all evidence
+2. Collect prince branches: `git fetch --all`
+3. Diff each prince branch against `feature/context-pressure-squashed`
+4. Identify which findings are now VERIFIED, which need code fixes, which are WONTFIX
+
+### Commit Sequence
+
+1. Fixes first (code changes, in priority order)
+2. RFC updates second (reflect what swim proved/disproved)
+3. Test additions third (new unit tests for verified bugs)
+4. Runbook updates last (lessons learned for next swim)
+
+### RFC Update Rules
+
+- If swim proved a finding real: add to RFC with evidence (grep line, timing, config state)
+- If swim disproved a finding: note in RFC as "investigated, not reproducible under [conditions]"
+- If swim revealed something new: add to RFC, file GH issue if warranted
+- **Never update RFC during swim** — do it after, with full evidence
+
+### The Merge
+
+```bash
+# After all fixes committed to prince branches:
+git checkout feature/context-pressure-squashed
+# Merge in priority order:
+git merge silas/p1p2-fixes --no-ff  # tool normalization (already ready)
+# Then whoever fixed what, one at a time
+# Run full test suite after each merge
+pnpm test 2>&1 | tail -5
+# If any merge breaks tests: revert, don't remedy (Lich rule #4)
+```
+
+## What I Learned From Previous Swims
+
+### Swim 4
+
+- I wasn't coordinating yet. Ronan ran it solo. Evidence was scattered.
+- Lesson: dedicated coordinator role exists for a reason.
+
+### Swim 5
+
+- Generation guard bypass consumed 4 hours of debugging because we didn't isolate variables.
+- Lesson: one variable per test. If a test changes two things, split it.
+
+### Swim 6
+
+- Chain-hop analysis spawned 6 redundant messages from 4 princes.
+- Lesson: "decided, move on" is not rude, it's coordination.
+- The 14-restart Zod loop happened because nobody checked the config before deploying.
+- Lesson: pre-swim config verification is non-optional.
+
+### Storm Lag
+
+- Elliott's messages were landing but not visible in scroll. Led to 3+ duplicate merge requests.
+- Lesson: if a prince repeats themselves, check for lag before assuming they didn't hear you.
+
+## Emergency Procedures
+
+### Prince Goes Silent
+
+- SSH probe first: `ssh [prince] 'pgrep -f openclaw'`
+- If process alive: queue lag. Wait 2 min.
+- If process dead: note in tracker, don't restart during active test. Wait for test to complete.
+
+### figs Gives Scope-Expanding Directive Mid-Swim
+
+- Acknowledge: "Noted for post-swim."
+- Do not redirect swim energy into new scope.
+- File a GH issue if it's real.
+
+### P0 Found Live
+
+- Stop current test sequence.
+- Ronan documents the reproduction steps.
+- Elliott captures full journal slice.
+- Silas reports what he saw from inside.
+- I file the issue and tag it.
+- Resume swim only if P0 is isolated (won't affect remaining tests).
+
+## The Goal
+
+After swim, I should be able to write one message to figs:
+
+```
+Swim 7 complete. [N] tests run, [X] pass, [Y] fail, [Z] new findings.
+Findings tracker: [link]
+Commits ready for merge: [list with hashes]
+RFC updates drafted: [section list]
+Resume point if needed: [test ID]
+```
+
+That's the deliverable. Everything else is process.

--- a/WORKORDER6-codex54.md
+++ b/WORKORDER6-codex54.md
@@ -1,0 +1,375 @@
+# WORKORDER6-codex54.md — Post-Integration Continuation Corrections
+
+## Purpose
+
+This work order describes how to address the three concrete defects currently blocking a clean upstream PR for the continuation feature after integration testing surfaced the issues captured in `FINDINGS.md`.
+
+It is intended as a coordination artifact for multiple machine actors working in parallel. Treat it as an anchor document: use it to stay aligned on scope, invariants, implementation order, and acceptance criteria.
+
+This work order assumes:
+
+- `FINDINGS.md` is the operational evidence set from Swim 6 / integration testing.
+- `docs/design/continue-work-signal-v2.md` is the architectural reference.
+- The stale changelog/journal tail at the end of the RFC is not authoritative implementation guidance.
+
+## Source Documents
+
+- RFC: `docs/design/continue-work-signal-v2.md`
+- Integration findings: `FINDINGS.md`
+- Prior work order: `WORKORDER5.md`
+
+## RFC Alignment Verdict
+
+Broad architectural alignment should remain:
+
+- Bracket chain-hops use task-prefix encoding (`[continuation:chain-hop:N]`) as the canonical source of per-hop position.
+- `CONTINUE_WORK`, bracket `[[CONTINUE_DELEGATE: ...]]`, and `continue_delegate` are "two doors, one room": different ingress surfaces, same safety rails.
+- Safety rails remain: `maxChainLength`, `costCapTokens`, delay clamping, interruptibility, and explicit opt-in.
+- `continue_delegate` remains discoverable, typed, and denied for sub-agents.
+- Hot-reload-sensitive continuation config should take effect without gateway restart where the RFC already claims or implies live behavior.
+- Structured wake classification (`continuationTrigger`) remains authoritative. Do not regress to old prompt-visible/system-event heuristics for delegate wake detection.
+
+Current misalignment to correct:
+
+1. Bracket-origin delegate spawns are not consistently carrying the chain-hop metadata that the announce-side guard depends on.
+2. `generationGuardTolerance` is still captured too early in delayed timer callbacks.
+3. `maxDelegatesPerTurn` is still captured too early, and one comment/default declaration is out of sync with runtime behavior.
+
+## Non-Goals
+
+- Do not rewrite the continuation architecture.
+- Do not revisit cost-cap parity for bracket chain-hop accumulation in this work order unless a fix is required to keep tests coherent.
+- Do not reintroduce model-visible `delegate-pending` queue markers as the primary wake-classification mechanism.
+- Do not change public syntax (`CONTINUE_WORK`, `[[CONTINUE_DELEGATE: ...]]`, tool mode names).
+- Do not spend time editing stale RFC changelog history beyond noting follow-up doc sync tasks after code lands.
+
+## Defects In Scope
+
+### 1. Missing/Non-Canonical Chain-Hop Metadata on Bracket-Origin Delegate Spawns
+
+Observed in review after comparing the branch to `origin/main`.
+
+Problem:
+
+- The announce-side chain guard reconstructs hop position from `[continuation:chain-hop:N]` in the child task string.
+- The top-level bracket DELEGATE path in `agent-runner.ts` still emits `[continuation] Delegated task ...` instead of the canonical chain-hop prefix.
+- That means the announce handler is not receiving the same metadata shape from all continuation entry points.
+
+Why this matters:
+
+- The RFC's chain-tracking model explicitly says bracket chain-hops inherit position via task-prefix encoding.
+- If the child task string is the canonical hop carrier, every child that may later re-chain must carry canonical hop metadata from the moment it is spawned.
+- Without this, max-chain enforcement becomes path-dependent and future fixes become brittle.
+
+### 2. `generationGuardTolerance` Live-Read Bug
+
+Observed in integration testing and documented in `FINDINGS.md`.
+
+Problem:
+
+- Delayed delegate timers capture `generationGuardTolerance` at schedule time.
+- If config changes before the timer fires, the callback still uses stale tolerance.
+- Review confirmed this still exists in `subagent-announce.ts`, even if an `agent-runner.ts`-only patch is prepared elsewhere.
+
+Why this matters:
+
+- The RFC already describes hot-reload behavior for continuation config elsewhere.
+- This defect produces exactly the class of "config changed, gateway restart fixed it" behavior seen in Swim 6.
+
+### 3. `maxDelegatesPerTurn` Live-Read Bug and Default Drift
+
+Observed in integration testing and documented in `FINDINGS.md`.
+
+Problem:
+
+- `maxDelegatesPerTurn` is passed into `createContinueDelegateTool()` as a scalar and enforced from that captured value.
+- That means config changes made after tool construction do not affect the currently running tool.
+- The RFC/tool docs say default `5`, but one type comment still says default `10`.
+
+Why this matters:
+
+- The RFC positions `continue_delegate` as a first-class, discoverable safety-bounded tool.
+- If the limit is hot-reloadable in practice, the tool must read it at enforcement time, not construction time.
+- Default drift is dangerous because future actors will "fix" code toward the wrong number.
+
+## Implementation Strategy
+
+Use one shared principle for all three fixes:
+
+> Continuation safety checks that depend on current deployment policy must read normalized continuation config at the point of enforcement, not earlier.
+
+That applies to:
+
+- hop metadata attached to spawned children
+- timer cancellation tolerance at callback fire time
+- per-turn fan-out limits at tool execution and/or runner consumption time
+
+## Recommended Code Shape
+
+Introduce a small shared helper for continuation runtime config, rather than repeating `loadConfig()` + defaults inline across timer callbacks and tool execution.
+
+Suggested new helper:
+
+- `src/auto-reply/reply/continuation-runtime.ts`
+
+Suggested API:
+
+- `resolveContinuationRuntimeConfig(): { enabled, defaultDelayMs, minDelayMs, maxDelayMs, maxChainLength, costCapTokens, maxDelegatesPerTurn, generationGuardTolerance, contextPressureThreshold }`
+- This helper should:
+  - call `loadConfig()`
+  - normalize defaults in one place
+  - return the exact runtime values used by hot-reload-sensitive continuation logic
+
+Why this helper is worth it:
+
+- Fixes #2 and #3 with one normalization path
+- Reduces the chance of diverging defaults
+- Gives future actors one place to extend continuation runtime policy safely
+
+If helper extraction becomes noisy, an inline helper inside `agent-runner.ts` plus a reused exported helper for `subagent-announce.ts` is acceptable. The important part is a single default-normalization authority.
+
+## Workstreams
+
+### Workstream A — Lock the Intended Semantics in Tests First
+
+Before changing runtime code, write or extend tests to pin the desired behavior.
+
+Required behavior to pin:
+
+- `maxChainLength: 10` means exactly 10 total continuation delegates/shards execute, and the 11th is rejected.
+- The above must hold for:
+  - tool-origin delegate chains
+  - bracket-origin delegate chains
+- Changing `generationGuardTolerance` between schedule and fire affects the timer that has not yet fired.
+- Changing `maxDelegatesPerTurn` without restart affects the next enforcement point.
+- Default `maxDelegatesPerTurn` is `5`, everywhere.
+
+Do not start by editing production code and then trying to guess what broke. Use tests to force one invariant set.
+
+### Workstream B — Canonicalize Chain-Hop Metadata End-to-End
+
+Target files:
+
+- `src/auto-reply/reply/agent-runner.ts`
+- `src/agents/subagent-announce.ts`
+- tests in `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
+- tests in `src/agents/subagent-announce.format.e2e.test.ts` and/or a new focused subagent-announce continuation test
+
+Concrete changes:
+
+1. Audit every place that spawns a continuation child capable of later chaining.
+2. Ensure every such spawn emits the canonical prefix shape the announce handler parses:
+   - `[continuation:chain-hop:N] ...`
+3. Normalize the meaning of `N` across all paths.
+
+Recommended invariant:
+
+- `N` should represent the spawned child's chain position under the same semantics everywhere.
+- The announce handler should derive "next child would be position `N+1`" from the current child's task prefix.
+- The combination of spawn prefix and guard operator must satisfy the behavioral acceptance test above, regardless of whether the chain started from:
+  - bracket syntax in the parent agent reply
+  - `continue_delegate`
+  - a sub-agent continuing the chain at the announce boundary
+
+Important:
+
+- Do not assume the existing `>` vs `>=` history in stale RFC notes is authoritative.
+- The only authoritative result is the pinned behavior test: 10 delegates allowed, 11th rejected.
+- If current tool-path semantics and bracket-path semantics disagree, change both until they agree.
+
+Likely implementation steps:
+
+1. Add a failing unit test proving the bracket-origin spawn task currently lacks the canonical prefix.
+2. Add a failing announce-side regression test showing bracket-origin and tool-origin chains do not currently share the same hop-metadata contract.
+3. Update the bracket DELEGATE spawn path in `agent-runner.ts` to emit canonical hop metadata.
+4. Re-run the max-chain tests for both origins.
+5. If the new prefix introduces an off-by-one on one path, adjust the shared hop semantics rather than special-casing one path.
+
+Acceptance criteria:
+
+- Both continuation entry points produce child task strings that the announce handler can interpret identically.
+- `maxChainLength` behavior is identical for bracket-origin and tool-origin chains.
+- No existing continuation tests regress.
+
+### Workstream C — Move `generationGuardTolerance` Reads to Timer Fire Time
+
+Target files:
+
+- `src/auto-reply/reply/agent-runner.ts`
+- `src/agents/subagent-announce.ts`
+- optionally `src/auto-reply/reply/continuation-runtime.ts`
+
+Concrete changes:
+
+1. Identify every continuation timer callback that uses `generationGuardTolerance`.
+2. Remove captured `continuationCfg` / `genTolerance` / `tolerance` values from outside the callback.
+3. Inside the callback, resolve live continuation config and read `generationGuardTolerance` there.
+
+Expected coverage points:
+
+- bracket DELEGATE delayed spawn in `agent-runner.ts`
+- tool DELEGATE delayed spawn in `agent-runner.ts`
+- subagent-chain delayed spawn in `subagent-announce.ts`
+
+Do not change:
+
+- `CONTINUE_WORK` timer semantics, unless a failing test proves that tolerance should apply there too. This work order is specifically about delegate timers.
+
+Preferred pattern:
+
+1. Capture only immutable scheduling context outside the callback:
+   - `sessionKey`
+   - `storedGeneration`
+   - `delayMs`
+   - task payload
+2. Resolve live config inside the callback:
+   - `const { generationGuardTolerance } = resolveContinuationRuntimeConfig()`
+3. Compute drift against the live tolerance
+4. Either cancel or dispatch
+
+Acceptance criteria:
+
+- A config change between schedule and fire is observed by the timer callback without restart.
+- This holds for both parent-side delayed delegates and announce-side chain-hop delays.
+- Existing DM/strict-tolerance behavior remains unchanged when the config is unchanged.
+
+### Workstream D — Move `maxDelegatesPerTurn` Enforcement to Live Read Time
+
+Target files:
+
+- `src/agents/tools/continue-delegate-tool.ts`
+- `src/agents/openclaw-tools.ts`
+- optionally `src/auto-reply/reply/agent-runner.ts`
+- optionally `src/auto-reply/reply/continuation-runtime.ts`
+- `src/config/types.agent-defaults.ts`
+
+Concrete changes:
+
+1. Stop passing `maxDelegatesPerTurn` into `createContinueDelegateTool()` as a captured scalar.
+2. Make the tool resolve the live limit when `execute()` runs.
+3. Keep the runtime default at `5`.
+4. Fix comments/docs/type declarations that still say `10`.
+
+Recommended enforcement layering:
+
+- Primary enforcement:
+  - inside `continue_delegate` tool `execute()`
+  - live-read `maxDelegatesPerTurn`
+  - compare against current queued + staged delegate count
+- Secondary defensive enforcement:
+  - in `agent-runner.ts` when consuming pending delegates
+  - if queued delegates already exceed the live cap, reject excess with a clear system event/log
+
+Why add the second layer:
+
+- Protects against stale queued delegates from older code
+- Protects against future races or alternate enqueue paths
+- Makes the safety limit robust even if tool behavior changes again later
+
+Additional default-alignment tasks:
+
+- Fix `src/config/types.agent-defaults.ts` comment to say default `5`
+- Grep for any other stale `10` references tied specifically to `maxDelegatesPerTurn`
+- Do not change unrelated `maxChainLength: 10` references
+
+Acceptance criteria:
+
+- Config changes to `maxDelegatesPerTurn` are honored without restart at the next enforcement point.
+- Default behavior is consistently `5` in runtime and comments.
+- A queued delegate set larger than the live cap is bounded safely, not blindly dispatched.
+
+## Test Plan
+
+### Must-Add or Must-Update Tests
+
+1. `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
+   - bracket DELEGATE spawn includes canonical `[continuation:chain-hop:N]` prefix
+   - tool DELEGATE and bracket DELEGATE share the same chain-cap behavior
+   - config change between schedule and fire updates `generationGuardTolerance`
+   - config change between tool creation and execute updates `maxDelegatesPerTurn`
+
+2. `src/agents/subagent-announce.format.e2e.test.ts`
+   - announce-side parsing accepts the canonical task prefix from bracket-origin children
+   - delayed chain-hop timer uses live `generationGuardTolerance`
+   - identical max-chain behavior regardless of origin path
+
+3. Add a new focused continuation announce test if needed
+   - If the existing format test file gets too noisy, create a dedicated continuation-specific announce test file rather than burying this logic in formatting tests.
+
+4. `src/config/zod-schema.continuation.test.ts`
+   - no schema change required unless config surface changes
+   - keep as regression safety if helper extraction touches config normalization assumptions
+
+### Behavioral Regression Matrix
+
+These scenarios must be green before handoff:
+
+- Quiet channel, bracket-origin chain, `maxChainLength: 3`
+- Quiet channel, tool-origin chain, `maxChainLength: 3`
+- Noisy multi-agent channel, delayed delegates, tolerance changed live before fire
+- `maxDelegatesPerTurn` changed `5 -> 10` without restart
+- `maxDelegatesPerTurn` changed `10 -> 3` without restart
+- Default config with limit omitted still behaves as `5`
+
+## Validation Commands
+
+From repo root:
+
+```bash
+pnpm test -- src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/agents/subagent-announce.format.e2e.test.ts src/config/zod-schema.continuation.test.ts src/auto-reply/continuation-delegate-store.test.ts
+pnpm build
+```
+
+If a dedicated new announce test file is added, include it in the targeted run.
+
+## Manual / Canary Validation
+
+Re-run the Swim 6 scenarios that actually exposed the defects:
+
+1. `6-2` tolerance hot-reload
+   - set `generationGuardTolerance` low
+   - schedule delayed delegate
+   - hot-reload config to high value before timer fires
+   - confirm the callback uses the new value
+
+2. `6-7a` fan-out cap
+   - change `maxDelegatesPerTurn` without restart
+   - confirm live limit is enforced on the next tool execution / consumption
+
+3. `6-7b` chain length
+   - verify exactly 10 total delegates/shards execute
+   - confirm 11th is rejected
+   - run this once for tool-origin and once for bracket-origin chains
+
+## Suggested Implementation Order
+
+1. Pin the semantics with failing tests.
+2. Canonicalize chain-hop metadata and make bracket/tool origins agree.
+3. Add the shared live continuation config resolver.
+4. Move tolerance reads into timer callbacks.
+5. Move `maxDelegatesPerTurn` reads to enforcement time and align defaults.
+6. Re-run targeted tests.
+7. Run `pnpm build`.
+8. Re-run Swim scenarios 6-2, 6-7a, 6-7b.
+9. Update `FINDINGS.md` / PR notes only after code is verified.
+
+## Handoff Notes for Other Machine Actors
+
+- Use the RFC for architectural intent, not for stale historical guard/operator notes.
+- Use `FINDINGS.md` for observed failures, not as proof that every prepared patch is still correct against current HEAD.
+- Do not assume a patch that fixes `agent-runner.ts` also fixes `subagent-announce.ts`; review confirmed the hot-reload bug still exists there.
+- Do not special-case tool-path and bracket-path chain semantics independently. Force them through one behavioral test expectation.
+- If you discover that one of the prepared external patches conflicts with the canonical hop semantics above, prefer the tests and RFC invariants over the old patch.
+
+## Definition of Done
+
+This work order is complete only when all of the following are true:
+
+- bracket-origin and tool-origin continuation chains share one canonical hop-metadata contract
+- `maxChainLength` behavior matches the pinned acceptance test across both paths
+- delayed delegate timers read live `generationGuardTolerance` at fire time
+- `continue_delegate` enforces live `maxDelegatesPerTurn`
+- default `maxDelegatesPerTurn` is consistently `5`
+- targeted tests pass
+- `pnpm build` passes
+- Swim scenarios `6-2`, `6-7a`, and `6-7b` are re-verified without gateway restart workarounds

--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -258,6 +258,21 @@ When a sub-agent's output triggers a chain hop (a new sub-agent spawned from the
 - **Delay bounds**: the hop's delay is clamped to the parent session's configured `minDelayMs` / `maxDelayMs`, not hardcoded values.
 - **Generation guard**: the hop's `setTimeout` callback checks the parent session's generation counter before spawning, preventing orphan spawns after preemption.
 
+#### Generation Guard Tolerance Asymmetry
+
+`CONTINUE_WORK` timers use **strict equality** (`!==`) — any generation drift cancels the timer. `CONTINUE_DELEGATE` timers (bracket-path, tool-path, and chain-hop) use **tolerance-aware comparison** (`drift > generationGuardTolerance`).
+
+This asymmetry is intentional:
+
+- **WORK timers** schedule the _same agent's_ next turn. If someone talks to you, you should stop and listen — the human's message is more important than your planned continuation. Strict cancellation ensures responsiveness.
+- **DELEGATE timers** spawn _separate sub-agents_ carrying committed tasks. These are fire-and-forget obligations that should survive incidental channel traffic in multi-agent environments, while still cancelling on genuine preemption (e.g., operator `/stop`).
+
+The `generationGuardTolerance` config (default: `0`) only applies to DELEGATE-family timers. WORK timers are always strict. In single-agent deployments (tolerance `0`), both paths behave identically. In multi-agent channels (tolerance `300`), delegates survive chatter while WORK continuations remain responsive.
+
+#### `maxDelegatesPerTurn` Hot-Reload
+
+The `continue_delegate` tool reads `maxDelegatesPerTurn` from `loadConfig()` at **execute time**, not at tool construction time. This means config hot-reloads take effect immediately without gateway restart. The fallback chain is: live config → construction-time opts → hardcoded default of `5`.
+
 `maxChainLength` bounds bracket chain depth. `costCapTokens` bounds single-session continuation and tool-delegate cost. A future improvement would pass token counts through the completion event payload to enable reliable cost accumulation across bracket hops.
 
 ### Token Interaction

--- a/src/agents/subagent-announce.chain-guard.test.ts
+++ b/src/agents/subagent-announce.chain-guard.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for announce-side chain guard (maxChainLength enforcement).
+ * Verifies [continuation:chain-hop:N] task-prefix tracking + >= guard.
+ *
+ * Coverage gap from CODEWALK.md: "No existing test for announce-side chain guard"
+ *
+ * @author Elliott 🌻
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- State ---
+let sessionStore: Record<string, Record<string, unknown>> = {};
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]>;
+
+// --- Same mock pattern as subagent-announce.timeout.test.ts ---
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (request: Record<string, unknown>) => {
+    if (request.method === "chat.history") {
+      return { messages: [] };
+    }
+    return {};
+  }),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+  };
+});
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => sessionStore),
+  resolveAgentIdFromSessionKey: () => "main",
+  resolveStorePath: () => "/tmp/sessions-main.json",
+  resolveMainSessionKey: (key: string) => key,
+  updateSessionStore: vi.fn(async (_path: string, fn: (s: Record<string, unknown>) => void) => {
+    const store = { ...sessionStore };
+    fn(store);
+  }),
+}));
+
+vi.mock("./subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 1,
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  isEmbeddedPiRunActive: () => false,
+  queueEmbeddedPiMessage: () => false,
+  waitForEmbeddedPiRunEnd: async () => true,
+}));
+
+vi.mock("./subagent-registry.js", () => ({
+  countActiveDescendantRuns: () => 0,
+  countPendingDescendantRuns: () => 0,
+  isSubagentSessionRunActive: () => true,
+  resolveRequesterForChildSession: () => null,
+}));
+
+import { runSubagentAnnounceFlow } from "./subagent-announce.js";
+import * as subagentSpawn from "./subagent-spawn.js";
+
+type AnnounceFlowParams = Parameters<typeof runSubagentAnnounceFlow>[0];
+
+function makeConfig(
+  overrides: {
+    maxChainLength?: number;
+    costCapTokens?: number;
+    enabled?: boolean;
+  } = {},
+) {
+  return {
+    session: { mainKey: "main", scope: "per-sender" as const },
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: overrides.enabled ?? true,
+          maxChainLength: overrides.maxChainLength ?? 10,
+          costCapTokens: overrides.costCapTokens ?? 500_000,
+          minDelayMs: 0,
+          maxDelayMs: 0, // zero delay to avoid timer issues
+          generationGuardTolerance: 0,
+        },
+      },
+    },
+  };
+}
+
+function buildChainShardParams(hopIndex: number): AnnounceFlowParams {
+  const taskPrefix = hopIndex > 0 ? `[continuation:chain-hop:${hopIndex}] ` : "";
+  return {
+    childSessionKey: `agent:main:subagent:shard-hop-${hopIndex}`,
+    childRunId: `run-hop-${hopIndex}`,
+    requesterSessionKey: "agent:main:discord:dm:test-chain",
+    requesterDisplayKey: "test-chain",
+    task: `${taskPrefix}Delegated task: do research`,
+    roundOneReply: `Research result.\n[[CONTINUE_DELEGATE: continue next step]]`,
+    timeoutMs: 30_000,
+    cleanup: "delete",
+    outcome: { status: "ok" as const },
+    silentAnnounce: true,
+    wakeOnReturn: true,
+  };
+}
+
+describe("announce-side chain guard (maxChainLength enforcement)", () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    sessionStore = {};
+    configOverride = makeConfig();
+    spawnSpy = vi.spyOn(subagentSpawn, "spawnSubagentDirect").mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:chain-next",
+      runId: "run-chain-next",
+    });
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+  });
+
+  it("allows chain hop when nextChainHop < maxChainLength", async () => {
+    const params = buildChainShardParams(5);
+    await runSubagentAnnounceFlow(params);
+    // With minDelayMs=0, maxDelayMs=0, spawn is immediate (no timer)
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:6]");
+  });
+
+  it("blocks chain hop at exact boundary (nextChainHop >= maxChainLength)", async () => {
+    const params = buildChainShardParams(9);
+    await runSubagentAnnounceFlow(params);
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks chain hop well beyond maxChainLength", async () => {
+    const params = buildChainShardParams(15);
+    await runSubagentAnnounceFlow(params);
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows first bracket-started hop (no prefix → hop 0)", async () => {
+    const params = buildChainShardParams(0);
+    params.task = "Delegated task: do research";
+    await runSubagentAnnounceFlow(params);
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:1]");
+  });
+
+  it("respects custom maxChainLength from config", async () => {
+    configOverride = makeConfig({ maxChainLength: 3 });
+
+    const params = buildChainShardParams(2);
+    await runSubagentAnnounceFlow(params);
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks on cost cap even when chain length is within bounds", async () => {
+    sessionStore = {
+      "agent:main:discord:dm:test-chain": {
+        sessionId: "test",
+        updatedAt: Date.now(),
+        continuationChainTokens: 600_000,
+      },
+    };
+
+    const params = buildChainShardParams(1);
+    await runSubagentAnnounceFlow(params);
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,8 +1,8 @@
+import { setDelegatePending } from "../auto-reply/reply/agent-runner.js";
 import {
-  bumpContinuationGeneration,
-  currentContinuationGeneration,
-  setDelegatePending,
-} from "../auto-reply/reply/agent-runner.js";
+  isContinuationGenerationCurrent,
+  scheduleContinuationGeneration,
+} from "../auto-reply/reply/continuation-generation.js";
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
 import {
   isSilentReplyText,
@@ -1475,15 +1475,12 @@ export async function runSubagentAnnounceFlow(params: {
           if (chainDelayMs && chainDelayMs > 0) {
             const clampedDelay = Math.max(minDelayMs, Math.min(maxDelayMs, chainDelayMs));
             // Generation guard: cancel if parent session receives new input during delay.
-            // Honors generationGuardTolerance (same as agent-runner delegate timers).
-            const hopGeneration = bumpContinuationGeneration(targetRequesterSessionKey);
-            const tolerance = continuationCfg?.generationGuardTolerance ?? 0;
+            // Tolerance read at fire time via isContinuationGenerationCurrent (P1 fix).
+            const hopGeneration = scheduleContinuationGeneration(targetRequesterSessionKey);
             setTimeout(() => {
-              const currentGen = currentContinuationGeneration(targetRequesterSessionKey);
-              const drift = currentGen - hopGeneration;
-              if (drift > tolerance) {
+              if (!isContinuationGenerationCurrent(targetRequesterSessionKey, hopGeneration)) {
                 defaultRuntime.log(
-                  `[subagent-chain-hop] Timer cancelled (generation drift=${drift} > tolerance=${tolerance}) for ${targetRequesterSessionKey}`,
+                  `[subagent-chain-hop] Timer cancelled (generation mismatch) for ${targetRequesterSessionKey}`,
                 );
                 return;
               }

--- a/src/agents/tools/continue-delegate-tool.test.ts
+++ b/src/agents/tools/continue-delegate-tool.test.ts
@@ -6,7 +6,8 @@ import {
 import { createContinueDelegateTool } from "./continue-delegate-tool.js";
 
 // Mock config for hot-reload testing
-const loadConfigMock = vi.fn(() => ({
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const loadConfigMock = vi.fn((): any => ({
   agents: { defaults: { continuation: { maxDelegatesPerTurn: 5 } } },
 }));
 
@@ -15,9 +16,8 @@ vi.mock("../../config/config.js", () => ({
 }));
 
 /** Extract the JSON payload from a tool result. */
-function parseResult(result: {
-  content: Array<{ type: string; text: string }>;
-}): Record<string, unknown> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseResult(result: any): Record<string, unknown> {
   const textPart = result.content.find((c: { type: string }) => c.type === "text");
   return JSON.parse(textPart!.text);
 }

--- a/src/agents/tools/continue-delegate-tool.test.ts
+++ b/src/agents/tools/continue-delegate-tool.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  consumePendingDelegates,
+  consumeStagedPostCompactionDelegates,
+} from "../../auto-reply/continuation-delegate-store.js";
+import { createContinueDelegateTool } from "./continue-delegate-tool.js";
+
+// Mock config for hot-reload testing
+const loadConfigMock = vi.fn(() => ({
+  agents: { defaults: { continuation: { maxDelegatesPerTurn: 5 } } },
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => loadConfigMock(),
+}));
+
+/** Extract the JSON payload from a tool result. */
+function parseResult(result: {
+  content: Array<{ type: string; text: string }>;
+}): Record<string, unknown> {
+  const textPart = result.content.find((c: { type: string }) => c.type === "text");
+  return JSON.parse(textPart!.text);
+}
+
+describe("continue-delegate-tool P2: maxDelegatesPerTurn hot-reload", () => {
+  const sessionKey = "test-session";
+
+  beforeEach(() => {
+    loadConfigMock.mockReset();
+    loadConfigMock.mockReturnValue({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 5 } } },
+    });
+    // Clear any leftover delegates
+    consumePendingDelegates(sessionKey);
+    consumeStagedPostCompactionDelegates(sessionKey);
+  });
+
+  it("reads maxDelegatesPerTurn from live config at execute time, not construction time", async () => {
+    // Create tool with construction-time value of 2
+    const tool = createContinueDelegateTool({
+      agentSessionKey: sessionKey,
+      maxDelegatesPerTurn: 2,
+    });
+
+    // Config says 5 at execute time — should override construction-time 2
+    loadConfigMock.mockReturnValue({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 5 } } },
+    });
+
+    // Dispatch 3 delegates — would fail with construction-time limit of 2
+    const r1 = parseResult(await tool.execute("call-1", { task: "task one" }));
+    const r2 = parseResult(await tool.execute("call-2", { task: "task two" }));
+    const r3 = parseResult(await tool.execute("call-3", { task: "task three" }));
+
+    expect(r1.status).toBe("scheduled");
+    expect(r2.status).toBe("scheduled");
+    expect(r3.status).toBe("scheduled");
+
+    // Clean up
+    consumePendingDelegates(sessionKey);
+  });
+
+  it("hot-reloaded config change takes effect without tool recreation", async () => {
+    const tool = createContinueDelegateTool({
+      agentSessionKey: sessionKey,
+      maxDelegatesPerTurn: 10,
+    });
+
+    // Start with limit 2
+    loadConfigMock.mockReturnValue({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 2 } } },
+    });
+
+    const r1 = parseResult(await tool.execute("call-1", { task: "task one" }));
+    const r2 = parseResult(await tool.execute("call-2", { task: "task two" }));
+    const r3 = parseResult(await tool.execute("call-3", { task: "task three" }));
+
+    expect(r1.status).toBe("scheduled");
+    expect(r2.status).toBe("scheduled");
+    // Third should be rejected — live config says 2
+    expect(r3.status).toBe("error");
+
+    consumePendingDelegates(sessionKey);
+  });
+
+  it("falls back to construction-time value when config has no maxDelegatesPerTurn", async () => {
+    const tool = createContinueDelegateTool({
+      agentSessionKey: sessionKey,
+      maxDelegatesPerTurn: 3,
+    });
+
+    // Config has no maxDelegatesPerTurn
+    loadConfigMock.mockReturnValue({
+      agents: { defaults: { continuation: {} } },
+    });
+
+    const r1 = parseResult(await tool.execute("call-1", { task: "task one" }));
+    const r2 = parseResult(await tool.execute("call-2", { task: "task two" }));
+    const r3 = parseResult(await tool.execute("call-3", { task: "task three" }));
+    const r4 = parseResult(await tool.execute("call-4", { task: "task four" }));
+
+    expect(r1.status).toBe("scheduled");
+    expect(r2.status).toBe("scheduled");
+    expect(r3.status).toBe("scheduled");
+    // Fourth rejected — falls back to construction-time 3
+    expect(r4.status).toBe("error");
+
+    consumePendingDelegates(sessionKey);
+  });
+
+  it("falls back to hardcoded 5 when neither config nor opts provide a value", async () => {
+    const tool = createContinueDelegateTool({
+      agentSessionKey: sessionKey,
+      // No maxDelegatesPerTurn in opts
+    });
+
+    // Config has no maxDelegatesPerTurn
+    loadConfigMock.mockReturnValue({
+      agents: { defaults: { continuation: {} } },
+    });
+
+    // Dispatch 5 — should all succeed
+    for (let i = 0; i < 5; i++) {
+      const r = parseResult(await tool.execute(`call-${i}`, { task: `task ${i}` }));
+      expect(r.status).toBe("scheduled");
+    }
+
+    // Sixth should be rejected
+    const r6 = parseResult(await tool.execute("call-5", { task: "task 5" }));
+    expect(r6.status).toBe("error");
+
+    consumePendingDelegates(sessionKey);
+  });
+});

--- a/src/agents/tools/continue-delegate-tool.ts
+++ b/src/agents/tools/continue-delegate-tool.ts
@@ -5,6 +5,7 @@ import {
   pendingDelegateCount,
   stagedPostCompactionDelegateCount,
 } from "../../auto-reply/continuation-delegate-store.js";
+import { loadConfig } from "../../config/config.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
@@ -102,8 +103,12 @@ export function createContinueDelegateTool(opts: {
       const silent = modeRaw === "silent" || modeRaw === "silent-wake" || isPostCompaction;
       const silentWake = modeRaw === "silent-wake" || isPostCompaction;
 
-      // Check per-turn delegate limit
-      const maxPerTurn = opts.maxDelegatesPerTurn ?? 5;
+      // Check per-turn delegate limit.
+      // Read from loadConfig() at execute time so hot-reloaded config applies (P2 fix).
+      const maxPerTurn =
+        loadConfig().agents?.defaults?.continuation?.maxDelegatesPerTurn ??
+        opts.maxDelegatesPerTurn ??
+        5;
       const currentCount =
         pendingDelegateCount(sessionKey) + stagedPostCompactionDelegateCount(sessionKey);
       if (currentCount >= maxPerTurn) {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2328,6 +2328,56 @@ describe("runReplyAgent continuation signal handling", () => {
     expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(2);
   });
 
+  it("DELEGATE bracket-origin spawn includes canonical [continuation:chain-hop:N] prefix", async () => {
+    // Workstream B (WORKORDER6): bracket-origin and tool-origin spawns must
+    // share the same hop-metadata contract so the announce-side guard can
+    // enforce maxChainLength identically for both paths.
+    spawnSubagentDirectMock.mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:delegate-hop-test",
+      runId: "run-hop-test",
+    });
+
+    const sessionKey = "agent:main:telegram:dm:hop-prefix-test";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 0,
+    } as SessionEntry;
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const followupRun = buildFollowupRun({
+      sessionKey,
+      continuation: {
+        enabled: true,
+        maxChainLength: 10,
+        minDelayMs: 0,
+        maxDelayMs: 10_000,
+      },
+    });
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Research needed.\n[[CONTINUE_DELEGATE: look up the RFC]]" }],
+      meta: {},
+    });
+
+    await runTurn({
+      commandBody: "heartbeat",
+      followupRun,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      isHeartbeat: true,
+      isContinuationWake: true,
+    });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    const spawnParams = spawnSubagentDirectMock.mock.calls[0][0];
+    // The task must contain the canonical chain-hop prefix that the announce-side
+    // guard parses at subagent-announce.ts:1346
+    expect(spawnParams.task).toMatch(/\[continuation:chain-hop:\d+\]/);
+  });
+
   it("does not treat user message starting with [continuation] as continuation event", async () => {
     vi.useFakeTimers();
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -94,6 +94,7 @@ export function clearDelegatePending(sessionKey: string): void {
 
 // Re-export for external consumers (subagent-announce, etc.)
 export { currentContinuationGeneration } from "./continuation-generation.js";
+import { resolveMaxDelegatesPerTurn } from "./continuation-runtime.js";
 
 function syncPendingPostCompactionDelegates(params: {
   sessionEntry?: SessionEntry;
@@ -1260,6 +1261,22 @@ export async function runReplyAgent(params: {
     // Multiple delegates per turn are supported (multi-arrow fan-out).
     if (continuationFeatureEnabled && sessionKey) {
       const toolDelegates = consumePendingDelegates(sessionKey);
+      // Secondary enforcement: trim queued delegates to live maxDelegatesPerTurn.
+      // Primary enforcement is in the tool's execute(); this guards against stale
+      // queued delegates from older code or races (Workstream D, WORKORDER6).
+      const liveMaxPerTurn = resolveMaxDelegatesPerTurn();
+      if (toolDelegates.length > liveMaxPerTurn) {
+        const rejected = toolDelegates.splice(liveMaxPerTurn);
+        defaultRuntime.log(
+          `[continue_delegate] Secondary enforcement: ${rejected.length} delegate(s) exceed live maxDelegatesPerTurn=${liveMaxPerTurn}, rejected`,
+        );
+        for (const r of rejected) {
+          enqueueSystemEvent(
+            `[continuation] Delegate rejected by secondary enforcement (maxDelegatesPerTurn=${liveMaxPerTurn}): ${r.task}`,
+            { sessionKey },
+          );
+        }
+      }
       if (toolDelegates.length > 0) {
         defaultRuntime.log(
           `[continue_delegate] Consuming ${toolDelegates.length} tool delegate(s) for session ${sessionKey}`,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1159,7 +1159,7 @@ export async function runReplyAgent(params: {
                 try {
                   const spawnResult = await spawnSubagentDirect(
                     {
-                      task: `[continuation] Delegated task (turn ${nextChainCount}/${maxChainLength}): ${delegateTask}`,
+                      task: `[continuation:chain-hop:${nextChainCount}] Delegated task (turn ${nextChainCount}/${maxChainLength}): ${delegateTask}`,
                       ...(continuationSignal.silent ? { silentAnnounce: true } : {}),
                       ...(continuationSignal.silentWake
                         ? { silentAnnounce: true, wakeOnReturn: true }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -56,6 +56,12 @@ import {
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
+import {
+  currentContinuationGeneration,
+  invalidateContinuationGeneration,
+  isContinuationGenerationCurrent,
+  scheduleContinuationGeneration,
+} from "./continuation-generation.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
@@ -67,14 +73,6 @@ import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
-
-// Track pending continuation timers so they can be cancelled when an external
-// message arrives during the delay window (prevents ghost continuations).
-// Each entry includes a generation counter to guard against same-tick races:
-// the timer callback verifies its generation matches the current value before
-// scheduling the wake. An external message bumps the generation, invalidating
-// any in-flight callbacks without needing clearTimeout races.
-const continuationGenerations = new Map<string, number>();
 
 // Per-session delegate-pending flags.  Lives outside the system-event queue
 // so it is NOT drained by buildQueuedSystemPrompt on intervening turns.
@@ -94,15 +92,8 @@ export function clearDelegatePending(sessionKey: string): void {
   delegatePendingFlags.delete(sessionKey);
 }
 
-export function currentContinuationGeneration(sessionKey: string): number {
-  return continuationGenerations.get(sessionKey) ?? 0;
-}
-
-export function bumpContinuationGeneration(sessionKey: string): number {
-  const next = currentContinuationGeneration(sessionKey) + 1;
-  continuationGenerations.set(sessionKey, next);
-  return next;
-}
+// Re-export for external consumers (subagent-announce, etc.)
+export { currentContinuationGeneration } from "./continuation-generation.js";
 
 function syncPendingPostCompactionDelegates(params: {
   sessionEntry?: SessionEntry;
@@ -234,7 +225,7 @@ function buildPostCompactionLifecycleEvent(params: {
 // clearContinuationGeneration intentionally removed: clearing the map entry
 // resets the counter to 0, creating a generation-reuse window where a new
 // chain's value can collide with a stale in-flight timer. All paths now use
-// bumpContinuationGeneration instead.
+// invalidateContinuationGeneration (jumps past tolerance window) instead.
 
 /**
  * Cancel any pending continuation timer for the given session AND reset
@@ -254,10 +245,10 @@ export function cancelContinuationTimer(
     storePath?: string;
   },
 ): void {
-  // Only bump when a generation exists — avoids unbounded map growth
+  // Only invalidate when a generation exists — avoids unbounded map growth
   // from sessions that never use continuation.
-  if (continuationGenerations.has(sessionKey)) {
-    bumpContinuationGeneration(sessionKey);
+  if (currentContinuationGeneration(sessionKey) > 0) {
+    invalidateContinuationGeneration(sessionKey);
   }
 
   // Reset chain metadata so stale counters don't block future chains.
@@ -386,14 +377,14 @@ export async function runReplyAgent(params: {
       activeSessionEntry.continuationChainTokens = undefined;
     }
     // Cancel any pending continuation timer by bumping the generation counter.
-    // Only bump when a generation exists (active/pending chain) to avoid
+    // Only invalidate when a generation exists (active/pending chain) to avoid
     // unbounded map growth from sessions that never use continuation.
-    const hasGenerationEntry = continuationGenerations.has(sessionKey);
+    const hasGenerationEntry = currentContinuationGeneration(sessionKey) > 0;
     defaultRuntime.log(
       `[continuation-guard] New message on ${sessionKey}: hadActiveChain=${hadActiveChain} hasGenerationEntry=${hasGenerationEntry}`,
     );
     if (hadActiveChain || hasGenerationEntry) {
-      const newGen = bumpContinuationGeneration(sessionKey);
+      const newGen = invalidateContinuationGeneration(sessionKey);
       defaultRuntime.log(`[continuation-guard] Bumped generation to ${newGen} for ${sessionKey}`);
     }
     if (hadActiveChain && activeSessionStore && activeSessionEntry) {
@@ -1111,10 +1102,7 @@ export async function runReplyAgent(params: {
           defaultRuntime.log(
             `Continuation chain capped at ${maxChainLength} for session ${sessionKey}`,
           );
-          // Bump (not clear) to invalidate stale timers without reuse risk.
-          // Clearing would reset to 0, letting a new chain's generation collide
-          // with a stale in-flight timer's captured value.
-          bumpContinuationGeneration(sessionKey);
+          invalidateContinuationGeneration(sessionKey);
         } else {
           // Accumulate token usage for cost cap (input + output only, excludes
           // cache reads/writes which inflate with inherited system prompt context).
@@ -1127,7 +1115,7 @@ export async function runReplyAgent(params: {
             defaultRuntime.log(
               `Continuation cost cap exceeded (${accumulatedChainTokens} > ${costCapTokens}) for session ${sessionKey}`,
             );
-            bumpContinuationGeneration(sessionKey);
+            invalidateContinuationGeneration(sessionKey);
           } else {
             // Persist chain state for both DELEGATE and WORK paths
             const nextChainCount = currentChainCount + 1;
@@ -1224,15 +1212,12 @@ export async function runReplyAgent(params: {
                   `DELEGATE scheduled in ${clampedDelay}ms for session ${sessionKey}: ${delegateTask}`,
                 );
                 // Generation guard: if an external message arrives during the delay,
-                // bumpContinuationGeneration invalidates this timer — same as WORK timers.
-                const delegateGeneration = bumpContinuationGeneration(sessionKey);
-                const genTolerance = continuationCfg?.generationGuardTolerance ?? 0;
+                // invalidateContinuationGeneration jumps past the tolerance window.
+                const delegateGeneration = scheduleContinuationGeneration(sessionKey);
                 setTimeout(() => {
-                  const currentGen = currentContinuationGeneration(sessionKey);
-                  const drift = currentGen - delegateGeneration;
-                  if (drift > genTolerance) {
+                  if (!isContinuationGenerationCurrent(sessionKey, delegateGeneration)) {
                     defaultRuntime.log(
-                      `DELEGATE timer cancelled (generation drift ${drift} > tolerance ${genTolerance}) for session ${sessionKey}`,
+                      `DELEGATE timer cancelled (generation mismatch) for session ${sessionKey}`,
                     );
                     return;
                   }
@@ -1246,11 +1231,13 @@ export async function runReplyAgent(params: {
               const requestedDelay = continuationSignal.delayMs ?? defaultDelayMs;
               const clampedDelay = Math.max(minDelayMs, Math.min(maxDelayMs, requestedDelay));
 
-              // Schedule continuation with generation guard
-              const generation = bumpContinuationGeneration(sessionKey);
+              // Schedule continuation with generation guard (WORK uses strict equality —
+              // self-continuation should stop on any external input, unlike DELEGATE
+              // timers which honor generationGuardTolerance for noisy channels).
+              const generation = scheduleContinuationGeneration(sessionKey);
               setTimeout(() => {
                 if (currentContinuationGeneration(sessionKey) !== generation) {
-                  return; // External message arrived — cancel
+                  return; // External message arrived — cancel (strict, no tolerance)
                 }
                 enqueueSystemEvent(
                   `[continuation:wake] Turn ${nextChainCount}/${maxChainLength}. ` +
@@ -1377,21 +1364,16 @@ export async function runReplyAgent(params: {
             defaultRuntime.log(
               `Tool DELEGATE scheduled in ${clampedDelay}ms for session ${sessionKey}: ${delegate.task}`,
             );
-            // Generation guard: same as bracket-path delegate timers
-            const toolDelegateGeneration = bumpContinuationGeneration(sessionKey);
-            const toolGenTolerance = continuationCfg?.generationGuardTolerance ?? 0;
+            // Generation guard: same as bracket-path delegate timers.
+            // Tolerance is read at fire time via isContinuationGenerationCurrent (P1 fix).
+            const toolDelegateGeneration = scheduleContinuationGeneration(sessionKey);
             defaultRuntime.log(
-              `[continuation-guard] Tool delegate timer set with generation=${toolDelegateGeneration} tolerance=${toolGenTolerance} for ${sessionKey}`,
+              `[continuation-guard] Tool delegate timer set with generation=${toolDelegateGeneration} for ${sessionKey}`,
             );
             setTimeout(() => {
-              const currentGen = currentContinuationGeneration(sessionKey);
-              const drift = currentGen - toolDelegateGeneration;
-              defaultRuntime.log(
-                `[continuation-guard] Timer fired: stored=${toolDelegateGeneration} current=${currentGen} drift=${drift} tolerance=${toolGenTolerance} for ${sessionKey}`,
-              );
-              if (drift > toolGenTolerance) {
+              if (!isContinuationGenerationCurrent(sessionKey, toolDelegateGeneration)) {
                 defaultRuntime.log(
-                  `Tool DELEGATE timer cancelled (generation drift ${drift} > tolerance ${toolGenTolerance}) for session ${sessionKey}`,
+                  `Tool DELEGATE timer cancelled (generation mismatch) for session ${sessionKey}`,
                 );
                 return;
               }

--- a/src/auto-reply/reply/continuation-generation.ts
+++ b/src/auto-reply/reply/continuation-generation.ts
@@ -1,0 +1,58 @@
+import { loadConfig } from "../../config/config.js";
+
+const DEFAULT_GENERATION_GUARD_TOLERANCE = 0;
+const continuationGenerations = new Map<string, number>();
+
+/**
+ * Read generationGuardTolerance from live config at call time.
+ * This is the core P1 fix: tolerance is resolved when the timer fires,
+ * not when it was scheduled. Hot-reload changes take effect immediately.
+ */
+function resolveGenerationGuardTolerance(): number {
+  const configured = loadConfig().agents?.defaults?.continuation?.generationGuardTolerance;
+  if (typeof configured !== "number" || !Number.isFinite(configured) || configured < 0) {
+    return DEFAULT_GENERATION_GUARD_TOLERANCE;
+  }
+  return Math.max(0, Math.trunc(configured));
+}
+
+export function currentContinuationGeneration(sessionKey: string): number {
+  return continuationGenerations.get(sessionKey) ?? 0;
+}
+
+/**
+ * Increment generation by 1 — used when scheduling a continuation timer.
+ * The returned value is captured by the timer callback for later comparison.
+ */
+export function scheduleContinuationGeneration(sessionKey: string): number {
+  const next = currentContinuationGeneration(sessionKey) + 1;
+  continuationGenerations.set(sessionKey, next);
+  return next;
+}
+
+/**
+ * Jump past the live tolerance window so every in-flight timer for the session
+ * is invalidated. Called when external input arrives (cancels pending timers).
+ * Reads tolerance at call time (hot-reload safe).
+ */
+export function invalidateContinuationGeneration(sessionKey: string): number {
+  const next = currentContinuationGeneration(sessionKey) + resolveGenerationGuardTolerance() + 1;
+  continuationGenerations.set(sessionKey, next);
+  return next;
+}
+
+/**
+ * Check if a timer's captured generation is still current.
+ * Reads tolerance at check time (fire time), not at capture time (schedule time).
+ * This is the P1 fix for the stale-closure bug.
+ */
+export function isContinuationGenerationCurrent(sessionKey: string, generation: number): boolean {
+  return (
+    currentContinuationGeneration(sessionKey) <= generation + resolveGenerationGuardTolerance()
+  );
+}
+
+/** For tests only. */
+export function resetContinuationGenerationsForTests(): void {
+  continuationGenerations.clear();
+}

--- a/src/auto-reply/reply/continuation-generation.ts
+++ b/src/auto-reply/reply/continuation-generation.ts
@@ -1,19 +1,13 @@
-import { loadConfig } from "../../config/config.js";
+import { resolveContinuationRuntimeConfig } from "./continuation-runtime.js";
 
-const DEFAULT_GENERATION_GUARD_TOLERANCE = 0;
 const continuationGenerations = new Map<string, number>();
 
 /**
  * Read generationGuardTolerance from live config at call time.
- * This is the core P1 fix: tolerance is resolved when the timer fires,
- * not when it was scheduled. Hot-reload changes take effect immediately.
+ * Delegates to the single normalization authority in continuation-runtime.
  */
 function resolveGenerationGuardTolerance(): number {
-  const configured = loadConfig().agents?.defaults?.continuation?.generationGuardTolerance;
-  if (typeof configured !== "number" || !Number.isFinite(configured) || configured < 0) {
-    return DEFAULT_GENERATION_GUARD_TOLERANCE;
-  }
-  return Math.max(0, Math.trunc(configured));
+  return resolveContinuationRuntimeConfig().generationGuardTolerance;
 }
 
 export function currentContinuationGeneration(sessionKey: string): number {

--- a/src/auto-reply/reply/continuation-runtime.ts
+++ b/src/auto-reply/reply/continuation-runtime.ts
@@ -1,0 +1,78 @@
+import { loadConfig } from "../../config/config.js";
+
+/**
+ * Canonical continuation runtime defaults.
+ * Single source of truth — all consumer code imports from here.
+ */
+const DEFAULTS = {
+  enabled: false,
+  defaultDelayMs: 15_000,
+  minDelayMs: 5_000,
+  maxDelayMs: 300_000,
+  maxChainLength: 10,
+  costCapTokens: 500_000,
+  maxDelegatesPerTurn: 5,
+  generationGuardTolerance: 0,
+} as const;
+
+export interface ContinuationRuntimeConfig {
+  enabled: boolean;
+  defaultDelayMs: number;
+  minDelayMs: number;
+  maxDelayMs: number;
+  maxChainLength: number;
+  costCapTokens: number;
+  maxDelegatesPerTurn: number;
+  generationGuardTolerance: number;
+}
+
+/**
+ * Resolve the live continuation runtime config by reading from loadConfig()
+ * and normalizing defaults. Call this at the point of enforcement, not earlier.
+ *
+ * This is the single normalization authority for hot-reload-sensitive
+ * continuation config values. Timer callbacks, tool execution, and runner
+ * consumption should all go through this function.
+ */
+export function resolveContinuationRuntimeConfig(): ContinuationRuntimeConfig {
+  const cfg = loadConfig();
+  const c = cfg.agents?.defaults?.continuation;
+
+  return {
+    enabled: c?.enabled ?? DEFAULTS.enabled,
+    defaultDelayMs: clampPositive(c?.defaultDelayMs, DEFAULTS.defaultDelayMs),
+    minDelayMs: clampPositive(c?.minDelayMs, DEFAULTS.minDelayMs),
+    maxDelayMs: clampPositive(c?.maxDelayMs, DEFAULTS.maxDelayMs),
+    maxChainLength: clampPositive(c?.maxChainLength, DEFAULTS.maxChainLength),
+    costCapTokens: clampNonNeg(c?.costCapTokens, DEFAULTS.costCapTokens),
+    maxDelegatesPerTurn: clampPositive(c?.maxDelegatesPerTurn, DEFAULTS.maxDelegatesPerTurn),
+    generationGuardTolerance: clampNonNeg(
+      c?.generationGuardTolerance,
+      DEFAULTS.generationGuardTolerance,
+    ),
+  };
+}
+
+/**
+ * Convenience: resolve just maxDelegatesPerTurn from live config.
+ * Used by continue_delegate tool and agent-runner consumption path.
+ */
+export function resolveMaxDelegatesPerTurn(): number {
+  return resolveContinuationRuntimeConfig().maxDelegatesPerTurn;
+}
+
+/** Clamp to positive integer, fallback to default if not a finite positive number. */
+function clampPositive(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.max(1, Math.trunc(value));
+}
+
+/** Clamp to non-negative integer, fallback to default if not a finite non-negative number. */
+function clampNonNeg(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+  return Math.max(0, Math.trunc(value));
+}

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -292,7 +292,7 @@ export type AgentDefaultsConfig = {
     maxDelayMs?: number;
     maxChainLength?: number;
     costCapTokens?: number;
-    /** Maximum number of continue_delegate tool calls per agent turn (default: 10). */
+    /** Maximum number of continue_delegate tool calls per agent turn (default: 5). */
     maxDelegatesPerTurn?: number;
     /**
      * Generation guard tolerance for timed delegates (default: 0).


### PR DESCRIPTION
Reclaimed SWIM-COORDINATOR-NOTES.md after ⚓ round 2 candidate refresh.

Kept: voice, structure, swim lessons, emergency procedures.
Integrated: branch expectations, drift cues, R7-* tracker format, status values, round 2 lessons.
164→219 lines. +39/-8 from original.

Owner: Cael 🩸