### PR TITLE
fix(#584): promote agent-runner.runtime to coreDistEntries to dedupe singleton state

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -144,6 +144,11 @@ function buildCoreDistEntries(): Record<string, string> {
     // Keep long-lived lazy runtime boundaries on stable filenames so rebuilt
     // dist/ trees do not strand already-running gateways on stale hashed chunks.
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
+    // #584: agent-runner.runtime is dynamically imported by get-reply-run.ts:108.
+    // Promoting it to a unified-graph entry forces rolldown to dedupe its singleton-bearing
+    // dependencies (delegate-store, state, context-pressure) with the rest of the build,
+    // eliminating the dual-chunk split that silently dropped continue_work tool calls.
+    "auto-reply/reply/agent-runner.runtime": "src/auto-reply/reply/agent-runner.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
     "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",


### PR DESCRIPTION
**Resolves [karmaterminal/openclaw-bootstrap#584](https://github.com/karmaterminal/openclaw-bootstrap/issues/584).**

## Root cause

\`src/auto-reply/reply/get-reply-run.ts:108\` dynamically imports \`agent-runner.runtime.js\`:
\`\`\`ts
agentRunnerRuntimePromise ??= import("./agent-runner.runtime.js");
\`\`\`

Rolldown (via tsdown) emits dynamically-imported modules as **isolated chunks**. Any singleton-bearing module reachable from that subgraph (\`delegate-store.ts\`, \`state.ts\`, almost certainly \`context-pressure.ts\` per #580) gets bundled as a satellite chunk INSIDE the agent-runner subgraph. The rest of the codebase reaches those same modules via static imports through \`coreDistEntries.index\`, producing the OTHER chunks. Two top-level \`Map<>\` instances per file, no cross-realm visibility.

## Effect (pre-fix, fleet measurement)

\`continue_work\` tool calls silently dropped at varying rates across boxes — tools wrote to Map A while agent-runner read from Map B:

| host | honor rate | sample |
|------|------------|--------|
| cael-spark   | 75% | 3/4 |
| ronan-spark  | 50% | 2/4 |
| silas-urudyne | 17–33% | 1/6 → 2/6 over different windows |
| elliott-arc  | ~0% (n=1, 300s timer never fired in 15min) |

Three independent verifications of the dual-bundle topology on three boxes:
- Original finding: \`silas-urudyne\` (chunk audit at canary \`0abaf078ea\`)
- \`cael-spark\` confirmation at rev \`2efa924c5\` (tip past canary — bug persists)
- \`ronan-spark\` confirmation at canary \`0abaf078ea\`

All three boxes show the same import topology: \`openclaw-tools\` imports a single \`delegate-store-*\` chunk, while \`agent-runner.runtime-*\` imports BOTH \`delegate-store-*\` chunks. \`state.ts\` shows the same dual-bundle pattern.

## Fix

Promote \`auto-reply/reply/agent-runner.runtime\` to \`coreDistEntries\` in \`tsdown.config.ts\`. The config already lists 16 \`.runtime\` entries with the comment *"Keep long-lived lazy runtime boundaries on stable filenames so rebuilt dist/ trees do not strand already-running gateways on stale hashed chunks."* Adding the agent-runner runtime to the same list promotes it to a unified-graph entry; rolldown then dedupes singleton deps with the rest of the build. Lazy-load \`import()\` semantics preserved (the dynamic import still works against an already-emitted entry chunk).

5-line change: 1 entry + 4-line comment.

## Post-fix verification

Built locally on \`silas-urudyne\`. Bundle inspection:

\`\`\`
$ ls dist/delegate-store*.js
dist/delegate-store-CX7aTPjR.js   # 7276B canonical chunk (holds Map<> instances)
dist/delegate-store-Clsvhrb5.js   # 139B re-export shim — NO Map<> declarations
$ ls dist/state-*.js | grep -v migrations | grep -v paths | grep -v dotenv
dist/state-DtaA7qmx.js   # canonical state.ts chunk
dist/state-et2O901b.js   # 116B re-export shim
$ grep -E 'import .* from "[./]+delegate-store' dist/auto-reply/reply/agent-runner.runtime.js
import { c as pendingDelegateCount, f as stagedPostCompactionDelegateCount, i as consumePendingWorkRequest, u as setTaskFlowDelegatesEnabled } from "../../delegate-store-CX7aTPjR.js";
\`\`\`

agent-runner.runtime now imports \`consumePendingWorkRequest\` from the same canonical chunk that the tools layer writes to. Single-realm singleton invariant restored.

Smoke: \`node -e "import('./dist/index.js')"\` exports clean.

All pre-push hooks pass: lint, oxlint, tsgo, import-cycles, madge-cycles, host-env-policy, etc.

## Awaiting

[B1 (#583)](https://github.com/karmaterminal/openclaw-bootstrap/issues/583) fleet adjudication for fix-confirmation. B1 procedure is a clean \`continue_work(delaySeconds=10)\` from a quiet session, expected Δsch=1 / Δset=1 / Δfired=1. Pre-fix runs are FAIL-by-construction (we know honor rate is 17–75%). Post-fix expectation: ≥3-of-4 box PASS at 100% honor.

Will post B1 verification results in a follow-up comment on #583 once peers have rebased onto this branch and run the procedure.

## Likely follow-ups (out of scope for this PR)

- **#580** (context-pressure inject path dark across band 1/2/3) is almost certainly the same realm-split applied to \`context-pressure.ts\`. Worth verifying it's also healed by this fix; if not, a sibling promotion may be needed for whichever module is the next dynamically-imported singleton root.
- Audit other \`import()\` callsites in src/ for the same potential singleton-leak pattern.