### PR TITLE
fix(compaction): inject Copilot IDE headers on summarization path (#159)

### DIFF
--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -28,6 +28,7 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
+import { buildCopilotIdeHeaders } from "../copilot-dynamic-headers.js";
 import { isTimeoutError } from "../failover-error.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -233,7 +234,11 @@ async function resolveModelAuth(
       reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
     };
   }
-  return { ok: true, apiKey: requestAuth.apiKey, headers: requestAuth.headers };
+  const headers =
+    model.provider === "github-copilot"
+      ? { ...buildCopilotIdeHeaders(), ...requestAuth.headers }
+      : requestAuth.headers;
+  return { ok: true, apiKey: requestAuth.apiKey, headers };
 }
 
 function clampNonNegativeInt(value: unknown, fallback: number): number {


### PR DESCRIPTION
Fixes #159.

## Problem
Compaction summarization was calling the Copilot chat endpoint without the `Editor-Version` / `User-Agent` headers that Copilot now requires for IDE auth. Every fleet node hit:

`[compaction] Full summarization failed: Summarization failed: 400 bad request: missing Editor-Version header for IDE auth`

The streaming chat-completion paths (`anthropic-transport-stream.ts:418`, `openai-transport-stream.ts:595`) already use `buildCopilotIdeHeaders()`. The compaction path in `compaction-safeguard.ts` does not — `modelRegistry.getApiKeyAndHeaders` does not inject them.

## Fix
In `resolveModelAuth` (compaction-safeguard.ts), merge in `buildCopilotIdeHeaders()` when the model is a Copilot provider. Mirrors the existing pattern in the streaming transports.

## Testing
- `pnpm check` clean (typecheck, lint, import cycles, boundary checks all pass)
- Manual verification: next compaction on a Copilot-backed model succeeds (deferred to fleet nodes after merge)