### PR TITLE
feat(continuation): instrument context-pressure precondition skip (refs #580)

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1201,6 +1201,18 @@ export async function runReplyAgent(params: {
         if (pressureEvent) {
           enqueueSystemEvent(pressureEvent, { sessionKey });
         }
+      } else {
+        // Precondition unmet — emit a single skip log so operators debugging
+        // "no band≥1 fires observed" can distinguish threshold-never-crossed
+        // from silent guard short-circuit. See RFC §4.2 precondition note.
+        const skipReason = !threshold
+          ? "no-threshold-configured"
+          : !activeSessionEntry.totalTokens
+            ? "totalTokens-not-populated"
+            : "contextWindow-unresolved";
+        const { createSubsystemLogger } = await import("../../logging/subsystem.js");
+        const pressureLog = createSubsystemLogger("continuation/context-pressure");
+        pressureLog.debug(`[context-pressure:skip] reason=${skipReason} session=${sessionKey}`);
       }
     }
 


### PR DESCRIPTION
## Summary
Adds a single \`[context-pressure:skip] reason=<...>\` DEBUG log line at \`src/auto-reply/reply/agent-runner.ts:~1193\`, emitted whenever the pressure-check guard short-circuits. Tiny (12 lines added).

### Why
\`openclaw-bootstrap#580\` has three princes reporting zero band≥1 fires of \`[context-pressure:fire]\` across the fleet. Tonight's investigation refuted the initial hypothesis (bundler realm-split) via structural inspection of \`dist/context-pressure-*.js\` post-PR #162:
- context-pressure was **always** single-chunked (pre-#162 snapshot: 2909 B, one chunk; post-#162: 2909 B, one chunk).
- Only one chunk holds \`lastFiredBand\` Map.
- Only one chunk imports context-pressure.

The real candidate root cause is the guard at \`agent-runner.ts:1193\`: when \`activeSessionEntry.totalTokens\` or the resolved \`pressureContextWindow\` is unpopulated for the turn, the entire pressure check is skipped silently. That's indistinguishable from "threshold never crossed" in the current logs, and it's a sticky investigation trap.

RFC §4.2 now documents the precondition (doc-only in karmaterminal/openclaw#163). This PR adds the matching runtime observability so the next #580 investigation can distinguish:

- \`no-threshold-configured\` — \`contextPressureThreshold\` not set in config
- \`totalTokens-not-populated\` — session accounting hasn't landed yet
- \`contextWindow-unresolved\` — neither \`agentCfgContextTokens\`, \`activeSessionEntry.contextTokens\`, nor \`DEFAULT_CONTEXT_TOKENS\` usable

### How to use
1. Bump the \`continuation/context-pressure\` subsystem to DEBUG on one prince.
2. Run normal workload for ~30 min.
3. \`grep '\\[context-pressure:skip\\]'\` on the journal / file log.
4. Tally reasons. That tells #580 investigation which branch is responsible.

### What this does NOT change
- \`[context-pressure:fire]\` log anchor (unchanged — RFC §6.1 contract).
- Band thresholds / dedup / post-compaction semantics.
- Any runtime behavior at INFO level (DEBUG-only emission).

### Test plan
- [x] \`pnpm tsgo\` clean.
- [ ] Deploy to ronan, bump pressure-log to DEBUG, run normal workload 30 min, confirm at least one \`[context-pressure:skip]\` emission with a recognizable \`reason=...\` value. (Morning task for figs to drive, not tonight.)

### References
- RFC doc PR: karmaterminal/openclaw#163
- Structural refutation + root-cause analysis: karmaterminal/openclaw-bootstrap#580 (evening update comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)