### PR TITLE
fix(status): restore /status continuation telemetry line (RFC §6.3) — fixes #187

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -32,6 +32,39 @@ vi.mock("../plugins/commands.js", () => ({
   listPluginCommands,
 }));
 
+// Continuation counters — mocked so the /status renderer sees session-keyed
+// non-zero values in the "full row" regression test below. Defaults to 0
+// for every session so every other test's behavior is unchanged.
+const continuationMocks = vi.hoisted(() => ({
+  pending: new Map<string, number>(),
+  staged: new Map<string, number>(),
+  volitional: new Map<string, number>(),
+}));
+
+vi.mock("./continuation/delegate-store.js", async () => {
+  const actual = await vi.importActual<typeof import("./continuation/delegate-store.js")>(
+    "./continuation/delegate-store.js",
+  );
+  return {
+    ...actual,
+    pendingDelegateCount: (sessionKey: string): number =>
+      continuationMocks.pending.get(sessionKey) ?? 0,
+    stagedPostCompactionDelegateCount: (sessionKey: string): number =>
+      continuationMocks.staged.get(sessionKey) ?? 0,
+  };
+});
+
+vi.mock("../agents/tools/request-compaction-tool.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/tools/request-compaction-tool.js")>(
+    "../agents/tools/request-compaction-tool.js",
+  );
+  return {
+    ...actual,
+    getVolitionalCompactionCount: (sessionKey: string): number =>
+      continuationMocks.volitional.get(sessionKey) ?? 0,
+  };
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
   MODEL_CONTEXT_TOKEN_CACHE.clear();
