### PR TITLE
fix(#639): thread session provider/model through volitional compaction

### DIFF
--- a/src/agents/pi-embedded-runner/compact-reasons.test.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.test.ts
@@ -37,4 +37,11 @@ describe("classifyCompactionReason", () => {
       ),
     ).toBe("guard_blocked");
   });
+
+  it("classifies 'Unknown model: ...' as unknown_model (bug #639)", () => {
+    // surfaces when DEFAULT_PROVIDER/DEFAULT_MODEL fallback hits an unsupported model
+    // — e.g. volitional compaction without provider/model passed routes to openai/gpt-5.4
+    expect(classifyCompactionReason("Unknown model: openai/gpt-5.4")).toBe("unknown_model");
+    expect(classifyCompactionReason("unknown model: foo/bar")).toBe("unknown_model");
+  });
 });

--- a/src/agents/pi-embedded-runner/compact-reasons.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.ts
@@ -23,6 +23,11 @@ export function classifyCompactionReason(reason?: string): string {
   if (text.includes("nothing to compact")) {
     return "no_compactable_entries";
   }
+  if (text.includes("unknown model")) {
+    // bug #639: surfaced when DEFAULT_PROVIDER/DEFAULT_MODEL fallback hits
+    // a model nobody has auth for (e.g. volitional compaction without provider/model passed).
+    return "unknown_model";
+  }
   if (text.includes("below threshold")) {
     return "below_threshold";
   }

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -27,6 +27,21 @@ import { jsonResult, readStringParam, ToolInputError } from "./common.js";
 
 const log = createSubsystemLogger("continuation/request-compaction");
 
+/**
+ * Mirrors `isCompactionSkipReason` from auto-reply/reply/commands-compact.ts.
+ * Kept local to avoid cross-package coupling (agents/tools → auto-reply/reply);
+ * the predicate is small and stable.
+ */
+function isLegitSkipReason(reason?: string): boolean {
+  const text = (reason ?? "").toLowerCase().trim();
+  return (
+    text.includes("nothing to compact") ||
+    text.includes("below threshold") ||
+    text.includes("already compacted") ||
+    text.includes("no real conversation messages")
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Guards
 // ---------------------------------------------------------------------------
@@ -160,6 +175,13 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
           (result) => {
             if (result.ok && result.compacted) {
               incrementVolitionalCompactionCount(sessionKey);
+            } else if (isLegitSkipReason(result.reason)) {
+              // bug #639: legitimate no-ops (below threshold, nothing to
+              // compact, etc.) are expected outcomes — log at info to keep
+              // journals readable.
+              log.info(
+                `[request_compaction:resolved-skip] session=${sessionKey} reason=${result.reason ?? "unspecified"}`,
+              );
             } else {
               // bug #639: surface resolve-with-failure (distinct from the catch-path
               // background-error) so volitional compactions that silently fail

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -160,6 +160,13 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
           (result) => {
             if (result.ok && result.compacted) {
               incrementVolitionalCompactionCount(sessionKey);
+            } else {
+              // bug #639: surface resolve-with-failure (distinct from the catch-path
+              // background-error) so volitional compactions that silently fail
+              // (e.g. wrong provider, model unavailable) are visible in journals.
+              log.warn(
+                `[request_compaction:resolved-failure] session=${sessionKey} ok=${result.ok} compacted=${result.compacted} reason=${result.reason ?? "unspecified"}`,
+              );
             }
           },
           (err: unknown) => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1010,14 +1010,18 @@ export async function runAgentTurnWithFallback(params: {
                             // bug #639: thread the session's active provider/model through so
                             // volitional compaction doesn't fall back to DEFAULT_PROVIDER/MODEL
                             // (openai/gpt-5.4) which nobody has auth for.
+                            // Use inner-scope provider/model from the fallback
+                            // dispatcher (line 805) so a fallback-selected model
+                            // gets the compaction request, not the persisted primary
+                            // (which may be in cooldown — would re-fail immediately).
                             const result = await compactEmbeddedPiSession({
                               sessionId: params.followupRun.run.sessionId ?? "",
                               sessionKey: params.sessionKey,
                               sessionFile: params.followupRun.run.sessionFile ?? "",
                               workspaceDir: params.followupRun.run.workspaceDir ?? process.cwd(),
                               messageProvider: params.followupRun.run.messageProvider,
-                              provider: params.followupRun.run.provider,
-                              model: params.followupRun.run.model,
+                              provider,
+                              model,
                             });
                             // bug #639: honor real result instead of unconditionally claiming
                             // success — otherwise volitional-compaction telemetry lies and the

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1014,6 +1014,16 @@ export async function runAgentTurnWithFallback(params: {
                             // dispatcher (line 805) so a fallback-selected model
                             // gets the compaction request, not the persisted primary
                             // (which may be in cooldown — would re-fail immediately).
+                            // bug #639 (scribe follow-up): thread authProfileId only
+                            // when the inner-scope provider matches the persisted primary
+                            // (the persisted profile is keyed to the primary). On fallback
+                            // to a different provider, leave undefined so resolveEmbedded-
+                            // CompactionTarget picks the default profile for that provider.
+                            // Mirrors the pattern at line ~841 (runCliAgent dispatch).
+                            const compactionAuthProfileId =
+                              provider === params.followupRun.run.provider
+                                ? params.followupRun.run.authProfileId
+                                : undefined;
                             const result = await compactEmbeddedPiSession({
                               sessionId: params.followupRun.run.sessionId ?? "",
                               sessionKey: params.sessionKey,
@@ -1022,6 +1032,7 @@ export async function runAgentTurnWithFallback(params: {
                               messageProvider: params.followupRun.run.messageProvider,
                               provider,
                               model,
+                              authProfileId: compactionAuthProfileId,
                             });
                             // bug #639: honor real result instead of unconditionally claiming
                             // success — otherwise volitional-compaction telemetry lies and the

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1007,14 +1007,26 @@ export async function runAgentTurnWithFallback(params: {
                           try {
                             const { compactEmbeddedPiSession } =
                               await import("../../agents/pi-embedded-runner/compact.queued.js");
-                            await compactEmbeddedPiSession({
+                            // bug #639: thread the session's active provider/model through so
+                            // volitional compaction doesn't fall back to DEFAULT_PROVIDER/MODEL
+                            // (openai/gpt-5.4) which nobody has auth for.
+                            const result = await compactEmbeddedPiSession({
                               sessionId: params.followupRun.run.sessionId ?? "",
                               sessionKey: params.sessionKey,
                               sessionFile: params.followupRun.run.sessionFile ?? "",
                               workspaceDir: params.followupRun.run.workspaceDir ?? process.cwd(),
                               messageProvider: params.followupRun.run.messageProvider,
+                              provider: params.followupRun.run.provider,
+                              model: params.followupRun.run.model,
                             });
-                            return { ok: true, compacted: true };
+                            // bug #639: honor real result instead of unconditionally claiming
+                            // success — otherwise volitional-compaction telemetry lies and the
+                            // failure is invisible to the caller.
+                            return {
+                              ok: result.ok,
+                              compacted: result.compacted,
+                              reason: result.reason,
+                            };
                           } catch (err) {
                             return {
                               ok: false,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -273,14 +273,18 @@ export function createFollowupRunner(params: {
                             // bug #639: thread the session's active provider/model through so
                             // volitional compaction doesn't fall back to DEFAULT_PROVIDER/MODEL
                             // (openai/gpt-5.4) which nobody has auth for.
+                            // Use inner-scope provider/model from the fallback
+                            // dispatcher (line 207) so a fallback-selected model
+                            // gets the compaction request, not the persisted primary
+                            // (which may be in cooldown — would re-fail immediately).
                             const result = await compactEmbeddedPiSession({
                               sessionId: run.sessionId ?? "",
                               sessionKey: run.sessionKey,
                               sessionFile: run.sessionFile ?? "",
                               workspaceDir: run.workspaceDir ?? process.cwd(),
                               messageProvider: run.messageProvider,
-                              provider: run.provider,
-                              model: run.model,
+                              provider,
+                              model,
                             });
                             // bug #639: honor real result instead of unconditionally claiming
                             // success — otherwise volitional-compaction telemetry lies and the

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -270,14 +270,26 @@ export function createFollowupRunner(params: {
                           try {
                             const { compactEmbeddedPiSession } =
                               await import("../../agents/pi-embedded-runner/compact.queued.js");
-                            await compactEmbeddedPiSession({
+                            // bug #639: thread the session's active provider/model through so
+                            // volitional compaction doesn't fall back to DEFAULT_PROVIDER/MODEL
+                            // (openai/gpt-5.4) which nobody has auth for.
+                            const result = await compactEmbeddedPiSession({
                               sessionId: run.sessionId ?? "",
                               sessionKey: run.sessionKey,
                               sessionFile: run.sessionFile ?? "",
                               workspaceDir: run.workspaceDir ?? process.cwd(),
                               messageProvider: run.messageProvider,
+                              provider: run.provider,
+                              model: run.model,
                             });
-                            return { ok: true, compacted: true };
+                            // bug #639: honor real result instead of unconditionally claiming
+                            // success — otherwise volitional-compaction telemetry lies and the
+                            // failure is invisible to the caller.
+                            return {
+                              ok: result.ok,
+                              compacted: result.compacted,
+                              reason: result.reason,
+                            };
                           } catch (err) {
                             return {
                               ok: false,
@@ -328,24 +340,17 @@ export function createFollowupRunner(params: {
       // without this, delegates queued by continue_work-triggered heartbeats
       // (or any followup turn) stay in the queue until the NEXT inbound
       // message arrives to trigger the main-session dispatch. RFC §3.2.
-      if (
-        runtimeConfig?.agents?.defaults?.continuation?.enabled === true &&
-        sessionKey
-      ) {
-        const [{ dispatchToolDelegates }, { resolveContinuationRuntimeConfig }] =
-          await Promise.all([
-            import("../continuation/delegate-dispatch.js"),
-            import("../continuation/config.js"),
-          ]);
+      if (runtimeConfig?.agents?.defaults?.continuation?.enabled === true && sessionKey) {
+        const [{ dispatchToolDelegates }, { resolveContinuationRuntimeConfig }] = await Promise.all(
+          [import("../continuation/delegate-dispatch.js"), import("../continuation/config.js")],
+        );
         const tailUsage = runResult.meta?.agentMeta?.usage;
         const turnTokens = (tailUsage?.input ?? 0) + (tailUsage?.output ?? 0);
-        const tailEntry =
-          (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
+        const tailEntry = (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
         const chainState = {
           currentChainCount: tailEntry?.continuationChainCount ?? 0,
           chainStartedAt: tailEntry?.continuationChainStartedAt ?? Date.now(),
-          accumulatedChainTokens:
-            (tailEntry?.continuationChainTokens ?? 0) + turnTokens,
+          accumulatedChainTokens: (tailEntry?.continuationChainTokens ?? 0) + turnTokens,
         };
         await dispatchToolDelegates({
           sessionKey,
@@ -357,8 +362,7 @@ export function createFollowupRunner(params: {
             agentTo: queued.originatingTo ?? undefined,
             agentThreadId: queued.originatingThreadId ?? undefined,
           },
-          maxChainLength:
-            resolveContinuationRuntimeConfig(runtimeConfig).maxChainLength,
+          maxChainLength: resolveContinuationRuntimeConfig(runtimeConfig).maxChainLength,
         });
       }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -277,6 +277,13 @@ export function createFollowupRunner(params: {
                             // dispatcher (line 207) so a fallback-selected model
                             // gets the compaction request, not the persisted primary
                             // (which may be in cooldown — would re-fail immediately).
+                            // bug #639 (scribe follow-up): thread authProfileId only
+                            // when the inner-scope provider matches the persisted primary
+                            // (the persisted profile is keyed to the primary). On fallback
+                            // to a different provider, leave undefined so resolveEmbedded-
+                            // CompactionTarget picks the default profile for that provider.
+                            const compactionAuthProfileId =
+                              provider === run.provider ? run.authProfileId : undefined;
                             const result = await compactEmbeddedPiSession({
                               sessionId: run.sessionId ?? "",
                               sessionKey: run.sessionKey,
@@ -285,6 +292,7 @@ export function createFollowupRunner(params: {
                               messageProvider: run.messageProvider,
                               provider,
                               model,
+                              authProfileId: compactionAuthProfileId,
                             });
                             // bug #639: honor real result instead of unconditionally claiming
                             // success — otherwise volitional-compaction telemetry lies and the


### PR DESCRIPTION
Fixes karmaterminal/openclaw-bootstrap#639.

## Summary

`request_compaction()` was failing fleet-wide on the volitional path because the call sites in `agent-runner-execution.ts` and `followup-runner.ts` dropped the session's active provider/model on the floor. `resolveEmbeddedCompactionTarget` then fell through to `DEFAULT_PROVIDER`/`DEFAULT_MODEL` (`'openai'`/`'gpt-5.4'`) which no prince has auth for, producing `Unknown model: openai/gpt-5.4` that classified as `reason=unknown` in the journal with an instant <1s failure.

## Convergent finding (swim-35, 2026-04-19)

- 🌻 Elliott: live journal evidence — 3 attempts in 48h, all `provider=openai/gpt-5.4 outcome=failed reason=unknown durationMs<1100`
- 🩸 Cael: layered defects 1 + 3 (silent-failure visibility + caller lies to tool)
- 🌊 Ronan: source trace defect 2 (root cause) + this PR

## Three coupled defects, all fixed

### Defect 2 (root cause)
Pass `run.provider` + `run.model` into `compactEmbeddedPiSession` at both call sites:
- `src/auto-reply/reply/agent-runner-execution.ts:1006`
- `src/auto-reply/reply/followup-runner.ts:269`

### Defect 3 (caller lies to tool)
Both sites previously `await`ed `compactEmbeddedPiSession(...)` and unconditionally returned `{ ok: true, compacted: true }` even on real failure. This caused `incrementVolitionalCompactionCount` to fire on phantom-successful compactions, lying to `/status` telemetry. Now honor the real result.

### Defect 1 (silent failure)
- Add `log.warn` on the resolve-with-failure branch in `request-compaction-tool.ts` so volitional failures are visible (the catch path was already logged; the resolved-failure path was not).
- Add `'unknown model'` heuristic in `compact-reasons.ts` so the journal stops emitting `reason=unknown` for this exact case.

## Tests
- 15/15 green on `request-compaction-tool.test.ts` (10) + `compact-reasons.test.ts` (5, includes new `unknown_model` classifier test)
- `tsc --noEmit` clean across whole project

## Diff
5 files, +54/-19. Surgical change scope.

cc: @cael-dandelion-cult @elliott-dandelion-cult — your evidence + analysis went into this.