### PR TITLE
fix(config): add truncateAfterCompaction to strict zod schema

### DIFF
--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -150,6 +150,7 @@ export const AgentDefaultsSchema = z
         postCompactionSections: z.array(z.string()).optional(),
         model: z.string().optional(),
         timeoutSeconds: z.number().int().positive().optional(),
+        truncateAfterCompaction: z.boolean().optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary
One-line schema gap fix. The runtime reads \`agents.defaults.compaction.truncateAfterCompaction\` (src/agents/pi-embedded-runner/compact.ts:1099) and every metadata layer declares it, but the strict zod validator was missing it — so \`openclaw config set agents.defaults.compaction.truncateAfterCompaction true\` returns \`Unrecognized key\`.

### Before
\`\`\`
$ openclaw config set agents.defaults.compaction.truncateAfterCompaction true
Error: Config validation failed: agents.defaults.compaction: Unrecognized key: \"truncateAfterCompaction\"
\`\`\`

### After
Config set succeeds; runtime consumer at \`compact.ts:1099\` picks it up at next compaction.

## Why this matters now
[karmaterminal/openclaw-bootstrap#370](https://github.com/karmaterminal/openclaw-bootstrap/issues/370) has Silas and Ronan's byte-grounded conclusion that flipping this flag is lossless (pre-summary message bodies \`buildSessionContext()\` already skips are removed; header + non-message state + unsummarized tail + DAG re-parenting all preserved). Their \"fleet-wide off\" observation was correct but the cause was stronger than they named: the validator wouldn't accept the key. This PR unblocks their recommendation.

## Test plan
- [x] \`pnpm test src/auto-reply/continuation/config.test.ts\` → 9/9 pass.
- [x] \`pnpm test src/config/schema.help.quality.test.ts\` → 21/21 pass.
- [ ] After deploy, \`openclaw config set agents.defaults.compaction.truncateAfterCompaction true\` succeeds, and runtime picks it up at next compaction cycle.

## Scope
- One line added. Matches the shape of surrounding optional booleans in the same compaction block.
- No behavior change: runtime + metadata layers already knew about the field.
- Does NOT flip the default (still \`undefined\`/off). Princes opt-in per-prince.

🤖 Generated with [Claude Code](https://claude.com/claude-code)