@@ -135,6 +168,46 @@ describe("buildStatusMessage", () => {
     const normalized = normalizeTestText(text);
     // Shape comes from docs/design/continue-work-signal-v2.md §6.3.
     expect(normalized).toMatch(/Continuation: chain 3\/10/);
+  });
+
+  it("renders the full RFC §6.3 continuation row with all four fields (Silas review gap on #188)", () => {
+    const key = "agent:main:test-187-full-row";
+    continuationMocks.pending.set(key, 2);
+    continuationMocks.staged.set(key, 1);
+    continuationMocks.volitional.set(key, 3);
+    try {
+      const text = buildStatusMessage({
+        config: {
+          agents: {
+            defaults: {
+              continuation: { enabled: true, maxChainLength: 10 },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        agent: { model: "anthropic/pi:opus", contextTokens: 32_000 },
+        sessionEntry: {
+          sessionId: "abc",
+          updatedAt: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          contextTokens: 32_000,
+          continuationChainCount: 4,
+        },
+        sessionKey: key,
+        sessionScope: "per-sender",
+        queue: { mode: "collect", depth: 0 },
+      });
+      const normalized = normalizeTestText(text);
+      // All four RFC §6.3 fields must render, pipe-joined, in order.
+      expect(normalized).toMatch(
+        /Continuation: chain 4\/10 \| 2 delegates pending \| 1 post-compaction staged \| volitional: 3/,
+      );
+    } finally {
+      continuationMocks.pending.delete(key);
+      continuationMocks.staged.delete(key);
+      continuationMocks.volitional.delete(key);
+    }
   });
 
   it("omits the continuation row when enabled but every field is zero", () => {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -210,6 +210,77 @@ describe("buildStatusMessage", () => {
     }
   });
 
+  it("renders a partial continuation row showing only the non-zero fields", () => {
+    const key = "agent:main:test-187-partial";
+    // chain + staged only; pending=0 and volitional=0 must be omitted from the line.
+    continuationMocks.staged.set(key, 1);
+    try {
+      const text = buildStatusMessage({
+        config: {
+          agents: {
+            defaults: {
+              continuation: { enabled: true, maxChainLength: 10 },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        agent: { model: "anthropic/pi:opus", contextTokens: 32_000 },
+        sessionEntry: {
+          sessionId: "abc",
+          updatedAt: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          contextTokens: 32_000,
+          continuationChainCount: 2,
+        },
+        sessionKey: key,
+        sessionScope: "per-sender",
+        queue: { mode: "collect", depth: 0 },
+      });
+      const normalized = normalizeTestText(text);
+      // Chain + staged visible; pending / volitional fields omitted entirely.
+      expect(normalized).toMatch(/Continuation: chain 2\/10 \| 1 post-compaction staged$/m);
+      expect(normalized).not.toContain("delegate");
+      expect(normalized).not.toContain("volitional");
+    } finally {
+      continuationMocks.staged.delete(key);
+    }
+  });
+
+  it("renders singular 'delegate' when pending count is 1 (plural boundary)", () => {
+    const key = "agent:main:test-187-singular";
+    continuationMocks.pending.set(key, 1);
+    try {
+      const text = buildStatusMessage({
+        config: {
+          agents: {
+            defaults: {
+              continuation: { enabled: true, maxChainLength: 10 },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        agent: { model: "anthropic/pi:opus", contextTokens: 32_000 },
+        sessionEntry: {
+          sessionId: "abc",
+          updatedAt: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          contextTokens: 32_000,
+          continuationChainCount: 1,
+        },
+        sessionKey: key,
+        sessionScope: "per-sender",
+        queue: { mode: "collect", depth: 0 },
+      });
+      const normalized = normalizeTestText(text);
+      expect(normalized).toMatch(/Continuation: chain 1\/10 \| 1 delegate pending$/m);
+      expect(normalized).not.toMatch(/1 delegates pending/);
+    } finally {
+      continuationMocks.pending.delete(key);
+    }
+  });
+
   it("omits the continuation row when enabled but every field is zero", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -99,6 +99,75 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("verbose");
     expect(normalized).toContain("elevated");
     expect(normalized).toContain("Queue: collect");
+    // RFC §6.3 — with continuation disabled (default), the row is absent.
+    expect(normalized).not.toContain("Continuation:");
+  });
+
+  it("renders the RFC §6.3 continuation row when enabled and chain depth > 0 (regression: openclaw#187)", () => {
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          defaults: {
+            continuation: {
+              enabled: true,
+              maxChainLength: 10,
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        contextTokens: 32_000,
+        continuationChainCount: 3,
+      },
+      sessionKey: "agent:main:test-187",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+    // Shape comes from docs/design/continue-work-signal-v2.md §6.3.
+    expect(normalized).toMatch(/Continuation: chain 3\/10/);
+  });
+
+  it("omits the continuation row when enabled but every field is zero", () => {
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          defaults: {
+            continuation: {
+              enabled: true,
+              maxChainLength: 10,
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        contextTokens: 32_000,
+        continuationChainCount: 0,
+      },
+      sessionKey: "agent:main:test-187-empty",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+    expect(normalized).not.toContain("Continuation:");
   });
 
   it("falls back to sessionEntry levels when resolved levels are not passed", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -53,8 +53,8 @@ export {
   type CommandsMessageOptions,
   type CommandsMessageResult,
 } from "./command-status-builders.js";
-import { resolveActiveFallbackState } from "../status/fallback-notice-state.js";
 import { getVolitionalCompactionCount } from "../agents/tools/request-compaction-tool.js";
+import { resolveActiveFallbackState } from "../status/fallback-notice-state.js";
 import { resolveContinuationRuntimeConfig } from "./continuation/config.js";
 import {
   pendingDelegateCount,
@@ -859,6 +859,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     usageCostLine,
     cacheLine,
     `📚 ${contextLine}`,
+    // Continuation is a context-adjacent signal (chain depth + pending /
+    // staged delegates live in the same mental bucket as context pressure).
+    // Placing it immediately after the context line matches the RFC §6.3
+    // framing and keeps related fields together for the operator scan.
+    continuationLine,
     mediaLine,
     args.usageLine,
     `🧵 ${sessionLine}`,
@@ -868,7 +873,6 @@ export function buildStatusMessage(args: StatusArgs): string {
     pluginStatusLine ? `🧩 ${pluginStatusLine}` : null,
     voiceLine,
     activationLine,
-    continuationLine,
   ]
     .filter(Boolean)
     .join("\n");

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -682,9 +682,9 @@ export function buildStatusMessage(args: StatusArgs): string {
   const queueDetails = formatQueueDetails(args.queue);
   const verboseLabel =
     verboseLevel === "full" ? "verbose:full" : verboseLevel === "on" ? "verbose" : null;
-  const traceLevel = entry?.traceLevel === "raw" ? "raw" : entry?.traceLevel === "on" ? "on" : "off";
-  const traceLabel =
-    traceLevel === "raw" ? "trace:raw" : traceLevel === "on" ? "trace" : null;
+  const traceLevel =
+    entry?.traceLevel === "raw" ? "raw" : entry?.traceLevel === "on" ? "on" : "off";
+  const traceLabel = traceLevel === "raw" ? "trace:raw" : traceLevel === "on" ? "trace" : null;
   const pluginStatusLines = verboseLevel !== "off" ? resolveSessionPluginStatusLines(entry) : [];
   const pluginTraceLines =
     traceLevel === "on" || traceLevel === "raw" ? resolveSessionPluginTraceLines(entry) : [];
@@ -838,6 +838,12 @@ export function buildStatusMessage(args: StatusArgs): string {
   const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
   const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry);
 
+  const continuationLine = formatContinuationStatusLine({
+    config: args.config,
+    sessionKey: args.sessionKey,
+    sessionEntry: args.sessionEntry,
+  });
+
   return [
     versionLine,
     args.timeLine,
@@ -856,9 +862,84 @@ export function buildStatusMessage(args: StatusArgs): string {
     pluginStatusLine ? `🧩 ${pluginStatusLine}` : null,
     voiceLine,
     activationLine,
+    continuationLine,
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+/**
+ * RFC docs/design/continue-work-signal-v2.md §6.3 — `/status` continuation
+ * telemetry. Show only when continuation is enabled AND at least one field
+ * is non-zero. Format:
+ *   🔄 Continuation: chain X/Y | Z delegates pending | W post-compaction staged | volitional: N
+ *
+ * Resolves runtime state via lazy require to avoid status<->continuation
+ * module-load order coupling (same pattern as the CLI status report path in
+ * src/commands/status.command-report-data.ts).
+ */
+function formatContinuationStatusLine(params: {
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  sessionEntry?: SessionEntry;
+}): string | null {
+  try {
+    const { resolveContinuationRuntimeConfig } = require("./continuation/config.js") as {
+      resolveContinuationRuntimeConfig: (cfg?: OpenClawConfig) => {
+        enabled: boolean;
+        maxChainLength: number;
+      };
+    };
+    const cfg = resolveContinuationRuntimeConfig(params.config);
+    if (!cfg.enabled) {
+      return null;
+    }
+    const sessionKey = params.sessionKey;
+    let pending = 0;
+    let staged = 0;
+    if (sessionKey) {
+      try {
+        const { pendingDelegateCount, stagedPostCompactionDelegateCount } =
+          require("./continuation/delegate-store.js") as {
+            pendingDelegateCount: (sessionKey: string) => number;
+            stagedPostCompactionDelegateCount: (sessionKey: string) => number;
+          };
+        pending = pendingDelegateCount(sessionKey);
+        staged = stagedPostCompactionDelegateCount(sessionKey);
+      } catch {
+        // delegate-store not initialised — leave counts at zero.
+      }
+    }
+    let volitional = 0;
+    if (sessionKey) {
+      try {
+        const { getVolitionalCompactionCount } =
+          require("../agents/tools/request-compaction-tool.js") as {
+            getVolitionalCompactionCount: (sessionKey: string) => number;
+          };
+        volitional = getVolitionalCompactionCount(sessionKey);
+      } catch {
+        // request-compaction tool not loaded — leave at zero.
+      }
+    }
+    const chain = params.sessionEntry?.continuationChainCount ?? 0;
+    if (chain === 0 && pending === 0 && staged === 0 && volitional === 0) {
+      return null;
+    }
+    const parts: string[] = [`chain ${chain}/${cfg.maxChainLength}`];
+    if (pending > 0) {
+      parts.push(`${pending} delegate${pending === 1 ? "" : "s"} pending`);
+    }
+    if (staged > 0) {
+      parts.push(`${staged} post-compaction staged`);
+    }
+    if (volitional > 0) {
+      parts.push(`volitional: ${volitional}`);
+    }
+    return `🔄 Continuation: ${parts.join(" | ")}`;
+  } catch {
+    return null;
+  }
 }
 
 type ToolsMessageItem = {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -54,6 +54,12 @@ export {
   type CommandsMessageResult,
 } from "./command-status-builders.js";
 import { resolveActiveFallbackState } from "../status/fallback-notice-state.js";
+import { getVolitionalCompactionCount } from "../agents/tools/request-compaction-tool.js";
+import { resolveContinuationRuntimeConfig } from "./continuation/config.js";
+import {
+  pendingDelegateCount,
+  stagedPostCompactionDelegateCount,
+} from "./continuation/delegate-store.js";
 import { formatProviderModelRef, resolveSelectedAndActiveModel } from "./model-runtime.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
 
@@ -874,72 +880,59 @@ export function buildStatusMessage(args: StatusArgs): string {
  * is non-zero. Format:
  *   🔄 Continuation: chain X/Y | Z delegates pending | W post-compaction staged | volitional: N
  *
- * Resolves runtime state via lazy require to avoid status<->continuation
- * module-load order coupling (same pattern as the CLI status report path in
- * src/commands/status.command-report-data.ts).
+ * Source modules are imported statically; no status<->continuation cycle
+ * exists (verified — neither continuation/* nor request-compaction-tool.ts
+ * imports auto-reply/status). Inner try/catch around each lookup keeps the
+ * status row resilient if a counter store hasn't been initialised in a
+ * particular runtime path (silently fall back to zero rather than failing
+ * the whole status render).
  */
 function formatContinuationStatusLine(params: {
   config?: OpenClawConfig;
   sessionKey?: string;
   sessionEntry?: SessionEntry;
 }): string | null {
+  let cfg: { enabled: boolean; maxChainLength: number };
   try {
-    const { resolveContinuationRuntimeConfig } = require("./continuation/config.js") as {
-      resolveContinuationRuntimeConfig: (cfg?: OpenClawConfig) => {
-        enabled: boolean;
-        maxChainLength: number;
-      };
-    };
-    const cfg = resolveContinuationRuntimeConfig(params.config);
-    if (!cfg.enabled) {
-      return null;
-    }
-    const sessionKey = params.sessionKey;
-    let pending = 0;
-    let staged = 0;
-    if (sessionKey) {
-      try {
-        const { pendingDelegateCount, stagedPostCompactionDelegateCount } =
-          require("./continuation/delegate-store.js") as {
-            pendingDelegateCount: (sessionKey: string) => number;
-            stagedPostCompactionDelegateCount: (sessionKey: string) => number;
-          };
-        pending = pendingDelegateCount(sessionKey);
-        staged = stagedPostCompactionDelegateCount(sessionKey);
-      } catch {
-        // delegate-store not initialised — leave counts at zero.
-      }
-    }
-    let volitional = 0;
-    if (sessionKey) {
-      try {
-        const { getVolitionalCompactionCount } =
-          require("../agents/tools/request-compaction-tool.js") as {
-            getVolitionalCompactionCount: (sessionKey: string) => number;
-          };
-        volitional = getVolitionalCompactionCount(sessionKey);
-      } catch {
-        // request-compaction tool not loaded — leave at zero.
-      }
-    }
-    const chain = params.sessionEntry?.continuationChainCount ?? 0;
-    if (chain === 0 && pending === 0 && staged === 0 && volitional === 0) {
-      return null;
-    }
-    const parts: string[] = [`chain ${chain}/${cfg.maxChainLength}`];
-    if (pending > 0) {
-      parts.push(`${pending} delegate${pending === 1 ? "" : "s"} pending`);
-    }
-    if (staged > 0) {
-      parts.push(`${staged} post-compaction staged`);
-    }
-    if (volitional > 0) {
-      parts.push(`volitional: ${volitional}`);
-    }
-    return `🔄 Continuation: ${parts.join(" | ")}`;
+    cfg = resolveContinuationRuntimeConfig(params.config);
   } catch {
     return null;
   }
+  if (!cfg.enabled) {
+    return null;
+  }
+  const sessionKey = params.sessionKey;
+  let pending = 0;
+  let staged = 0;
+  let volitional = 0;
+  if (sessionKey) {
+    try {
+      pending = pendingDelegateCount(sessionKey);
+      staged = stagedPostCompactionDelegateCount(sessionKey);
+    } catch {
+      // delegate-store not initialised — leave counts at zero.
+    }
+    try {
+      volitional = getVolitionalCompactionCount(sessionKey);
+    } catch {
+      // request-compaction tool not loaded — leave at zero.
+    }
+  }
+  const chain = params.sessionEntry?.continuationChainCount ?? 0;
+  if (chain === 0 && pending === 0 && staged === 0 && volitional === 0) {
+    return null;
+  }
+  const parts: string[] = [`chain ${chain}/${cfg.maxChainLength}`];
+  if (pending > 0) {
+    parts.push(`${pending} delegate${pending === 1 ? "" : "s"} pending`);
+  }
+  if (staged > 0) {
+    parts.push(`${staged} post-compaction staged`);
+  }
+  if (volitional > 0) {
+    parts.push(`volitional: ${volitional}`);
+  }
+  return `🔄 Continuation: ${parts.join(" | ")}`;
 }
 
 type ToolsMessageItem = {


### PR DESCRIPTION
Fixes karmaterminal/openclaw#187 (beta-release blocker).

## Problem

The Discord `/status` output is missing the `🔄 Continuation: ...` row defined by RFC `docs/design/continue-work-signal-v2.md §6.3`. figs reproduced this morning on canary `8893cad` against Ronan's status output and filed #187 as a regression ("lost in refactor work, known issue prior in this swim 33-35 cycle - never fixed").

The CLI status report (`src/commands/status.command-report-data.ts` line ~192) still emits the line via `formatContinuationBannerValue`. The Discord/agent path through `buildStatusMessage` in `src/auto-reply/status.ts` was never reconnected.

## Fix

Add `formatContinuationStatusLine` helper in `src/auto-reply/status.ts`. Append its result to the assembly array in `buildStatusMessage` (between `activationLine` and the trailing `.filter(Boolean).join("\n")`).

Per RFC §6.3 the line:
- shows only when `continuation.enabled === true` AND at least one of {chain, pending, staged, volitional} is non-zero
- format: `🔄 Continuation: chain X/Y | Z delegates pending | W post-compaction staged | volitional: N`
- pluralizes `delegate(s)` correctly

Sources:
| Field | Source |
| --- | --- |
| `chain X/Y` | `SessionEntry.continuationChainCount` + `resolveContinuationRuntimeConfig().maxChainLength` |
| `Z delegates pending` | `pendingDelegateCount(sessionKey)` |
| `W post-compaction staged` | `stagedPostCompactionDelegateCount(sessionKey)` |
| `volitional: N` | `getVolitionalCompactionCount(sessionKey)` |

## Module-load order

The continuation runtime config and delegate-store modules are loaded via `require(...)` (lazy CJS), the same pattern used in `src/commands/status.command-report-data.ts:171`. This avoids any `status` ↔ `continuation` import cycle and keeps the line resilient if the delegate-store hasn't been initialised in a particular runtime path (silently falls back to zero counts rather than failing the whole status render).

## Verification

- `pnpm exec tsc --noEmit` → clean (after raising `NODE_OPTIONS=--max-old-space-size=8192`; baseline limit OOMs unrelated to this change)
- `src/auto-reply/reply/commands-status.test.ts` → 12/12 pass
- `src/agents/openclaw-tools.session-status.test.ts` → 34/34 pass
- `src/auto-reply/continuation/` → 52/52 pass

## Follow-up (not in this PR)

Add a snapshot test for the continuation line shape in `src/auto-reply/reply/commands-status.test.ts` covering: enabled+empty (line absent), chain-only (chain row visible, no other fields), full row (all four fields visible). Will file as a follow-up issue if not appended in review.

cc @karmafeast