### PR TITLE
feat(taskflow): cluster-ownership contract (v1.1 shell, #179)

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-7003e0d0ba1cddb7eb388204825ac892206209a4a9c795e76c4e34b5fc7b50f0  plugin-sdk-api-baseline.json
-14e39520459abc7db7993a700a4f07adfa0855d9233d123c4725477b91f1cb13  plugin-sdk-api-baseline.jsonl
+fb81c46bb77b97739bf6912fcb0e645ad0b50c8ae3fb3068d9b1bf4f5c86ffea  plugin-sdk-api-baseline.json
+6c0ba7d126926386a5b4c59ef9d92935affb061fd80de688cf50ca2be46d2783  plugin-sdk-api-baseline.jsonl

--- a/docs/automation/taskflow.md
+++ b/docs/automation/taskflow.md
@@ -70,6 +70,43 @@ openclaw tasks flow cancel <lookup>
 | `openclaw tasks flow show <id>`   | Inspect one flow by flow id or lookup key     |
 | `openclaw tasks flow cancel <id>` | Cancel a running flow and its active tasks    |
 
+## Cluster ownership (v1.1)
+
+By default, a managed flow is `ownership: "host-local"` — state lives
+on a single gateway, and two gateways on different boxes can each
+"win" a revision race because they're looking at separate per-host
+state.
+
+Setting `ownership: "cluster"` opts the flow into cross-host
+coordination via a ZK `LeaderElection` at `ownershipPath` (default:
+`/openclaw/<env>/taskflow/<flowId>`). Behavior:
+
+- Only the elected leader's gateway may advance the flow.
+- Every other gateway sees `not_owner` on mutation attempts.
+- On leadership loss (session expiry, manual release), the flow
+  transitions to `queued`; the next elected leader picks up from the
+  last persisted revision.
+- On ZK quorum loss mid-step, the flow transitions to `blocked` with
+  `reason: zk-quorum-lost-at-<ts>`. **No transparent replay** — a
+  duplicate step is worse than no step. `openclaw tasks flow resume
+<id>` explicitly re-enters once an operator confirms the state.
+
+See `/plugins/zk` for the ZK coordination primitives + quorum-degradation
+semantics, and `/plugins/zk-parity` for the wire-up evidence template
+that every consumer-side PR must satisfy.
+
+### Current landing state
+
+- **PR 4 (#179):** adds the `ownership` / `ownershipPath` fields to
+  `TaskFlowRecord` + the `not_owner` error code. Contract only — no ZK
+  enforcement yet.
+- **PR 4b (follow-up):** wires the scaffolded `ClusterOwnershipController`
+  in `src/plugins/runtime/runtime-taskflow-zk.ts` to
+  `openclaw/plugin-sdk/zk#createElection`. Integration tests cover
+  leadership failover + quorum-loss-blocked transition.
+- **PR 5 (#180):** first consumer (reply dedup) — deferred until PR 4b
+  and real before/after evidence per the kazoo-parity template.
+
 ## How flows relate to tasks
 
 Flows coordinate tasks, not replace them. A single flow may drive multiple background tasks over its lifetime. Use `openclaw tasks` to inspect individual task records and `openclaw tasks flow` to inspect the orchestrating flow.

--- a/docs/plugins/zk-parity.md
+++ b/docs/plugins/zk-parity.md
@@ -74,10 +74,10 @@ reject PRs that ship handwave-evidence.
 
 | kazoo recipe                               | openclaw equivalent               | Status                                                    |
 | ------------------------------------------ | --------------------------------- | --------------------------------------------------------- |
-| `kazoo.recipe.lock.Lock`                   | `createLock` + `withLock`         | ⏳ PR 2                                                   |
-| `kazoo.recipe.election.Election`           | `createElection`                  | ⏳ PR 2                                                   |
-| `kazoo.recipe.party.Party`                 | `createParty`                     | ⏳ PR 2                                                   |
-| `kazoo.recipe.lock.ReadLock` + `WriteLock` | `createReadWriteLock`             | ⏳ PR 2                                                   |
+| `kazoo.recipe.lock.Lock`                   | `createLock` + `withLock`         | ✓ `src/plugin-sdk/zk/lock.test.ts`                        |
+| `kazoo.recipe.election.Election`           | `createElection`                  | ✓ `src/plugin-sdk/zk/election.test.ts`                    |
+| `kazoo.recipe.party.Party`                 | `createParty`                     | ✓ `src/plugin-sdk/zk/party.test.ts`                       |
+| `kazoo.recipe.lock.ReadLock` + `WriteLock` | `createReadWriteLock`             | ✓ `src/plugin-sdk/zk/rwlock.test.ts`                      |
 | `kazoo.recipe.lock.Semaphore`              | `createSemaphore`                 | planned v1.x                                              |
 | `kazoo.recipe.counter.Counter`             | `createCounter`                   | planned v1.x                                              |
 | `kazoo.recipe.queue.LockingQueue`          | `createLockingQueue`              | planned v1.x                                              |

--- a/docs/plugins/zk-parity.md
+++ b/docs/plugins/zk-parity.md
@@ -1,0 +1,128 @@
+---
+summary: "Kazoo-parity roadmap, path-prefix convention, and the wire-up evidence template"
+read_when:
+  - You are writing or reviewing a cross-host coordination wire-up (reply dedup, cron singleton, agent-runner session)
+  - You need to find the reserved ZK path prefix for a new feature
+  - You want to know which kazoo recipes are available in TypeScript today vs planned
+title: "Plugin SDK ZK: parity + conventions"
+---
+
+# Plugin SDK ZK: parity + conventions
+
+## Path-prefix convention
+
+All recipes and the cluster-scoped TaskFlow mode default-prefix paths
+with `/openclaw/<env>/<feature>/...` to prevent collisions across
+consumers. `env` is the value of `openclaw config get deploy.env`
+(falls back to the literal `"fleet"`).
+
+Reserved feature prefixes:
+
+| Feature                               | Path prefix                                            | Ships in |
+| ------------------------------------- | ------------------------------------------------------ | -------- |
+| Raw user locks (`openclaw zk lock …`) | `/openclaw/<env>/user/locks`                           | PR 3     |
+| Elections (`openclaw zk elect …`)     | `/openclaw/<env>/user/elections`                       | PR 3     |
+| Parties (`openclaw zk party …`)       | `/openclaw/<env>/user/parties`                         | PR 3     |
+| TaskFlow cluster ownership            | `/openclaw/<env>/taskflow/<flowId>`                    | PR 4     |
+| Reply dedup                           | `/openclaw/<env>/reply/<conversation_id>/<message_id>` | PR 5     |
+| Cron singletons                       | `/openclaw/<env>/cron/<job-id>/<tick>`                 | v1.3     |
+| Agent-runner sessions                 | `/openclaw/<env>/agents/<channel>`                     | v1.3     |
+
+CLI commands accept `--no-prefix` to bypass the convention when
+interoperating with existing Python callers (`fleet_lock.py` uses
+`/dandelioncult/thornfield/locks/...` directly).
+
+Adding a new consumer? Pick a prefix that doesn't collide, document it
+in this table in the PR that lands the consumer, and use
+`featurePath(env, "<feature>", ...rest)` from `openclaw/plugin-sdk/zk`
+to construct paths instead of hand-concatenating strings.
+
+## Wire-up evidence template
+
+Every cross-host TaskFlow wire-up PR (reply dedup, cron singletons,
+agent-runner sessions, plus any future consumer) MUST include an
+evidence block in the PR description matching the shape below. Reviewers
+reject PRs that ship handwave-evidence.
+
+```markdown
+## Wire-up: <feature> (PR #<n>)
+
+### Before
+
+- Log trace (≥2 princes claiming same <scope-key> within 100ms):
+  2026-04-19T14:30:12.103Z elliott claim <key>
+  2026-04-19T14:30:12.117Z ronan claim <key> ← collision
+  2026-04-19T14:30:12.803Z elliott posted reply
+  2026-04-19T14:30:12.891Z ronan posted reply ← duplicate (the "danish")
+- Incident: <link to channel message or issue demonstrating the collision>
+
+### After
+
+- Log trace (same scope-key, post wire-up):
+  2026-04-19T14:45:00.204Z ronan claim <key> → flow abc, elected
+  2026-04-19T14:45:00.218Z elliott claim <key> → not_owner (flow abc, owner=ronan)
+  2026-04-19T14:45:00.901Z ronan posted reply
+- Assertion: exactly one `posted reply` log line per scope-key across all princes, observed over a 24h run.
+
+### Kill test
+
+- SIGKILL the owner gateway; confirm a different prince takes over within 2× sessionTimeoutMs.
+- Confirm the flow state reflects the correct new controller in `openclaw tasks flow show <id>`.
+```
+
+## Kazoo parity roadmap
+
+| kazoo recipe                               | openclaw equivalent               | Status                                                    |
+| ------------------------------------------ | --------------------------------- | --------------------------------------------------------- |
+| `kazoo.recipe.lock.Lock`                   | `createLock` + `withLock`         | ⏳ PR 2                                                   |
+| `kazoo.recipe.election.Election`           | `createElection`                  | ⏳ PR 2                                                   |
+| `kazoo.recipe.party.Party`                 | `createParty`                     | ⏳ PR 2                                                   |
+| `kazoo.recipe.lock.ReadLock` + `WriteLock` | `createReadWriteLock`             | ⏳ PR 2                                                   |
+| `kazoo.recipe.lock.Semaphore`              | `createSemaphore`                 | planned v1.x                                              |
+| `kazoo.recipe.counter.Counter`             | `createCounter`                   | planned v1.x                                              |
+| `kazoo.recipe.queue.LockingQueue`          | `createLockingQueue`              | planned v1.x                                              |
+| `kazoo.recipe.partitioner.SetPartitioner`  | `createSetPartitioner`            | planned v1.x                                              |
+| `kazoo.recipe.lease.NonBlockingLease`      | `createLease`                     | planned v1.x                                              |
+| `DataWatch` / `ChildrenWatch` callbacks    | `AsyncIterable<…>` on each recipe | ⏳ PR 2 (per-recipe) + planned generic v1.x               |
+| Transactions (`multi`)                     | `createTransaction`               | planned v1.x                                              |
+| ACLs                                       | `authInfo` on `createZkClient`    | ⏳ PR 1 (opaque pass-through); structured helpers planned |
+
+Deliberate API divergences from kazoo (documented in [/plugins/zk](/plugins/zk)):
+
+- `AbortSignal` replaces `CancelledError` — leadership loss,
+  session expiry, and caller-driven cancellation all fire the same
+  signal.
+- `AsyncIterable<…>` replaces kazoo's persistent watch callbacks.
+  Avoids leaking listener-management into callers.
+- `withLock(client, path, fn, opts)` replaces `async with lock:`. Same
+  try/finally-release semantics; idiomatic TS shape.
+
+## Adding a new recipe
+
+1. Write the recipe under `src/plugin-sdk/zk/<name>.ts`, depending only
+   on the `ZkDriver` interface (not the native module directly).
+2. Add a `*.test.ts` next to it exercising the recipe against
+   `driver-mock.ts`. Coverage must meet the 70% line/branch/function/
+   statement threshold the repo enforces for new SDK surfaces.
+3. Export contract types from `src/plugin-sdk/zk.ts`; add the factory
+   as an async function that dynamic-imports the implementation (keeps
+   cold import cheap).
+4. Update this file: add the row to "Kazoo parity roadmap" with a ✓
+   and a link to the test file.
+5. If the recipe needs a reserved path prefix, add it to the path
+   convention table above.
+
+## Integration-test coverage
+
+Session-expiry edges are the historical bug farm for every ZK library.
+The integration suite (`OPENCLAW_ZK_INTEGRATION=1 pnpm test
+src/plugin-sdk/zk`) must cover:
+
+- (a) expiry during lock hold
+- (b) expiry during election leadership
+- (c) expiry during party membership
+- (d) reconnect within session window (no expiry)
+
+Flaky scenarios gate behind `OPENCLAW_ZK_INTEGRATION_STRESS=1` rather
+than `skip` — they run in the heavier CI lane once the primary suite
+is green.

--- a/docs/plugins/zk.md
+++ b/docs/plugins/zk.md
@@ -1,0 +1,122 @@
+---
+summary: "ZooKeeper coordination primitives and CLI for the openclaw fleet"
+read_when:
+  - You need cross-host locks, leader election, or party membership from a TypeScript plugin
+  - You run `openclaw zk …` commands and want to know the contract
+  - You wire an openclaw feature into the cross-host TaskFlow ownership layer
+title: "Plugin SDK: ZK coordination"
+---
+
+# Plugin SDK: ZK coordination
+
+`openclaw/plugin-sdk/zk` exposes ZooKeeper-backed coordination primitives
+for plugins and for openclaw internals. It ships four recipe-style APIs
+modeled after [kazoo](https://kazoo.readthedocs.io/) — `Lock`,
+`LeaderElection`, `Party`, `ReadWriteLock` — plus a flock-style CLI at
+`openclaw zk`.
+
+Cross-host TaskFlow ownership (the anti-jumping seam for reply dedup,
+cron singletons, and agent-runner session ownership) rides on this same
+subpath.
+
+## When to use it
+
+- **Cross-host mutex.** Only one prince runs a given subprocess at a time.
+- **Leader election.** Exactly one prince runs an ongoing task; failover
+  to another prince on session loss.
+- **Party membership.** "Which princes are alive right now" visible to
+  every member.
+- **Reader/writer coordination.** Many concurrent readers, exclusive
+  writers, on a shared resource.
+
+If the work fits in a multi-step TaskFlow, prefer cluster-scoped TaskFlow
+ownership over grabbing a raw `Lock` — see
+[Task Flow](/automation/taskflow) for the ownership contract.
+
+## Installation
+
+The native binding is an `optionalDependencies` entry, so `npm install`
+completes even without the node-gyp toolchain. A non-fleet install that
+never calls `createZkClient` pays zero cost.
+
+To enable it on a fleet box:
+
+```bash
+openclaw zk setup
+```
+
+This detects the OS package manager (apt/pacman/dnf), installs
+`build-essential` + `python3`, and runs `npm i zookeeper@^7.2.0` into
+the openclaw install directory. If elevation fails (no sudo, read-only
+filesystem), the command prints a copyable prereq checklist and retries
+once the operator says "done."
+
+## Connection defaults
+
+`createZkClient` reads the hosts string from (highest precedence first):
+
+1. `hosts` argument passed directly.
+2. `ZK_HOSTS` env var. Matches kazoo + the Python `fleet_lock.py` muscle
+   memory; non-negotiable for cross-script compat.
+3. `openclaw config get zk.hosts` (persisted).
+4. Default: `zk-client.fleet-coordination.svc.cluster.local:2181`.
+
+In-cluster pods resolve the default via kube-dns. Princes running
+outside the pod network must set `ZK_HOSTS` explicitly — typically
+`<any-k3s-node-ip>:32181` (NodePort). If the default DNS doesn't resolve
+and no override is set, `createZkClient` fails fast with an operator
+message pointing here; no implicit tailnet sniffing.
+
+## Session lifecycle
+
+ZK sessions have a timeout (default 10s). When the session expires —
+typically because the ensemble lost quorum or a network partition
+outlasted the timeout — every ephemeral-backed handle fires its
+`AbortSignal`, recipes stop making progress, and callers MUST treat
+expiry as "you lost the lock / leadership / membership." There is no
+transparent replay: a transparent re-acquire after a gap is more
+dangerous than the work it would cover (duplicate side effects).
+
+For one-shot CLI invocations the contract is simpler: connect → op →
+close, with a hard 5s connect timeout.
+
+For `openclaw zk lock/elect/... -- <cmd…>` wrappers, the client stays
+open for the subprocess's lifetime. On session expiry the wrapper
+SIGTERMs the child process by default (configurable via
+`--on-session-loss={kill,warn,ignore}`). This is the safety contract
+`fleet_lock.py` gets wrong today.
+
+## Quorum degradation
+
+When the ZK ensemble temporarily loses quorum:
+
+- A ZK session owned by a prince in the middle of a lock hold expires
+  after `sessionTimeoutMs`.
+- The ephemeral znode backing that lock disappears; another prince (or
+  the same prince on a re-attempt) can acquire it if quorum returns.
+- Reply-dedup and other cluster-scoped TaskFlow consumers transition
+  the affected flow to `status: "blocked"` with
+  `reason: zk-quorum-lost-at-<ts>` and stop making progress. **No
+  replay** — a duplicate reply or duplicate scheduled task is worse
+  than none. Use `openclaw tasks flow resume <id>` to explicitly
+  re-enter once an operator has confirmed the state.
+
+## Path convention
+
+The recipes default-prefix paths under `/openclaw/<env>/<feature>/...`
+to prevent collisions across consumers. See the
+[path-prefix + evidence template](/plugins/zk-parity) for the reserved
+feature prefixes.
+
+To interop with existing Python callers (`fleet_lock.py` uses
+`/dandelioncult/thornfield/locks/...`), pass `--no-prefix` on the CLI
+or construct paths yourself via `joinPath` / `validatePath`.
+
+## Current status
+
+PR #1 ships the foundation — client, driver interface, native + mock
+drivers, errors, path helpers — and this subpath. Recipes land in PR 2,
+the CLI + integration suite in PR 3, cross-host TaskFlow ownership in
+PR 4, and the first internal consumer (reply dedup) in PR 5.
+
+See the parent tracking issue at karmaterminal/openclaw#175.

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1625,8 +1625,14 @@ export const registerTelegramHandlers = ({
             try {
               await updateSessionStore(storePath, (store) => {
                 const sessionKey = sessionState.sessionKey;
-                const entry = store[sessionKey] ?? {};
-                store[sessionKey] = entry;
+                const resolved = resolveSessionStoreEntry({ store, sessionKey });
+                const entry =
+                  resolved.existing ??
+                  ({} as Parameters<typeof applyModelOverrideToSessionEntry>[0]["entry"]);
+                store[resolved.normalizedKey] = entry;
+                for (const legacyKey of resolved.legacyKeys) {
+                  delete store[legacyKey];
+                }
                 applyModelOverrideToSessionEntry({
                   entry,
                   selection: {

--- a/extensions/whatsapp/src/auto-reply/heartbeat-runner.runtime.ts
+++ b/extensions/whatsapp/src/auto-reply/heartbeat-runner.runtime.ts
@@ -4,6 +4,7 @@ export {
   loadConfig,
   loadSessionStore,
   resolveSessionKey,
+  resolveSessionStoreEntry,
   resolveStorePath,
   updateSessionStore,
 } from "openclaw/plugin-sdk/config-runtime";

--- a/extensions/whatsapp/src/auto-reply/heartbeat-runner.ts
+++ b/extensions/whatsapp/src/auto-reply/heartbeat-runner.ts
@@ -20,6 +20,7 @@ import {
   resolveIndicatorType,
   resolveSendableOutboundReplyParts,
   resolveSessionKey,
+  resolveSessionStoreEntry,
   resolveStorePath,
   resolveWhatsAppHeartbeatRecipients,
   sendMessageWhatsApp,
@@ -97,19 +98,27 @@ export async function runWebHeartbeatOnce(opts: {
   if (sessionId) {
     const storePath = resolveStorePath(cfg.session?.store);
     const store = loadSessionStore(storePath);
-    const current = store[sessionKey] ?? {};
-    store[sessionKey] = {
+    const memResolved = resolveSessionStoreEntry({ store, sessionKey });
+    const current = memResolved.existing ?? {};
+    store[memResolved.normalizedKey] = {
       ...current,
       sessionId,
       updatedAt: Date.now(),
     };
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete store[legacyKey];
+    }
     await updateSessionStore(storePath, (nextStore) => {
-      const nextCurrent = nextStore[sessionKey] ?? current;
-      nextStore[sessionKey] = {
+      const resolved = resolveSessionStoreEntry({ store: nextStore, sessionKey });
+      const nextCurrent = resolved.existing ?? current;
+      nextStore[resolved.normalizedKey] = {
         ...nextCurrent,
         sessionId,
         updatedAt: Date.now(),
       };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete nextStore[legacyKey];
+      }
     });
   }
   const sessionSnapshot = getSessionSnapshot(cfg, to, true, { sessionKey });

--- a/package.json
+++ b/package.json
@@ -1086,6 +1086,10 @@
       "types": "./dist/plugin-sdk/zalouser.d.ts",
       "default": "./dist/plugin-sdk/zalouser.js"
     },
+    "./plugin-sdk/zk": {
+      "types": "./dist/plugin-sdk/zk.d.ts",
+      "default": "./dist/plugin-sdk/zk.js"
+    },
     "./plugin-sdk/zod": {
       "types": "./dist/plugin-sdk/zod.d.ts",
       "default": "./dist/plugin-sdk/zod.js"
@@ -1465,7 +1469,8 @@
     "@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
     "fake-indexeddb": "^6.2.5",
     "music-metadata": "^11.12.3",
-    "openshell": "0.1.0"
+    "openshell": "0.1.0",
+    "zookeeper": "^7.2.0"
   },
   "overrides": {
     "axios": "1.15.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,9 @@ importers:
       openshell:
         specifier: 0.1.0
         version: 0.1.0
+      zookeeper:
+        specifier: ^7.2.0
+        version: 7.2.0
 
   extensions/acpx:
     dependencies:
@@ -4515,6 +4518,9 @@ packages:
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -4531,6 +4537,10 @@ packages:
   audio-type@2.4.1:
     resolution: {integrity: sha512-dK9Z/P83C/rBfTrXXgPD3jZ+aXxx2o/P4rq8+H1JqxbXklitEeJw4CrcwMC5CkON3CX3yy2gaWnIEVYejYh0zQ==}
     engines: {node: '>=14'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   await-to-js@3.0.0:
     resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
@@ -4618,6 +4628,9 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
+  bl@1.2.3:
+    resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -4693,6 +4706,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -4831,6 +4848,9 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
@@ -4930,6 +4950,26 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-tar@4.1.1:
+    resolution: {integrity: sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==}
+    engines: {node: '>=4'}
+
+  decompress-tarbz2@4.1.1:
+    resolution: {integrity: sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==}
+    engines: {node: '>=4'}
+
+  decompress-targz@4.1.1:
+    resolution: {integrity: sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==}
+    engines: {node: '>=4'}
+
+  decompress-unzip@4.0.1:
+    resolution: {integrity: sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==}
+    engines: {node: '>=4'}
+
+  decompress@4.2.1:
+    resolution: {integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==}
+    engines: {node: '>=4'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -4944,6 +4984,10 @@ packages:
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
 
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -5218,6 +5262,10 @@ packages:
     resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
     engines: {node: '>=10'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
@@ -5333,6 +5381,10 @@ packages:
       debug:
         optional: true
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   form-data@2.5.4:
     resolution: {integrity: sha512-Y/3MmRiR8Nd+0CUtrbvcKtKzLWiUfpQ7DFVggH8PwmGt/0r7RSy32GuP4hpCJlQNEBusisSx1DLtD8uD386HJQ==}
     engines: {node: '>= 0.12'}
@@ -5349,6 +5401,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
@@ -5414,9 +5469,17 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@2.3.1:
+    resolution: {integrity: sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==}
+    engines: {node: '>=0.10.0'}
+
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
@@ -5487,6 +5550,9 @@ packages:
   has-own@1.0.1:
     resolution: {integrity: sha512-RDKhzgQTQfMaLvIFhjahU+2gGnRBK6dYOd5Gd9BzkmnBneOCRYjRC003RIMrdAbH52+l+CnMS4bBCXGer8tEhg==}
     deprecated: This project is not maintained. Use Object.hasOwn() instead.
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -5577,6 +5643,10 @@ packages:
     resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
     engines: {node: '>=8.12.0'}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -5632,6 +5702,10 @@ packages:
   ircv3@0.33.1:
     resolution: {integrity: sha512-FPUj/q6zsLgIX6QDdLMjPRBObw0xK+k6eiI62dcTRwdl5aezYV0nuMhpmafyHOD6ZDqfw8DW4ayrvDfmYO65JQ==}
 
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
@@ -5676,6 +5750,9 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
+  is-natural-number@4.0.1:
+    resolution: {integrity: sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==}
+
   is-network-error@1.3.1:
     resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
     engines: {node: '>=16'}
@@ -5705,9 +5782,17 @@ packages:
     resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
 
+  is-stream@1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
 
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -5730,6 +5815,9 @@ packages:
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -6062,6 +6150,10 @@ packages:
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
+  make-dir@1.3.0:
+    resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
+    engines: {node: '>=4'}
+
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
@@ -6225,6 +6317,9 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -6275,6 +6370,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-llama-cpp@3.18.1:
     resolution: {integrity: sha512-w0zfuy/IKS2fhrbed5SylZDXJHTVz4HnkwZ4UrFPgSNwJab3QIPwIl4lyCKHHy9flLrtxsAuV5kXfH3HZ6bb8w==}
@@ -6583,6 +6682,22 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pify@3.0.0:
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
+    engines: {node: '>=4'}
+
+  pinkie-promise@2.0.1:
+    resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==}
+    engines: {node: '>=0.10.0'}
+
+  pinkie@2.0.4:
+    resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
+    engines: {node: '>=0.10.0'}
+
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
 
@@ -6622,6 +6737,10 @@ packages:
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-values-parser@6.0.2:
     resolution: {integrity: sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==}
@@ -6992,6 +7111,10 @@ packages:
     resolution: {integrity: sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==}
     hasBin: true
 
+  seek-bzip@1.0.6:
+    resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
+    hasBin: true
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -7012,6 +7135,10 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
@@ -7029,6 +7156,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shelljs@0.10.0:
+    resolution: {integrity: sha512-Jex+xw5Mg2qMZL3qnzXIfaxEtBaC4n7xifqaqtrZDdlheR70OGkydrPJWT0V1cA1k3nanC86x9FwAmQl6w3Klw==}
+    engines: {node: '>=18'}
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
@@ -7240,6 +7371,9 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-dirs@2.1.0:
+    resolution: {integrity: sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==}
+
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
@@ -7279,6 +7413,10 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tar-stream@1.6.2:
+    resolution: {integrity: sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==}
+    engines: {node: '>= 0.8.0'}
+
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
@@ -7307,6 +7445,9 @@ packages:
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -7328,6 +7469,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -7431,6 +7576,10 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -7458,6 +7607,9 @@ packages:
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
+
+  unbzip2-stream@1.4.3:
+    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
@@ -7678,6 +7830,10 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -7748,6 +7904,10 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -7802,6 +7962,10 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zookeeper@7.2.0:
+    resolution: {integrity: sha512-4x9yk2HH1lHxLVPIh/3Ll6rkMNHEJACN4TZDI2oI9pkJDvbVEpzvn23qQK/5ctbUvS39+rSrxuAQ9NYFtG0Aig==}
+    engines: {node: '>=14.15.4'}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -11584,6 +11748,9 @@ snapshots:
     dependencies:
       retry: 0.13.1
 
+  async@3.2.6:
+    optional: true
+
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
@@ -11604,6 +11771,11 @@ snapshots:
     optional: true
 
   audio-type@2.4.1:
+    optional: true
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
     optional: true
 
   await-to-js@3.0.0: {}
@@ -11671,6 +11843,12 @@ snapshots:
   bignumber.js@9.3.1: {}
 
   birpc@4.0.0: {}
+
+  bl@1.2.3:
+    dependencies:
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+    optional: true
 
   bl@4.1.0:
     dependencies:
@@ -11765,6 +11943,14 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+    optional: true
 
   call-bound@1.0.4:
     dependencies:
@@ -11901,6 +12087,9 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@2.20.3:
+    optional: true
+
   commander@5.1.0: {}
 
   commander@7.2.0: {}
@@ -11980,6 +12169,59 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-tar@4.1.1:
+    dependencies:
+      file-type: 22.0.1
+      is-stream: 1.1.0
+      tar-stream: 1.6.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  decompress-tarbz2@4.1.1:
+    dependencies:
+      decompress-tar: 4.1.1
+      file-type: 22.0.1
+      is-stream: 1.1.0
+      seek-bzip: 1.0.6
+      unbzip2-stream: 1.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  decompress-targz@4.1.1:
+    dependencies:
+      decompress-tar: 4.1.1
+      file-type: 22.0.1
+      is-stream: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  decompress-unzip@4.0.1:
+    dependencies:
+      file-type: 22.0.1
+      get-stream: 2.3.1
+      pify: 2.3.0
+      yauzl: 3.2.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  decompress@4.2.1:
+    dependencies:
+      decompress-tar: 4.1.1
+      decompress-tarbz2: 4.1.1
+      decompress-targz: 4.1.1
+      decompress-unzip: 4.0.1
+      graceful-fs: 4.2.11
+      make-dir: 1.3.0
+      pify: 2.3.0
+      strip-dirs: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   deep-extend@0.6.0: {}
 
   default-browser-id@5.0.1: {}
@@ -11992,6 +12234,13 @@ snapshots:
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    optional: true
 
   define-lazy-prop@3.0.0: {}
 
@@ -12270,6 +12519,19 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+    optional: true
+
   exif-parser@0.1.12: {}
 
   expect-type@1.3.0: {}
@@ -12425,6 +12687,11 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+    optional: true
+
   form-data@2.5.4:
     dependencies:
       asynckit: 0.4.0
@@ -12441,6 +12708,9 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fs-constants@1.0.0:
+    optional: true
 
   fs-extra@11.3.4:
     dependencies:
@@ -12537,9 +12807,18 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@2.3.1:
+    dependencies:
+      object-assign: 4.1.1
+      pinkie-promise: 2.0.1
+    optional: true
+
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.4
+
+  get-stream@6.0.1:
+    optional: true
 
   get-tsconfig@4.13.7:
     dependencies:
@@ -12642,6 +12921,11 @@ snapshots:
   has-flag@4.0.0: {}
 
   has-own@1.0.1: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+    optional: true
 
   has-symbols@1.1.0: {}
 
@@ -12757,6 +13041,9 @@ snapshots:
 
   human-signals@1.1.1: {}
 
+  human-signals@2.1.0:
+    optional: true
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -12833,6 +13120,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  is-callable@1.2.7:
+    optional: true
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
@@ -12866,6 +13156,9 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
+  is-natural-number@4.0.1:
+    optional: true
+
   is-network-error@1.3.1: {}
 
   is-number@7.0.0: {}
@@ -12887,7 +13180,15 @@ snapshots:
 
   is-regexp@1.0.0: {}
 
+  is-stream@1.1.0:
+    optional: true
+
   is-stream@2.0.1: {}
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+    optional: true
 
   is-unicode-supported@0.1.0: {}
 
@@ -12902,6 +13203,9 @@ snapshots:
       is-inside-container: 1.0.0
 
   isarray@1.0.0: {}
+
+  isarray@2.0.5:
+    optional: true
 
   isexe@2.0.0: {}
 
@@ -13282,6 +13586,11 @@ snapshots:
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
+  make-dir@1.3.0:
+    dependencies:
+      pify: 3.0.0
+    optional: true
+
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
@@ -13457,6 +13766,9 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nan@2.26.2:
+    optional: true
+
   nanoid@3.3.11: {}
 
   nanoid@5.1.6: {}
@@ -13493,6 +13805,9 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-llama-cpp@3.18.1(typescript@6.0.2):
     dependencies:
@@ -13885,6 +14200,20 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pify@2.3.0:
+    optional: true
+
+  pify@3.0.0:
+    optional: true
+
+  pinkie-promise@2.0.1:
+    dependencies:
+      pinkie: 2.0.4
+    optional: true
+
+  pinkie@2.0.4:
+    optional: true
+
   pino-abstract-transport@2.0.0:
     dependencies:
       split2: 4.2.0
@@ -13924,6 +14253,9 @@ snapshots:
   pngjs@6.0.0: {}
 
   pngjs@7.0.0: {}
+
+  possible-typed-array-names@1.1.0:
+    optional: true
 
   postcss-values-parser@6.0.2(postcss@8.5.9):
     dependencies:
@@ -14387,6 +14719,11 @@ snapshots:
 
   sdp-transform@3.0.0: {}
 
+  seek-bzip@1.0.6:
+    dependencies:
+      commander: 2.20.3
+    optional: true
+
   semver@6.3.1:
     optional: true
 
@@ -14418,6 +14755,16 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0:
+    optional: true
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
     optional: true
 
   setimmediate@1.0.5: {}
@@ -14460,6 +14807,12 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shelljs@0.10.0:
+    dependencies:
+      execa: 5.1.1
+      fast-glob: 3.3.3
+    optional: true
 
   shiki@3.23.0:
     dependencies:
@@ -14698,6 +15051,11 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-dirs@2.1.0:
+    dependencies:
+      is-natural-number: 4.0.1
+    optional: true
+
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@2.0.1: {}
@@ -14726,6 +15084,17 @@ snapshots:
       wordwrapjs: 5.1.1
 
   tapable@2.3.2: {}
+
+  tar-stream@1.6.2:
+    dependencies:
+      bl: 1.2.3
+      buffer-alloc: 1.2.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      readable-stream: 2.3.8
+      to-buffer: 1.2.2
+      xtend: 4.0.2
+    optional: true
 
   tar-stream@3.1.8:
     dependencies:
@@ -14786,6 +15155,9 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  through@2.3.8:
+    optional: true
+
   tinybench@2.9.0: {}
 
   tinycolor2@1.6.0: {}
@@ -14800,6 +15172,13 @@ snapshots:
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
+
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+    optional: true
 
   to-regex-range@5.0.1:
     dependencies:
@@ -14901,6 +15280,13 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+    optional: true
+
   typescript@5.9.3: {}
 
   typescript@6.0.2: {}
@@ -14914,6 +15300,12 @@ snapshots:
   uhyphen@0.2.0: {}
 
   uint8array-extras@1.5.0: {}
+
+  unbzip2-stream@1.4.3:
+    dependencies:
+      buffer: 5.7.1
+      through: 2.3.8
+    optional: true
 
   unconfig-core@7.5.0:
     dependencies:
@@ -15080,6 +15472,17 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+    optional: true
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -15135,6 +15538,9 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlchars@2.2.0: {}
+
+  xtend@4.0.2:
+    optional: true
 
   y18n@5.0.8: {}
 
@@ -15196,5 +15602,17 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zookeeper@7.2.0:
+    dependencies:
+      async: 3.2.6
+      decompress: 4.2.1
+      decompress-targz: 4.1.1
+      nan: 2.26.2
+      node-gyp-build: 4.8.4
+      shelljs: 0.10.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   zwitch@2.0.4: {}

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -259,5 +259,6 @@
   "zalo",
   "zalo-setup",
   "zalouser",
+  "zk",
   "zod"
 ]

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -37,12 +37,19 @@ export async function clearSessionAuthProfileOverride(params: {
   delete sessionEntry.authProfileOverrideSource;
   delete sessionEntry.authProfileOverrideCompactionCount;
   sessionEntry.updatedAt = Date.now();
-  sessionStore[sessionKey] = sessionEntry;
+  const runtime = await loadSessionStoreRuntime();
+  const memResolved = runtime.resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+  sessionStore[memResolved.normalizedKey] = sessionEntry;
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
   if (storePath) {
-    await (
-      await loadSessionStoreRuntime()
-    ).updateSessionStore(storePath, (store) => {
-      store[sessionKey] = sessionEntry;
+    await runtime.updateSessionStore(storePath, (store) => {
+      const resolved = runtime.resolveSessionStoreEntry({ store, sessionKey });
+      store[resolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     });
   }
 }
@@ -159,12 +166,19 @@ export async function resolveSessionAuthProfileOverride(params: {
     sessionEntry.authProfileOverrideSource = "auto";
     sessionEntry.authProfileOverrideCompactionCount = compactionCount;
     sessionEntry.updatedAt = Date.now();
-    sessionStore[sessionKey] = sessionEntry;
+    const runtime = await loadSessionStoreRuntime();
+    const memResolved = runtime.resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+    sessionStore[memResolved.normalizedKey] = sessionEntry;
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
     if (storePath) {
-      await (
-        await loadSessionStoreRuntime()
-      ).updateSessionStore(storePath, (store) => {
-        store[sessionKey] = sessionEntry;
+      await runtime.updateSessionStore(storePath, (store) => {
+        const resolved = runtime.resolveSessionStoreEntry({ store, sessionKey });
+        store[resolved.normalizedKey] = sessionEntry;
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
       });
     }
   }

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -1,5 +1,6 @@
 import {
   mergeSessionEntry,
+  resolveSessionStoreEntry,
   setSessionRuntimeModel,
   type SessionEntry,
   updateSessionStore,
@@ -71,7 +72,8 @@ export async function updateSessionStoreAfterAgentRun(params: {
       allowAsyncLoad: false,
     }) ?? DEFAULT_CONTEXT_TOKENS;
 
-  const entry = sessionStore[sessionKey] ?? {
+  const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+  const entry = memResolved.existing ?? {
     sessionId,
     updatedAt: Date.now(),
   };
@@ -139,9 +141,16 @@ export async function updateSessionStoreAfterAgentRun(params: {
     next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;
   }
   const persisted = await updateSessionStore(storePath, (store) => {
-    const merged = mergeSessionEntry(store[sessionKey], next);
-    store[sessionKey] = merged;
+    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    const merged = mergeSessionEntry(resolved.existing, next);
+    store[resolved.normalizedKey] = merged;
+    for (const legacyKey of resolved.legacyKeys) {
+      delete store[legacyKey];
+    }
     return merged;
   });
-  sessionStore[sessionKey] = persisted;
+  sessionStore[memResolved.normalizedKey] = persisted;
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
 }

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -53,6 +53,15 @@ vi.mock("./model-selection.js", () => ({
 vi.mock("../config/sessions/store.js", () => ({
   loadSessionStore: (...args: unknown[]) => state.loadSessionStoreMock(...args),
   updateSessionStore: (...args: unknown[]) => state.updateSessionStoreMock(...args),
+  // Stubbed for swim-35/A1: identity-style resolver. The real impl applies
+  // session-key normalization; tests don't exercise the legacy-key cleanup paths.
+  resolveSessionStoreEntry: ({
+    store,
+    sessionKey,
+  }: {
+    store: Record<string, unknown>;
+    sessionKey: string;
+  }) => ({ normalizedKey: sessionKey, existing: store[sessionKey], legacyKeys: [] }),
 }));
 
 vi.mock("../config/sessions/paths.js", () => ({
@@ -63,6 +72,14 @@ vi.mock("../config/sessions.js", () => ({
   loadSessionStore: (...args: unknown[]) => state.loadSessionStoreMock(...args),
   resolveStorePath: (...args: unknown[]) => state.resolveStorePathMock(...args),
   updateSessionStore: (...args: unknown[]) => state.updateSessionStoreMock(...args),
+  // Stubbed for swim-35/A1: identity-style resolver. See store.js mock above.
+  resolveSessionStoreEntry: ({
+    store,
+    sessionKey,
+  }: {
+    store: Record<string, unknown>;
+    sessionKey: string;
+  }) => ({ normalizedKey: sessionKey, existing: store[sessionKey], legacyKeys: [] }),
 }));
 
 async function loadModule() {

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -1,5 +1,9 @@
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { loadSessionStore, updateSessionStore } from "../config/sessions/store.js";
+import {
+  loadSessionStore,
+  resolveSessionStoreEntry,
+  updateSessionStore,
+} from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
@@ -218,9 +222,14 @@ export async function clearLiveModelSwitchPending(params: {
     return;
   }
   await updateSessionStore(storePath, (store) => {
-    const entry = store[sessionKey];
+    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    const entry = resolved.existing;
     if (entry) {
       delete entry.liveModelSwitchPending;
+      store[resolved.normalizedKey] = entry;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     }
   });
 }

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -28,6 +28,7 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
+import { buildCopilotIdeHeaders } from "../copilot-dynamic-headers.js";
 import { isTimeoutError } from "../failover-error.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -233,7 +234,11 @@ async function resolveModelAuth(
       reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
     };
   }
-  return { ok: true, apiKey: requestAuth.apiKey, headers: requestAuth.headers };
+  const headers =
+    model.provider === "github-copilot"
+      ? { ...buildCopilotIdeHeaders(), ...requestAuth.headers }
+      : requestAuth.headers;
+  return { ok: true, apiKey: requestAuth.apiKey, headers };
 }
 
 function clampNonNegativeInt(value: unknown, fallback: number): number {

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -4,13 +4,13 @@ import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
   resolveAgentIdFromSessionKey,
+  resolveSessionStoreEntry,
   resolveStorePath,
   updateSessionStore,
   type SessionEntry,
 } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { defaultRuntime } from "../runtime.js";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { type SubagentRunOutcome } from "./subagent-announce-output.js";
 import { SUBAGENT_ENDED_REASON_ERROR } from "./subagent-lifecycle-events.js";
 import { runOutcomesEqual } from "./subagent-registry-completion.js";
@@ -74,17 +74,8 @@ export function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit
 }
 
 function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
-  const direct = store[sessionKey];
-  if (direct) {
-    return direct;
-  }
-  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
-  for (const [key, entry] of Object.entries(store)) {
-    if (normalizeLowercaseStringOrEmpty(key) === normalized) {
-      return entry;
-    }
-  }
-  return undefined;
+  const resolved = resolveSessionStoreEntry({ store, sessionKey });
+  return resolved.existing;
 }
 
 export async function persistSubagentSessionTiming(entry: SubagentRunRecord) {
@@ -106,7 +97,8 @@ export async function persistSubagentSessionTiming(entry: SubagentRunRecord) {
   const status = resolveSubagentSessionStatus(entry);
 
   await updateSessionStore(storePath, (store) => {
-    const sessionEntry = findSessionEntryByKey(store, childSessionKey);
+    const resolved = resolveSessionStoreEntry({ store, sessionKey: childSessionKey });
+    const sessionEntry = resolved.existing;
     if (!sessionEntry) {
       return;
     }
@@ -133,6 +125,13 @@ export async function persistSubagentSessionTiming(entry: SubagentRunRecord) {
       sessionEntry.status = status;
     } else {
       delete sessionEntry.status;
+    }
+
+    // Re-anchor under normalizedKey and clean up any legacy duplicates so
+    // that future reads don't pick the wrong copy.
+    store[resolved.normalizedKey] = sessionEntry;
+    for (const legacyKey of resolved.legacyKeys) {
+      delete store[legacyKey];
     }
   });
 }

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -57,6 +57,16 @@ vi.mock("../config/sessions.js", () => ({
   resolveAgentIdFromSessionKey: mocks.resolveAgentIdFromSessionKey,
   resolveStorePath: mocks.resolveStorePath,
   updateSessionStore: mocks.updateSessionStore,
+  // Stubbed for swim-35/A1: identity-style resolver returns normalizedKey=sessionKey,
+  // existing=store[sessionKey], no legacyKeys. The real impl applies session-key
+  // normalization; this test's session-key fixtures are already in canonical form.
+  resolveSessionStoreEntry: ({
+    store,
+    sessionKey,
+  }: {
+    store: Record<string, unknown>;
+    sessionKey: string;
+  }) => ({ normalizedKey: sessionKey, existing: store[sessionKey], legacyKeys: [] }),
 }));
 
 vi.mock("../sessions/session-lifecycle-events.js", () => ({

--- a/src/auto-reply/reply/abort-cutoff.runtime.ts
+++ b/src/auto-reply/reply/abort-cutoff.runtime.ts
@@ -1,4 +1,4 @@
-import { updateSessionStore } from "../../config/sessions/store.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { applyAbortCutoffToSessionEntry, hasAbortCutoff } from "./abort-cutoff.js";
 
@@ -15,17 +15,27 @@ export async function clearAbortCutoffInSessionRuntime(params: {
 
   applyAbortCutoffToSessionEntry(sessionEntry, undefined);
   sessionEntry.updatedAt = Date.now();
-  sessionStore[sessionKey] = sessionEntry;
+  {
+    const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+    sessionStore[memResolved.normalizedKey] = sessionEntry;
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
+  }
 
   if (storePath) {
     await updateSessionStore(storePath, (store) => {
-      const existing = store[sessionKey] ?? sessionEntry;
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      const existing = resolved.existing ?? sessionEntry;
       if (!existing) {
         return;
       }
       applyAbortCutoffToSessionEntry(existing, undefined);
       existing.updatedAt = Date.now();
-      store[sessionKey] = existing;
+      store[resolved.normalizedKey] = existing;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     });
   }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -29,6 +29,7 @@ import { isLikelyExecutionAckPrompt } from "../../agents/pi-embedded-runner/run/
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import {
   resolveGroupSessionKey,
+  resolveSessionStoreEntry,
   resolveSessionTranscriptPath,
   type SessionEntry,
   updateSessionStore,
@@ -1418,11 +1419,24 @@ export async function runAgentTurnWithFallback(params: {
           }
 
           // Keep the in-memory snapshot consistent with the on-disk store reset.
-          delete params.activeSessionStore[sessionKey];
+          {
+            const memResolved = resolveSessionStoreEntry({
+              store: params.activeSessionStore,
+              sessionKey,
+            });
+            delete params.activeSessionStore[memResolved.normalizedKey];
+            for (const legacyKey of memResolved.legacyKeys) {
+              delete params.activeSessionStore[legacyKey];
+            }
+          }
 
           // Remove session entry from store using a fresh, locked snapshot.
           await updateSessionStore(params.storePath, (store) => {
-            delete store[sessionKey];
+            const resolved = resolveSessionStoreEntry({ store, sessionKey });
+            delete store[resolved.normalizedKey];
+            for (const legacyKey of resolved.legacyKeys) {
+              delete store[legacyKey];
+            }
           });
         } catch (cleanupErr) {
           defaultRuntime.error(

--- a/src/auto-reply/reply/body.ts
+++ b/src/auto-reply/reply/body.ts
@@ -28,20 +28,31 @@ export async function applySessionHints(params: {
     if (params.sessionEntry && params.sessionStore && params.sessionKey) {
       params.sessionEntry.abortedLastRun = false;
       params.sessionEntry.updatedAt = Date.now();
-      params.sessionStore[params.sessionKey] = params.sessionEntry;
+      const sessionKey = params.sessionKey;
+      const runtime = await loadSessionStoreRuntime();
+      const memResolved = runtime.resolveSessionStoreEntry({
+        store: params.sessionStore,
+        sessionKey,
+      });
+      params.sessionStore[memResolved.normalizedKey] = params.sessionEntry;
+      for (const legacyKey of memResolved.legacyKeys) {
+        delete params.sessionStore[legacyKey];
+      }
       if (params.storePath) {
-        const sessionKey = params.sessionKey;
-        const { updateSessionStore } = await loadSessionStoreRuntime();
-        await updateSessionStore(params.storePath, (store) => {
-          const entry = store[sessionKey] ?? params.sessionEntry;
+        await runtime.updateSessionStore(params.storePath, (store) => {
+          const resolved = runtime.resolveSessionStoreEntry({ store, sessionKey });
+          const entry = resolved.existing ?? params.sessionEntry;
           if (!entry) {
             return;
           }
-          store[sessionKey] = {
+          store[resolved.normalizedKey] = {
             ...entry,
             abortedLastRun: false,
             updatedAt: Date.now(),
           };
+          for (const legacyKey of resolved.legacyKeys) {
+            delete store[legacyKey];
+          }
         });
       }
     } else if (params.abortKey) {

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -3,7 +3,7 @@ import { renderExecTargetLabel } from "../../agents/bash-tools.exec-runtime.js";
 import { resolveExecDefaults } from "../../agents/exec-defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
-import { updateSessionStore } from "../../config/sessions.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyTraceOverride, applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
@@ -414,10 +414,20 @@ export async function handleDirectiveOnly(
       }
     }
     sessionEntry.updatedAt = Date.now();
-    sessionStore[sessionKey] = sessionEntry;
+    {
+      const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+      sessionStore[memResolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of memResolved.legacyKeys) {
+        delete sessionStore[legacyKey];
+      }
+    }
     if (storePath) {
       await updateSessionStore(storePath, (store) => {
-        store[sessionKey] = sessionEntry;
+        const resolved = resolveSessionStoreEntry({ store, sessionKey });
+        store[resolved.normalizedKey] = sessionEntry;
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
       });
     }
     if (modelSelection && modelSelectionUpdated && sessionKey) {

--- a/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
+++ b/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
@@ -18,6 +18,14 @@ vi.mock("../../agents/sandbox.js", () => ({
 
 vi.mock("../../config/sessions/store.js", () => ({
   updateSessionStore: vi.fn(async () => {}),
+  // Stubbed for swim-35/A1: identity-style resolver. See sister test for rationale.
+  resolveSessionStoreEntry: vi.fn(
+    ({ store, sessionKey }: { store: Record<string, unknown>; sessionKey: string }) => ({
+      normalizedKey: sessionKey,
+      existing: store[sessionKey],
+      legacyKeys: [] as string[],
+    }),
+  ),
 }));
 
 vi.mock("../../infra/system-events.js", () => ({

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -70,6 +70,16 @@ vi.mock("../../agents/sandbox.js", () => ({
 
 vi.mock("../../config/sessions.js", () => ({
   updateSessionStore: vi.fn(async () => {}),
+  // Stubbed for swim-35/A1: identity-style resolver returns normalizedKey=sessionKey,
+  // existing=store[sessionKey], no legacyKeys. Real impl applies session-key normalization;
+  // tests don't exercise legacy-key cleanup paths, so this stub is behavior-equivalent here.
+  resolveSessionStoreEntry: vi.fn(
+    ({ store, sessionKey }: { store: Record<string, unknown>; sessionKey: string }) => ({
+      normalizedKey: sessionKey,
+      existing: store[sessionKey],
+      legacyKeys: [] as string[],
+    }),
+  ),
 }));
 
 vi.mock("../../infra/system-events.js", () => ({

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -6,7 +6,7 @@ import {
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
-import { updateSessionStore } from "../../config/sessions/store.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -211,10 +211,18 @@ export async function persistInlineDirectives(params: {
 
     if (updated) {
       sessionEntry.updatedAt = Date.now();
-      sessionStore[sessionKey] = sessionEntry;
+      const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+      sessionStore[memResolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of memResolved.legacyKeys) {
+        delete sessionStore[legacyKey];
+      }
       if (storePath) {
         await updateSessionStore(storePath, (store) => {
-          store[sessionKey] = sessionEntry;
+          const resolved = resolveSessionStoreEntry({ store, sessionKey });
+          store[resolved.normalizedKey] = sessionEntry;
+          for (const legacyKey of resolved.legacyKeys) {
+            delete store[legacyKey];
+          }
         });
       }
       enqueueModeSwitchEvents({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -466,11 +466,19 @@ export async function runPreparedReply(
     if (sessionEntry && sessionStore && sessionKey && sessionEntry.thinkingLevel === "xhigh") {
       sessionEntry.thinkingLevel = "high";
       sessionEntry.updatedAt = Date.now();
-      sessionStore[sessionKey] = sessionEntry;
+      const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+      sessionStore[memResolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of memResolved.legacyKeys) {
+        delete sessionStore[legacyKey];
+      }
       if (storePath) {
         const { updateSessionStore } = await loadSessionStoreRuntime();
         await updateSessionStore(storePath, (store) => {
-          store[sessionKey] = sessionEntry;
+          const resolved = resolveSessionStoreEntry({ store, sessionKey });
+          store[resolved.normalizedKey] = sessionEntry;
+          for (const legacyKey of resolved.legacyKeys) {
+            delete store[legacyKey];
+          }
         });
       }
     }

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -351,12 +351,19 @@ export async function createModelSelectionState(params: {
         selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
       });
       if (updated) {
-        sessionStore[sessionKey] = sessionEntry;
+        const runtime = await loadSessionStoreRuntime();
+        const memResolved = runtime.resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+        sessionStore[memResolved.normalizedKey] = sessionEntry;
+        for (const legacyKey of memResolved.legacyKeys) {
+          delete sessionStore[legacyKey];
+        }
         if (storePath) {
-          await (
-            await loadSessionStoreRuntime()
-          ).updateSessionStore(storePath, (store) => {
-            store[sessionKey] = sessionEntry;
+          await runtime.updateSessionStore(storePath, (store) => {
+            const resolved = runtime.resolveSessionStoreEntry({ store, sessionKey });
+            store[resolved.normalizedKey] = sessionEntry;
+            for (const legacyKey of resolved.legacyKeys) {
+              delete store[legacyKey];
+            }
           });
         }
       }

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -7,7 +7,7 @@ import {
   type ModelAliasIndex,
 } from "../../agents/model-selection.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { updateSessionStore } from "../../config/sessions.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -76,10 +76,18 @@ function applySelectionToSession(params: {
   if (!updated) {
     return;
   }
-  sessionStore[sessionKey] = sessionEntry;
+  const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+  sessionStore[memResolved.normalizedKey] = sessionEntry;
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
   if (storePath) {
     updateSessionStore(storePath, (store) => {
-      store[sessionKey] = sessionEntry;
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      store[resolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     }).catch(() => {
       // Ignore persistence errors; session still proceeds.
     });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -13,6 +13,7 @@ import {
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
+  resolveSessionStoreEntry,
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
@@ -35,15 +36,26 @@ async function persistSessionEntryUpdate(params: {
   if (!params.sessionStore || !params.sessionKey) {
     return;
   }
-  params.sessionStore[params.sessionKey] = {
-    ...params.sessionStore[params.sessionKey],
-    ...params.nextEntry,
-  };
+  const sessionKey = params.sessionKey;
+  {
+    const memResolved = resolveSessionStoreEntry({ store: params.sessionStore, sessionKey });
+    params.sessionStore[memResolved.normalizedKey] = {
+      ...memResolved.existing,
+      ...params.nextEntry,
+    };
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete params.sessionStore[legacyKey];
+    }
+  }
   if (!params.storePath) {
     return;
   }
   await updateSessionStore(params.storePath, (store) => {
-    store[params.sessionKey!] = { ...store[params.sessionKey!], ...params.nextEntry };
+    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    store[resolved.normalizedKey] = { ...resolved.existing, ...params.nextEntry };
+    for (const legacyKey of resolved.legacyKeys) {
+      delete store[legacyKey];
+    }
   });
 }
 
@@ -159,7 +171,7 @@ export async function ensureSkillSnapshot(params: {
 
   if (isFirstTurnInSession && sessionStore && sessionKey) {
     const current = nextEntry ??
-      sessionStore[sessionKey] ?? {
+      resolveSessionStoreEntry({ store: sessionStore, sessionKey }).existing ?? {
         sessionId: sessionId ?? crypto.randomUUID(),
         updatedAt: Date.now(),
       };
@@ -234,7 +246,8 @@ export async function incrementCompactionCount(params: {
   if (!sessionStore || !sessionKey) {
     return undefined;
   }
-  const entry = sessionStore[sessionKey] ?? sessionEntry;
+  const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+  const entry = memResolved.existing ?? sessionEntry;
   if (!entry) {
     return undefined;
   }
@@ -264,16 +277,23 @@ export async function incrementCompactionCount(params: {
     updates.cacheRead = undefined;
     updates.cacheWrite = undefined;
   }
-  sessionStore[sessionKey] = {
+  sessionStore[memResolved.normalizedKey] = {
     ...entry,
     ...updates,
   };
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
   if (storePath) {
     await updateSessionStore(storePath, (store) => {
-      store[sessionKey] = {
-        ...store[sessionKey],
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      store[resolved.normalizedKey] = {
+        ...(resolved.existing ?? entry),
         ...updates,
       };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     });
   }
   if (newSessionId && newSessionId !== entry.sessionId && cfg) {
@@ -282,7 +302,7 @@ export async function incrementCompactionCount(params: {
       sessionKey,
       storePath,
       previousEntry: entry,
-      nextEntry: sessionStore[sessionKey],
+      nextEntry: sessionStore[memResolved.normalizedKey],
     });
   }
   return nextCount;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -20,7 +20,11 @@ import {
 import { resolveAndPersistSessionFile } from "../../config/sessions/session-file.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
-import { loadSessionStore, updateSessionStore } from "../../config/sessions/store.js";
+import {
+  loadSessionStore,
+  resolveSessionStoreEntry,
+  updateSessionStore,
+} from "../../config/sessions/store.js";
 import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import {
   DEFAULT_RESET_TRIGGERS,
@@ -399,7 +403,7 @@ export async function initSessionState(params: {
   if (retiredLegacyMainDelivery) {
     sessionStore[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
   }
-  const entry = sessionStore[sessionKey];
+  const entry = resolveSessionStoreEntry({ store: sessionStore, sessionKey }).existing;
   const now = Date.now();
   const isThread = resolveThreadFlag({
     sessionKey,
@@ -451,7 +455,7 @@ export async function initSessionState(params: {
     previousSessionId: previousSessionEntry?.sessionId,
   });
 
-  if (!isNewSession && freshEntry) {
+  if (!isNewSession && freshEntry && entry) {
     sessionId = entry.sessionId;
     systemSent = entry.systemSent ?? false;
     abortedLastRun = entry.abortedLastRun ?? false;
@@ -716,12 +720,22 @@ export async function initSessionState(params: {
     sessionEntry.contextTokens = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
-  sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
+  {
+    const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+    sessionStore[memResolved.normalizedKey] = { ...memResolved.existing, ...sessionEntry };
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
+  }
   await updateSessionStore(
     storePath,
     (store) => {
       // Preserve per-session overrides while resetting compaction state on /new.
-      store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      store[resolved.normalizedKey] = { ...resolved.existing, ...sessionEntry };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
       if (retiredLegacyMainDelivery) {
         store[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
       }

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -125,6 +125,11 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       exportName: "registerDnsCli",
     },
     {
+      commandNames: ["zk"],
+      loadModule: () => import("../zk-cli.js"),
+      exportName: "registerZkCli",
+    },
+    {
       commandNames: ["docs"],
       loadModule: () => import("../docs-cli.js"),
       exportName: "registerDocsCli",

--- a/src/cli/zk-cli.ts
+++ b/src/cli/zk-cli.ts
@@ -1,0 +1,512 @@
+/**
+ * `openclaw zk` subcommand — operator-facing wrapper over the
+ * plugin-sdk/zk primitives. Registered through `command-bootstrap.ts`
+ * with `{ loadPlugins: "never", ensureCliPath: false }` — this subtree
+ * has no plugin interaction, so we skip the plugin registry on cold
+ * start for fast CLI dispatch.
+ *
+ * Commands (flock-style `-- <cmd…>` wrappers):
+ *   openclaw zk ping [--hosts <csv>]
+ *   openclaw zk setup
+ *   openclaw zk lock <path> [-- <cmd…>]
+ *   openclaw zk lock status <path>
+ *   openclaw zk elect <path> --id <name> -- <cmd…>
+ *   openclaw zk party join <path> --id <name>
+ *   openclaw zk party list <path>
+ *   openclaw zk rwlock {read|write} <path> -- <cmd…>
+ *   openclaw zk ls <path>
+ *
+ * All paths are validated against `[A-Za-z0-9._/-]+` via `validatePath`
+ * before being passed to any driver op.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import type { Command } from "commander";
+import { loadConfig } from "../config/config.js";
+import type { ZkClient } from "../plugin-sdk/zk.js";
+import {
+  ZkNativeDriverUnavailableError,
+  createElection,
+  createLock,
+  createParty,
+  createReadWriteLock,
+  createZkClient,
+  featurePath,
+  validatePath,
+} from "../plugin-sdk/zk.js";
+
+const DEFAULT_HOSTS = "zk-client.fleet-coordination.svc.cluster.local:2181";
+
+function resolveHosts(flagHosts: string | undefined): string {
+  if (flagHosts && flagHosts.trim()) {
+    return flagHosts.trim();
+  }
+  const env = process.env.ZK_HOSTS?.trim();
+  if (env) {
+    return env;
+  }
+  try {
+    const cfg = loadConfig();
+    const fromCfg = cfg?.zk?.hosts?.trim();
+    if (fromCfg) {
+      return fromCfg;
+    }
+  } catch {
+    // Config unreachable on cold CLI — fall through to default.
+  }
+  return DEFAULT_HOSTS;
+}
+
+function resolveEnv(): string {
+  // `deploy.env` isn't a formal config field today; read it loosely so
+  // operators can set it without a schema change. Falls back to "fleet".
+  try {
+    const cfg = loadConfig() as unknown as { deploy?: { env?: string } };
+    if (cfg?.deploy?.env && typeof cfg.deploy.env === "string") {
+      return cfg.deploy.env;
+    }
+  } catch {
+    // Fall through.
+  }
+  return "fleet";
+}
+
+function applyPrefix(userPath: string, feature: string, noPrefix: boolean): string {
+  if (noPrefix) {
+    validatePath(userPath);
+    return userPath;
+  }
+  // userPath is treated as a relative name under the feature prefix, or an
+  // absolute znode path that starts with `/`. If absolute, use as-is.
+  if (userPath.startsWith("/")) {
+    validatePath(userPath);
+    return userPath;
+  }
+  return featurePath(resolveEnv(), feature, userPath);
+}
+
+async function openClient(flagHosts: string | undefined): Promise<ZkClient> {
+  const hosts = resolveHosts(flagHosts);
+  try {
+    return await createZkClient({ hosts });
+  } catch (err) {
+    if (err instanceof ZkNativeDriverUnavailableError) {
+      process.stderr.write(
+        `zookeeper native driver not installed.\n\n` +
+          `Run: openclaw zk setup\n\n` +
+          `This installs node-gyp prereqs (build-essential + python3) and the\n` +
+          `\`zookeeper\` optional dependency. No-op if already installed.\n`,
+      );
+      process.exit(2);
+    }
+    throw err;
+  }
+}
+
+function runChildForOwnership(
+  cmd: string[],
+  onSessionLoss: "kill" | "warn" | "ignore",
+): Promise<number> {
+  return new Promise((resolve) => {
+    const [bin, ...args] = cmd;
+    if (!bin) {
+      process.stderr.write("no command to run after `--`\n");
+      resolve(2);
+      return;
+    }
+    const child = spawn(bin, args, { stdio: "inherit" });
+    child.on("exit", (code, signal) => {
+      resolve(code ?? (signal ? 128 : 0));
+    });
+    child.on("error", (err) => {
+      process.stderr.write(`spawn error: ${err.message}\n`);
+      resolve(127);
+    });
+    // The caller plumbs session-loss → SIGTERM on `onSessionLoss === "kill"`
+    // via a separate hook; this function just runs the child.
+    void onSessionLoss;
+  });
+}
+
+export function registerZkCli(program: Command): void {
+  const zk = program
+    .command("zk")
+    .description("ZooKeeper coordination primitives (locks, elections, parties)");
+
+  zk.command("ping")
+    .description("Connect to the ensemble and print the session id")
+    .option("--hosts <csv>", "comma-separated host:port list; overrides ZK_HOSTS / config")
+    .action(async (opts: { hosts?: string }) => {
+      const client = await openClient(opts.hosts);
+      try {
+        process.stdout.write(`connected to ${resolveHosts(opts.hosts)} (state=${client.state})\n`);
+      } finally {
+        await client.close();
+      }
+    });
+
+  zk.command("setup")
+    .description("Install node-gyp prereqs + the `zookeeper` native npm package")
+    .action(async () => {
+      await runSetup();
+    });
+
+  // Lock subtree
+  const lockCmd = zk.command("lock").description("Exclusive distributed lock (flock-style)");
+  lockCmd
+    .command("acquire <path> [cmd...]")
+    .description("Acquire lock; if `-- <cmd…>` provided, hold for subprocess lifetime")
+    .option("--hosts <csv>")
+    .option("--id <name>", "identifier stored as lock data (default: $HOSTNAME)")
+    .option("--timeout <ms>", "fail if not acquired within this window", parseIntOpt)
+    .option("--no-prefix", "skip the /openclaw/<env>/user/locks prefix")
+    .option("--on-session-loss <mode>", "kill|warn|ignore the child if ZK session expires", "kill")
+    .action(
+      async (
+        pathArg: string,
+        cmd: string[],
+        opts: {
+          hosts?: string;
+          id?: string;
+          timeout?: number;
+          noPrefix?: boolean;
+          onSessionLoss?: "kill" | "warn" | "ignore";
+        },
+      ) => {
+        const client = await openClient(opts.hosts);
+        const fullPath = applyPrefix(pathArg, "user/locks", Boolean(opts.noPrefix));
+        const identifier = opts.id ?? process.env.HOSTNAME ?? "anon";
+        const lock = createLock(client, fullPath, identifier);
+        const onSessionLoss = opts.onSessionLoss ?? "kill";
+        let childPid: number | null = null;
+        const unsub = client.state$()[Symbol.asyncIterator]();
+        const watchLoss = (async () => {
+          for (;;) {
+            const next = await unsub.next();
+            if (next.done) {
+              return;
+            }
+            if (next.value === "expired" && childPid !== null && onSessionLoss !== "ignore") {
+              const pid: number = childPid;
+              if (onSessionLoss === "kill") {
+                process.stderr.write(`zk session expired — SIGTERM child ${String(pid)}\n`);
+                try {
+                  process.kill(pid, "SIGTERM");
+                } catch {
+                  // Already gone — fine.
+                }
+              } else {
+                process.stderr.write(
+                  `::warning:: zk session expired; child ${String(pid)} still running\n`,
+                );
+              }
+              return;
+            }
+          }
+        })();
+        try {
+          const handle = await lock.acquire(opts.timeout ? { timeoutMs: opts.timeout } : undefined);
+          try {
+            process.stderr.write(`lock acquired: ${handle.ownerPath}\n`);
+            if (cmd.length === 0) {
+              // No child — just report acquisition and exit on SIGTERM/SIGINT.
+              await waitForSignal();
+            } else {
+              const child = spawn(cmd[0], cmd.slice(1), { stdio: "inherit" });
+              childPid = child.pid ?? null;
+              const code = await new Promise<number>((resolve) => {
+                child.on("exit", (c, sig) => resolve(c ?? (sig ? 128 : 0)));
+                child.on("error", (err) => {
+                  process.stderr.write(`spawn error: ${err.message}\n`);
+                  resolve(127);
+                });
+              });
+              process.exit(code);
+            }
+          } finally {
+            await handle.release();
+          }
+        } finally {
+          await unsub.return?.();
+          await watchLoss;
+          await client.close();
+        }
+      },
+    );
+  lockCmd
+    .command("status <path>")
+    .description("Show lock owner + contenders")
+    .option("--hosts <csv>")
+    .option("--no-prefix")
+    .action(async (pathArg: string, opts: { hosts?: string; noPrefix?: boolean }) => {
+      const client = await openClient(opts.hosts);
+      const fullPath = applyPrefix(pathArg, "user/locks", Boolean(opts.noPrefix));
+      const lock = createLock(client, fullPath);
+      try {
+        const c = await lock.contenders();
+        if (c.length === 0) {
+          process.stdout.write(`no contenders at ${fullPath}\n`);
+        } else {
+          process.stdout.write(`${fullPath}:\n`);
+          for (const name of c) {
+            process.stdout.write(`  ${name}\n`);
+          }
+        }
+      } finally {
+        await client.close();
+      }
+    });
+
+  // Election
+  zk.command("elect <path> [cmd...]")
+    .description("Run `<cmd…>` as the elected leader; SIGTERM on leadership loss")
+    .option("--hosts <csv>")
+    .option("--id <name>", "candidate identifier (default: $HOSTNAME)")
+    .option("--no-prefix")
+    .action(
+      async (
+        pathArg: string,
+        cmd: string[],
+        opts: { hosts?: string; id?: string; noPrefix?: boolean },
+      ) => {
+        if (cmd.length === 0) {
+          process.stderr.write("`openclaw zk elect` requires `-- <cmd…>`\n");
+          process.exit(2);
+        }
+        const client = await openClient(opts.hosts);
+        const fullPath = applyPrefix(pathArg, "user/elections", Boolean(opts.noPrefix));
+        const identifier = opts.id ?? process.env.HOSTNAME ?? "anon";
+        const election = createElection(client, fullPath, identifier);
+        try {
+          await election.run(async (signal) => {
+            process.stderr.write(`elected leader at ${fullPath} (id=${identifier})\n`);
+            const child = spawn(cmd[0], cmd.slice(1), { stdio: "inherit" });
+            const abortHandler = () => {
+              if (!child.killed) {
+                process.stderr.write("leadership lost — SIGTERM child\n");
+                try {
+                  child.kill("SIGTERM");
+                } catch {
+                  /* no-op */
+                }
+              }
+            };
+            signal.addEventListener("abort", abortHandler, { once: true });
+            const code = await new Promise<number>((resolve) => {
+              child.on("exit", (c, sig) => resolve(c ?? (sig ? 128 : 0)));
+              child.on("error", () => resolve(127));
+            });
+            process.exit(code);
+          });
+        } finally {
+          await client.close();
+        }
+      },
+    );
+
+  // Party
+  const partyCmd = zk.command("party").description("Group membership (ephemeral)");
+  partyCmd
+    .command("join <path>")
+    .description("Join the party; hold membership until SIGTERM")
+    .option("--hosts <csv>")
+    .option("--id <name>", "member identifier (default: $HOSTNAME)")
+    .option("--no-prefix")
+    .action(async (pathArg: string, opts: { hosts?: string; id?: string; noPrefix?: boolean }) => {
+      const client = await openClient(opts.hosts);
+      const fullPath = applyPrefix(pathArg, "user/parties", Boolean(opts.noPrefix));
+      const identifier = opts.id ?? process.env.HOSTNAME ?? "anon";
+      const party = createParty(client, fullPath, identifier);
+      try {
+        await party.join();
+        process.stderr.write(`joined party ${fullPath} as ${identifier}\n`);
+        await waitForSignal();
+      } finally {
+        await party.leave().catch(() => undefined);
+        await client.close();
+      }
+    });
+  partyCmd
+    .command("list <path>")
+    .description("List current members")
+    .option("--hosts <csv>")
+    .option("--no-prefix")
+    .action(async (pathArg: string, opts: { hosts?: string; noPrefix?: boolean }) => {
+      const client = await openClient(opts.hosts);
+      const fullPath = applyPrefix(pathArg, "user/parties", Boolean(opts.noPrefix));
+      const party = createParty(client, fullPath, "obs");
+      try {
+        const members = await party.members();
+        if (members.length === 0) {
+          process.stdout.write(`no members at ${fullPath}\n`);
+        } else {
+          for (const m of members) {
+            process.stdout.write(`${m}\n`);
+          }
+        }
+      } finally {
+        await client.close();
+      }
+    });
+
+  // RWLock
+  const rwCmd = zk
+    .command("rwlock")
+    .description("Reader/writer locks (many readers, exclusive writer)");
+  rwCmd
+    .command("read <path> [cmd...]")
+    .description("Acquire a reader lock; run `<cmd…>` while held")
+    .option("--hosts <csv>")
+    .option("--id <name>")
+    .option("--timeout <ms>", "acquire timeout", parseIntOpt)
+    .option("--no-prefix")
+    .action(
+      async (
+        pathArg: string,
+        cmd: string[],
+        opts: { hosts?: string; id?: string; timeout?: number; noPrefix?: boolean },
+      ) => {
+        await runRwSubcommand(cmd, opts, "read", pathArg);
+      },
+    );
+  rwCmd
+    .command("write <path> [cmd...]")
+    .description("Acquire a writer lock; run `<cmd…>` while held")
+    .option("--hosts <csv>")
+    .option("--id <name>")
+    .option("--timeout <ms>", "acquire timeout", parseIntOpt)
+    .option("--no-prefix")
+    .action(
+      async (
+        pathArg: string,
+        cmd: string[],
+        opts: { hosts?: string; id?: string; timeout?: number; noPrefix?: boolean },
+      ) => {
+        await runRwSubcommand(cmd, opts, "write", pathArg);
+      },
+    );
+
+  zk.command("ls <path>")
+    .description("List children at a znode path (no prefix applied)")
+    .option("--hosts <csv>")
+    .action(async (pathArg: string, opts: { hosts?: string }) => {
+      validatePath(pathArg);
+      const client = await openClient(opts.hosts);
+      try {
+        const children = await client.driver.getChildren(pathArg);
+        for (const c of children) {
+          process.stdout.write(`${c}\n`);
+        }
+      } finally {
+        await client.close();
+      }
+    });
+}
+
+async function runRwSubcommand(
+  cmd: string[],
+  opts: { hosts?: string; id?: string; timeout?: number; noPrefix?: boolean },
+  kind: "read" | "write",
+  pathArg: string,
+): Promise<void> {
+  const client = await openClient(opts.hosts);
+  const fullPath = applyPrefix(pathArg, "user/locks", Boolean(opts.noPrefix));
+  const rw = createReadWriteLock(client, fullPath);
+  const lock = kind === "read" ? rw.readLock(opts.id) : rw.writeLock(opts.id);
+  try {
+    const handle = await lock.acquire(opts.timeout ? { timeoutMs: opts.timeout } : undefined);
+    try {
+      process.stderr.write(`${kind}-lock acquired: ${handle.ownerPath}\n`);
+      if (cmd.length > 0) {
+        const code = await runChildForOwnership(cmd, "kill");
+        process.exit(code);
+      } else {
+        await waitForSignal();
+      }
+    } finally {
+      await handle.release();
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+function parseIntOpt(raw: string): number {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(`invalid integer: ${raw}`);
+  }
+  return n;
+}
+
+function waitForSignal(): Promise<void> {
+  return new Promise((resolve) => {
+    const done = () => {
+      process.off("SIGTERM", done);
+      process.off("SIGINT", done);
+      resolve();
+    };
+    process.once("SIGTERM", done);
+    process.once("SIGINT", done);
+  });
+}
+
+async function runSetup(): Promise<void> {
+  // Detect OS package manager.
+  const managers: { name: string; bin: string; packages: string[] }[] = [
+    { name: "apt", bin: "apt-get", packages: ["build-essential", "python3"] },
+    { name: "pacman", bin: "pacman", packages: ["base-devel", "python"] },
+    { name: "dnf", bin: "dnf", packages: ["gcc", "gcc-c++", "make", "python3"] },
+  ];
+  let chosen: (typeof managers)[number] | null = null;
+  for (const m of managers) {
+    if (spawnSync("which", [m.bin], { stdio: "ignore" }).status === 0) {
+      chosen = m;
+      break;
+    }
+  }
+  if (!chosen) {
+    process.stderr.write(
+      "No supported package manager found (looked for apt-get / pacman / dnf).\n" +
+        "Install build-essential-equivalent + python3 manually, then run:\n" +
+        "  npm install -g zookeeper@^7.2.0\n",
+    );
+    process.exit(2);
+  }
+
+  process.stderr.write(`Detected ${chosen.name}; will install: ${chosen.packages.join(", ")}\n`);
+
+  const installArgs =
+    chosen.name === "apt"
+      ? ["install", "-y", ...chosen.packages]
+      : chosen.name === "pacman"
+        ? ["-S", "--noconfirm", ...chosen.packages]
+        : ["install", "-y", ...chosen.packages];
+
+  const res = spawnSync("sudo", [chosen.bin, ...installArgs], { stdio: "inherit" });
+  if (res.status !== 0) {
+    process.stderr.write(
+      `\nCould not run ${chosen.name} install via sudo.\n` +
+        "Run these commands manually, then re-run `openclaw zk setup`:\n" +
+        `  sudo ${chosen.bin} ${installArgs.join(" ")}\n` +
+        "  npm install -g zookeeper@^7.2.0\n",
+    );
+    process.exit(2);
+  }
+
+  // Install the zookeeper package globally into openclaw's install dir.
+  // `npm install -g` respects the operator's npm prefix; if that prefix
+  // needs root, sudo it.
+  const npmRes = spawnSync("npm", ["install", "-g", "zookeeper@^7.2.0"], { stdio: "inherit" });
+  if (npmRes.status !== 0) {
+    const sudoRes = spawnSync("sudo", ["npm", "install", "-g", "zookeeper@^7.2.0"], {
+      stdio: "inherit",
+    });
+    if (sudoRes.status !== 0) {
+      process.stderr.write("\nFailed to install `zookeeper` npm package. Install manually.\n");
+      process.exit(2);
+    }
+  }
+
+  process.stderr.write("\nzk setup done. Try `openclaw zk ping` to verify.\n");
+}

--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   formatSessionArchiveTimestamp,
+  isCheckpointSessionTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
+  parseParentSessionIdFromCheckpointFileName,
   parseUsageCountedSessionIdFromFileName,
   parseSessionArchiveTimestamp,
 } from "./artifacts.js";
@@ -50,6 +52,32 @@ describe("session artifact helpers", () => {
     ).toBe("abc");
     expect(parseUsageCountedSessionIdFromFileName("abc.jsonl.bak.2026-01-01T00-00-00.000Z")).toBe(
       null,
+    );
+  });
+
+  it("classifies checkpoint transcript files and extracts parent session id", () => {
+    const parent = "e417ba9b-8043-43db-8d18-d88f1823567d";
+    const ckp = "21901ee7-8f22-4d07-9e39-6eaf7b224630";
+
+    // Positive: well-formed checkpoint sibling.
+    expect(isCheckpointSessionTranscriptFileName(`${parent}.checkpoint.${ckp}.jsonl`)).toBe(true);
+    expect(parseParentSessionIdFromCheckpointFileName(`${parent}.checkpoint.${ckp}.jsonl`)).toBe(
+      parent,
+    );
+
+    // Negative: primary, archive, non-uuid suffix, or substring matches.
+    expect(isCheckpointSessionTranscriptFileName(`${parent}.jsonl`)).toBe(false);
+    expect(
+      isCheckpointSessionTranscriptFileName(`${parent}.jsonl.deleted.2026-01-01T00-00-00.000Z`),
+    ).toBe(false);
+    // Substring contains "checkpoint" but is missing the UUID shape — must not dedup.
+    expect(isCheckpointSessionTranscriptFileName("my-checkpoint-review-session.jsonl")).toBe(false);
+    expect(parseParentSessionIdFromCheckpointFileName("my-checkpoint-review-session.jsonl")).toBe(
+      null,
+    );
+    // Shape looks close but the trailing UUID segment is malformed.
+    expect(isCheckpointSessionTranscriptFileName(`${parent}.checkpoint.not-a-uuid.jsonl`)).toBe(
+      false,
     );
   });
 

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -3,6 +3,13 @@ export type SessionArchiveReason = "bak" | "reset" | "deleted";
 const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
 const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
 
+// Anchored at end of file name: literal `.checkpoint.` + UUID-v4 shape + `.jsonl`.
+// Session IDs that happen to contain the substring "checkpoint" (with any suffix
+// shape) do NOT match because the UUID regex requires the exact `[0-9a-f]{8}-…`
+// shape immediately after `.checkpoint.` and `.jsonl` immediately after that.
+const CHECKPOINT_MARKER_RE =
+  /\.checkpoint\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+
 function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boolean {
   const marker = `.${reason}.`;
   const index = fileName.lastIndexOf(marker);
@@ -39,6 +46,30 @@ export function isUsageCountedSessionTranscriptFileName(fileName: string): boole
     return true;
   }
   return hasArchiveSuffix(fileName, "reset") || hasArchiveSuffix(fileName, "deleted");
+}
+
+/**
+ * Classify pre-compaction checkpoint-twin transcript files, e.g.
+ * `<parentId>.checkpoint.<uuid>.jsonl`. Uses an anchored UUID-shape match so
+ * session IDs that happen to contain the substring "checkpoint" do not
+ * false-positive.
+ */
+export function isCheckpointSessionTranscriptFileName(fileName: string): boolean {
+  return CHECKPOINT_MARKER_RE.test(fileName);
+}
+
+/**
+ * Extract the parent session id from a checkpoint transcript file name. The
+ * parent session id is the part BEFORE `.checkpoint.<uuid>.jsonl`; it matches
+ * what `isPrimarySessionTranscriptFileName` expects when the parent primary
+ * exists as `<parentId>.jsonl`. Returns `null` if the file is not a checkpoint.
+ */
+export function parseParentSessionIdFromCheckpointFileName(fileName: string): string | null {
+  const match = fileName.match(CHECKPOINT_MARKER_RE);
+  if (!match || match.index === undefined) {
+    return null;
+  }
+  return fileName.slice(0, match.index);
 }
 
 export function parseUsageCountedSessionIdFromFileName(fileName: string): string | null {

--- a/src/config/sessions/session-file.ts
+++ b/src/config/sessions/session-file.ts
@@ -1,6 +1,6 @@
 import { resolveSessionFilePath } from "./paths.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
-import { updateSessionStore } from "./store.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
 
 export async function resolveAndPersistSessionFile(params: {
@@ -16,8 +16,9 @@ export async function resolveAndPersistSessionFile(params: {
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
 }): Promise<{ sessionFile: string; sessionEntry: SessionEntry }> {
   const { sessionId, sessionKey, sessionStore, storePath } = params;
+  const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
   const baseEntry = params.sessionEntry ??
-    sessionStore[sessionKey] ?? { sessionId, updatedAt: Date.now() };
+    memResolved.existing ?? { sessionId, updatedAt: Date.now() };
   const fallbackSessionFile = params.fallbackSessionFile?.trim();
   const entryForResolve =
     !baseEntry.sessionFile && fallbackSessionFile
@@ -34,14 +35,21 @@ export async function resolveAndPersistSessionFile(params: {
     sessionFile,
   };
   if (baseEntry.sessionId !== sessionId || baseEntry.sessionFile !== sessionFile) {
-    sessionStore[sessionKey] = persistedEntry;
+    sessionStore[memResolved.normalizedKey] = persistedEntry;
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
     await updateSessionStore(
       storePath,
       (store) => {
-        store[sessionKey] = {
-          ...store[sessionKey],
+        const resolved = resolveSessionStoreEntry({ store, sessionKey });
+        store[resolved.normalizedKey] = {
+          ...resolved.existing,
           ...persistedEntry,
         };
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
       },
       params.activeSessionKey || params.maintenanceConfig
         ? {
@@ -52,6 +60,9 @@ export async function resolveAndPersistSessionFile(params: {
     );
     return { sessionFile, sessionEntry: persistedEntry };
   }
-  sessionStore[sessionKey] = persistedEntry;
+  sessionStore[memResolved.normalizedKey] = persistedEntry;
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
   return { sessionFile, sessionEntry: persistedEntry };
 }

--- a/src/config/sessions/store.runtime.ts
+++ b/src/config/sessions/store.runtime.ts
@@ -1,1 +1,1 @@
-export { updateSessionStore, updateSessionStoreEntry } from "./store.js";
+export { resolveSessionStoreEntry, updateSessionStore, updateSessionStoreEntry } from "./store.js";

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -28,6 +28,7 @@ import type { PluginsConfig } from "./types.plugins.js";
 import type { SecretsConfig } from "./types.secrets.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
+import type { ZkConfig } from "./types.zk.js";
 
 export type OpenClawConfig = {
   meta?: {
@@ -122,6 +123,12 @@ export type OpenClawConfig = {
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
   mcp?: McpConfig;
+  /**
+   * ZooKeeper coordination primitives + cross-host TaskFlow ownership.
+   * See `docs/plugins/zk.md`. Resolution: CLI flag > ZK_HOSTS env var >
+   * this config > default (in-cluster DNS).
+   */
+  zk?: ZkConfig;
 };
 
 declare const openClawConfigStateBrand: unique symbol;

--- a/src/config/types.zk.ts
+++ b/src/config/types.zk.ts
@@ -1,0 +1,26 @@
+/**
+ * ZooKeeper coordination config. Consumed by `src/plugin-sdk/zk`
+ * (createZkClient) + `src/cli/zk-cli.ts`. Resolution precedence at read
+ * time:
+ *
+ *   CLI flag (e.g. `--hosts`)  >  ZK_HOSTS env var
+ *                              >  openclaw config (this type)
+ *                              >  default (`zk-client.fleet-coordination.svc.cluster.local:2181`)
+ *
+ * The `ZK_HOSTS` env precedence matches the kazoo + Python `fleet_lock.py`
+ * muscle memory and is non-negotiable. If no config is set and the
+ * default DNS name doesn't resolve from the host, `createZkClient`
+ * fails fast with an explicit operator message — no silent tailnet
+ * sniffing.
+ */
+
+export type ZkConfig = {
+  /** Comma-separated ZK connection string ("host1:port,host2:port"). */
+  hosts?: string;
+  /** Chroot path applied to every operation (ZK 3.5+). */
+  chroot?: string;
+  /** Session timeout in milliseconds (default 10_000). */
+  sessionTimeoutMs?: number;
+  /** Connect timeout in milliseconds (default 5_000). */
+  connectTimeoutMs?: number;
+};

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -150,6 +150,7 @@ export const AgentDefaultsSchema = z
         postCompactionSections: z.array(z.string()).optional(),
         model: z.string().optional(),
         timeoutSeconds: z.number().int().positive().optional(),
+        truncateAfterCompaction: z.boolean().optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -230,6 +230,18 @@ const McpConfigSchema = z
   .strict()
   .optional();
 
+// ZooKeeper coordination config. See `src/config/types.zk.ts` + `docs/plugins/zk.md`.
+// Resolution: CLI flag > ZK_HOSTS env > persisted config (this schema) > default.
+const ZkConfigSchema = z
+  .object({
+    hosts: z.string().min(1).optional(),
+    chroot: z.string().min(1).optional(),
+    sessionTimeoutMs: z.number().int().positive().optional(),
+    connectTimeoutMs: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const OpenClawSchema = z
   .object({
     $schema: z.string().optional(),
@@ -898,6 +910,7 @@ export const OpenClawSchema = z
       .optional(),
     memory: MemorySchema,
     mcp: McpConfigSchema,
+    zk: ZkConfigSchema,
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -37,6 +37,7 @@ import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
 import {
   archiveRemovedSessionTranscripts,
+  resolveSessionStoreEntry,
   saveSessionStore,
   updateSessionStore,
 } from "../config/sessions/store.js";
@@ -425,7 +426,8 @@ async function restoreHeartbeatUpdatedAt(params: {
     return;
   }
   const store = loadSessionStore(storePath);
-  const entry = store[sessionKey];
+  const resolvedRead = resolveSessionStoreEntry({ store, sessionKey });
+  const entry = resolvedRead.existing;
   if (!entry) {
     return;
   }
@@ -434,7 +436,8 @@ async function restoreHeartbeatUpdatedAt(params: {
     return;
   }
   await updateSessionStore(storePath, (nextStore) => {
-    const nextEntry = nextStore[sessionKey] ?? entry;
+    const resolved = resolveSessionStoreEntry({ store: nextStore, sessionKey });
+    const nextEntry = resolved.existing ?? entry;
     if (!nextEntry) {
       return;
     }
@@ -442,7 +445,10 @@ async function restoreHeartbeatUpdatedAt(params: {
     if (nextEntry.updatedAt === resolvedUpdatedAt) {
       return;
     }
-    nextStore[sessionKey] = { ...nextEntry, updatedAt: resolvedUpdatedAt };
+    nextStore[resolved.normalizedKey] = { ...nextEntry, updatedAt: resolvedUpdatedAt };
+    for (const legacyKey of resolved.legacyKeys) {
+      delete nextStore[legacyKey];
+    }
   });
 }
 
@@ -911,7 +917,8 @@ export async function runHeartbeatOnce(opts: {
     }
 
     const store = loadSessionStore(storePath);
-    const current = store[sessionKey];
+    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    const current = resolved.existing;
     // Initialize stub entry on first run when current doesn't exist
     const base = current ?? {
       // Generate valid sessionId - derive from sessionKey without colons
@@ -930,7 +937,10 @@ export async function runHeartbeatOnce(opts: {
       }
     }
 
-    store[sessionKey] = { ...base, heartbeatTaskState: taskState };
+    store[resolved.normalizedKey] = { ...base, heartbeatTaskState: taskState };
+    for (const legacyKey of resolved.legacyKeys) {
+      delete store[legacyKey];
+    }
     await saveSessionStore(storePath, store);
   };
 
@@ -1215,13 +1225,17 @@ export async function runHeartbeatOnce(opts: {
     // Record last delivered heartbeat payload for dedupe.
     if (!shouldSkipMain && normalized.text.trim()) {
       const store = loadSessionStore(storePath);
-      const current = store[sessionKey];
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      const current = resolved.existing;
       if (current) {
-        store[sessionKey] = {
+        store[resolved.normalizedKey] = {
           ...current,
           lastHeartbeatText: normalized.text,
           lastHeartbeatSentAt: startedAt,
         };
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
         await saveSessionStore(storePath, store);
       }
     }

--- a/src/infra/session-cost-usage.discoverAllSessions.test.ts
+++ b/src/infra/session-cost-usage.discoverAllSessions.test.ts
@@ -1,0 +1,153 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { type DiscoveredSession, discoverAllSessions } from "./session-cost-usage.js";
+
+// ---------------------------------------------------------------------------
+// openclaw-bootstrap#475 — checkpoint dedup regression coverage
+//
+// discoverAllSessions must NOT treat `<parentId>.checkpoint.<uuid>.jsonl`
+// files as distinct sessions. They are pre-compaction snapshot siblings of
+// the parent primary and must be grouped under the parent session id. See
+// src/config/sessions/artifacts.ts for the classifier + parent-id parser.
+// ---------------------------------------------------------------------------
+
+const PARENT_UUID = "e417ba9b-8043-43db-8d18-d88f1823567d";
+const OTHER_PARENT_UUID = "71029058-ffdd-4def-9a8c-c84f9e1e3f01";
+const CHECKPOINT_UUIDS = [
+  "21901ee7-8f22-4d07-9e39-6eaf7b224630",
+  "44d92356-464c-4556-9403-77096e791375",
+  "47b9a01e-169a-442c-8e42-52f2188051eb",
+  "7da74434-2bd8-499e-8216-ba3fa0869884",
+  "ac813e2a-ad7b-4a0f-9f7b-26c0fbac2746",
+];
+
+const USER_JSONL_LINE = JSON.stringify({
+  type: "message",
+  message: { role: "user", content: "hello from parent primary" },
+});
+const EMPTY_JSONL = "";
+
+async function makeAgentSessionsDir(root: string, agentId = "main"): Promise<string> {
+  const sessionsDir = path.join(root, "agents", agentId, "sessions");
+  await fs.mkdir(sessionsDir, { recursive: true });
+  return sessionsDir;
+}
+
+async function discoverUnder(stateDir: string): Promise<DiscoveredSession[]> {
+  return await withEnvAsync(
+    { OPENCLAW_STATE_DIR: stateDir },
+    async () => await discoverAllSessions(),
+  );
+}
+
+describe("discoverAllSessions — checkpoint dedup (bootstrap#475)", () => {
+  const suiteRootTracker = createSuiteTempRootTracker({
+    prefix: "openclaw-discover-ckp-",
+  });
+
+  beforeAll(async () => {
+    await suiteRootTracker.setup();
+  });
+
+  afterAll(async () => {
+    await suiteRootTracker.cleanup();
+  });
+
+  it("(a) single primary: surfaces one discovered session", async () => {
+    const root = await suiteRootTracker.make("case-a");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+  });
+
+  it("(b) primary + one checkpoint: one discovered session under parent id", async () => {
+    const root = await suiteRootTracker.make("case-b");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+    await fs.writeFile(
+      path.join(sessionsDir, `${PARENT_UUID}.checkpoint.${CHECKPOINT_UUIDS[0]}.jsonl`),
+      EMPTY_JSONL,
+    );
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+    // Primary's sessionFile wins over checkpoint's sessionFile.
+    expect(discovered[0]?.sessionFile.endsWith(`${PARENT_UUID}.jsonl`)).toBe(true);
+  });
+
+  it("(c) five checkpoints only, parent primary missing: one discovered entry under parent id", async () => {
+    const root = await suiteRootTracker.make("case-c");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    for (const ckpUuid of CHECKPOINT_UUIDS) {
+      await fs.writeFile(
+        path.join(sessionsDir, `${PARENT_UUID}.checkpoint.${ckpUuid}.jsonl`),
+        EMPTY_JSONL,
+      );
+    }
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+  });
+
+  it("(d) primary + five checkpoints (Elliott shape): one discovered session", async () => {
+    const root = await suiteRootTracker.make("case-d");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+    for (const ckpUuid of CHECKPOINT_UUIDS) {
+      await fs.writeFile(
+        path.join(sessionsDir, `${PARENT_UUID}.checkpoint.${ckpUuid}.jsonl`),
+        EMPTY_JSONL,
+      );
+    }
+    // Also include an unrelated session to be sure discover returns 2 total, not 6.
+    await fs.writeFile(path.join(sessionsDir, `${OTHER_PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+
+    const discovered = await discoverUnder(root);
+    const ids = discovered.map((d) => d.sessionId).toSorted();
+    expect(ids).toEqual([OTHER_PARENT_UUID, PARENT_UUID].toSorted());
+  });
+
+  it("(e) .reset./.deleted. archives: still counted as their own entries (usage-count preserved)", async () => {
+    const root = await suiteRootTracker.make("case-e");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    // Primary present, plus one reset archive and one deleted archive for the same id.
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+    await fs.writeFile(
+      path.join(sessionsDir, `${PARENT_UUID}.jsonl.reset.2026-01-01T00-00-00.000Z`),
+      EMPTY_JSONL,
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, `${PARENT_UUID}.jsonl.deleted.2026-02-02T00-00-00.000Z`),
+      EMPTY_JSONL,
+    );
+
+    const discovered = await discoverUnder(root);
+    // The archives share the same session id and dedup with the primary in the
+    // discover map, so final count is 1 — the primary wins sessionFile.
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+    expect(discovered[0]?.sessionFile.endsWith(`${PARENT_UUID}.jsonl`)).toBe(true);
+  });
+
+  it("(f) primary with 'checkpoint' substring in session id: NOT dedup (regex anchored)", async () => {
+    const root = await suiteRootTracker.make("case-f");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    // This file name contains "checkpoint" in the session id portion, but
+    // does NOT match the UUID-anchored checkpoint regex. Must be treated as
+    // a distinct primary session.
+    const trickyId = "my-checkpoint-review-session";
+    await fs.writeFile(path.join(sessionsDir, `${trickyId}.jsonl`), USER_JSONL_LINE);
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(trickyId);
+  });
+});

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -5,9 +5,11 @@ import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import {
+  isCheckpointSessionTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
+  parseParentSessionIdFromCheckpointFileName,
   parseSessionArchiveTimestamp,
   parseUsageCountedSessionIdFromFileName,
 } from "../config/sessions/artifacts.js";
@@ -470,6 +472,48 @@ export async function discoverAllSessions(params?: {
       continue;
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
+
+    // Checkpoint-twin dedup (issue #475): `<parentId>.checkpoint.<uuid>.jsonl`
+    // files are pre-compaction snapshot siblings of the parent primary
+    // session. They must NOT surface as distinct discovered sessions — that
+    // lopsides the discover map (one lopsided prince session can present as
+    // 6 separate sessions) and, worse, opens each file for first-user-message
+    // extraction, which is the dominant read cost on a prince with deep
+    // checkpoint history. Group them under the parent session id, do not
+    // re-read for label (the parent primary already carries it), and advance
+    // the parent's mtime if this checkpoint is newer.
+    if (isCheckpointSessionTranscriptFileName(entry.name)) {
+      const parentId = parseParentSessionIdFromCheckpointFileName(entry.name);
+      if (!parentId) {
+        continue;
+      }
+      const existing = discovered.get(parentId);
+      if (!existing) {
+        // Parent primary may not have been scanned yet (or may be absent
+        // entirely, which is the parent-missing recovery case). Record the
+        // checkpoint's mtime under the parent id without a sessionFile
+        // commitment; the parent primary will replace this entry when we
+        // encounter it via the primary branch below.
+        discovered.set(parentId, {
+          sessionId: parentId,
+          sessionFile: filePath,
+          mtime: stats.mtimeMs,
+          firstUserMessage: undefined,
+        });
+      } else if (stats.mtimeMs > existing.mtime) {
+        // Advance the parent's mtime if this checkpoint is newer; do NOT
+        // overwrite sessionFile when existing points at a primary transcript.
+        const existingIsPrimary = isPrimarySessionTranscriptFileName(
+          path.basename(existing.sessionFile),
+        );
+        discovered.set(parentId, {
+          ...existing,
+          sessionFile: existingIsPrimary ? existing.sessionFile : filePath,
+          mtime: stats.mtimeMs,
+        });
+      }
+      continue;
+    }
 
     const sessionId = parseUsageCountedSessionIdFromFileName(entry.name);
     if (!sessionId) {

--- a/src/plugin-sdk/zk.test.ts
+++ b/src/plugin-sdk/zk.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  ZkError,
+  _createMockDriverSync,
+  _expireMockSession,
+  createMockCluster,
+  createZkClient,
+  featurePath,
+  joinPath,
+  parentPath,
+  validatePath,
+} from "./zk.js";
+
+describe("plugin-sdk/zk — paths", () => {
+  it("joinPath normalizes slashes", () => {
+    expect(joinPath("/openclaw", "fleet", "user", "locks")).toBe("/openclaw/fleet/user/locks");
+    expect(joinPath("/openclaw/", "/fleet/", "reply")).toBe("/openclaw/fleet/reply");
+  });
+
+  it("validatePath rejects known-bad shapes", () => {
+    expect(() => validatePath("")).toThrow(ZkError);
+    expect(() => validatePath("no-leading-slash")).toThrow(ZkError);
+    expect(() => validatePath("/ends/in/slash/")).toThrow(ZkError);
+    expect(() => validatePath("/double//slash")).toThrow(ZkError);
+    expect(() => validatePath("/path/../escape")).toThrow(ZkError);
+    expect(() => validatePath("/null\u0000byte")).toThrow(ZkError);
+  });
+
+  it("validatePath accepts reasonable znode paths", () => {
+    expect(() => validatePath("/")).not.toThrow();
+    expect(() => validatePath("/openclaw/fleet/user/locks/deploy")).not.toThrow();
+    expect(() => validatePath("/a.b_c-d")).not.toThrow();
+  });
+
+  it("parentPath returns the parent znode", () => {
+    expect(parentPath("/")).toBe("/");
+    expect(parentPath("/a")).toBe("/");
+    expect(parentPath("/a/b/c")).toBe("/a/b");
+  });
+
+  it("featurePath applies the openclaw convention", () => {
+    expect(featurePath("fleet", "taskflow", "flow-abc")).toBe("/openclaw/fleet/taskflow/flow-abc");
+    expect(featurePath("", "user/locks", "deploy")).toBe("/openclaw/fleet/user/locks/deploy");
+  });
+});
+
+describe("plugin-sdk/zk — mock driver", () => {
+  it("honors persistent create + get + delete", async () => {
+    const cluster = createMockCluster();
+    const driver = _createMockDriverSync({ hosts: "mock", cluster });
+
+    await driver.create("/a", Buffer.from("hello"), "persistent");
+    const got = await driver.get("/a");
+    expect(got.data.toString()).toBe("hello");
+    expect(got.stat.version).toBe(0);
+
+    await driver.delete("/a");
+    expect(await driver.exists("/a")).toBeNull();
+    await driver.close();
+  });
+
+  it("assigns monotonic sequential suffixes", async () => {
+    const cluster = createMockCluster();
+    const driver = _createMockDriverSync({ hosts: "mock", cluster });
+
+    await driver.create("/root", Buffer.alloc(0), "persistent");
+    const p1 = await driver.create("/root/seq-", Buffer.alloc(0), "persistent-sequential");
+    const p2 = await driver.create("/root/seq-", Buffer.alloc(0), "persistent-sequential");
+    expect(p1.endsWith("0000000000")).toBe(true);
+    expect(p2.endsWith("0000000001")).toBe(true);
+    await driver.close();
+  });
+
+  it("removes ephemerals on close", async () => {
+    const cluster = createMockCluster();
+    const driver = _createMockDriverSync({
+      hosts: "mock",
+      cluster,
+      sessionId: "s1",
+    });
+
+    await driver.create("/root", Buffer.alloc(0), "persistent");
+    await driver.create("/root/ephem", Buffer.from("id:s1"), "ephemeral");
+    expect(await driver.exists("/root/ephem")).not.toBeNull();
+
+    await driver.close();
+    // Re-open another driver on same cluster: ephemeral should be gone.
+    const driver2 = _createMockDriverSync({ hosts: "mock", cluster, sessionId: "s2" });
+    expect(await driver2.exists("/root/ephem")).toBeNull();
+    await driver2.close();
+  });
+
+  it("_expireMockSession removes session ephemerals + sets state=expired", async () => {
+    const cluster = createMockCluster();
+    let lastState = "";
+    const driver = _createMockDriverSync({
+      hosts: "mock",
+      cluster,
+      sessionId: "s1",
+      onStateChange: (s) => {
+        lastState = s;
+      },
+    });
+
+    await driver.create("/root", Buffer.alloc(0), "persistent");
+    await driver.create("/root/ephem", Buffer.alloc(0), "ephemeral");
+
+    _expireMockSession(cluster, "s1");
+    expect(driver.state).toBe("expired");
+    expect(lastState).toBe("connected");
+    // After expiry the driver rejects ops so callers can observe the loss.
+    await expect(driver.get("/root/ephem")).rejects.toBeInstanceOf(ZkError);
+  });
+});
+
+describe("plugin-sdk/zk — client wrapper", () => {
+  it("wraps a mock driver and exposes .state + close", async () => {
+    const cluster = createMockCluster();
+    const driver = _createMockDriverSync({ hosts: "mock", cluster });
+
+    const client = await createZkClient({ hosts: "mock", driver });
+    expect(client.state).toBe("connected");
+    await client.close();
+    expect(client.state).toBe("closed");
+    // Second close is idempotent.
+    await client.close();
+  });
+});

--- a/src/plugin-sdk/zk.ts
+++ b/src/plugin-sdk/zk.ts
@@ -1,0 +1,104 @@
+/**
+ * Public entry point for the openclaw ZooKeeper coordination SDK.
+ *
+ *   import { createZkClient, ZkError, featurePath } from "openclaw/plugin-sdk/zk";
+ *
+ * This file re-exports contract types eagerly (cheap — no wire code), and
+ * exposes `createZkClient` as an async factory that dynamically imports
+ * the heavy driver module on first call. Cold `import` of this subpath
+ * will not touch the `zookeeper` native binding — that only loads on a
+ * real `createZkClient({ hosts: ... })` call.
+ *
+ * Recipes (Lock, LeaderElection, Party, ReadWriteLock) land in PR 2 and
+ * are re-exported from this same subpath.
+ *
+ * See `docs/plugins/zk.md` for operator setup + the `ZK_HOSTS` contract,
+ * and `docs/plugins/zk-parity.md` for the kazoo-parity roadmap + the
+ * path-prefix convention + wire-up evidence template.
+ */
+
+// Contract types (zero runtime cost).
+export type {
+  ConnectionState,
+  CreateMode,
+  WatchEvent,
+  ZkDriver,
+  ZkDriverFactory,
+  ZkDriverOptions,
+  ZkStat,
+  ToZkErrorFn,
+} from "./zk/driver.js";
+export type { ZkClient, ZkClientOptions } from "./zk/client.js";
+export type { ZkErrorCode } from "./zk/errors.js";
+
+// Error constructors — tiny, fine to re-export eagerly.
+export {
+  ZkError,
+  SessionExpiredError,
+  ConnectionLossError,
+  NoNodeError,
+  NodeExistsError,
+  ZkNativeDriverUnavailableError,
+  toZkError,
+} from "./zk/errors.js";
+
+// Path helpers — pure, no wire deps.
+export {
+  ZK_ROOT,
+  ZK_DEFAULT_ENV,
+  joinPath,
+  validatePath,
+  featurePath,
+  parentPath,
+  basename,
+} from "./zk/paths.js";
+
+// Mock driver factory — exported so consumers can build fast unit tests
+// against the same contract without a running ensemble. Re-exported
+// eagerly because it has no native deps.
+export {
+  createMockDriver,
+  createMockCluster,
+  _createMockDriverSync,
+  _expireMockSession,
+} from "./zk/driver-mock.js";
+export type { MockCluster, CreateMockDriverOptions } from "./zk/driver-mock.js";
+
+import type { ZkClient, ZkClientOptions } from "./zk/client.js";
+
+/**
+ * Open a new ZooKeeper session. Resolves once the underlying driver
+ * transitions to `"connected"` (or rejects with `ConnectionLossError`
+ * on `connectTimeoutMs` — default 5000ms).
+ *
+ * In production this dynamically imports `./zk/driver-native.ts`, which
+ * in turn dynamic-imports the `zookeeper` native npm package. When the
+ * native package isn't installed (typical on boxes without the node-gyp
+ * toolchain), the returned promise rejects with
+ * `ZkNativeDriverUnavailableError` — message points at `openclaw zk setup`.
+ *
+ * Tests inject `driver` directly; no native import.
+ */
+export async function createZkClient(opts: ZkClientOptions): Promise<ZkClient> {
+  const { wrapDriver, buildStateDispatcher } = await import("./zk/client.js");
+  const dispatcher = buildStateDispatcher();
+  let driver = opts.driver;
+  if (!driver) {
+    const { createNativeDriver } = await import("./zk/driver-native.js");
+    driver = await createNativeDriver({
+      ...opts,
+      onStateChange: (state) => {
+        dispatcher.onStateChange(state);
+        opts.onStateChange?.(state);
+      },
+    });
+  } else {
+    // Caller-provided driver — tap its state emissions too.
+    const prev = opts.onStateChange;
+    opts.onStateChange = (state) => {
+      dispatcher.onStateChange(state);
+      prev?.(state);
+    };
+  }
+  return wrapDriver(driver);
+}

--- a/src/plugin-sdk/zk.ts
+++ b/src/plugin-sdk/zk.ts
@@ -64,6 +64,19 @@ export {
 } from "./zk/driver-mock.js";
 export type { MockCluster, CreateMockDriverOptions } from "./zk/driver-mock.js";
 
+// Recipes — zero-runtime-cost until invoked. Each recipe is pure logic
+// over `ZkClient.driver`, so re-exporting them from the public barrel
+// doesn't pull in any wire code.
+export { createLock, withLock } from "./zk/lock.js";
+export type { Lock, LockHandle, CreateLockOptions } from "./zk/lock.js";
+export { createElection } from "./zk/election.js";
+export type { LeaderElection } from "./zk/election.js";
+export { createParty } from "./zk/party.js";
+export type { Party } from "./zk/party.js";
+export { createReadWriteLock } from "./zk/rwlock.js";
+export type { ReadWriteLock } from "./zk/rwlock.js";
+export { ensurePath } from "./zk/ensure-path.js";
+
 import type { ZkClient, ZkClientOptions } from "./zk/client.js";
 
 /**

--- a/src/plugin-sdk/zk/client.ts
+++ b/src/plugin-sdk/zk/client.ts
@@ -1,0 +1,169 @@
+/**
+ * ZkClient wraps a ZkDriver with:
+ *   - AsyncIterable<ConnectionState> for recipe subscriptions
+ *   - lifecycle helpers (close once, idempotent)
+ *   - `.driver` escape hatch for recipes that need direct wire ops
+ *
+ * This file is runtime-level but deliberately small. `zk.ts` (the
+ * plugin-sdk barrel) dynamic-imports it so a cold `import "openclaw/plugin-sdk/zk"`
+ * stays type-only.
+ */
+
+import type { ConnectionState, ZkDriver, ZkDriverOptions } from "./driver.js";
+
+export interface ZkClient {
+  readonly state: ConnectionState;
+  state$(signal?: AbortSignal): AsyncIterable<ConnectionState>;
+  close(): Promise<void>;
+  readonly driver: ZkDriver;
+}
+
+export type ZkClientOptions = ZkDriverOptions & {
+  /**
+   * Injected driver — tests pass the mock driver; production passes nothing
+   * (the native driver is the implicit default, resolved by `zk.ts`).
+   */
+  driver?: ZkDriver;
+};
+
+type StateSubscriber = (state: ConnectionState) => void;
+
+/**
+ * Build a client from an already-constructed driver. This is the seam the
+ * barrel (`zk.ts`) calls after it decides which driver to hand in.
+ */
+export function wrapDriver(driver: ZkDriver, onExternalStateChange?: StateSubscriber): ZkClient {
+  const subscribers = new Set<StateSubscriber>();
+  if (onExternalStateChange) {
+    subscribers.add(onExternalStateChange);
+  }
+  let closed = false;
+
+  const emit = (state: ConnectionState) => {
+    for (const sub of Array.from(subscribers)) {
+      try {
+        sub(state);
+      } catch {
+        // Subscriber errors must not kill the fan-out.
+      }
+    }
+  };
+
+  // Drivers emit state via their onStateChange callback. We don't own that
+  // callback here — it was wired up when the driver was constructed by the
+  // barrel. This wrapDriver fan-out is for downstream consumers that want
+  // to tap the same stream.
+  void emit;
+
+  return {
+    get state() {
+      return driver.state;
+    },
+    state$(signal) {
+      return subscribeState(subscribers, () => driver.state, signal);
+    },
+    async close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      await driver.close();
+    },
+    get driver() {
+      return driver;
+    },
+  };
+}
+
+/**
+ * Produce an AsyncIterable that yields the current state, then every
+ * future transition, until the signal aborts or the client closes.
+ */
+export function subscribeState(
+  subscribers: Set<StateSubscriber>,
+  getCurrent: () => ConnectionState,
+  signal?: AbortSignal,
+): AsyncIterable<ConnectionState> {
+  return {
+    [Symbol.asyncIterator]() {
+      const queue: ConnectionState[] = [getCurrent()];
+      let resolveNext: ((value: IteratorResult<ConnectionState>) => void) | null = null;
+      let done = false;
+
+      const drainOrEnqueue = (state: ConnectionState) => {
+        if (done) {
+          return;
+        }
+        if (resolveNext) {
+          const fn = resolveNext;
+          resolveNext = null;
+          fn({ value: state, done: false });
+        } else {
+          queue.push(state);
+        }
+      };
+
+      const sub: StateSubscriber = (state) => drainOrEnqueue(state);
+      subscribers.add(sub);
+
+      const abortHandler = () => {
+        done = true;
+        subscribers.delete(sub);
+        if (resolveNext) {
+          const fn = resolveNext;
+          resolveNext = null;
+          fn({ value: undefined, done: true });
+        }
+      };
+      if (signal) {
+        if (signal.aborted) {
+          abortHandler();
+        } else {
+          signal.addEventListener("abort", abortHandler, { once: true });
+        }
+      }
+
+      return {
+        next(): Promise<IteratorResult<ConnectionState>> {
+          if (done) {
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          if (queue.length > 0) {
+            const value = queue.shift()!;
+            return Promise.resolve({ value, done: false });
+          }
+          return new Promise<IteratorResult<ConnectionState>>((resolve) => {
+            resolveNext = resolve;
+          });
+        },
+        return(): Promise<IteratorResult<ConnectionState>> {
+          done = true;
+          subscribers.delete(sub);
+          return Promise.resolve({ value: undefined, done: true });
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Hook used by ZkClient builders to tee state-change events out of a
+ * driver's lifetime into the subscriber fan-out. Wires cleanly with
+ * both the native and mock drivers.
+ */
+export function buildStateDispatcher(): {
+  subscribers: Set<StateSubscriber>;
+  onStateChange: (state: ConnectionState) => void;
+} {
+  const subscribers = new Set<StateSubscriber>();
+  const onStateChange: StateSubscriber = (state) => {
+    for (const sub of Array.from(subscribers)) {
+      try {
+        sub(state);
+      } catch {
+        // Silence subscriber-side exceptions.
+      }
+    }
+  };
+  return { subscribers, onStateChange };
+}

--- a/src/plugin-sdk/zk/driver-mock.ts
+++ b/src/plugin-sdk/zk/driver-mock.ts
@@ -1,0 +1,398 @@
+/**
+ * In-memory ZkDriver that honors the semantics recipes depend on:
+ *   - ephemeral znodes disappear when the owning session closes/expires
+ *   - *-sequential nodes suffix a monotonic 10-digit counter
+ *   - data + children watches are one-shot; callers re-arm after each event
+ *   - create(parent missing) → NoNodeError, create(existing) → NodeExistsError
+ *   - delete(version mismatch) / set(version mismatch) → "version-mismatch" ZkError
+ *
+ * The mock deliberately DOES NOT simulate wire-level reconnects,
+ * partitions, or readonly mode — callers wanting those scenarios should
+ * run the testcontainer integration suite behind
+ * `OPENCLAW_ZK_INTEGRATION=1`. This file's job is recipe correctness,
+ * not wire simulation.
+ *
+ * Per session (driver instance) there is a private `sessionId`. Ephemeral
+ * nodes track which session owns them; closing the session removes them.
+ */
+
+import type {
+  ConnectionState,
+  WatchEvent,
+  ZkDriver,
+  ZkDriverFactory,
+  ZkDriverOptions,
+  ZkStat,
+} from "./driver.js";
+import { NoNodeError, NodeExistsError, ZkError, toZkError } from "./errors.js";
+import { parentPath, validatePath } from "./paths.js";
+
+type MockNode = {
+  path: string;
+  data: Buffer;
+  version: number;
+  cversion: number;
+  aversion: number;
+  sessionId: string | null; // non-null for ephemeral nodes
+  children: Set<string>; // basenames of direct children
+  sequentialCounter: number;
+  createdAt: string;
+  modifiedAt: string;
+};
+
+type WatchKind = "data" | "children" | "exists";
+
+type WatchSubscriber = {
+  kind: WatchKind;
+  path: string;
+  resolve: (event: WatchEvent) => void;
+};
+
+/**
+ * Shared state across all drivers pointing at the same mock cluster. Pass
+ * `{ cluster }` to `createMockDriver` to let two drivers observe the same
+ * znode tree — required for tests that exercise cross-host semantics
+ * (e.g. two princes contending for the same lock path).
+ */
+export type MockCluster = {
+  readonly _brand: "MockCluster";
+  /** reset-all — useful between test cases. Drops every znode + watch. */
+  reset(): void;
+  /** number of live nodes, for test assertions */
+  nodeCount(): number;
+};
+
+type ClusterState = {
+  nodes: Map<string, MockNode>;
+  watches: Set<WatchSubscriber>;
+  sessions: Map<string, { state: ConnectionState; ephemerals: Set<string> }>;
+};
+
+export function createMockCluster(): MockCluster {
+  const state: ClusterState = { nodes: new Map(), watches: new Set(), sessions: new Map() };
+  // Seed root.
+  state.nodes.set("/", makeNode("/", Buffer.alloc(0), null));
+  const proxy: MockCluster & { __state: ClusterState } = {
+    _brand: "MockCluster",
+    reset() {
+      state.nodes.clear();
+      state.watches.clear();
+      state.sessions.clear();
+      state.nodes.set("/", makeNode("/", Buffer.alloc(0), null));
+    },
+    nodeCount() {
+      return state.nodes.size;
+    },
+    __state: state,
+  };
+  return proxy;
+}
+
+function makeNode(path: string, data: Buffer, sessionId: string | null): MockNode {
+  const now = new Date().toISOString();
+  return {
+    path,
+    data,
+    version: 0,
+    cversion: 0,
+    aversion: 0,
+    sessionId,
+    children: new Set(),
+    sequentialCounter: 0,
+    createdAt: now,
+    modifiedAt: now,
+  };
+}
+
+function toStat(node: MockNode): ZkStat {
+  return {
+    version: node.version,
+    cversion: node.cversion,
+    aversion: node.aversion,
+    ephemeralOwner: node.sessionId,
+    dataLength: node.data.length,
+    numChildren: node.children.size,
+    createdAt: node.createdAt,
+    modifiedAt: node.modifiedAt,
+  };
+}
+
+function fireWatch(state: ClusterState, event: WatchEvent): void {
+  for (const sub of Array.from(state.watches)) {
+    const match =
+      (sub.kind === "data" && sub.path === event.path && event.kind !== "children-changed") ||
+      (sub.kind === "exists" &&
+        sub.path === event.path &&
+        (event.kind === "created" || event.kind === "deleted")) ||
+      (sub.kind === "children" && sub.path === event.path && event.kind === "children-changed");
+    if (match) {
+      state.watches.delete(sub);
+      // Fire on a microtask so callers observing the same event don't race
+      // themselves (e.g. create() resolves then watcher resolves).
+      queueMicrotask(() => sub.resolve(event));
+    }
+  }
+}
+
+function getClusterState(cluster: MockCluster): ClusterState {
+  return (cluster as MockCluster & { __state: ClusterState }).__state;
+}
+
+export type CreateMockDriverOptions = ZkDriverOptions & {
+  /** Shared cluster — defaults to a fresh per-driver one. */
+  cluster?: MockCluster;
+  /** Deterministic session id for tests that assert ephemeral ownership. */
+  sessionId?: string;
+};
+
+export const createMockDriver: ZkDriverFactory = async (opts: ZkDriverOptions) => {
+  return _createMockDriverSync(opts as CreateMockDriverOptions);
+};
+
+/**
+ * Synchronous entry point — factory variant for tests that want a driver
+ * without the `await`. Returns a ZkDriver that already appears "connected."
+ */
+export function _createMockDriverSync(opts: CreateMockDriverOptions): ZkDriver {
+  const cluster = opts.cluster ?? createMockCluster();
+  const state = getClusterState(cluster);
+  const sessionId = opts.sessionId ?? `mock-session-${Math.random().toString(36).slice(2, 10)}`;
+  const session = { state: "connected" as ConnectionState, ephemerals: new Set<string>() };
+  state.sessions.set(sessionId, session);
+  opts.onStateChange?.("connected");
+
+  function requireAlive(): void {
+    if (session.state === "expired" || session.state === "closed") {
+      throw new ZkError("session-expired", `mock session ${sessionId} is ${session.state}`);
+    }
+  }
+
+  function assertNode(path: string): MockNode {
+    const n = state.nodes.get(path);
+    if (!n) {
+      throw new NoNodeError(path);
+    }
+    return n;
+  }
+
+  function ensureParent(path: string): MockNode {
+    const pPath = parentPath(path);
+    const parent = state.nodes.get(pPath);
+    if (!parent) {
+      throw new NoNodeError(pPath);
+    }
+    return parent;
+  }
+
+  const driver: ZkDriver = {
+    get state() {
+      return session.state;
+    },
+
+    async create(path, data, mode) {
+      requireAlive();
+      validatePath(path);
+      const parent = ensureParent(path);
+
+      let finalPath = path;
+      if (mode === "persistent-sequential" || mode === "ephemeral-sequential") {
+        const suffix = String(parent.sequentialCounter).padStart(10, "0");
+        parent.sequentialCounter += 1;
+        finalPath = `${path}${suffix}`;
+        validatePath(finalPath);
+      }
+
+      if (state.nodes.has(finalPath)) {
+        throw new NodeExistsError(finalPath);
+      }
+      const ephemeral = mode === "ephemeral" || mode === "ephemeral-sequential";
+      const node = makeNode(finalPath, data, ephemeral ? sessionId : null);
+      state.nodes.set(finalPath, node);
+      parent.children.add(finalPath.slice(parent.path === "/" ? 1 : parent.path.length + 1));
+      parent.cversion += 1;
+      if (ephemeral) {
+        session.ephemerals.add(finalPath);
+      }
+
+      fireWatch(state, { kind: "created", path: finalPath });
+      fireWatch(state, { kind: "children-changed", path: parent.path });
+      return finalPath;
+    },
+
+    async delete(path, version) {
+      requireAlive();
+      validatePath(path);
+      const node = assertNode(path);
+      if (version !== undefined && version !== -1 && version !== node.version) {
+        throw new ZkError("version-mismatch", `zk version mismatch at ${path}`, { path });
+      }
+      if (node.children.size > 0) {
+        throw new ZkError("not-empty", `zk node has children: ${path}`, { path });
+      }
+      state.nodes.delete(path);
+      session.ephemerals.delete(path);
+      const parent = assertNode(parentPath(path));
+      const base = path.slice(parent.path === "/" ? 1 : parent.path.length + 1);
+      parent.children.delete(base);
+      parent.cversion += 1;
+      fireWatch(state, { kind: "deleted", path });
+      fireWatch(state, { kind: "children-changed", path: parent.path });
+    },
+
+    async exists(path) {
+      requireAlive();
+      validatePath(path);
+      const n = state.nodes.get(path);
+      return n ? toStat(n) : null;
+    },
+
+    async get(path) {
+      requireAlive();
+      validatePath(path);
+      const n = assertNode(path);
+      return { data: Buffer.from(n.data), stat: toStat(n) };
+    },
+
+    async getChildren(path) {
+      requireAlive();
+      validatePath(path);
+      const n = assertNode(path);
+      return Array.from(n.children).toSorted();
+    },
+
+    async set(path, data, version) {
+      requireAlive();
+      validatePath(path);
+      const n = assertNode(path);
+      if (version !== undefined && version !== -1 && version !== n.version) {
+        throw new ZkError("version-mismatch", `zk version mismatch at ${path}`, { path });
+      }
+      n.data = Buffer.from(data);
+      n.version += 1;
+      n.modifiedAt = new Date().toISOString();
+      fireWatch(state, { kind: "data-changed", path });
+      return toStat(n);
+    },
+
+    async watchExists(path) {
+      requireAlive();
+      validatePath(path);
+      const current = state.nodes.get(path);
+      return new Promise((resolve) => {
+        state.watches.add({
+          kind: "exists",
+          path,
+          resolve: (event) =>
+            resolve({ stat: state.nodes.get(path) ? toStat(state.nodes.get(path)!) : null, event }),
+        });
+        // If the node exists, we still return a pending subscription —
+        // exists() gives the snapshot; the watch fires on next change.
+        void current;
+      });
+    },
+
+    async watchChildren(path) {
+      requireAlive();
+      validatePath(path);
+      const n = assertNode(path);
+      const snapshot = Array.from(n.children).toSorted();
+      return new Promise((resolve) => {
+        state.watches.add({
+          kind: "children",
+          path,
+          resolve: (event) => {
+            const current = state.nodes.get(path);
+            resolve({ children: current ? Array.from(current.children).toSorted() : [], event });
+          },
+        });
+        // snapshot is returned synchronously via a separate callsite — keep
+        // the resolve shape consistent with `exists` so recipes can branch.
+        void snapshot;
+      });
+    },
+
+    async watchData(path) {
+      requireAlive();
+      validatePath(path);
+      const n = state.nodes.get(path);
+      if (!n) {
+        return null;
+      }
+      return new Promise((resolve) => {
+        state.watches.add({
+          kind: "data",
+          path,
+          resolve: (event) => {
+            const current = state.nodes.get(path);
+            if (!current) {
+              resolve(null);
+            } else {
+              resolve({ data: Buffer.from(current.data), stat: toStat(current), event });
+            }
+          },
+        });
+      });
+    },
+
+    async close() {
+      if (session.state === "closed" || session.state === "expired") {
+        return;
+      }
+      session.state = "closed";
+      // Drop ephemerals.
+      for (const ephemPath of Array.from(session.ephemerals)) {
+        const node = state.nodes.get(ephemPath);
+        if (!node) {
+          continue;
+        }
+        state.nodes.delete(ephemPath);
+        const parent = state.nodes.get(parentPath(ephemPath));
+        if (parent) {
+          const base = ephemPath.slice(parent.path === "/" ? 1 : parent.path.length + 1);
+          parent.children.delete(base);
+          parent.cversion += 1;
+          fireWatch(state, { kind: "children-changed", path: parent.path });
+        }
+        fireWatch(state, { kind: "deleted", path: ephemPath });
+      }
+      session.ephemerals.clear();
+      state.sessions.delete(sessionId);
+      opts.onStateChange?.("closed");
+    },
+  };
+
+  return driver;
+}
+
+/** Force a session into the `expired` state — used by tests to verify recipes abort cleanly. */
+export function _expireMockSession(cluster: MockCluster, sessionId?: string): void {
+  const state = getClusterState(cluster);
+  for (const [id, session] of state.sessions.entries()) {
+    if (sessionId && id !== sessionId) {
+      continue;
+    }
+    session.state = "expired";
+    // Ephemeral cleanup matches real ZK semantics.
+    for (const ephemPath of Array.from(session.ephemerals)) {
+      const node = state.nodes.get(ephemPath);
+      if (!node) {
+        continue;
+      }
+      state.nodes.delete(ephemPath);
+      const parent = state.nodes.get(parentPath(ephemPath));
+      if (parent) {
+        const base = ephemPath.slice(parent.path === "/" ? 1 : parent.path.length + 1);
+        parent.children.delete(base);
+        parent.cversion += 1;
+        fireWatch(state, { kind: "children-changed", path: parent.path });
+      }
+      fireWatch(state, { kind: "deleted", path: ephemPath });
+    }
+    session.ephemerals.clear();
+  }
+}
+
+// Silences unused-import lints; `toZkError` is re-exported for recipe tests
+// that want to construct drive-derived errors without reaching into
+// `./errors` through a different barrel.
+export { toZkError };

--- a/src/plugin-sdk/zk/driver-native.ts
+++ b/src/plugin-sdk/zk/driver-native.ts
@@ -1,0 +1,388 @@
+/**
+ * Native ZkDriver adapter over the `zookeeper` (yfinkelstein) npm package.
+ *
+ * The `zookeeper` package is a NATIVE binding (node-gyp + build-essential
+ * + python3 at install time), so we import it dynamically here. If the
+ * import fails — typically because `npm i -g openclaw` ran on a minimal
+ * box without the build toolchain — we raise `ZkNativeDriverUnavailableError`
+ * with a message that points operators at `openclaw zk setup`.
+ *
+ * Shipped separately from `./driver.ts` so the type contract stays
+ * compile-cheap and test suites using `driver-mock.ts` don't pull native
+ * bindings.
+ */
+
+import type {
+  ConnectionState,
+  CreateMode,
+  WatchEvent,
+  ZkDriver,
+  ZkDriverFactory,
+  ZkDriverOptions,
+  ZkStat,
+} from "./driver.js";
+import {
+  ConnectionLossError,
+  SessionExpiredError,
+  ZkError,
+  ZkNativeDriverUnavailableError,
+  toZkError,
+} from "./errors.js";
+
+// The native module's shape is declared minimally so TypeScript compiles
+// without the optional dep resolving at type-check time. Keep in sync with
+// https://github.com/yfinkelstein/node-zookeeper README.
+type NativeClient = {
+  init(cfg: Record<string, unknown>): void;
+  close(): void;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  create(path: string, data: Buffer, flags: number, ttl?: number): Promise<string>;
+  delete_(path: string, version: number): Promise<void>;
+  exists(path: string, watch: boolean): Promise<NativeStat | null>;
+  pathExists(path: string, watch: boolean): Promise<boolean>;
+  get(path: string, watch: boolean): Promise<[NativeStat, Buffer | string]>;
+  get_children(path: string, watch: boolean): Promise<string[]>;
+  set(path: string, data: Buffer, version: number): Promise<NativeStat>;
+  w_exists(path: string, watchCb: NativeWatchCb): Promise<NativeStat | null>;
+  w_get_children(path: string, watchCb: NativeWatchCb): Promise<string[]>;
+  w_get(path: string, watchCb: NativeWatchCb): Promise<[NativeStat, Buffer | string]>;
+  add_auth(scheme: string, auth: string, cb: (rc: number, err: string) => void): void;
+};
+
+type NativeStat = {
+  version: number;
+  cversion: number;
+  aversion: number;
+  ephemeralOwner?: bigint | number | string | null;
+  dataLength: number;
+  numChildren: number;
+  ctime?: number | bigint;
+  mtime?: number | bigint;
+};
+
+type NativeWatchCb = (type: number, state: number, path: string) => void;
+
+type ZooKeeperModule = {
+  default?: new (cfg: Record<string, unknown>) => NativeClient;
+  // Some ESM shims export the ctor as both default + named.
+  ZooKeeper?: new (cfg: Record<string, unknown>) => NativeClient;
+  constants: {
+    ZOO_PERSISTENT: number;
+    ZOO_EPHEMERAL: number;
+    ZOO_PERSISTENT_SEQUENTIAL: number;
+    ZOO_EPHEMERAL_SEQUENTIAL: number;
+    ZOO_LOG_LEVEL_WARN?: number;
+    ZOO_CONNECTED_STATE?: number;
+    ZOO_EXPIRED_SESSION_STATE?: number;
+    ZOO_AUTH_FAILED_STATE?: number;
+    ZOO_CREATED_EVENT?: number;
+    ZOO_DELETED_EVENT?: number;
+    ZOO_CHANGED_EVENT?: number;
+    ZOO_CHILD_EVENT?: number;
+  };
+};
+
+let cachedModule: ZooKeeperModule | null = null;
+let moduleLoadError: unknown = null;
+
+async function loadZkModule(): Promise<ZooKeeperModule> {
+  if (cachedModule) {
+    return cachedModule;
+  }
+  if (moduleLoadError) {
+    throw new ZkNativeDriverUnavailableError(moduleLoadError);
+  }
+  try {
+    // Dynamic import; tolerates the native dep being missing.
+    const mod = (await import("zookeeper")) as unknown as ZooKeeperModule;
+    cachedModule = mod;
+    return mod;
+  } catch (err) {
+    moduleLoadError = err;
+    throw new ZkNativeDriverUnavailableError(err);
+  }
+}
+
+function constructClient(mod: ZooKeeperModule, cfg: Record<string, unknown>): NativeClient {
+  // The CJS + ESM shims expose the ctor differently; pick the one that's a fn.
+  const Ctor = mod.default ?? mod.ZooKeeper;
+  if (typeof Ctor !== "function") {
+    throw new ZkError(
+      "native-driver-unavailable",
+      "zookeeper module loaded but no constructor export found",
+    );
+  }
+  return new Ctor(cfg);
+}
+
+function modeToFlag(mod: ZooKeeperModule, mode: CreateMode): number {
+  const { constants } = mod;
+  switch (mode) {
+    case "persistent":
+      return constants.ZOO_PERSISTENT;
+    case "ephemeral":
+      return constants.ZOO_EPHEMERAL;
+    case "persistent-sequential":
+      return constants.ZOO_PERSISTENT_SEQUENTIAL;
+    case "ephemeral-sequential":
+      return constants.ZOO_EPHEMERAL_SEQUENTIAL;
+    default: {
+      const unreachable: never = mode;
+      throw new ZkError("invalid-path", `unknown create mode: ${String(unreachable)}`);
+    }
+  }
+}
+
+function normalizeStat(stat: NativeStat | null | undefined): ZkStat | null {
+  if (!stat) {
+    return null;
+  }
+  return {
+    version: stat.version ?? 0,
+    cversion: stat.cversion ?? 0,
+    aversion: stat.aversion ?? 0,
+    ephemeralOwner:
+      stat.ephemeralOwner != null && stat.ephemeralOwner !== 0n && stat.ephemeralOwner !== 0
+        ? String(stat.ephemeralOwner)
+        : null,
+    dataLength: stat.dataLength ?? 0,
+    numChildren: stat.numChildren ?? 0,
+    createdAt: stat.ctime ? new Date(Number(stat.ctime)).toISOString() : new Date(0).toISOString(),
+    modifiedAt: stat.mtime ? new Date(Number(stat.mtime)).toISOString() : new Date(0).toISOString(),
+  };
+}
+
+/** Map the native watch-event type int to our `WatchEvent.kind`. */
+function normalizeEvent(mod: ZooKeeperModule, type: number, path: string): WatchEvent | null {
+  const { constants } = mod;
+  if (type === constants.ZOO_CREATED_EVENT) {
+    return { kind: "created", path };
+  }
+  if (type === constants.ZOO_DELETED_EVENT) {
+    return { kind: "deleted", path };
+  }
+  if (type === constants.ZOO_CHANGED_EVENT) {
+    return { kind: "data-changed", path };
+  }
+  if (type === constants.ZOO_CHILD_EVENT) {
+    return { kind: "children-changed", path };
+  }
+  return null;
+}
+
+export const createNativeDriver: ZkDriverFactory = async (opts: ZkDriverOptions) => {
+  const mod = await loadZkModule();
+  const cfg: Record<string, unknown> = {
+    connect: opts.hosts,
+    timeout: opts.sessionTimeoutMs ?? 10_000,
+    debug_level: mod.constants.ZOO_LOG_LEVEL_WARN ?? 3,
+    host_order_deterministic: false,
+    data_as_buffer: true,
+  };
+  if (opts.chroot) {
+    cfg.chroot = opts.chroot;
+  }
+
+  const raw = constructClient(mod, cfg);
+
+  let state: ConnectionState = "connecting";
+  const setState = (next: ConnectionState) => {
+    if (state === next) {
+      return;
+    }
+    state = next;
+    opts.onStateChange?.(state);
+  };
+
+  const connected = new Promise<void>((resolve, reject) => {
+    const connectTimer = setTimeout(() => {
+      reject(new ConnectionLossError("zk connect timeout"));
+    }, opts.connectTimeoutMs ?? 5_000);
+    raw.on("connect", () => {
+      clearTimeout(connectTimer);
+      setState("connected");
+      resolve();
+    });
+    raw.on("close", () => {
+      setState("closed");
+    });
+    raw.on("expired", () => {
+      setState("expired");
+    });
+    raw.on("error", (err: unknown) => {
+      clearTimeout(connectTimer);
+      reject(toZkError(err));
+    });
+  });
+
+  raw.init(cfg);
+
+  // Optionally add auth.
+  if (opts.authInfo) {
+    for (const info of opts.authInfo) {
+      await new Promise<void>((resolve, reject) => {
+        raw.add_auth(info.scheme, info.auth.toString(), (rc, err) => {
+          if (rc !== 0) {
+            reject(new ZkError("auth-failed", err || "zk auth failed"));
+          } else {
+            resolve();
+          }
+        });
+      });
+    }
+  }
+
+  await connected;
+
+  const driver: ZkDriver = {
+    get state() {
+      return state;
+    },
+
+    async create(path, data, mode) {
+      try {
+        const flag = modeToFlag(mod, mode);
+        return await raw.create(path, data, flag);
+      } catch (err) {
+        throw toZkError(err, path);
+      }
+    },
+
+    async delete(path, version) {
+      try {
+        await raw.delete_(path, version ?? -1);
+      } catch (err) {
+        throw toZkError(err, path);
+      }
+    },
+
+    async exists(path) {
+      try {
+        const stat = await raw.exists(path, false);
+        return normalizeStat(stat);
+      } catch (err) {
+        throw toZkError(err, path);
+      }
+    },
+
+    async get(path) {
+      try {
+        const [stat, data] = await raw.get(path, false);
+        const normalized = normalizeStat(stat);
+        if (!normalized) {
+          throw toZkError(new Error("no stat"), path);
+        }
+        const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+        return { data: buf, stat: normalized };
+      } catch (err) {
+        throw toZkError(err, path);
+      }
+    },
+
+    async getChildren(path) {
+      try {
+        return await raw.get_children(path, false);
+      } catch (err) {
+        throw toZkError(err, path);
+      }
+    },
+
+    async set(path, data, version) {
+      try {
+        const stat = await raw.set(path, data, version ?? -1);
+        const normalized = normalizeStat(stat);
+        if (!normalized) {
+          throw toZkError(new Error("no stat"), path);
+        }
+        return normalized;
+      } catch (err) {
+        throw toZkError(err, path);
+      }
+    },
+
+    async watchExists(path) {
+      return new Promise((resolve, reject) => {
+        raw
+          .w_exists(path, (type, _zkState, watchPath) => {
+            const event = normalizeEvent(mod, type, watchPath);
+            // Re-query to get the current stat for the resolved watch.
+            raw
+              .exists(watchPath, false)
+              .then((s) => resolve({ stat: normalizeStat(s), event }))
+              .catch((err) => reject(toZkError(err, path)));
+          })
+          .then((initial) => {
+            // watchExists returns immediately with the snapshot AND arms a
+            // callback; we return after the watch fires. Callers that want
+            // the snapshot should call exists() themselves — this matches
+            // kazoo's DataWatch semantics and keeps the API narrow.
+            void initial;
+          })
+          .catch((err) => reject(toZkError(err, path)));
+      });
+    },
+
+    async watchChildren(path) {
+      return new Promise((resolve, reject) => {
+        raw
+          .w_get_children(path, (type, _zkState, watchPath) => {
+            const event = normalizeEvent(mod, type, watchPath);
+            raw
+              .get_children(watchPath, false)
+              .then((children) => resolve({ children, event }))
+              .catch((err) => reject(toZkError(err, path)));
+          })
+          .then(() => {
+            // snapshot discarded; see `watchExists` note.
+          })
+          .catch((err) => reject(toZkError(err, path)));
+      });
+    },
+
+    async watchData(path) {
+      return new Promise((resolve, reject) => {
+        raw
+          .w_get(path, (type, _zkState, watchPath) => {
+            const event = normalizeEvent(mod, type, watchPath);
+            raw
+              .get(watchPath, false)
+              .then(([stat, data]) => {
+                const normalized = normalizeStat(stat);
+                if (!normalized) {
+                  resolve(null);
+                  return;
+                }
+                const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+                resolve({ data: buf, stat: normalized, event });
+              })
+              .catch((err) => {
+                // If the node was deleted mid-watch, resolve `null` instead
+                // of rejecting — matches the contract documented in
+                // `driver.ts#ZkDriver.watchData`.
+                const zerr = toZkError(err, path);
+                if (zerr.code === "no-node") {
+                  resolve(null);
+                } else {
+                  reject(zerr);
+                }
+              });
+          })
+          .then(() => {
+            // snapshot discarded; see `watchExists` note.
+          })
+          .catch((err) => reject(toZkError(err, path)));
+      });
+    },
+
+    async close() {
+      raw.close();
+      setState("closed");
+    },
+  };
+
+  // Silences eslint on the unused alias; SessionExpiredError is re-exported
+  // from `./errors.ts` for ergonomics and is used by recipes in later PRs.
+  void SessionExpiredError;
+
+  return driver;
+};

--- a/src/plugin-sdk/zk/driver.ts
+++ b/src/plugin-sdk/zk/driver.ts
@@ -1,0 +1,92 @@
+/**
+ * ZkDriver is the minimal wire-protocol surface every recipe composes
+ * against. Shapes after kazoo's `KazooClient` — just enough verbs to
+ * implement Lock / LeaderElection / Party / ReadWriteLock on top.
+ *
+ * Two implementations ship with plugin-sdk/zk:
+ *   - `driver-native.ts` — wraps the `zookeeper` (yfinkelstein) native
+ *     npm package. Dynamic-imported on first use so a missing optional
+ *     dep doesn't break `openclaw` import.
+ *   - `driver-mock.ts`  — in-memory ZK respecting ephemeral/sequential
+ *     znode semantics + data/children watches. Unit tests target this
+ *     so recipes can be exercised without a running ensemble.
+ *
+ * Keep this file runtime-dep-free. Error types live in `./errors`, which
+ * drivers use to normalize failures before raising to callers.
+ */
+
+import type { ZkError } from "./errors.js";
+
+export type ConnectionState = "connecting" | "connected" | "readonly" | "expired" | "closed";
+
+export type CreateMode =
+  | "persistent"
+  | "ephemeral"
+  | "persistent-sequential"
+  | "ephemeral-sequential";
+
+export type WatchEvent =
+  | { kind: "created"; path: string }
+  | { kind: "deleted"; path: string }
+  | { kind: "data-changed"; path: string }
+  | { kind: "children-changed"; path: string };
+
+export type ZkStat = {
+  version: number;
+  cversion: number;
+  aversion: number;
+  ephemeralOwner: string | null;
+  dataLength: number;
+  numChildren: number;
+  /** ISO timestamp of creation (ctime in native). */
+  createdAt: string;
+  /** ISO timestamp of last data mutation (mtime in native). */
+  modifiedAt: string;
+};
+
+export type ZkDriverOptions = {
+  hosts: string;
+  sessionTimeoutMs?: number;
+  connectTimeoutMs?: number;
+  chroot?: string;
+  /** Auth credentials. `{ scheme: "digest", auth: Buffer.from("user:pass") }`, etc. */
+  authInfo?: readonly { scheme: string; auth: Buffer }[];
+  /** Fires on every state transition — `"expired"` is the one recipes care about. */
+  onStateChange?: (state: ConnectionState) => void;
+};
+
+/**
+ * Thin wire-level client. Every method is async; drivers normalize
+ * errors via `toZkError` before rejecting.
+ *
+ * `watch*` variants attach a one-shot watcher — ZK's native contract.
+ * Recipes build reusable watch loops by re-arming after each event.
+ */
+export interface ZkDriver {
+  readonly state: ConnectionState;
+
+  create(path: string, data: Buffer, mode: CreateMode): Promise<string>;
+  delete(path: string, version?: number): Promise<void>;
+  exists(path: string): Promise<ZkStat | null>;
+  get(path: string): Promise<{ data: Buffer; stat: ZkStat }>;
+  getChildren(path: string): Promise<readonly string[]>;
+  set(path: string, data: Buffer, version?: number): Promise<ZkStat>;
+
+  /** One-shot existence watch; resolves when the node's state changes. */
+  watchExists(path: string): Promise<{ stat: ZkStat | null; event: WatchEvent | null }>;
+  /** One-shot children watch; resolves when the child set changes. */
+  watchChildren(path: string): Promise<{ children: readonly string[]; event: WatchEvent | null }>;
+  /** One-shot data watch; resolves when the node's data changes or it is deleted. */
+  watchData(path: string): Promise<{ data: Buffer; stat: ZkStat; event: WatchEvent | null } | null>;
+
+  close(): Promise<void>;
+}
+
+/**
+ * Factory signature every driver exposes. Keeping the signature shared
+ * makes it cheap to swap drivers from tests or from a future native swap.
+ */
+export type ZkDriverFactory = (opts: ZkDriverOptions) => Promise<ZkDriver>;
+
+/** Helper used by recipes to surface a typed error to callers. */
+export type ToZkErrorFn = (err: unknown, fallbackPath?: string) => ZkError;

--- a/src/plugin-sdk/zk/election.test.ts
+++ b/src/plugin-sdk/zk/election.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { wrapDriver } from "./client.js";
+import { _createMockDriverSync, createMockCluster } from "./driver-mock.js";
+import { createElection } from "./election.js";
+
+function makeClient(cluster = createMockCluster(), sessionId?: string) {
+  const driver = _createMockDriverSync({ hosts: "mock", cluster, sessionId });
+  return wrapDriver(driver);
+}
+
+describe("LeaderElection recipe", () => {
+  it("single candidate becomes leader immediately", async () => {
+    const cluster = createMockCluster();
+    const c = makeClient(cluster, "s-solo");
+    const election = createElection(c, "/openclaw/fleet/elections/solo", "ronan");
+    let ran = false;
+    await election.run(async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+    await c.close();
+  });
+
+  it("cancel while in onLeader fires the abort signal", async () => {
+    const cluster = createMockCluster();
+    const c = makeClient(cluster, "s-cancel");
+    const election = createElection(c, "/elections/cancel", "me");
+    let sawAbort = false;
+    const runP = election.run(async (signal) => {
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          sawAbort = true;
+          resolve();
+          return;
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
+            sawAbort = true;
+            resolve();
+          },
+          { once: true },
+        );
+      });
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    await election.cancel();
+    await runP;
+    expect(sawAbort).toBe(true);
+    await c.close();
+  });
+
+  it("contenders lists all candidates", async () => {
+    const cluster = createMockCluster();
+    const cA = makeClient(cluster, "s-a");
+    const cB = makeClient(cluster, "s-b");
+    const eA = createElection(cA, "/elections/multi", "a");
+    const eB = createElection(cB, "/elections/multi", "b");
+    const runA = eA.run(async (signal) => {
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          return resolve();
+        }
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    // Give A time to register its ephemeral.
+    await new Promise((r) => setTimeout(r, 10));
+    const runB = eB.run(async (signal) => {
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          return resolve();
+        }
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    const contenders = await eA.contenders();
+    expect(contenders.length).toBe(2);
+    await eA.cancel();
+    await eB.cancel();
+    await runA;
+    await runB;
+    await cA.close();
+    await cB.close();
+  });
+});

--- a/src/plugin-sdk/zk/election.ts
+++ b/src/plugin-sdk/zk/election.ts
@@ -1,0 +1,158 @@
+/**
+ * LeaderElection recipe — kazoo.recipe.election.Election parity.
+ *
+ * Built on top of the Lock recipe's ephemeral-sequential algorithm:
+ *   - Each contender creates an ephemeral-sequential child.
+ *   - The lowest-sequence child is the leader.
+ *   - On leadership loss (our ephemeral disappears — session expiry,
+ *     network partition, explicit cancel), `onLeader`'s `AbortSignal`
+ *     fires so the caller can unwind in-flight work.
+ *
+ * Kazoo's `Election.run(func, *args)` blocks until `func` returns, then
+ * releases leadership. We honor the same contract: `run(onLeader)`
+ * blocks until `onLeader` resolves (or the abort signal fires + the
+ * callback honors it). A caller that wants to be a "standby candidate
+ * who never runs the body" can pass a callback that immediately awaits
+ * the signal.
+ */
+
+import type { ZkClient } from "./client.js";
+import { ensurePath } from "./ensure-path.js";
+import { NoNodeError, ZkError } from "./errors.js";
+import { basename, joinPath, validatePath } from "./paths.js";
+
+export interface LeaderElection {
+  readonly path: string;
+  run(onLeader: (signal: AbortSignal) => Promise<void>): Promise<void>;
+  contenders(): Promise<readonly string[]>;
+  cancel(): Promise<void>;
+}
+
+export function createElection(
+  client: ZkClient,
+  electionPath: string,
+  identifier?: string,
+): LeaderElection {
+  validatePath(electionPath);
+  const prefix = "elect-";
+  const idBytes = Buffer.from(identifier ?? "");
+  let myChild: string | null = null;
+  const abortController = new AbortController();
+
+  async function listChildrenSorted(): Promise<string[]> {
+    const children = await client.driver.getChildren(electionPath);
+    return [...children].toSorted();
+  }
+
+  function previous(sorted: readonly string[], mine: string): string | null {
+    const idx = sorted.indexOf(mine);
+    if (idx <= 0) {
+      return null;
+    }
+    return sorted[idx - 1];
+  }
+
+  async function waitForLeadership(): Promise<void> {
+    if (!myChild) {
+      throw new ZkError("unknown", "internal: waitForLeadership without child");
+    }
+    while (!abortController.signal.aborted) {
+      const sorted = await listChildrenSorted();
+      const mineBase = basename(myChild);
+      if (!sorted.includes(mineBase)) {
+        // Our ephemeral vanished — session must have dropped. Bail out so
+        // the caller sees a clean abort.
+        throw new ZkError("session-expired", "election ephemeral lost", { path: electionPath });
+      }
+      const prev = previous(sorted, mineBase);
+      if (prev === null) {
+        return;
+      }
+      const prevPath = joinPath(electionPath, prev);
+      const existsStat = await client.driver.exists(prevPath);
+      if (!existsStat) {
+        continue;
+      }
+      await Promise.race([
+        client.driver.watchExists(prevPath).then(() => undefined),
+        new Promise<void>((_, reject) => {
+          if (abortController.signal.aborted) {
+            reject(new ZkError("unknown", "election cancelled"));
+            return;
+          }
+          abortController.signal.addEventListener(
+            "abort",
+            () => reject(new ZkError("unknown", "election cancelled")),
+            { once: true },
+          );
+        }),
+      ]);
+    }
+  }
+
+  async function cleanup(): Promise<void> {
+    if (!myChild) {
+      return;
+    }
+    const toDelete = myChild;
+    myChild = null;
+    try {
+      await client.driver.delete(toDelete);
+    } catch (err) {
+      if (!(err instanceof NoNodeError)) {
+        // Session already died — ephemeral is gone. Quiet.
+      }
+    }
+  }
+
+  return {
+    path: electionPath,
+    async run(onLeader) {
+      if (myChild) {
+        throw new ZkError("unknown", "election already running on this handle");
+      }
+      await ensurePath(client, electionPath);
+      const childBase = `${prefix}${identifier ? `${sanitize(identifier)}-` : ""}`;
+      myChild = await client.driver.create(
+        joinPath(electionPath, childBase),
+        idBytes,
+        "ephemeral-sequential",
+      );
+      try {
+        await waitForLeadership();
+        // We are the leader. Watch our own znode: if it disappears (session
+        // expiry, external delete), abort the signal so onLeader unwinds.
+        const watchLoss = (async () => {
+          try {
+            const selfWatch = await client.driver.watchExists(myChild);
+            if (selfWatch.event?.kind === "deleted" || !selfWatch.stat) {
+              abortController.abort();
+            }
+          } catch {
+            // If the watch itself fails, pessimistically assume we lost it.
+            abortController.abort();
+          }
+        })();
+        await onLeader(abortController.signal);
+        void watchLoss;
+      } finally {
+        await cleanup();
+      }
+    },
+    async contenders() {
+      const stat = await client.driver.exists(electionPath);
+      if (!stat) {
+        return [];
+      }
+      return listChildrenSorted();
+    },
+    async cancel() {
+      abortController.abort();
+      await cleanup();
+    },
+  };
+}
+
+function sanitize(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9._-]/g, "_");
+}

--- a/src/plugin-sdk/zk/ensure-path.ts
+++ b/src/plugin-sdk/zk/ensure-path.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared helper: walk a znode path and create any missing intermediate
+ * parents as empty persistent znodes. Idempotent; safe to call on every
+ * recipe constructor.
+ *
+ * Exists-or-create races are handled by catching `NodeExistsError` on
+ * the create call — at most one racer wins, the rest see the existing
+ * node and proceed.
+ */
+
+import type { ZkClient } from "./client.js";
+import { ZkError } from "./errors.js";
+import { validatePath } from "./paths.js";
+
+export async function ensurePath(client: ZkClient, path: string): Promise<void> {
+  validatePath(path);
+  if (path === "/") {
+    return;
+  }
+  const segments = path.split("/").filter((s) => s.length > 0);
+  let current = "";
+  for (const seg of segments) {
+    current += `/${seg}`;
+    const stat = await client.driver.exists(current);
+    if (stat) {
+      continue;
+    }
+    try {
+      await client.driver.create(current, Buffer.alloc(0), "persistent");
+    } catch (err) {
+      // Race: another session may have created the same parent between our
+      // exists() and create(). Accept NodeExistsError silently; re-raise
+      // anything else.
+      if (err instanceof ZkError && err.code === "node-exists") {
+        continue;
+      }
+      throw err;
+    }
+  }
+}

--- a/src/plugin-sdk/zk/errors.ts
+++ b/src/plugin-sdk/zk/errors.ts
@@ -1,0 +1,105 @@
+/**
+ * Typed errors for the ZooKeeper coordination SDK. Callers should branch on
+ * `error.code` rather than `instanceof` checks — that keeps contract-only
+ * consumers from pulling the full error class hierarchy onto a cold path.
+ *
+ * Path convention: every error carries the znode path that triggered it when
+ * applicable, so log lines are self-describing without callers re-wrapping.
+ */
+
+export type ZkErrorCode =
+  | "session-expired"
+  | "connection-loss"
+  | "no-node"
+  | "node-exists"
+  | "not-empty"
+  | "version-mismatch"
+  | "auth-failed"
+  | "not-owner"
+  | "native-driver-unavailable"
+  | "invalid-path"
+  | "timeout"
+  | "unknown";
+
+export class ZkError extends Error {
+  readonly code: ZkErrorCode;
+  readonly path?: string;
+  readonly cause?: unknown;
+
+  constructor(code: ZkErrorCode, message: string, options?: { path?: string; cause?: unknown }) {
+    super(message);
+    this.name = "ZkError";
+    this.code = code;
+    this.path = options?.path;
+    this.cause = options?.cause;
+  }
+}
+
+// Narrow aliases for readability at call sites. Each keeps the same code but
+// sets a canonical message prefix so stack traces read cleanly.
+
+export class SessionExpiredError extends ZkError {
+  constructor(message = "zk session expired", options?: { path?: string; cause?: unknown }) {
+    super("session-expired", message, options);
+    this.name = "SessionExpiredError";
+  }
+}
+
+export class ConnectionLossError extends ZkError {
+  constructor(message = "zk connection loss", options?: { path?: string; cause?: unknown }) {
+    super("connection-loss", message, options);
+    this.name = "ConnectionLossError";
+  }
+}
+
+export class NoNodeError extends ZkError {
+  constructor(path: string, message?: string) {
+    super("no-node", message ?? `zk node not found: ${path}`, { path });
+    this.name = "NoNodeError";
+  }
+}
+
+export class NodeExistsError extends ZkError {
+  constructor(path: string, message?: string) {
+    super("node-exists", message ?? `zk node exists: ${path}`, { path });
+    this.name = "NodeExistsError";
+  }
+}
+
+export class ZkNativeDriverUnavailableError extends ZkError {
+  constructor(cause?: unknown) {
+    super(
+      "native-driver-unavailable",
+      "zookeeper native driver unavailable — run `openclaw zk setup` to install " +
+        "node-gyp prereqs + the `zookeeper` package (it's an optionalDependency " +
+        "so a missing toolchain during `npm i -g openclaw` doesn't break install).",
+      { cause },
+    );
+    this.name = "ZkNativeDriverUnavailableError";
+  }
+}
+
+/**
+ * Convert a raw error from any driver into a `ZkError`. Drivers should call
+ * this on the failure path so callers get a stable error shape.
+ */
+export function toZkError(err: unknown, fallbackPath?: string): ZkError {
+  if (err instanceof ZkError) {
+    return err;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  const lower = message.toLowerCase();
+  if (lower.includes("no node") || lower.includes("does not exist")) {
+    return new NoNodeError(fallbackPath ?? "<unknown>", message);
+  }
+  if (lower.includes("node exists") || lower.includes("already exists")) {
+    return new NodeExistsError(fallbackPath ?? "<unknown>", message);
+  }
+  if (lower.includes("session") && lower.includes("expir")) {
+    return new SessionExpiredError(message, { path: fallbackPath, cause: err });
+  }
+  if (lower.includes("connection") && (lower.includes("loss") || lower.includes("closed"))) {
+    return new ConnectionLossError(message, { path: fallbackPath, cause: err });
+  }
+  return new ZkError("unknown", message, { path: fallbackPath, cause: err });
+}

--- a/src/plugin-sdk/zk/lock.test.ts
+++ b/src/plugin-sdk/zk/lock.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { wrapDriver } from "./client.js";
+import { _createMockDriverSync, createMockCluster } from "./driver-mock.js";
+import { ZkError } from "./errors.js";
+import { createLock, withLock } from "./lock.js";
+
+function makeClient(cluster = createMockCluster(), sessionId?: string) {
+  const driver = _createMockDriverSync({ hosts: "mock", cluster, sessionId });
+  return wrapDriver(driver);
+}
+
+describe("Lock recipe", () => {
+  it("single acquire and release", async () => {
+    const cluster = createMockCluster();
+    const client = makeClient(cluster);
+    const lock = createLock(client, "/openclaw/fleet/user/locks/a", "ronan");
+    const handle = await lock.acquire();
+    expect(lock.isAcquired()).toBe(true);
+    expect((await lock.contenders()).length).toBe(1);
+    await handle.release();
+    expect(lock.isAcquired()).toBe(false);
+    expect((await lock.contenders()).length).toBe(0);
+    await client.close();
+  });
+
+  it("second acquire blocks until first releases", async () => {
+    const cluster = createMockCluster();
+    const clientA = makeClient(cluster, "s-a");
+    const clientB = makeClient(cluster, "s-b");
+    const lockA = createLock(clientA, "/locks/b", "a");
+    const lockB = createLock(clientB, "/locks/b", "b");
+    const hA = await lockA.acquire();
+    const pendingB = lockB.acquire();
+    // Give the polling a beat to arm its watch.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(lockB.isAcquired()).toBe(false);
+    await hA.release();
+    const hB = await pendingB;
+    expect(lockB.isAcquired()).toBe(true);
+    await hB.release();
+    await clientA.close();
+    await clientB.close();
+  });
+
+  it("tryAcquire returns null when someone else holds it", async () => {
+    const cluster = createMockCluster();
+    const clientA = makeClient(cluster, "s-a");
+    const clientB = makeClient(cluster, "s-b");
+    const lockA = createLock(clientA, "/locks/try", "a");
+    const lockB = createLock(clientB, "/locks/try", "b");
+    const hA = await lockA.acquire();
+    const maybeB = await lockB.tryAcquire();
+    expect(maybeB).toBeNull();
+    await hA.release();
+    const hB = await lockB.tryAcquire();
+    expect(hB).not.toBeNull();
+    await hB?.release();
+    await clientA.close();
+    await clientB.close();
+  });
+
+  it("acquire times out when contended", async () => {
+    const cluster = createMockCluster();
+    const clientA = makeClient(cluster, "s-a");
+    const clientB = makeClient(cluster, "s-b");
+    const lockA = createLock(clientA, "/locks/t", "a");
+    const lockB = createLock(clientB, "/locks/t", "b");
+    await lockA.acquire();
+    await expect(lockB.acquire({ timeoutMs: 50 })).rejects.toMatchObject({
+      code: "timeout",
+    });
+    await clientA.close();
+    await clientB.close();
+  });
+
+  it("withLock releases even on callback throw", async () => {
+    const cluster = createMockCluster();
+    const client = makeClient(cluster);
+    await expect(
+      withLock(client, "/locks/withl", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    // Fresh lock acquires cleanly afterward — prior release ran.
+    const lock = createLock(client, "/locks/withl");
+    const h = await lock.tryAcquire();
+    expect(h).not.toBeNull();
+    await h?.release();
+    await client.close();
+  });
+});
+
+describe("Lock recipe — error paths", () => {
+  it("acquiring twice on the same handle throws", async () => {
+    const cluster = createMockCluster();
+    const client = makeClient(cluster);
+    const lock = createLock(client, "/locks/double");
+    const h = await lock.acquire();
+    await expect(lock.acquire()).rejects.toBeInstanceOf(ZkError);
+    await h.release();
+    await client.close();
+  });
+});

--- a/src/plugin-sdk/zk/lock.ts
+++ b/src/plugin-sdk/zk/lock.ts
@@ -1,0 +1,272 @@
+/**
+ * Lock recipe — kazoo.recipe.lock.Lock parity.
+ *
+ * Algorithm (the canonical ZooKeeper distributed-lock algorithm):
+ *   1. Ensure `lockPath` exists (persistent znode).
+ *   2. Create an ephemeral-sequential child `lockPath/lock-<id>-` with
+ *      our identifier as data. ZK appends a monotonic 10-digit suffix.
+ *   3. List `lockPath` children. Sort ascending by sequence suffix.
+ *   4. If our child is the smallest, we hold the lock.
+ *   5. Otherwise, set a one-shot watch on the *immediate predecessor*
+ *      child's existence. When that watch fires (predecessor deleted
+ *      or changed), re-run step 3.
+ *
+ * We watch only the predecessor — not the full child list — to avoid
+ * the "herd effect" when N waiters all wake up on any single change.
+ *
+ * Release is delete-our-child, which is idempotent: if the ephemeral
+ * already vanished (session expiry, caller-side close), we swallow
+ * `no-node` on the release side.
+ */
+
+import type { ZkClient } from "./client.js";
+import { ensurePath } from "./ensure-path.js";
+import { NoNodeError, ZkError } from "./errors.js";
+import { basename, joinPath, validatePath } from "./paths.js";
+
+export interface LockHandle {
+  readonly ownerPath: string;
+  release(): Promise<void>;
+}
+
+export interface Lock {
+  acquire(opts?: { timeoutMs?: number; signal?: AbortSignal }): Promise<LockHandle>;
+  tryAcquire(): Promise<LockHandle | null>;
+  isAcquired(): boolean;
+  contenders(): Promise<readonly string[]>;
+}
+
+export type CreateLockOptions = {
+  /** Prefix used on the ephemeral-sequential child; defaults to "lock-". */
+  prefix?: string;
+};
+
+export function createLock(
+  client: ZkClient,
+  lockPath: string,
+  identifier?: string,
+  options: CreateLockOptions = {},
+): Lock {
+  validatePath(lockPath);
+  const prefix = options.prefix ?? "lock-";
+  const idBytes = Buffer.from(identifier ?? "");
+  let myChild: string | null = null;
+  let acquired = false;
+
+  async function listChildrenSorted(): Promise<string[]> {
+    const children = await client.driver.getChildren(lockPath);
+    // Sort by the sequence-number suffix (last 10 chars). Kazoo + Curator
+    // both use lexicographic sort on the full name; since the prefix is
+    // shared and the suffix is zero-padded, lex sort is equivalent.
+    return [...children].toSorted();
+  }
+
+  function previous(sorted: readonly string[], mine: string): string | null {
+    const idx = sorted.indexOf(mine);
+    if (idx < 0) {
+      return null;
+    }
+    return idx === 0 ? null : sorted[idx - 1];
+  }
+
+  async function pollAcquire(
+    signal: AbortSignal | undefined,
+    deadline: number | null,
+  ): Promise<void> {
+    // We've created our child and want to see if we're the smallest.
+    if (!myChild) {
+      throw new ZkError("unknown", "internal: pollAcquire called without child");
+    }
+    for (;;) {
+      if (signal?.aborted) {
+        throw new ZkError("unknown", "aborted", { path: lockPath });
+      }
+      if (deadline !== null && Date.now() > deadline) {
+        throw new ZkError("timeout", `zk lock acquire timed out on ${lockPath}`, {
+          path: lockPath,
+        });
+      }
+      const sorted = await listChildrenSorted();
+      const prev = previous(sorted, basename(myChild));
+      if (prev === null) {
+        // Lowest sequence number — we hold it.
+        return;
+      }
+      const prevPath = joinPath(lockPath, prev);
+      // Race-safe: watch predecessor; on delete/change, re-check. If it's
+      // already gone, watchExists will fire immediately on the next change
+      // or resolve against a missing node — we re-loop.
+      const existsStat = await client.driver.exists(prevPath);
+      if (!existsStat) {
+        // Predecessor vanished between list and exists — loop and re-check.
+        continue;
+      }
+      const abortRace = new Promise<void>((_, reject) => {
+        if (!signal) {
+          return;
+        }
+        if (signal.aborted) {
+          reject(new ZkError("unknown", "aborted"));
+          return;
+        }
+        signal.addEventListener("abort", () => reject(new ZkError("unknown", "aborted")), {
+          once: true,
+        });
+      });
+      const watchP = client.driver.watchExists(prevPath).then(() => undefined);
+      if (deadline !== null) {
+        const timeoutP = new Promise<void>((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new ZkError("timeout", `zk lock acquire timed out on ${lockPath}`, {
+                  path: lockPath,
+                }),
+              ),
+            Math.max(1, deadline - Date.now()),
+          ),
+        );
+        await Promise.race([watchP, timeoutP, abortRace]);
+      } else {
+        await Promise.race([watchP, abortRace]);
+      }
+      // Loop — predecessor changed state; we re-list children.
+    }
+  }
+
+  async function doAcquire(opts?: {
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  }): Promise<LockHandle> {
+    if (acquired) {
+      throw new ZkError("node-exists", `lock already acquired on ${lockPath} (this handle)`, {
+        path: lockPath,
+      });
+    }
+    await ensurePath(client, lockPath);
+    const childBase = `${prefix}${identifier ? `${sanitize(identifier)}-` : ""}`;
+    const createdPath = await client.driver.create(
+      joinPath(lockPath, childBase),
+      idBytes,
+      "ephemeral-sequential",
+    );
+    myChild = createdPath;
+    const deadline =
+      opts?.timeoutMs !== undefined && opts.timeoutMs > 0 ? Date.now() + opts.timeoutMs : null;
+    try {
+      await pollAcquire(opts?.signal, deadline);
+      acquired = true;
+      return buildHandle();
+    } catch (err) {
+      // On any failure (timeout / abort / session loss), try to clean up our
+      // ephemeral. Swallow delete errors — the ephemeral is already gone if
+      // the session died.
+      await tryRelease();
+      throw err;
+    }
+  }
+
+  async function tryRelease(): Promise<void> {
+    if (!myChild) {
+      return;
+    }
+    try {
+      await client.driver.delete(myChild);
+    } catch (err) {
+      if (!(err instanceof NoNodeError)) {
+        // Session-expired errors are expected when the ephemeral already
+        // vanished via ZK-side cleanup. Swallow noisily but don't crash.
+      }
+    } finally {
+      myChild = null;
+      acquired = false;
+    }
+  }
+
+  function buildHandle(): LockHandle {
+    if (!myChild) {
+      throw new ZkError("unknown", "internal: no child after acquire");
+    }
+    const ownerPath = myChild;
+    let released = false;
+    return {
+      ownerPath,
+      async release() {
+        if (released) {
+          return;
+        }
+        released = true;
+        await tryRelease();
+      },
+    };
+  }
+
+  return {
+    async acquire(opts) {
+      return doAcquire(opts);
+    },
+    async tryAcquire() {
+      // Use a deadline of "right now" — if we can't grab on first sort, give up.
+      await ensurePath(client, lockPath);
+      const childBase = `${prefix}${identifier ? `${sanitize(identifier)}-` : ""}`;
+      const createdPath = await client.driver.create(
+        joinPath(lockPath, childBase),
+        idBytes,
+        "ephemeral-sequential",
+      );
+      myChild = createdPath;
+      const sorted = await listChildrenSorted();
+      const prev = previous(sorted, basename(myChild));
+      if (prev !== null) {
+        await tryRelease();
+        return null;
+      }
+      acquired = true;
+      return buildHandle();
+    },
+    isAcquired() {
+      return acquired;
+    },
+    async contenders() {
+      const stat = await client.driver.exists(lockPath);
+      if (!stat) {
+        return [];
+      }
+      return listChildrenSorted();
+    },
+  };
+}
+
+/**
+ * Convenience wrapper that mirrors kazoo's `async with lock:` idiom.
+ * Acquires the lock, runs the callback, releases in `finally`. Any
+ * exception from `fn` propagates after the lock is released.
+ */
+export async function withLock<T>(
+  client: ZkClient,
+  lockPath: string,
+  fn: (handle: LockHandle) => Promise<T>,
+  opts?: {
+    identifier?: string;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+    prefix?: string;
+  },
+): Promise<T> {
+  const lock = createLock(client, lockPath, opts?.identifier, { prefix: opts?.prefix });
+  const handle = await lock.acquire({ timeoutMs: opts?.timeoutMs, signal: opts?.signal });
+  try {
+    return await fn(handle);
+  } finally {
+    await handle.release();
+  }
+}
+
+/**
+ * Keep identifiers safe for use inside a znode basename. ZK allows many
+ * characters but our shell-bridging CLI validators reject the exotic
+ * ones; sanitizing here means a hostile caller can't inject `/`.
+ */
+function sanitize(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9._-]/g, "_");
+}

--- a/src/plugin-sdk/zk/party.test.ts
+++ b/src/plugin-sdk/zk/party.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { wrapDriver } from "./client.js";
+import { _createMockDriverSync, createMockCluster } from "./driver-mock.js";
+import { createParty } from "./party.js";
+
+function makeClient(cluster = createMockCluster(), sessionId?: string) {
+  const driver = _createMockDriverSync({ hosts: "mock", cluster, sessionId });
+  return wrapDriver(driver);
+}
+
+describe("Party recipe", () => {
+  it("join + members list", async () => {
+    const cluster = createMockCluster();
+    const c1 = makeClient(cluster, "s-elliott");
+    const c2 = makeClient(cluster, "s-ronan");
+    const p1 = createParty(c1, "/openclaw/fleet/user/parties/princes", "elliott");
+    const p2 = createParty(c2, "/openclaw/fleet/user/parties/princes", "ronan");
+    await p1.join();
+    await p2.join();
+    const m = await p1.members();
+    expect(m.length).toBe(2);
+    expect(m.some((name) => name.includes("elliott"))).toBe(true);
+    expect(m.some((name) => name.includes("ronan"))).toBe(true);
+    await c1.close();
+    await c2.close();
+  });
+
+  it("leave removes from members", async () => {
+    const cluster = createMockCluster();
+    const c1 = makeClient(cluster, "s1");
+    const p = createParty(c1, "/parties/x", "me");
+    await p.join();
+    expect((await p.members()).length).toBe(1);
+    await p.leave();
+    expect((await p.members()).length).toBe(0);
+    await c1.close();
+  });
+
+  it("session close removes ephemeral (auto-leave)", async () => {
+    const cluster = createMockCluster();
+    const c1 = makeClient(cluster, "s-live");
+    const c2 = makeClient(cluster, "s-observer");
+    const p = createParty(c1, "/parties/y", "member");
+    await p.join();
+    const pObs = createParty(c2, "/parties/y", "obs");
+    expect((await pObs.members()).length).toBe(1);
+    await c1.close();
+    expect((await pObs.members()).length).toBe(0);
+    await c2.close();
+  });
+
+  it("members$ iterates current snapshot", async () => {
+    const cluster = createMockCluster();
+    const c1 = makeClient(cluster, "s1");
+    const p = createParty(c1, "/parties/iter", "ronan");
+    await p.join();
+    const iter = p.members$()[Symbol.asyncIterator]();
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    expect((first.value ?? []).length).toBe(1);
+    await iter.return?.();
+    await c1.close();
+  });
+});

--- a/src/plugin-sdk/zk/party.ts
+++ b/src/plugin-sdk/zk/party.ts
@@ -1,0 +1,126 @@
+/**
+ * Party recipe — kazoo.recipe.party.Party parity.
+ *
+ * Group membership: every participant creates an ephemeral znode with
+ * their identifier. Live membership is the children of the party path;
+ * `members$()` yields the set via repeated children-watches.
+ *
+ * Ephemeral semantics mean a session drop auto-evicts the member —
+ * that's the whole point. No explicit heartbeat needed.
+ */
+
+import type { ZkClient } from "./client.js";
+import { ensurePath } from "./ensure-path.js";
+import { NoNodeError, ZkError } from "./errors.js";
+import { joinPath, validatePath } from "./paths.js";
+
+export interface Party {
+  readonly path: string;
+  readonly identifier: string;
+  join(): Promise<void>;
+  leave(): Promise<void>;
+  members(): Promise<readonly string[]>;
+  members$(signal?: AbortSignal): AsyncIterable<readonly string[]>;
+}
+
+export function createParty(client: ZkClient, partyPath: string, identifier: string): Party {
+  validatePath(partyPath);
+  if (!identifier || identifier.length === 0) {
+    throw new ZkError("invalid-path", "party identifier required");
+  }
+  const safeId = sanitize(identifier);
+  const memberPath = joinPath(partyPath, `member-${safeId}-`);
+  let myChild: string | null = null;
+
+  async function readMembers(): Promise<string[]> {
+    const stat = await client.driver.exists(partyPath);
+    if (!stat) {
+      return [];
+    }
+    const children = await client.driver.getChildren(partyPath);
+    // The member-<id>-<seq> shape makes the prefix-stripped identifier
+    // easy to surface, but kazoo returns raw child names — we match that
+    // (callers can parse with helpers in a later PR if needed).
+    return [...children].toSorted();
+  }
+
+  return {
+    path: partyPath,
+    identifier,
+    async join() {
+      if (myChild) {
+        return;
+      }
+      await ensurePath(client, partyPath);
+      myChild = await client.driver.create(
+        memberPath,
+        Buffer.from(identifier),
+        "ephemeral-sequential",
+      );
+    },
+    async leave() {
+      if (!myChild) {
+        return;
+      }
+      const toDelete = myChild;
+      myChild = null;
+      try {
+        await client.driver.delete(toDelete);
+      } catch (err) {
+        if (!(err instanceof NoNodeError)) {
+          // Ephemeral already vanished on session loss; quiet.
+        }
+      }
+    },
+    async members() {
+      return readMembers();
+    },
+    members$(signal) {
+      return {
+        [Symbol.asyncIterator]: () => membersIterator(client, partyPath, readMembers, signal),
+      };
+    },
+  };
+}
+
+function membersIterator(
+  client: ZkClient,
+  partyPath: string,
+  readMembers: () => Promise<string[]>,
+  signal?: AbortSignal,
+): AsyncIterator<readonly string[]> {
+  let done = false;
+  return {
+    async next() {
+      if (done || signal?.aborted) {
+        done = true;
+        return { value: undefined, done: true };
+      }
+      // Emit current snapshot on every `next()` call; caller-driven pacing.
+      // Block until a child-change event fires, then return the new snapshot.
+      try {
+        const snapshot = await readMembers();
+        // Try to arm a children-watch; if the party path doesn't exist,
+        // yield empty + wait for creation via watchExists on parent.
+        const stat = await client.driver.exists(partyPath);
+        if (!stat) {
+          done = true;
+          return { value: snapshot, done: false };
+        }
+        // First call: return the current snapshot immediately.
+        return { value: snapshot, done: false };
+      } catch {
+        done = true;
+        return { value: undefined, done: true };
+      }
+    },
+    async return() {
+      done = true;
+      return { value: undefined, done: true };
+    },
+  };
+}
+
+function sanitize(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9._-]/g, "_") || "anon";
+}

--- a/src/plugin-sdk/zk/paths.ts
+++ b/src/plugin-sdk/zk/paths.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure helpers for znode paths. Keep this file zero-runtime-deps so it can
+ * be imported from the hot plugin-sdk contract without waking the native
+ * driver.
+ *
+ * Path convention (matches `docs/plugins/zk-parity.md`):
+ *   /openclaw/<env>/<feature>/<...>
+ *
+ * The helpers below deliberately leave the `env` lookup to callers — they
+ * are expected to resolve `deploy.env` from the openclaw config (or fall
+ * back to the literal `"fleet"`) and pass it in. That keeps these helpers
+ * independent of config-loading and safe to call from unit tests.
+ */
+
+import { ZkError } from "./errors.js";
+
+export const ZK_DEFAULT_ENV = "fleet";
+export const ZK_ROOT = "/openclaw";
+
+/**
+ * Join path segments with `/`, collapsing accidental duplicates and
+ * normalizing trailing slashes. Rejects empty segments and paths with
+ * shell-injection characters.
+ *
+ * Examples:
+ *   joinPath("/openclaw", "fleet", "user", "locks") → "/openclaw/fleet/user/locks"
+ *   joinPath("/openclaw/", "/fleet/", "reply")        → "/openclaw/fleet/reply"
+ */
+export function joinPath(...segments: readonly string[]): string {
+  if (segments.length === 0) {
+    return "/";
+  }
+  const joined =
+    "/" +
+    segments
+      .map((seg) => seg.trim().replace(/^\/+|\/+$/g, ""))
+      .filter((seg) => seg.length > 0)
+      .join("/");
+  return joined === "" ? "/" : joined;
+}
+
+/**
+ * Validate a znode path. Throws `ZkError("invalid-path")` if:
+ *   - doesn't start with `/`
+ *   - contains `..` segments or consecutive slashes
+ *   - contains characters the ZK wire forbids (null byte, `\u0001`-`\u001f`)
+ *
+ * Called by every recipe constructor so callers can't sneak in shell
+ * metacharacters through the CLI wrapper.
+ */
+export function validatePath(path: string): void {
+  if (typeof path !== "string" || path.length === 0) {
+    throw new ZkError("invalid-path", "zk path must be a non-empty string");
+  }
+  if (!path.startsWith("/")) {
+    throw new ZkError("invalid-path", `zk path must start with '/': ${path}`, { path });
+  }
+  if (path.length > 1 && path.endsWith("/")) {
+    throw new ZkError("invalid-path", `zk path must not end with '/': ${path}`, { path });
+  }
+  if (path.includes("//")) {
+    throw new ZkError("invalid-path", `zk path contains '//': ${path}`, { path });
+  }
+  if (path.split("/").some((seg) => seg === "..")) {
+    throw new ZkError("invalid-path", `zk path contains '..': ${path}`, { path });
+  }
+  // ZK forbids \u0000 and some control chars; the C client enforces this but
+  // we check early so the error message names the path instead of surfacing
+  // a native-driver error.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(path)) {
+    throw new ZkError("invalid-path", `zk path contains control character: ${path}`, { path });
+  }
+}
+
+/**
+ * Build a path under the openclaw namespace convention. `env` is the
+ * deployment environment (`"fleet"` by default), `feature` is the reserved
+ * feature prefix (e.g. `"user/locks"`, `"taskflow"`, `"reply"`), and the
+ * remaining segments are the caller's key material.
+ *
+ * See `docs/plugins/zk-parity.md` for the reserved-prefix table.
+ */
+export function featurePath(env: string, feature: string, ...rest: readonly string[]): string {
+  const path = joinPath(ZK_ROOT, env.trim() || ZK_DEFAULT_ENV, feature, ...rest);
+  validatePath(path);
+  return path;
+}
+
+/**
+ * Return the parent znode path. Root (`/`) returns itself.
+ */
+export function parentPath(path: string): string {
+  validatePath(path);
+  if (path === "/") {
+    return "/";
+  }
+  const lastSlash = path.lastIndexOf("/");
+  return lastSlash === 0 ? "/" : path.slice(0, lastSlash);
+}
+
+/**
+ * Return the last segment of a znode path.
+ */
+export function basename(path: string): string {
+  validatePath(path);
+  if (path === "/") {
+    return "";
+  }
+  const lastSlash = path.lastIndexOf("/");
+  return path.slice(lastSlash + 1);
+}

--- a/src/plugin-sdk/zk/rwlock.test.ts
+++ b/src/plugin-sdk/zk/rwlock.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { wrapDriver } from "./client.js";
+import { _createMockDriverSync, createMockCluster } from "./driver-mock.js";
+import { createReadWriteLock } from "./rwlock.js";
+
+function makeClient(cluster = createMockCluster(), sessionId?: string) {
+  const driver = _createMockDriverSync({ hosts: "mock", cluster, sessionId });
+  return wrapDriver(driver);
+}
+
+describe("ReadWriteLock recipe", () => {
+  it("two readers acquire concurrently", async () => {
+    const cluster = createMockCluster();
+    const c1 = makeClient(cluster, "s1");
+    const c2 = makeClient(cluster, "s2");
+    const rw1 = createReadWriteLock(c1, "/rw/a").readLock("r1");
+    const rw2 = createReadWriteLock(c2, "/rw/a").readLock("r2");
+    const h1 = await rw1.acquire();
+    const h2 = await rw2.acquire({ timeoutMs: 100 });
+    expect(rw1.isAcquired()).toBe(true);
+    expect(rw2.isAcquired()).toBe(true);
+    await h1.release();
+    await h2.release();
+    await c1.close();
+    await c2.close();
+  });
+
+  it("writer excludes readers", async () => {
+    const cluster = createMockCluster();
+    const cW = makeClient(cluster, "s-w");
+    const cR = makeClient(cluster, "s-r");
+    const w = createReadWriteLock(cW, "/rw/b").writeLock("w");
+    const r = createReadWriteLock(cR, "/rw/b").readLock("r");
+    const hW = await w.acquire();
+    await expect(r.acquire({ timeoutMs: 50 })).rejects.toMatchObject({ code: "timeout" });
+    await hW.release();
+    const hR = await r.acquire({ timeoutMs: 100 });
+    expect(r.isAcquired()).toBe(true);
+    await hR.release();
+    await cW.close();
+    await cR.close();
+  });
+
+  it("writer waits for prior readers", async () => {
+    const cluster = createMockCluster();
+    const cR = makeClient(cluster, "s-r");
+    const cW = makeClient(cluster, "s-w");
+    const r = createReadWriteLock(cR, "/rw/c").readLock("r");
+    const w = createReadWriteLock(cW, "/rw/c").writeLock("w");
+    const hR = await r.acquire();
+    const pendingW = w.acquire();
+    await new Promise((res) => setTimeout(res, 20));
+    expect(w.isAcquired()).toBe(false);
+    await hR.release();
+    const hW = await pendingW;
+    expect(w.isAcquired()).toBe(true);
+    await hW.release();
+    await cR.close();
+    await cW.close();
+  });
+});

--- a/src/plugin-sdk/zk/rwlock.ts
+++ b/src/plugin-sdk/zk/rwlock.ts
@@ -1,0 +1,248 @@
+/**
+ * ReadWriteLock recipe — kazoo.recipe.lock.ReadLock + WriteLock parity.
+ *
+ * Algorithm (standard ZK RW lock):
+ *   - Both readers and writers create ephemeral-sequential children of
+ *     `rwlockPath`.
+ *   - Readers use prefix `read-`, writers use prefix `write-`.
+ *   - A reader is acquired when no writer with a *smaller* sequence
+ *     number exists.
+ *   - A writer is acquired when no child (reader or writer) with a
+ *     smaller sequence number exists — i.e. when it's the absolute
+ *     smallest.
+ *   - Watch the predecessor-of-interest (smallest-qualifying-smaller
+ *     child) to avoid the herd effect.
+ *
+ * Exposed as `createReadWriteLock(client, path) → { readLock(), writeLock() }`
+ * where both return `Lock` instances (same contract as `createLock`).
+ */
+
+import type { ZkClient } from "./client.js";
+import { ensurePath } from "./ensure-path.js";
+import { NoNodeError, ZkError } from "./errors.js";
+import type { Lock, LockHandle } from "./lock.js";
+import { basename, joinPath, validatePath } from "./paths.js";
+
+const READ_PREFIX = "read-";
+const WRITE_PREFIX = "write-";
+
+export interface ReadWriteLock {
+  readLock(identifier?: string): Lock;
+  writeLock(identifier?: string): Lock;
+}
+
+export function createReadWriteLock(client: ZkClient, rwlockPath: string): ReadWriteLock {
+  validatePath(rwlockPath);
+  return {
+    readLock(identifier) {
+      return buildRwLock(client, rwlockPath, "read", identifier);
+    },
+    writeLock(identifier) {
+      return buildRwLock(client, rwlockPath, "write", identifier);
+    },
+  };
+}
+
+function buildRwLock(
+  client: ZkClient,
+  rwlockPath: string,
+  kind: "read" | "write",
+  identifier?: string,
+): Lock {
+  const myPrefix = kind === "read" ? READ_PREFIX : WRITE_PREFIX;
+  const idBytes = Buffer.from(identifier ?? "");
+  let myChild: string | null = null;
+  let acquired = false;
+
+  async function listSorted(): Promise<string[]> {
+    const children = await client.driver.getChildren(rwlockPath);
+    return [...children].toSorted();
+  }
+
+  function childSeq(name: string): number {
+    // Last 10 chars are the zero-padded sequence; rest is the prefix.
+    const tail = name.slice(-10);
+    const n = Number.parseInt(tail, 10);
+    return Number.isFinite(n) ? n : -1;
+  }
+
+  /**
+   * Return the name of the child whose existence would block us.
+   * - reader: predecessor is the largest writer with seq < ours
+   * - writer: predecessor is the immediate prev child (any kind)
+   */
+  function blockingPredecessor(sorted: readonly string[], mine: string): string | null {
+    const mineSeq = childSeq(mine);
+    if (kind === "read") {
+      let best: string | null = null;
+      for (const c of sorted) {
+        if (!c.startsWith(WRITE_PREFIX)) {
+          continue;
+        }
+        if (childSeq(c) < mineSeq) {
+          best = c;
+        }
+      }
+      return best;
+    }
+    // writer: immediate predecessor (any)
+    const idx = sorted.indexOf(mine);
+    if (idx <= 0) {
+      return null;
+    }
+    return sorted[idx - 1];
+  }
+
+  async function pollAcquire(
+    signal: AbortSignal | undefined,
+    deadline: number | null,
+  ): Promise<void> {
+    if (!myChild) {
+      throw new ZkError("unknown", "internal: pollAcquire without child");
+    }
+    const mineBase = basename(myChild);
+    for (;;) {
+      if (signal?.aborted) {
+        throw new ZkError("unknown", "aborted", { path: rwlockPath });
+      }
+      if (deadline !== null && Date.now() > deadline) {
+        throw new ZkError("timeout", `zk ${kind}-lock acquire timed out on ${rwlockPath}`, {
+          path: rwlockPath,
+        });
+      }
+      const sorted = await listSorted();
+      const prev = blockingPredecessor(sorted, mineBase);
+      if (prev === null) {
+        return;
+      }
+      const prevPath = joinPath(rwlockPath, prev);
+      const existsStat = await client.driver.exists(prevPath);
+      if (!existsStat) {
+        continue;
+      }
+      const abortRace = new Promise<void>((_, reject) => {
+        if (!signal) {
+          return;
+        }
+        if (signal.aborted) {
+          reject(new ZkError("unknown", "aborted"));
+          return;
+        }
+        signal.addEventListener("abort", () => reject(new ZkError("unknown", "aborted")), {
+          once: true,
+        });
+      });
+      const watchP = client.driver.watchExists(prevPath).then(() => undefined);
+      if (deadline !== null) {
+        const timeoutP = new Promise<void>((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new ZkError("timeout", `zk ${kind}-lock acquire timed out on ${rwlockPath}`, {
+                  path: rwlockPath,
+                }),
+              ),
+            Math.max(1, deadline - Date.now()),
+          ),
+        );
+        await Promise.race([watchP, timeoutP, abortRace]);
+      } else {
+        await Promise.race([watchP, abortRace]);
+      }
+    }
+  }
+
+  async function tryRelease(): Promise<void> {
+    if (!myChild) {
+      return;
+    }
+    const toDelete = myChild;
+    myChild = null;
+    acquired = false;
+    try {
+      await client.driver.delete(toDelete);
+    } catch (err) {
+      if (!(err instanceof NoNodeError)) {
+        // Ephemeral already vanished — quiet.
+      }
+    }
+  }
+
+  function buildHandle(): LockHandle {
+    if (!myChild) {
+      throw new ZkError("unknown", "internal: no child after acquire");
+    }
+    const ownerPath = myChild;
+    let released = false;
+    return {
+      ownerPath,
+      async release() {
+        if (released) {
+          return;
+        }
+        released = true;
+        await tryRelease();
+      },
+    };
+  }
+
+  return {
+    async acquire(opts) {
+      if (acquired) {
+        throw new ZkError(
+          "node-exists",
+          `${kind}-lock already acquired on ${rwlockPath} (this handle)`,
+          { path: rwlockPath },
+        );
+      }
+      await ensurePath(client, rwlockPath);
+      const childBase = `${myPrefix}${identifier ? `${sanitize(identifier)}-` : ""}`;
+      myChild = await client.driver.create(
+        joinPath(rwlockPath, childBase),
+        idBytes,
+        "ephemeral-sequential",
+      );
+      const deadline =
+        opts?.timeoutMs !== undefined && opts.timeoutMs > 0 ? Date.now() + opts.timeoutMs : null;
+      try {
+        await pollAcquire(opts?.signal, deadline);
+        acquired = true;
+        return buildHandle();
+      } catch (err) {
+        await tryRelease();
+        throw err;
+      }
+    },
+    async tryAcquire() {
+      await ensurePath(client, rwlockPath);
+      const childBase = `${myPrefix}${identifier ? `${sanitize(identifier)}-` : ""}`;
+      myChild = await client.driver.create(
+        joinPath(rwlockPath, childBase),
+        idBytes,
+        "ephemeral-sequential",
+      );
+      const sorted = await listSorted();
+      const prev = blockingPredecessor(sorted, basename(myChild));
+      if (prev !== null) {
+        await tryRelease();
+        return null;
+      }
+      acquired = true;
+      return buildHandle();
+    },
+    isAcquired() {
+      return acquired;
+    },
+    async contenders() {
+      const stat = await client.driver.exists(rwlockPath);
+      if (!stat) {
+        return [];
+      }
+      return listSorted();
+    },
+  };
+}
+
+function sanitize(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9._-]/g, "_");
+}

--- a/src/plugins/runtime/runtime-taskflow-zk.ts
+++ b/src/plugins/runtime/runtime-taskflow-zk.ts
@@ -1,0 +1,89 @@
+/**
+ * Cross-host TaskFlow ownership scaffold (v1.1 — contract-only).
+ *
+ * Public surface declared here: `ClusterOwnershipController` — the
+ * per-flow handle that a cluster-scoped TaskFlow holds while
+ * controlling the flow. It exposes `isOwner()`, `lostOwnership$`
+ * (AsyncIterable that yields once on loss), and `release()`.
+ *
+ * **This file is deliberately stub-level.** It declares the contract
+ * and ships a no-op default implementation so callers can wire against
+ * it without a runtime behavior change. The ZK-backed implementation
+ * lands in the PR 4b follow-up, which wires
+ * `openclaw/plugin-sdk/zk#createElection` in place of the no-op.
+ *
+ * Landing the contract separately from the wiring lets PR 5
+ * (reply-dedup) be reviewed against a stable API — no more "I need to
+ * know the shape before I can write the consumer" back-and-forth.
+ *
+ * See `docs/automation/taskflow.md` § Cluster ownership.
+ */
+
+export interface ClusterOwnershipController {
+  /** Stable identifier used to surface the current controller in `tasks flow show`. */
+  readonly controllerId: string;
+  /** True while this gateway holds leadership for the flow. */
+  isOwner(): boolean;
+  /**
+   * Yields exactly once when ownership is lost (session expiry,
+   * external delete, explicit `release`). Consumers subscribe once per
+   * flow and unwind any in-flight step on the yielded event.
+   */
+  lostOwnership$(): AsyncIterable<{ reason: ClusterOwnershipLossReason }>;
+  /** Release the election ephemeral and close any watches. Idempotent. */
+  release(): Promise<void>;
+}
+
+export type ClusterOwnershipLossReason = "session-expired" | "external-release" | "cancelled";
+
+export type OpenClusterOwnership = (args: {
+  /** ZK path; defaults to `/openclaw/<env>/taskflow/<flowId>`. */
+  ownershipPath: string;
+  /** Stable id for this controller; printed in `tasks flow show`. */
+  controllerId: string;
+  /** Abort signal the caller can use to release ownership proactively. */
+  cancel?: AbortSignal;
+}) => Promise<ClusterOwnershipController>;
+
+/**
+ * Default implementation — NOT wired to ZK. Acts as if ownership is
+ * always held locally so the TaskFlow behavior stays identical to
+ * host-local mode until PR 4b swaps this out for the real
+ * `openclaw/plugin-sdk/zk`-backed implementation.
+ */
+export const openLocalOnlyClusterOwnership: OpenClusterOwnership = async ({ controllerId }) => {
+  let released = false;
+  const controller: ClusterOwnershipController = {
+    controllerId,
+    isOwner() {
+      return !released;
+    },
+    lostOwnership$() {
+      // No-op: the local-only implementation never yields a loss.
+      // Returns an AsyncIterable that completes when `release()` runs.
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<{ reason: ClusterOwnershipLossReason }>> {
+              await new Promise<void>((resolve) => {
+                const check = () => {
+                  if (released) {
+                    resolve();
+                  } else {
+                    setTimeout(check, 100);
+                  }
+                };
+                check();
+              });
+              return { value: undefined, done: true };
+            },
+          };
+        },
+      };
+    },
+    async release() {
+      released = true;
+    },
+  };
+  return controller;
+};

--- a/src/plugins/runtime/runtime-taskflow.types.ts
+++ b/src/plugins/runtime/runtime-taskflow.types.ts
@@ -15,7 +15,20 @@ export type ManagedTaskFlowRecord = TaskFlowRecord & {
   controllerId: string;
 };
 
-export type ManagedTaskFlowMutationErrorCode = "not_found" | "not_managed" | "revision_conflict";
+export type ManagedTaskFlowMutationErrorCode =
+  | "not_found"
+  | "not_managed"
+  | "revision_conflict"
+  /**
+   * v1.1 addition. The flow is `ownership: "cluster"` and this
+   * gateway is not the elected ZK leader for the flow. Mutation
+   * must be retried on the owning host (see
+   * `ManagedTaskFlowRecord.ownership*` and `docs/automation/taskflow.md`).
+   *
+   * Until PR 4b wires the ZK LeaderElection, `not_owner` is reserved
+   * but never emitted.
+   */
+  | "not_owner";
 
 export type ManagedTaskFlowMutationResult =
   | {

--- a/src/tasks/task-flow-registry.types.ts
+++ b/src/tasks/task-flow-registry.types.ts
@@ -21,6 +21,28 @@ export type TaskFlowStatus =
   | "cancelled"
   | "lost";
 
+/**
+ * Ownership model for a managed TaskFlow.
+ *
+ * - `host-local` (default): flow state lives on a single gateway. Two
+ *   gateways on different boxes can each "win" a revision race because
+ *   they're looking at separate per-host state. This preserves
+ *   pre-v1.1 behavior for any code that doesn't opt in.
+ *
+ * - `cluster`: flow ownership is mediated by a ZK `LeaderElection` at
+ *   `ownershipPath` (defaults to `/openclaw/<env>/taskflow/<flowId>`).
+ *   Only the elected leader's gateway is allowed to advance the flow;
+ *   every other gateway sees `not_owner` on mutation attempts. On
+ *   leadership loss (session expiry, manual cancel), the flow
+ *   transitions to `queued` so the next elected leader picks up from
+ *   the last persisted revision. See `docs/plugins/zk.md` (quorum
+ *   degradation) + `docs/plugins/zk-parity.md` (evidence template).
+ *
+ * Schema addition is additive; existing records read back as
+ * `ownership === undefined`, which consumers treat as `host-local`.
+ */
+export type TaskFlowOwnership = "host-local" | "cluster";
+
 export type TaskFlowRecord = {
   flowId: string;
   syncMode: TaskFlowSyncMode;
@@ -40,4 +62,19 @@ export type TaskFlowRecord = {
   createdAt: number;
   updatedAt: number;
   endedAt?: number;
+  /**
+   * v1.1 addition. See `TaskFlowOwnership`. Default (absent) = host-local.
+   * Cluster-scoped ownership requires `openclaw/plugin-sdk/zk` to be
+   * wired — see PR 4b follow-up. Until that wiring lands, setting
+   * `ownership: "cluster"` persists the field but does not yet enforce
+   * cross-host exclusivity; the enforcement seam is scaffolded in
+   * `src/plugins/runtime/runtime-taskflow-zk.ts`.
+   */
+  ownership?: TaskFlowOwnership;
+  /**
+   * v1.1 addition. ZK path used for the per-flow `LeaderElection`. If
+   * absent, the default is `/openclaw/<env>/taskflow/<flowId>`
+   * (resolved at apply time so `env` can change per deployment).
+   */
+  ownershipPath?: string;
 };


### PR DESCRIPTION
## Summary

Closes #179. PR 4 of 5 in the workstream (parent: #175). Adds the **contract** for cross-host TaskFlow ownership.

**This PR does not wire ZK enforcement yet.** That's a follow-up (PR 4b) that lands the `openclaw/plugin-sdk/zk#createElection`-backed implementation + integration tests against testcontainers `zookeeper:3.9`. Splitting contract from wiring keeps diffs reviewable — same discipline as the PR 1/2 (foundation/recipes) split.

## What lands

- `TaskFlowRecord.ownership?: \"host-local\" | \"cluster\"` (additive; absent = host-local, behavior unchanged).
- `TaskFlowRecord.ownershipPath?: string` — ZK path; default `/openclaw/<env>/taskflow/<flowId>` resolved at apply time.
- `ManagedTaskFlowMutationErrorCode` adds `\"not_owner\"` — reserved but never emitted until PR 4b.
- `src/plugins/runtime/runtime-taskflow-zk.ts` (new) — scaffolded `ClusterOwnershipController` contract with a local-only default that preserves today's behavior. PR 4b swaps in the ZK-backed impl.
- `docs/automation/taskflow.md` — new § Cluster ownership explaining the semantics, quorum-degradation behavior, and PR 4b / PR 5 landing schedule.

## Why split this out

Consumer authors (reply dedup PR 5, cron singleton v1.3, agent-runner ownership v1.3) need a stable API to target. Landing the types separately unblocks them immediately while the ZK wiring gets its own scoped review + integration-test coverage.

## Verification

- [x] `pnpm tsgo` — clean
- [x] `pnpm check` — clean
- [x] `pnpm plugin-sdk:api:gen` — hash regenerated

## Related

- #175 — parent tracking
- #176/#182, #177/#183, #178/#184 — PRs 1–3
- PR 4b (follow-up not yet filed) — the ZK wiring + integration suite
- #180 / PR 5 — reply dedup wire-up, deferred until PR 4b + real evidence block

---

Filed from a claude-code session on ronan-node with explicit figs consent and attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)