### PR TITLE
feat(status): surface continuation runtime state in /status banner (RFC §6.3)

### DIFF
--- a/src/commands/status.command-report-data.ts
+++ b/src/commands/status.command-report-data.ts
@@ -26,6 +26,37 @@ import {
 import type { MemoryPluginStatus, MemoryStatusSnapshot } from "./status.scan.shared.js";
 import type { SessionStatus, StatusSummary } from "./status.types.js";
 
+/**
+ * Format the /status continuation overview row per RFC §6.3. Pure function
+ * over already-resolved config + runtime totals; the live queries (TaskFlow
+ * lookups per session key) live at the caller.
+ *
+ * @returns the formatted banner value, or `undefined` when continuation is
+ *   disabled (so the caller can skip rendering the row).
+ */
+export function formatContinuationBannerValue(params: {
+  enabled: boolean;
+  maxChainLength: number;
+  maxDelegatesPerTurn: number;
+  pendingDelegatesTotal: number;
+  postCompactionStagedTotal: number;
+}): string | undefined {
+  if (!params.enabled) {
+    return undefined;
+  }
+  const parts: string[] = ["enabled", `chain max ${params.maxChainLength}`];
+  if (params.pendingDelegatesTotal > 0) {
+    parts.push(
+      `${params.pendingDelegatesTotal} delegate${params.pendingDelegatesTotal === 1 ? "" : "s"} pending`,
+    );
+  }
+  if (params.postCompactionStagedTotal > 0) {
+    parts.push(`${params.postCompactionStagedTotal} post-compaction`);
+  }
+  parts.push(`fan-out max ${params.maxDelegatesPerTurn}`);
+  return parts.join(" · ");
+}
+
 export async function buildStatusCommandReportData(params: {
   opts: {
     deep?: boolean;
@@ -127,10 +158,44 @@ export async function buildStatusCommandReportData(params: {
             };
           };
         const cfg = resolveContinuationRuntimeConfig();
-        if (!cfg.enabled) {
-          return undefined;
+
+        // RFC §6.3 — surface runtime continuation state. TaskFlow-backed
+        // counters are queryable cold-path from the CLI (SQLite persistent);
+        // in-memory counters (volitional compaction count, session-entry
+        // chain depth) are not — they live only in the gateway process and
+        // are skipped here. Aggregate across the session keys the status
+        // summary already knows about.
+        let pendingTotal = 0;
+        let stagedTotal = 0;
+        if (cfg.enabled) {
+          try {
+            const { pendingDelegateCount, stagedPostCompactionDelegateCount } =
+              require("../auto-reply/continuation/delegate-store.js") as {
+                pendingDelegateCount: (sessionKey: string) => number;
+                stagedPostCompactionDelegateCount: (sessionKey: string) => number;
+              };
+            const seen = new Set<string>();
+            for (const session of params.summary.sessions.recent) {
+              if (!session.key || seen.has(session.key)) {
+                continue;
+              }
+              seen.add(session.key);
+              pendingTotal += pendingDelegateCount(session.key);
+              stagedTotal += stagedPostCompactionDelegateCount(session.key);
+            }
+          } catch {
+            // TaskFlow not initialised or lookup failed — fall back to
+            // config-only shape silently rather than hiding the whole row.
+          }
         }
-        return `enabled · chain max ${cfg.maxChainLength} · fan-out max ${cfg.maxDelegatesPerTurn}`;
+
+        return formatContinuationBannerValue({
+          enabled: cfg.enabled,
+          maxChainLength: cfg.maxChainLength,
+          maxDelegatesPerTurn: cfg.maxDelegatesPerTurn,
+          pendingDelegatesTotal: pendingTotal,
+          postCompactionStagedTotal: stagedTotal,
+        });
       } catch {
         return undefined;
       }

--- a/src/commands/status.continuation-banner.test.ts
+++ b/src/commands/status.continuation-banner.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { formatContinuationBannerValue } from "./status.command-report-data.ts";
+
+describe("formatContinuationBannerValue (status /status continuation banner, RFC §6.3)", () => {
+  const baseEnabled = {
+    enabled: true as const,
+    maxChainLength: 10,
+    maxDelegatesPerTurn: 5,
+    pendingDelegatesTotal: 0,
+    postCompactionStagedTotal: 0,
+  };
+
+  it("returns undefined when continuation is disabled — overview row is omitted", () => {
+    expect(
+      formatContinuationBannerValue({
+        ...baseEnabled,
+        enabled: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("config-only fallback when enabled and all runtime counters are zero (quiet session)", () => {
+    expect(formatContinuationBannerValue(baseEnabled)).toBe(
+      "enabled · chain max 10 · fan-out max 5",
+    );
+  });
+
+  it("surfaces pending delegates when non-zero — plural", () => {
+    expect(
+      formatContinuationBannerValue({
+        ...baseEnabled,
+        pendingDelegatesTotal: 2,
+      }),
+    ).toBe("enabled · chain max 10 · 2 delegates pending · fan-out max 5");
+  });
+
+  it("surfaces single pending delegate with singular noun", () => {
+    expect(
+      formatContinuationBannerValue({
+        ...baseEnabled,
+        pendingDelegatesTotal: 1,
+      }),
+    ).toBe("enabled · chain max 10 · 1 delegate pending · fan-out max 5");
+  });
+
+  it("surfaces post-compaction staged count when non-zero", () => {
+    expect(
+      formatContinuationBannerValue({
+        ...baseEnabled,
+        postCompactionStagedTotal: 1,
+      }),
+    ).toBe("enabled · chain max 10 · 1 post-compaction · fan-out max 5");
+  });
+
+  it("surfaces both pending and post-compaction staged when both non-zero (active session shape)", () => {
+    expect(
+      formatContinuationBannerValue({
+        ...baseEnabled,
+        pendingDelegatesTotal: 2,
+        postCompactionStagedTotal: 1,
+      }),
+    ).toBe("enabled · chain max 10 · 2 delegates pending · 1 post-compaction · fan-out max 5");
+  });
+});


### PR DESCRIPTION
## Summary
Wires runtime continuation telemetry into the \`/status\` overview row per RFC §6.3. Previously showed only static config (\`enabled · chain max 10 · fan-out max 5\`). Now surfaces \`K delegates pending\` and \`J post-compaction\` when either is non-zero. Idle / quiet sessions still render the config-only shape (no regression).

## Before / after

### Before (idle)
\`\`\`
Continuation: enabled · chain max 10 · fan-out max 5
\`\`\`

### Before (active — no change, telemetry hidden)
\`\`\`
Continuation: enabled · chain max 10 · fan-out max 5
\`\`\`

### After (idle — unchanged)
\`\`\`
Continuation: enabled · chain max 10 · fan-out max 5
\`\`\`

### After (active)
\`\`\`
Continuation: enabled · chain max 10 · 2 delegates pending · 1 post-compaction · fan-out max 5
\`\`\`

## Changes
- Extract \`formatContinuationBannerValue\` as an exported pure helper (same file).
- Wire the IIFE to aggregate \`pendingDelegateCount\` + \`stagedPostCompactionDelegateCount\` across \`params.summary.sessions.recent\` session keys. Both are TaskFlow-backed (SQLite) and therefore queryable cold-path from the CLI.
- New \`status.continuation-banner.test.ts\` with 6 unit tests for the formatter: disabled → undefined, idle → config-only, singular/plural pending, post-compaction-only, both-non-zero.

## Scope: what's NOT in this PR
- \`getVolitionalCompactionCount\` and \`SessionEntry.continuationChainCount\` are **in-memory only** in the gateway process — not queryable cold-path from the status CLI without a gateway-methods RPC. Surfacing them requires that RPC + its route-registration (separate PR).
- The RFC §6.3 table shows \`chain 3/10\` shape; for now we only show \`chain max N\` because the \`3/\` part requires the in-memory field above. If someone wires a gateway RPC for runtime SessionEntry state, the banner helper's signature is already the right shape to receive it.

## Test plan
- [x] \`pnpm test src/commands/status.continuation-banner.test.ts\` → 6/6 pass.
- [x] \`pnpm test src/commands/status.command-report-data.test.ts\` → existing 1/1 pass (no regression).
- [x] \`pnpm tsgo\` clean.

## Refs
- \`docs/design/continue-work-signal-v2.md\` §6.3 (continuation telemetry spec)
- karmaterminal/openclaw-bootstrap#580 (continuation observability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)