### PR TITLE
fix(#473): co-locate subagent-announce continuation runtime to avoid dist path mismatch

### DIFF
--- a/src/agents/subagent-announce.continuation.runtime.test.ts
+++ b/src/agents/subagent-announce.continuation.runtime.test.ts
@@ -1,0 +1,82 @@
+// Regression coverage for issue #473:
+// `subagent-announce.ts` lazy-loads the continuation drain via
+// `importRuntimeModule(import.meta.url, [...])`. That dynamic import path
+// is NOT bundler-rewritten; the bundler emits the source modules into a
+// flat hashed dist layout and the lazy import resolves against the dist
+// file's own URL. Pre-fix, the import targeted
+// `../auto-reply/continuation/{delegate-dispatch,config}.js` which does not
+// exist post-bundle, producing `ERR_MODULE_NOT_FOUND` at runtime.
+//
+// Fix shape (mirrors `subagent-registry.runtime.ts`):
+//   1. Co-located runtime entry `subagent-announce.continuation.runtime.ts`
+//      that re-exports the two needed symbols.
+//   2. Registered as a tsdown bundler entry so it lands at a stable on-disk
+//      path post-bundle.
+//   3. `subagent-announce.ts` lazy-imports against `["./subagent-announce.continuation.runtime", ".js"]`
+//      which resolves cleanly against the same dist directory.
+//
+// These tests assert the contract of the fix so a refactor that drops the
+// runtime entry, the bundler registration, or the symbol re-exports fails
+// loudly instead of silently regressing to `ERR_MODULE_NOT_FOUND` in
+// production.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import tsdownConfig from "../../tsdown.config.ts";
+import * as continuationRuntime from "./subagent-announce.continuation.runtime.js";
+
+type TsdownConfigEntry = {
+  entry?: Record<string, string> | string[];
+};
+
+function asConfigArray(config: unknown): TsdownConfigEntry[] {
+  return Array.isArray(config) ? (config as TsdownConfigEntry[]) : [config as TsdownConfigEntry];
+}
+
+function entriesOfMainGraph(): Record<string, string> {
+  const configs = asConfigArray(tsdownConfig);
+  const main = configs.find((c) => {
+    const entry = c.entry;
+    if (!entry || Array.isArray(entry)) {
+      return false;
+    }
+    return Object.keys(entry).includes("subagent-registry.runtime");
+  });
+  if (!main || !main.entry || Array.isArray(main.entry)) {
+    throw new Error("could not locate main dist graph in tsdown config");
+  }
+  return main.entry;
+}
+
+describe("subagent-announce continuation runtime entry (issue #473)", () => {
+  it("registers the continuation runtime as a tsdown bundler entry", () => {
+    const entries = entriesOfMainGraph();
+    expect(entries).toHaveProperty("agents/subagent-announce.continuation.runtime");
+    expect(entries["agents/subagent-announce.continuation.runtime"]).toBe(
+      "src/agents/subagent-announce.continuation.runtime.ts",
+    );
+  });
+
+  it("exports dispatchToolDelegates from the continuation runtime", () => {
+    expect(typeof continuationRuntime.dispatchToolDelegates).toBe("function");
+  });
+
+  it("exports resolveContinuationRuntimeConfig from the continuation runtime", () => {
+    expect(typeof continuationRuntime.resolveContinuationRuntimeConfig).toBe("function");
+  });
+
+  it("subagent-announce lazy-imports the runtime entry by its co-located path, not the source-tree path", () => {
+    // Post-bundle, the dist emits `agents/subagent-announce.continuation.runtime.js`
+    // adjacent to the bundled subagent-announce code. The pre-fix path
+    // (`../auto-reply/continuation/delegate-dispatch.js`) does not exist
+    // post-bundle and would resolve to a non-existent nested path.
+    const announceSrc = readFileSync(
+      resolve(process.cwd(), "src/agents/subagent-announce.ts"),
+      "utf8",
+    );
+    expect(announceSrc).toContain('"./subagent-announce.continuation.runtime"');
+    expect(announceSrc).not.toContain('"../auto-reply/continuation/delegate-dispatch.js"');
+    expect(announceSrc).not.toContain('"../auto-reply/continuation/config.js"');
+  });
+});

--- a/src/agents/subagent-announce.continuation.runtime.ts
+++ b/src/agents/subagent-announce.continuation.runtime.ts
@@ -1,0 +1,19 @@
+// Co-located runtime entry for subagent-announce continuation drain.
+//
+// Bug #473 fix: `subagent-announce.ts` lazy-loads
+// `../auto-reply/continuation/{delegate-dispatch,config}.js` via
+// `importRuntimeModule(import.meta.url, [...])`. The bundler does not rewrite
+// the path expression inside `importRuntimeModule`, and the flat-dist emission
+// drops the source-tree subdirectory, so at runtime the import resolves to a
+// non-existent nested path and fails with `ERR_MODULE_NOT_FOUND`.
+//
+// The fix mirrors `subagent-registry.runtime.ts`: declare a co-located runtime
+// entry whose path resolves cleanly post-bundle, and route the dynamic import
+// through it. This keeps the cycle-avoidance property of the lazy import
+// (delegate-dispatch never enters the static graph of subagent-announce)
+// while giving the bundler a stable on-disk target.
+//
+// Registered as a tsdown bundler entry: `agents/subagent-announce.continuation.runtime`
+// in `tsdown.config.ts`.
+export { dispatchToolDelegates } from "../auto-reply/continuation/delegate-dispatch.js";
+export { resolveContinuationRuntimeConfig } from "../auto-reply/continuation/config.js";

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -157,10 +157,12 @@ async function drainChildContinuationQueue(params: {
     // subagent-announce.ts`.
     const [dispatchModule, configModule] = await Promise.all([
       importRuntimeModule<ContinuationDispatchModule>(import.meta.url, [
-        "../auto-reply/continuation/delegate-dispatch.js",
+        "./subagent-announce.continuation.runtime",
+        ".js",
       ]),
       importRuntimeModule<ContinuationConfigModule>(import.meta.url, [
-        "../auto-reply/continuation/config.js",
+        "./subagent-announce.continuation.runtime",
+        ".js",
       ]),
     ]);
     const { dispatchToolDelegates } = dispatchModule;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -147,6 +147,8 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
     "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
+    "agents/subagent-announce.continuation.runtime":
+      "src/agents/subagent-announce.continuation.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",


### PR DESCRIPTION
Fixes karmaterminal/openclaw-bootstrap#473.

## Summary
`subagent-announce` continuation drain fails with `ERR_MODULE_NOT_FOUND` at runtime because the dynamic `importRuntimeModule()` path `'../auto-reply/continuation/{delegate-dispatch,config}.js'` is not rewritten by tsdown. The flat-dist emission drops the source-tree subdirectory, so at runtime the import resolves to a non-existent nested path.

## Fix
Mirrors the existing `subagent-registry.runtime.ts` pattern that already solved this same class of problem:

- New file: `src/agents/subagent-announce.continuation.runtime.ts` — re-exports the two symbols the announce path needs (`dispatchToolDelegates`, `resolveContinuationRuntimeConfig`).
- Registered as a tsdown bundler entry (`agents/subagent-announce.continuation.runtime`) so it lands at a stable on-disk path post-bundle.
- Updated `subagent-announce.ts` lazy import to `['./subagent-announce.continuation.runtime', '.js']` — resolves cleanly against the same dist directory the runtime is loaded from.

Preserves the cycle-avoidance property of the lazy import (delegate-dispatch never imported eagerly).

## Test plan
- [x] `pnpm build` — clean, runtime entry lands at expected dist path
- [x] Manual: subagent-announce continuation drain no longer throws `ERR_MODULE_NOT_FOUND` on a fresh dist
- [ ] CI

## Scope
- 1 new file (re-exports only), 1 import path update, 1 bundler entry add. No behavior change beyond fixing the import resolution.

🩸