### PR TITLE
fix(continuation): release hedge timer ref on natural fire (#189)

### DIFF
--- a/src/auto-reply/continuation/delegate-dispatch.test.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock TaskFlow registry — delegate-store resolves it transitively.
+const mockFlows = new Map<string, Record<string, unknown>>();
+let flowIdCounter = 0;
+
+vi.mock("../../tasks/task-flow-registry.js", () => ({
+  createManagedTaskFlow: vi.fn((params: Record<string, unknown>) => {
+    const flowId = `flow-${++flowIdCounter}`;
+    mockFlows.set(flowId, {
+      flowId,
+      syncMode: "managed",
+      ownerKey: params.ownerKey,
+      controllerId: params.controllerId,
+      status: "queued",
+      stateJson: params.stateJson,
+      goal: params.goal,
+      currentStep: params.currentStep,
+      revision: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    return mockFlows.get(flowId);
+  }),
+  listTaskFlowsForOwnerKey: vi.fn((ownerKey: string) =>
+    [...mockFlows.values()].filter((f) => f.ownerKey === ownerKey),
+  ),
+  finishFlow: vi.fn((params: { flowId: string; expectedRevision: number }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (!flow || flow.revision !== params.expectedRevision) {
+      return { applied: false, reason: flow ? "revision_conflict" : "not_found" };
+    }
+    flow.status = "succeeded";
+    flow.revision = flow.revision + 1;
+    return { applied: true, flow: { ...flow } };
+  }),
+  failFlow: vi.fn((params: { flowId: string }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (flow) {
+      flow.status = "failed";
+    }
+    return { applied: !!flow };
+  }),
+  deleteTaskFlowRecordById: vi.fn((flowId: string) => {
+    mockFlows.delete(flowId);
+  }),
+}));
+
+import { dispatchToolDelegates, resetDelegateDispatchHedgesForTests } from "./delegate-dispatch.js";
+import { cancelPendingDelegates, enqueuePendingDelegate } from "./delegate-store.js";
+import { hasLiveContinuationTimerRefs, resetContinuationStateForTests } from "./state.js";
+
+beforeEach(() => {
+  mockFlows.clear();
+  flowIdCounter = 0;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  resetDelegateDispatchHedgesForTests();
+  resetContinuationStateForTests();
+  mockFlows.clear();
+  vi.useRealTimers();
+});
+
+describe("hedge timer ref/handle cleanup (openclaw#189)", () => {
+  it("releases the timer ref + handle after a natural hedge fire", async () => {
+    const sessionKey = "session-hedge-natural";
+
+    // Queue an unmatured delegate so `dispatchToolDelegates` arms a hedge.
+    enqueuePendingDelegate(sessionKey, { task: "deferred work", delayMs: 30_000 });
+
+    await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+    expect(hasLiveContinuationTimerRefs(sessionKey)).toBe(true);
+
+    // Cancel the delegate before the hedge fires so the re-dispatch hits
+    // the empty-queue / no-unmatured path — isolates the natural-fire
+    // cleanup we're asserting.
+    cancelPendingDelegates(sessionKey);
+
+    await vi.advanceTimersByTimeAsync(30_000 + 100);
+    // Drain the fire-and-forget re-dispatch promise.
+    await vi.runAllTimersAsync();
+
+    // Before the fix: the natural-fire branch deleted the hedgeTimers map
+    // entry but never called unregisterContinuationTimerHandle, so the
+    // ref count stayed >= 1. The fix makes the natural-fire path mirror
+    // clearHedgeTimer's cleanup.
+    expect(hasLiveContinuationTimerRefs(sessionKey)).toBe(false);
+  });
+
+  it("releases the timer ref + handle on explicit clearHedgeTimer", async () => {
+    const sessionKey = "session-hedge-cancel";
+
+    enqueuePendingDelegate(sessionKey, { task: "deferred", delayMs: 30_000 });
+
+    await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+    expect(hasLiveContinuationTimerRefs(sessionKey)).toBe(true);
+
+    // Cancel then re-dispatch: the follow-up call sees no unmatured
+    // delegate and takes the clearHedgeTimer branch, which should drop
+    // the ref to zero.
+    cancelPendingDelegates(sessionKey);
+    await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(hasLiveContinuationTimerRefs(sessionKey)).toBe(false);
+  });
+});

--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -56,6 +56,11 @@ function armHedgeTimer(
   retainContinuationTimerRef(sessionKey);
   const handle = setTimeout(() => {
     hedgeTimers.delete(sessionKey);
+    // Release ref + handle registration on natural fire (matches
+    // clearHedgeTimer on cancel). Without this, every hedge that fires
+    // naturally leaks a timer-ref and handle, keeping continuation state
+    // alive past its useful lifetime. openclaw#189.
+    unregisterContinuationTimerHandle(sessionKey, handle);
     log.info(`[continuation:delegate-hedge-fired] session=${sessionKey}`);
     void dispatchToolDelegates({ sessionKey, ...params }).catch((err) => {
       log.info(


### PR DESCRIPTION
## Summary

Closes #189.

`armHedgeTimer` in `src/auto-reply/continuation/delegate-dispatch.ts` registers each hedge handle in the continuation timer registry and increments the per-session ref count. `clearHedgeTimer` (cancel path) and `resetDelegateDispatchHedgesForTests` both call `unregisterContinuationTimerHandle` to undo that registration — but the natural-fire path inside the `setTimeout` callback only removed the entry from the `hedgeTimers` map and never released the ref/handle.

Consequence: every hedge that fires naturally (instead of being cancelled by a follow-up `dispatchToolDelegates` call) leaks one timer-ref and one live handle entry. `hasLiveContinuationTimerRefs` stays `true` forever for that session, keeping continuation state alive past its useful lifetime.

Fix: one `unregisterContinuationTimerHandle(sessionKey, handle)` call in the natural-fire branch, mirroring `clearHedgeTimer`.

## Test plan

New test: `src/auto-reply/continuation/delegate-dispatch.test.ts`.

- [x] `releases the timer ref + handle after a natural hedge fire` — arms a hedge, cancels the underlying delegate, advances fake timers past the fire point, asserts `hasLiveContinuationTimerRefs === false`. Reliably fails on the pre-fix code and passes with the fix.
- [x] `releases the timer ref + handle on explicit clearHedgeTimer` — regression guard for the existing cancel path.
- [x] `pnpm test src/auto-reply/continuation/` — 36/36 passing.
- [x] `pnpm tsgo` — clean.

## Scope

Intentionally narrow: 1 line of production code + 2 tests. No behavioral change beyond the ref/handle cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)