### PR TITLE
feat(continuation): add :reach breadcrumb to context-pressure guard (#580)

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1182,7 +1182,17 @@ export async function runReplyAgent(params: {
     // --- Context-pressure pre-run injection (RFC §4.2) ---
     // Fire before the agent turn so the agent can act on pressure in this turn.
     const continuationEnabledForPressure = cfg?.agents?.defaults?.continuation?.enabled === true;
+    // Reach-breadcrumb (#580): emit an info-level log immediately inside the
+    // outer guard so operators can distinguish "guard never entered" from
+    // "entered but inner branch silently no-ops." Post-#164 instrumentation
+    // showed zero `:fire` AND zero `:skip` lines fleet-wide on 9d9b3bae7e
+    // despite debug-level logging on three princes; that pattern is only
+    // explainable if this block isn't reached at all on normal turns.
     if (continuationEnabledForPressure && sessionKey && activeSessionEntry) {
+      const { createSubsystemLogger: createReachLogger } = await import("../../logging/subsystem.js");
+      createReachLogger("continuation/context-pressure").info(
+        `[context-pressure:reach] precondition-check entered session=${sessionKey}`,
+      );
       const { checkContextPressure } = await import("../continuation/context-pressure.js");
       const pressureConfig = resolveContinuationRuntimeConfig(cfg);
       const threshold = pressureConfig.contextPressureThreshold;


### PR DESCRIPTION
## Reach-breadcrumb for #580

Successor instrumentation to #164. Adds a single info-level log line immediately inside the outer guard at `agent-runner.ts:1183`:

```
[context-pressure:reach] precondition-check entered session=<key>
```

### Why

[#580 finding-comment](https://github.com/karmaterminal/openclaw-bootstrap/issues/580#issuecomment-4274582968) shows that on `9d9b3bae7e` deployed fleet-wide, with `logging.level=debug` confirmed live (the `continuation/signal` subsystem produces many debug lines per turn on all three observed princes), the `continuation/context-pressure` subsystem produces:

- **0** `[context-pressure:fire]` lines
- **0** `[context-pressure:skip]` lines

The new #164 `:skip` instrumentation is the key signal here — if `totalTokens` were unpopulated (the most common silent-skip condition), it would log `:skip reason=totalTokens-not-populated`. It doesn't. So the entire pre-run injection block isn't being entered.

### What this PR proves

After deploy, journals will tell us which of two remaining hypotheses is true:

1. **`:reach` never fires** → outer guard `(continuationEnabledForPressure && sessionKey && activeSessionEntry)` is genuinely false on normal turns. Likely culprit: `activeSessionEntry` becomes null/undefined between line 931 (initial assignment) and line 1185 (this guard), via the `runMemoryFlushIfNeeded`/`runPreflightCompactionIfNeeded` reassignments at 1091/1107. Or there's an early-return above the block that we haven't traced.
2. **`:reach` fires but no `:fire` or `:skip` follows** → outer guard is true, but the inner `if (threshold && totalTokens && contextWindow)` short-circuits in a way that doesn't take the else-branch either. Would point to the dynamic import failing silently, or to the `checkContextPressure` returning early before its own log lines.

### Risk

Minimal. 10 lines, no behavior change, single dynamic import (already used 3 lines below for the `:skip` log so the import resolution path is the same). Info-level log so it survives any future debug-filter regression.

### Verification plan

1. Land + deploy fleet-wide.
2. After ~30min of normal traffic on at least 3 princes:
   ```
   journalctl --user -u openclaw-gateway --since "30 min ago" \
     | grep -E "context-pressure:(reach|fire|skip)"
   ```
3. Update #580 with which hypothesis was confirmed.

cc figs / fleet — this is the next step from the morning's #580 trace analysis. Anchored to issue per `anchor in gh issues or it didnt happen`.
