### PR TITLE
tests(continuation/X5.1): add request-compaction-tool.test.ts — resolves bootstrap#542

### DIFF
--- a/src/agents/tools/request-compaction-tool.test.ts
+++ b/src/agents/tools/request-compaction-tool.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolInputError } from "./common.js";
+import {
+  _guards,
+  _resetGuardState,
+  _resetVolitionalCounts,
+  _setPending,
+  createRequestCompactionTool,
+  type RequestCompactionToolOpts,
+} from "./request-compaction-tool.js";
+
+const SESSION_KEY = "agent:main:discord:channel:test-session";
+const SESSION_ID = "test-session-id-x5.1";
+const TURN_REASON =
+  "context pressure at 92%, working state evacuated to memory files and 2 post-compaction delegates staged.";
+
+type ExecuteResult = Awaited<ReturnType<ReturnType<typeof createRequestCompactionTool>["execute"]>>;
+
+type JsonPayload = {
+  status: string;
+  guard?: string;
+  contextUsage?: number;
+  threshold?: number;
+  reason?: string;
+  retryAfterSeconds?: number;
+  note?: string;
+};
+
+function readJsonPayload(result: ExecuteResult): JsonPayload {
+  // jsonResult() returns content = [{ type: "text", text: JSON.stringify(...) }]
+  const content = (result as { content: Array<{ type: string; text: string }> }).content;
+  expect(content[0]?.type).toBe("text");
+  return JSON.parse(content[0]?.text ?? "{}") as JsonPayload;
+}
+
+function buildOpts(overrides: Partial<RequestCompactionToolOpts> = {}): RequestCompactionToolOpts {
+  return {
+    agentSessionKey: SESSION_KEY,
+    sessionId: SESSION_ID,
+    getContextUsage: () => 0.85,
+    triggerCompaction: vi.fn(async () => ({ ok: true, compacted: true })),
+    ...overrides,
+  };
+}
+
+describe("request_compaction tool (swim-34/X5.1)", () => {
+  beforeEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+  });
+
+  afterEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+    vi.restoreAllMocks();
+  });
+
+  // (a) ToolInputError on missing session
+  it("throws ToolInputError when agentSessionKey is absent", async () => {
+    const tool = createRequestCompactionTool(buildOpts({ agentSessionKey: undefined }));
+    await expect(tool.execute("call-1", { reason: TURN_REASON })).rejects.toBeInstanceOf(
+      ToolInputError,
+    );
+  });
+
+  it("throws ToolInputError when sessionId is absent", async () => {
+    const tool = createRequestCompactionTool(buildOpts({ sessionId: undefined }));
+    await expect(tool.execute("call-2", { reason: TURN_REASON })).rejects.toBeInstanceOf(
+      ToolInputError,
+    );
+  });
+
+  // (b) context_threshold guard when usage < 70%
+  it("rejects with context_threshold guard when contextUsage is below MIN_CONTEXT_THRESHOLD (70%)", async () => {
+    const tool = createRequestCompactionTool(buildOpts({ getContextUsage: () => 0.5 }));
+    const result = await tool.execute("call-3", { reason: TURN_REASON });
+    const payload = readJsonPayload(result);
+    expect(payload.status).toBe("rejected");
+    expect(payload.guard).toBe("context_threshold");
+    expect(payload.contextUsage).toBe(50);
+    expect(payload.threshold).toBe(Math.round(_guards.MIN_CONTEXT_THRESHOLD * 100));
+    expect(payload.reason).toMatch(/below the minimum threshold/i);
+  });
+
+  it("still rejects at exactly 69% (just below the floor)", async () => {
+    const tool = createRequestCompactionTool(buildOpts({ getContextUsage: () => 0.69 }));
+    const payload = readJsonPayload(await tool.execute("call-3b", { reason: TURN_REASON }));
+    expect(payload.status).toBe("rejected");
+    expect(payload.guard).toBe("context_threshold");
+  });
+
+  // (c) enqueue when >=70% no rate limit
+  it("enqueues compaction when contextUsage >= MIN_CONTEXT_THRESHOLD and no rate limit", async () => {
+    const triggerCompaction = vi.fn(async () => ({ ok: true, compacted: true }));
+    const tool = createRequestCompactionTool(
+      buildOpts({ getContextUsage: () => 0.92, triggerCompaction }),
+    );
+    const payload = readJsonPayload(await tool.execute("call-4", { reason: TURN_REASON }));
+    expect(payload.status).toBe("compaction_requested");
+    expect(payload.contextUsage).toBe(92);
+    expect(payload.reason).toBe(TURN_REASON);
+    expect(payload.note).toMatch(/Compaction has been enqueued/i);
+    // The background call is fire-and-forget; drain microtasks before assertion.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(triggerCompaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts at exactly the 70% threshold (inclusive floor)", async () => {
+    const tool = createRequestCompactionTool(buildOpts({ getContextUsage: () => 0.7 }));
+    const payload = readJsonPayload(await tool.execute("call-4b", { reason: TURN_REASON }));
+    expect(payload.status).toBe("compaction_requested");
+  });
+
+  // (d) rate_limit guard within 5 minutes
+  it("rejects with rate_limit guard when called again within RATE_LIMIT_MS window", async () => {
+    vi.useFakeTimers();
+    const startMs = 1_700_000_000_000;
+    vi.setSystemTime(new Date(startMs));
+    try {
+      const tool = createRequestCompactionTool(buildOpts({ getContextUsage: () => 0.85 }));
+      // First request: accepted.
+      const first = readJsonPayload(await tool.execute("call-5a", { reason: TURN_REASON }));
+      expect(first.status).toBe("compaction_requested");
+      await Promise.resolve();
+
+      // Advance less than the rate-limit window — second call should be rejected.
+      vi.setSystemTime(new Date(startMs + _guards.RATE_LIMIT_MS - 1000));
+      const second = readJsonPayload(await tool.execute("call-5b", { reason: TURN_REASON }));
+      expect(second.status).toBe("rejected");
+      expect(second.guard).toBe("rate_limit");
+      expect(second.retryAfterSeconds).toBeGreaterThan(0);
+      expect(second.retryAfterSeconds).toBeLessThanOrEqual(Math.ceil(_guards.RATE_LIMIT_MS / 1000));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("accepts a new request once the rate-limit window has elapsed", async () => {
+    vi.useFakeTimers();
+    const startMs = 1_700_000_000_000;
+    vi.setSystemTime(new Date(startMs));
+    try {
+      const tool = createRequestCompactionTool(buildOpts({ getContextUsage: () => 0.85 }));
+      readJsonPayload(await tool.execute("call-5c", { reason: TURN_REASON }));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The in-flight promise has resolved and `pendingCompactionSessions` cleared.
+      vi.setSystemTime(new Date(startMs + _guards.RATE_LIMIT_MS + 1));
+      const payload = readJsonPayload(await tool.execute("call-5d", { reason: TURN_REASON }));
+      expect(payload.status).toBe("compaction_requested");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // (e) [already-pending] short-circuit
+  it("short-circuits with status=already_pending when a compaction is already in-flight", async () => {
+    _setPending(SESSION_KEY);
+    const triggerCompaction = vi.fn(async () => ({ ok: true, compacted: true }));
+    const tool = createRequestCompactionTool(
+      buildOpts({ getContextUsage: () => 0.95, triggerCompaction }),
+    );
+    const payload = readJsonPayload(await tool.execute("call-6", { reason: TURN_REASON }));
+    expect(payload.status).toBe("already_pending");
+    expect(payload.reason).toMatch(/already in-flight/i);
+    // triggerCompaction must not be re-entered on this call.
+    expect(triggerCompaction).not.toHaveBeenCalled();
+  });
+
+  // (f) wire markers: jsonResult payload stays stable for downstream consumers
+  it("emits the documented status markers (compaction_requested / rejected / already_pending)", async () => {
+    // Case: accepted
+    const acceptTool = createRequestCompactionTool(buildOpts({ getContextUsage: () => 0.85 }));
+    const accepted = readJsonPayload(await acceptTool.execute("call-7a", { reason: TURN_REASON }));
+    expect(accepted.status).toBe("compaction_requested");
+
+    // Case: below threshold
+    _resetGuardState();
+    const belowTool = createRequestCompactionTool(buildOpts({ getContextUsage: () => 0.5 }));
+    const below = readJsonPayload(await belowTool.execute("call-7b", { reason: TURN_REASON }));
+    expect(below.status).toBe("rejected");
+    expect(below.guard).toBe("context_threshold");
+
+    // Case: already pending
+    _resetGuardState();
+    _setPending(SESSION_KEY);
+    const pendingTool = createRequestCompactionTool(buildOpts({ getContextUsage: () => 0.9 }));
+    const pending = readJsonPayload(await pendingTool.execute("call-7c", { reason: TURN_REASON }));
+    expect(pending.status).toBe("already_pending");
+  });
+});


### PR DESCRIPTION
## Summary
Implements swim-34/X5.1 test authoring per [karmaterminal/openclaw-bootstrap#542](https://github.com/karmaterminal/openclaw-bootstrap/issues/542). New file \`src/agents/tools/request-compaction-tool.test.ts\`, **10 tests (all passing)**.

## Scope
All six cases called out in #542 plus four edge cases that close the \`>70\` vs \`>=70\` fencepost ambiguity the issue body flagged:

| # | Test | Spec row |
|---|---|---|
| 1 | ToolInputError when \`agentSessionKey\` is absent | (a) |
| 2 | ToolInputError when \`sessionId\` is absent | (a) |
| 3 | \`context_threshold\` rejection when usage < \`MIN_CONTEXT_THRESHOLD\` | (b) |
| 4 | Still rejects at 69% (just-below-floor edge) | edge |
| 5 | Enqueues when usage ≥ \`MIN_CONTEXT_THRESHOLD\` with no rate limit | (c) |
| 6 | Accepts at exactly 70% (inclusive-floor edge) | edge (fencepost resolved) |
| 7 | \`rate_limit\` rejection within \`RATE_LIMIT_MS\` window | (d) |
| 8 | Accepts again once rate-limit window has elapsed | edge |
| 9 | \`[already-pending]\` short-circuit does NOT re-enter \`triggerCompaction\` | (e) |
| 10 | Documented status markers stable (\`compaction_requested\` / \`rejected\` / \`already_pending\`) | (f) |

## Fencepost resolution
Source is \`if (contextUsage < MIN_CONTEXT_THRESHOLD) { reject }\` — so **exactly 70% is accepted** (inclusive floor). Tests 4 + 6 pin that. The spec's prose wobbled between \`>70\` and \`>=70\`; the source is the source of truth and the spec can match it going forward.

## Uses existing test helpers
All state manipulation goes through the exported \`_resetGuardState\`, \`_setPending\`, \`_resetVolitionalCounts\`, and \`_guards\` helpers from the source module — no internal-state poking, no prototype mutation, per the repo testing guide.

## Run it
\`\`\`
pnpm test src/agents/tools/request-compaction-tool.test.ts
# → 10 passed, 553ms
\`\`\`

## Out of scope
- C1.1 (#532) \`WIRE_MARKERS\` shared-const work — this PR uses the literal status strings from the source file; if C1.1 lands a shared \`WIRE_MARKERS\` export, test (10) can import from it.
- B6.1 (#535) dispatcher shape — noted as related in the #542 body; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)