### PR TITLE
fix(continuation): use -1 sentinel for dedup so band=0 fires once (#580)

### DIFF
--- a/src/auto-reply/continuation/context-pressure.test.ts
+++ b/src/auto-reply/continuation/context-pressure.test.ts
@@ -77,4 +77,35 @@ describe("checkContextPressure", () => {
   it("returns null for zero context window", () => {
     expect(checkContextPressure({ ...base, contextWindow: 0, totalTokens: 100 })).toBeNull();
   });
+
+  // #580 regression: when configured threshold is below the lowest hard-coded
+  // band (currently 25%), the resolved band is 0. Without the -1 sentinel,
+  // first-time-seen sessions had previous=0 (the `?? 0` default), so the very
+  // first crossing collided band===previous===0 and was dedup-suppressed,
+  // producing zero `:fire` events fleet-wide despite `:reach` firing every
+  // turn. The sentinel ensures the first crossing of any band fires once.
+  it("#580: fires once at sub-25% threshold (band=0) for first-time-seen session", () => {
+    const lowParams = {
+      sessionKey: "low-threshold-session",
+      contextWindow: 200_000,
+      threshold: 0.05, // 5% — well below the lowest hard-coded band (25%)
+      totalTokens: 20_000, // 10% — above threshold, below all bands → resolves to band 0
+    };
+
+    const first = checkContextPressure(lowParams);
+    expect(first).not.toBeNull();
+    expect(first).toContain("[system:context-pressure]");
+    expect(first).toContain("10%");
+
+    // Second call at same band-0 level: dedup should suppress.
+    const second = checkContextPressure(lowParams);
+    expect(second).toBeNull();
+
+    // Escalating into a real band still fires.
+    const escalated = checkContextPressure({
+      ...lowParams,
+      totalTokens: 60_000, // 30% → band 25
+    });
+    expect(escalated).not.toBeNull();
+  });
 });

--- a/src/auto-reply/continuation/context-pressure.ts
+++ b/src/auto-reply/continuation/context-pressure.ts
@@ -11,6 +11,12 @@
  * Band dedup: equality-based. The same band doesn't fire twice consecutively,
  * but a new band (including a lower band after compaction) always fires.
  *
+ * The dedup sentinel is -1, NOT 0. A first-time-seen session has previous=-1,
+ * so even band=0 (ratio below the lowest hard-coded band) fires once. This
+ * matters when the configured `contextPressureThreshold` is below the lowest
+ * band (currently 25%): without the sentinel, every session's first crossing
+ * collides band===previous===0 and is suppressed silently. (#580)
+ *
  * RFC: docs/design/continue-work-signal-v2.md §4.2
  */
 
@@ -90,7 +96,11 @@ export function checkContextPressure(params: {
   const band = resolveContextPressureBand(ratio);
 
   // Dedup: same band as last time → suppress.
-  const previous = lastFiredBand.get(sessionKey) ?? 0;
+  // Sentinel -1 ensures first-time-seen sessions fire once even when band===0
+  // (which happens for any ratio below the lowest hard-coded band, currently
+  // 25%). Using `?? 0` here would silently suppress every first crossing of
+  // sub-25% thresholds. See #580 for the bytes.
+  const previous = lastFiredBand.get(sessionKey) ?? -1;
   if (band === previous) {
     return null;
   }


### PR DESCRIPTION
## Summary

`checkContextPressure()` had three silent `return null` paths after `:reach`. The dedup check used `?? 0` for the missing-key default, which collided with the resolved band value of 0 for any ratio below the lowest hard-coded `PRESSURE_BAND` (currently 25%).

For sessions with `contextPressureThreshold` below 0.25, the very first crossing produced `band === previous === 0` and was dedup-suppressed silently. Result: zero `:fire` events fleet-wide despite `:reach` firing every turn.

This PR uses `-1` as the missing-key sentinel so the first crossing of any band — including band 0 — fires once. Subsequent same-band calls still dedup correctly.

## Diagnostic data (from #171's `:reach` instrumentation)

| Box     | threshold | uptime | `:reach` | `:skip` | `:fire` |
|---------|-----------|--------|-----------|----------|----------|
| cael    | 0.05      | 30 s   | 1+        | 0        | 0        |
| ronan   | 0.05      | 36 min | 75        | 0        | 0        |

See `karmaterminal/openclaw-bootstrap#580` comments [4274816644](https://github.com/karmaterminal/openclaw-bootstrap/issues/580#issuecomment-4274816644) (cael) and [4274816937](https://github.com/karmaterminal/openclaw-bootstrap/issues/580#issuecomment-4274816937) (ronan) for full bytes.

## Test

Added regression test `#580: fires once at sub-25% threshold (band=0) for first-time-seen session`. All 11 existing context-pressure tests still pass.

```
\u2713 src/auto-reply/continuation/context-pressure.test.ts (11 tests) 3ms
Test Files  1 passed (1)
     Tests  11 passed (11)
```

## Refs

- Closes (depends on fleet verification): karmaterminal/openclaw-bootstrap#580
- Diagnostic instrumentation: #171
- Cleanup tracker: karmaterminal/openclaw-bootstrap#602

## Validation plan

After merge + deploy, fleet boxes with `contextPressureThreshold=0.05` should start emitting `:fire` events at band 0 on the first turn after restart, then dedup-suppress subsequent same-band turns until escalation to band 25.