### PR TITLE
fix(continuation): honor delayMs on continue_delegate tool path (swim-35/A2)

### DIFF
--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -17,11 +17,67 @@ import type { SpawnSubagentContext } from "../../agents/subagent-spawn.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveContinuationRuntimeConfig } from "./config.js";
-import { consumePendingDelegates } from "./delegate-store.js";
+import { consumePendingDelegates, peekSoonestUnmaturedDelegateDueAt } from "./delegate-store.js";
 import { checkContinuationBudget, type ChainState } from "./scheduler.js";
-import { setDelegatePending } from "./state.js";
+import {
+  setDelegatePending,
+  registerContinuationTimerHandle,
+  retainContinuationTimerRef,
+  unregisterContinuationTimerHandle,
+} from "./state.js";
 
 const log = createSubsystemLogger("continuation/delegate-dispatch");
+
+// Per-session hedge timer for re-checking unmatured pending delegates in fully
+// quiet channels (no further response-finalize event). Idempotent per
+// sessionKey: a fresh dispatch call cancels + replaces any existing hedge.
+// See swim-35/A2 verdict.
+const hedgeTimers = new Map<string, NodeJS.Timeout>();
+
+function clearHedgeTimer(sessionKey: string): void {
+  const existing = hedgeTimers.get(sessionKey);
+  if (existing) {
+    clearTimeout(existing);
+    hedgeTimers.delete(sessionKey);
+    unregisterContinuationTimerHandle(sessionKey, existing);
+  }
+}
+
+function armHedgeTimer(
+  sessionKey: string,
+  fireAt: number,
+  params: { chainState: ChainState; ctx: DelegateDispatchContext; maxChainLength: number },
+): void {
+  clearHedgeTimer(sessionKey);
+  const fireIn = Math.max(0, fireAt - Date.now());
+  log.info(
+    `[continuation:delegate-hedge-armed] fireIn=${fireIn}ms fireAt=${fireAt} session=${sessionKey}`,
+  );
+  retainContinuationTimerRef(sessionKey);
+  const handle = setTimeout(() => {
+    hedgeTimers.delete(sessionKey);
+    log.info(`[continuation:delegate-hedge-fired] session=${sessionKey}`);
+    void dispatchToolDelegates({ sessionKey, ...params }).catch((err) => {
+      log.info(
+        `[continuation:delegate-hedge-error] error=${err instanceof Error ? err.message : String(err)} session=${sessionKey}`,
+      );
+    });
+  }, fireIn);
+  registerContinuationTimerHandle(sessionKey, handle);
+  handle.unref();
+  hedgeTimers.set(sessionKey, handle);
+}
+
+/**
+ * Test-only: cancel any pending hedge timers and clear the registry.
+ */
+export function resetDelegateDispatchHedgesForTests(): void {
+  for (const [sessionKey, handle] of hedgeTimers) {
+    clearTimeout(handle);
+    unregisterContinuationTimerHandle(sessionKey, handle);
+  }
+  hedgeTimers.clear();
+}
 
 export type DelegateDispatchContext = {
   sessionKey: string;
@@ -46,6 +102,21 @@ export async function dispatchToolDelegates(params: {
   const { sessionKey, chainState, ctx } = params;
   const config = resolveContinuationRuntimeConfig();
   const toolDelegates = consumePendingDelegates(sessionKey);
+
+  // Arm (or re-arm) a hedge timer for any unmatured queued delegates so they
+  // still fire in fully-quiet channels where no further response-finalize
+  // arrives. The hedge re-invokes this function; idempotent per sessionKey.
+  // See swim-35/A2 verdict.
+  const soonestUnmaturedDueAt = peekSoonestUnmaturedDelegateDueAt(sessionKey);
+  if (soonestUnmaturedDueAt !== undefined) {
+    armHedgeTimer(sessionKey, soonestUnmaturedDueAt, {
+      chainState: params.chainState,
+      ctx: params.ctx,
+      maxChainLength: params.maxChainLength,
+    });
+  } else {
+    clearHedgeTimer(sessionKey);
+  }
 
   if (toolDelegates.length === 0) {
     return { dispatched: 0, rejected: 0 };

--- a/src/auto-reply/continuation/delegate-store.test.ts
+++ b/src/auto-reply/continuation/delegate-store.test.ts
@@ -106,7 +106,6 @@ describe("delegate store — TaskFlow-backed", () => {
     enqueuePendingDelegate("session-1", {
       task: "silent task",
       mode: "silent-wake",
-      delayMs: 5000,
     });
 
     const delegates = consumePendingDelegates("session-1");
@@ -162,5 +161,69 @@ describe("post-compaction delegate staging", () => {
     expect(regular[0].task).toBe("regular");
     expect(postCompact).toHaveLength(1);
     expect(postCompact[0].task).toBe("post-compact");
+  });
+});
+
+describe("consumePendingDelegates — delayMs gating (swim-35/A2)", () => {
+  it("leaves an unmatured delegate (delayMs in the future) in queued state", () => {
+    enqueuePendingDelegate("session-1", { task: "future", delayMs: 60_000 });
+
+    const matured = consumePendingDelegates("session-1");
+    expect(matured).toEqual([]);
+    expect(pendingDelegateCount("session-1")).toBe(1);
+  });
+
+  it("drains a matured delegate (delayMs elapsed)", () => {
+    enqueuePendingDelegate("session-1", { task: "due", delayMs: 0 });
+
+    const matured = consumePendingDelegates("session-1");
+    expect(matured).toHaveLength(1);
+    expect(matured[0].task).toBe("due");
+    expect(pendingDelegateCount("session-1")).toBe(0);
+  });
+
+  it("drains matured entries and re-parks unmatured entries in the same call", () => {
+    enqueuePendingDelegate("session-1", { task: "due", delayMs: 0 });
+    enqueuePendingDelegate("session-1", { task: "future", delayMs: 60_000 });
+
+    const matured = consumePendingDelegates("session-1");
+    expect(matured.map((d) => d.task)).toEqual(["due"]);
+    // The unmatured entry stays queued for the next consume cycle.
+    expect(pendingDelegateCount("session-1")).toBe(1);
+  });
+
+  it("treats omitted delayMs as zero (matures immediately, preserves legacy behavior)", () => {
+    enqueuePendingDelegate("session-1", { task: "no-delay" });
+
+    const matured = consumePendingDelegates("session-1");
+    expect(matured).toHaveLength(1);
+    expect(matured[0].task).toBe("no-delay");
+  });
+});
+
+describe("peekSoonestUnmaturedDelegateDueAt (swim-35/A2)", () => {
+  it("returns undefined when no entries are queued", async () => {
+    const { peekSoonestUnmaturedDelegateDueAt } = await import("./delegate-store.js");
+    expect(peekSoonestUnmaturedDelegateDueAt("empty")).toBeUndefined();
+  });
+
+  it("returns undefined when all queued entries are already due", async () => {
+    const { peekSoonestUnmaturedDelegateDueAt } = await import("./delegate-store.js");
+    enqueuePendingDelegate("session-1", { task: "due", delayMs: 0 });
+    expect(peekSoonestUnmaturedDelegateDueAt("session-1")).toBeUndefined();
+  });
+
+  it("returns the soonest dueAt across multiple unmatured entries", async () => {
+    const { peekSoonestUnmaturedDelegateDueAt } = await import("./delegate-store.js");
+    const before = Date.now();
+    enqueuePendingDelegate("session-1", { task: "far", delayMs: 120_000 });
+    enqueuePendingDelegate("session-1", { task: "near", delayMs: 30_000 });
+    enqueuePendingDelegate("session-1", { task: "mid", delayMs: 60_000 });
+
+    const soonest = peekSoonestUnmaturedDelegateDueAt("session-1");
+    expect(soonest).toBeDefined();
+    // Soonest should be the 30s one — within tolerance of `before + 30000`.
+    expect(soonest!).toBeGreaterThanOrEqual(before + 30_000);
+    expect(soonest!).toBeLessThan(before + 30_000 + 5_000);
   });
 });

--- a/src/auto-reply/continuation/delegate-store.ts
+++ b/src/auto-reply/continuation/delegate-store.ts
@@ -148,13 +148,24 @@ export function enqueuePendingDelegate(
 }
 
 /**
- * Consume all pending delegates for a session.
- * Returns delegates in FIFO order. Finishes backing flow records with
- * `releasedAt` audit trail. Skips corrupt payloads via `failFlow`.
- * Only pushes delegates where `finishFlow` was applied (concurrency-safe).
+ * Consume pending delegates for a session whose `delayMs` horizon has matured.
+ *
+ * Filters by `Date.now() >= flow.createdAt + (state.delayMs ?? 0)`. Matured
+ * entries are finished with the `releasedAt` audit trail and returned in FIFO
+ * order. Unmatured entries are left in `queued` state to be re-checked on the
+ * next consume cycle (filter-at-consume; preserves `mode=silent` no-wake
+ * semantics — see swim-35/A2 verdict).
+ *
+ * Skips corrupt payloads via `failFlow`. Only pushes delegates where
+ * `finishFlow` was applied (concurrency-safe).
+ *
+ * Callers that need to know when to retry the consume cycle in a quiet channel
+ * should call `peekSoonestUnmaturedDelegateDueAt(sessionKey)` immediately after
+ * this returns. Pairing avoids a separate query path.
  */
 export function consumePendingDelegates(sessionKey: string): PendingContinuationDelegate[] {
   const delegates: PendingContinuationDelegate[] = [];
+  const now = Date.now();
 
   for (const flow of listQueuedPendingFlows(sessionKey)) {
     const state = decodeDelegateState(flow);
@@ -165,6 +176,15 @@ export function consumePendingDelegates(sessionKey: string): PendingContinuation
         currentStep: "Rejected invalid continuation payload",
         blockedSummary: "Pending continuation delegate payload could not be decoded.",
       });
+      continue;
+    }
+
+    // Filter-at-consume: leave unmatured entries in `queued` so the next
+    // response-finalize (or the hedge timer armed by the dispatch caller)
+    // re-checks them. Honors `delayMs` on the tool path without threading a
+    // wake-pathway timer (which would change `mode=silent` semantics).
+    const dueAt = flow.createdAt + (state.delayMs ?? 0);
+    if (now < dueAt) {
       continue;
     }
 
@@ -182,6 +202,34 @@ export function consumePendingDelegates(sessionKey: string): PendingContinuation
   }
 
   return delegates;
+}
+
+/**
+ * Peek the soonest `dueAt` (createdAt + delayMs) across queued, unmatured
+ * pending delegates for a session.
+ *
+ * Returns `undefined` if there are no unmatured entries. Used by
+ * `dispatchToolDelegates` to arm a hedge `setTimeout` so unmatured entries
+ * still fire in fully-quiet channels where no further response-finalize
+ * arrives. See swim-35/A2 verdict.
+ */
+export function peekSoonestUnmaturedDelegateDueAt(sessionKey: string): number | undefined {
+  const now = Date.now();
+  let soonest: number | undefined;
+  for (const flow of listQueuedPendingFlows(sessionKey)) {
+    const state = decodeDelegateState(flow);
+    if (!state) {
+      continue;
+    }
+    const dueAt = flow.createdAt + (state.delayMs ?? 0);
+    if (dueAt <= now) {
+      continue;
+    }
+    if (soonest === undefined || dueAt < soonest) {
+      soonest = dueAt;
+    }
+  }
+  return soonest;
 }
 
 /**


### PR DESCRIPTION
Fixes karmaterminal/openclaw-bootstrap#627. Sibling to #581 (signal-path coalescing).

## Bug

The tool-form `continue_delegate` path persisted `delayMs` to the TaskFlow-backed pending-delegate store but **never consulted it at consume time**. `consumePendingDelegates` drained every queued entry on the next response-finalize event, so delegates fired at engine-horizon ~14s for `delayMs=30000` (n=2 isolation on cael-node, canary `e0ba8f83f7`).

The bracket-form `continue_work` path goes through `scheduler.ts:181-205` + `delayedReservations` Map and honors `setTimeout(delayMs)` cleanly. This was a missing-feature on the tool path, not a regression on the working signal path.

## Fix shape — filter-at-consume + hedge timer

Per Silas's `mode=silent` architectural catch on #sprites-of-thornfield (msg `1495344085857210550`):

1. **`consumePendingDelegates` filter-at-consume** — gates by `Date.now() >= flow.createdAt + (state.delayMs ?? 0)`. Matured entries are finished with the `releasedAt` audit trail; unmatured entries stay in `queued` state to be re-checked on the next consume cycle. Preserves both `mode=silent` (no-wake) and `mode=silent-wake` semantics intact.

2. **New `peekSoonestUnmaturedDelegateDueAt(sessionKey)` helper** — exposes the soonest unmatured `dueAt` for hedge scheduling.

3. **`dispatchToolDelegates` hedge timer** — arms a per-session hedge `setTimeout` for `(soonestUnmaturedDueAt - now)` so unmatured entries still fire in fully-quiet channels where no further response-finalize arrives. Idempotent per `sessionKey` (cancel + replace on every dispatch). The hedge fires the consume check, **not a wake-event** — semantically distinct from `scheduler.ts:181-205`'s wake-pathway timer, so `mode=silent`'s no-wake guarantee still holds.

## Why not Option A (route through `delayedReservations`)?

Option A would unify both paths under one timer, but the signal-path `setTimeout` assumes a wake-pathway exists. Routing the tool path through it would either change `mode=silent` semantics (currently fires whenever-next-event-arrives, no wake) or bypass the timer for `silent` mode (defeats the routing). Filter-at-consume preserves user-visible semantics. Path unification can become a follow-up if appetite exists.

## Tests

- 9 existing `delegate-store.test.ts` tests still pass (one updated to drop incidental `delayMs` that was masking the bug).
- 4 new tests for filter-at-consume gating: unmatured stays queued, matured drains, mixed batch drains-and-reparks, omitted `delayMs` treated as zero (legacy behavior).
- 3 new tests for `peekSoonestUnmaturedDelegateDueAt`: empty, all-due, soonest-of-many.
- All 52 `src/auto-reply/continuation/` tests pass.

## Verdict + lineage

- Verdict (byte-cited n=2): `karmaterminal/openclaw-bootstrap` `swims/swim-35/A2/cael-n2-verdict-2026-04-19T08-50Z/verdict.md`
- Sibling issue: karmaterminal/openclaw-bootstrap#627
- Lineage parent: karmaterminal/openclaw-bootstrap#581 (different mechanism — coalescing under load on signal path)
- Fleet vote: filter-at-consume converged across all four princes (Cael, Silas, Ronan, Elliott)

## Diff size

3 files, +189/-7. All in `src/auto-reply/continuation/`.
