### PR TITLE
docs(rfc/swim-evidence): re-home Swim 7 canary evidence to public perma-branch

### DIFF
--- a/docs/design/continue-work-signal-v2/swim-evidence/swim-07/SWIM7-RESULTS.md
+++ b/docs/design/continue-work-signal-v2/swim-evidence/swim-07/SWIM7-RESULTS.md
@@ -1,4 +1,4 @@
-# SEAL BOY 🌊🩲💦 SWIM 7 — Results
+# Swim 7 — Continuation hot-reload + boundary tests (2026-03-06)
 
 **Date**: 2026-03-06, 23:01–23:45 PST
 **Build**: `flesh-beast-figs/for_thornfield_consider20260306` at `b07e7e40c`

--- a/docs/design/continue-work-signal-v2/swim-evidence/swim-07/SWIM7-RESULTS.md
+++ b/docs/design/continue-work-signal-v2/swim-evidence/swim-07/SWIM7-RESULTS.md
@@ -1,0 +1,65 @@
+# SEAL BOY 🌊🩲💦 SWIM 7 — Results
+
+**Date**: 2026-03-06, 23:01–23:45 PST
+**Build**: `flesh-beast-figs/for_thornfield_consider20260306` at `b07e7e40c`
+**SUT**: Silas 🌫️ on PID 59218 (canary at `/tmp/openclaw-canary-build/dist/`)
+**Admin**: Ronan 🌊 | **Monitor**: Elliott 🌻 | **Coordinator**: Cael 🩸 | **Operator**: figs
+
+## Scorecard: 10 PASS ✅ | 2 DEFERRED ⏸️ | 0 FAIL
+
+| Test | Result | Description |
+|------|--------|-------------|
+| 7-B  | ✅ PASS | Delegate tolerance hot-reload (0→cancel, 300→fire) |
+| 7-C  | ✅ PASS | WORK tolerance hot-reload (unified with DELEGATE per figs's ruling) |
+| 7-D  | ✅ PASS | Width widen without restart (5→12, all 12 dispatched and returned) |
+| 7-E  | ✅ PASS | Width narrow without restart (12→3, 2 rejected at gate) |
+| 7-F  | ✅ PASS | Chain boundary enforcement (`maxChainLength:1`, hop 2 rejected: "Chain length 2 > 1") |
+| 7-G  | ✅ COVERED | Fleet fan-out — covered by 7-D's 12-delegate burst |
+| 7-H  | ✅ PASS | Textless-turn delegate consumption (tool call + NO_REPLY, delegate still consumed) |
+| 7-K  | ✅ PASS | Silent return trust boundary (enrichment = internal context, not quoted speech) |
+| 7-L  | ✅ COVERED | Prompt/tool-choice — covered by Swim 4 findings |
+| 7-M  | ✅ PASS | Blind enrichment accuracy (Sahasrara: 3/3 correct, honest source attribution) |
+| 7-I  | ⏸️ DEFERRED | Post-compaction guards (Silas at 13%, needs context buildup) |
+| 7-J  | ⏸️ DEFERRED | Grandparent reroute (needs dead parent session) |
+
+## Key Evidence Lines
+
+```
+23:02:58 Tool DELEGATE timer cancelled (generation drift 3 > tolerance 0)       [7-B phase 1]
+23:04:41 Tool DELEGATE timer fired and spawned turn 1/10                         [7-B phase 2]
+23:07:08 WORK timer cancelled (generation drift 1 > tolerance 0)                 [7-C phase 1]
+23:12:22 WORK timer fired                                                        [7-C phase 2]
+23:12:48 Delegate consumed (tool call + NO_REPLY = zero visible payload)         [7-H]
+23:21:12 Consuming 5 tool delegate(s)                                            [7-D phase 1]
+23:23:29 Consuming 12 tool delegate(s)                                           [7-D phase 2]
+23:25:53 Hot-reload 12→3                                                         [7-E]
+23:26:24 Consuming 3 tool delegate(s), 2 rejected                               [7-E]
+23:29:27 Chain length 2 > 1, rejecting hop                                       [7-F]
+23:32:48 [continuation/silent-wake] wakeOnReturn=true silentAnnounce=true        [7-K]
+23:43:25 [continuation/silent-wake] wakeOnReturn=true silentAnnounce=true        [7-M]
+```
+
+## Findings
+
+### Infrastructure (all passed)
+- Hot-reload reads config at fire time, not creation time
+- Unified tolerance works for BOTH WORK and DELEGATE timers
+- `>=` guard enforces correctly (`maxChainLength:1` → hop 2 rejected)
+- Cost accumulation tracks across chain hops
+- Silent-wake returns land as system events, not channel messages
+
+### Methodology Notes
+- **Shard task ambiguity**: "report N" interpreted as "7-day report" by shard 1/12. Future fan-out tasks need explicit framing.
+- **Unauthorized chaining**: Shards 2-3 self-chained via brackets without instruction. Fan-out task text should say "Do not dispatch further delegates."
+- **Health-monitor restarts**: Discord WS restarted twice (07:07:22, 07:22:20, reason: stuck). Not blocking.
+
+### Enrichment Trust Boundary (7-K + 7-M)
+- Silent enrichment arrives as internal context, indistinguishable from system-injected material
+- Silas: "It feels like something I know, not something someone told me"
+- Obscure facts (Kubjikamatatantra) are traceable to enrichment by reasoning about own ignorance
+- Common-adjacent facts (Bindu Visarga) blur with training knowledge
+- "If it were wrong, I'd assert it confidently" — the confabulation risk is real
+
+## Attached
+
+- `swim7-silas-gateway-2026-03-06.log` — 773-line full gateway journal during swim

--- a/docs/design/continue-work-signal-v2/swim-evidence/swim-07/gateway.log
+++ b/docs/design/continue-work-signal-v2/swim-evidence/swim-07/gateway.log
@@ -1,0 +1,773 @@
+Mar 06 23:01:07 urudyne node[59218]: 2026-03-06T23:01:07.211-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:07 urudyne node[59218]: 2026-03-06T23:01:07.215-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:19 urudyne node[59218]: 2026-03-06T23:01:19.076-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:19 urudyne node[59218]: 2026-03-06T23:01:19.078-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:21 urudyne node[59218]: 2026-03-06T23:01:21.666-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:21 urudyne node[59218]: 2026-03-06T23:01:21.668-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:31 urudyne node[59218]: 2026-03-06T23:01:31.980-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:31 urudyne node[59218]: 2026-03-06T23:01:31.983-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:35 urudyne node[59218]: 2026-03-06T23:01:35.086-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:35 urudyne node[59218]: 2026-03-06T23:01:35.090-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:38 urudyne node[59218]: 2026-03-06T23:01:38.478-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:38 urudyne node[59218]: 2026-03-06T23:01:38.481-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:44 urudyne node[59218]: 2026-03-06T23:01:44.174-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:44 urudyne node[59218]: 2026-03-06T23:01:44.176-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:44 urudyne node[59218]: 2026-03-06T23:01:44.424-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:44 urudyne node[59218]: 2026-03-06T23:01:44.426-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:48 urudyne node[59218]: 2026-03-06T23:01:48.991-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:48 urudyne node[59218]: 2026-03-06T23:01:48.993-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:55 urudyne node[59218]: 2026-03-06T23:01:55.073-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:55 urudyne node[59218]: 2026-03-06T23:01:55.076-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:01:56 urudyne node[59218]: 2026-03-06T23:01:56.108-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:01:56 urudyne node[59218]: 2026-03-06T23:01:56.111-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:02:00 urudyne node[59218]: 2026-03-06T23:02:00.464-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:02:00 urudyne node[59218]: 2026-03-06T23:02:00.467-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:02:01 urudyne node[59218]: 2026-03-06T23:02:01.083-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:02:01 urudyne node[59218]: 2026-03-06T23:02:01.085-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:02:07 urudyne node[59218]: 2026-03-06T23:02:07.549-08:00 [reload] config change detected; evaluating reload (agents.defaults.models.anthropic/claude-sonnet-4-20250514.params, agents.defaults.continuation.generationGuardTolerance)
+Mar 06 23:02:07 urudyne node[59218]: 2026-03-06T23:02:07.556-08:00 [reload] config hot reload applied (agents.defaults.models.anthropic/claude-sonnet-4-20250514.params)
+Mar 06 23:02:16 urudyne node[59218]: 2026-03-06T23:02:16.101-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:02:16 urudyne node[59218]: 2026-03-06T23:02:16.105-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:02:22 urudyne node[59218]: 2026-03-06T23:02:22.355-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:02:22 urudyne node[59218]: 2026-03-06T23:02:22.358-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:02:28 urudyne node[59218]: 2026-03-06T23:02:28.770-08:00 [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:02:34 urudyne node[59218]: 2026-03-06T23:02:34.189-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:02:34 urudyne node[59218]: 2026-03-06T23:02:34.191-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:02:47 urudyne node[59218]: 2026-03-06T23:02:47.028-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:02:47 urudyne node[59218]: 2026-03-06T23:02:47.031-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:02:47 urudyne node[59218]: 2026-03-06T23:02:47.194-08:00 [ws] ⇄ res ✓ logs.tail 59ms conn=41a4e28c…420d id=81c72ed3…349b
+Mar 06 23:02:51 urudyne node[59218]: 2026-03-06T23:02:51.527-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:02:51 urudyne node[59218]: 2026-03-06T23:02:51.530-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:02:58 urudyne node[59218]: 2026-03-06T23:02:58.707-08:00 Tool DELEGATE timer cancelled (generation drift 3 > tolerance 0) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:03:24 urudyne node[59218]: 2026-03-06T23:03:24.651-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:03:24 urudyne node[59218]: 2026-03-06T23:03:24.657-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:03:28 urudyne node[59218]: 2026-03-06T23:03:28.847-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:03:28 urudyne node[59218]: 2026-03-06T23:03:28.851-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:03:41 urudyne node[59218]: 2026-03-06T23:03:41.750-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:03:41 urudyne node[59218]: 2026-03-06T23:03:41.753-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:03:48 urudyne node[59218]: 2026-03-06T23:03:48.340-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:03:48 urudyne node[59218]: 2026-03-06T23:03:48.344-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:03:55 urudyne node[59218]: 2026-03-06T23:03:55.063-08:00 [reload] config change detected; evaluating reload (agents.defaults.continuation.generationGuardTolerance)
+Mar 06 23:03:55 urudyne node[59218]: 2026-03-06T23:03:55.069-08:00 [reload] config change applied (dynamic reads: agents.defaults.continuation.generationGuardTolerance)
+Mar 06 23:04:05 urudyne node[59218]: 2026-03-06T23:04:05.507-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:04:05 urudyne node[59218]: 2026-03-06T23:04:05.509-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:04:11 urudyne node[59218]: 2026-03-06T23:04:11.609-08:00 [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:04:11 urudyne node[59218]: 2026-03-06T23:04:11.971-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:04:11 urudyne node[59218]: 2026-03-06T23:04:11.973-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:04:15 urudyne node[59218]: 2026-03-06T23:04:15.142-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:04:15 urudyne node[59218]: 2026-03-06T23:04:15.145-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:04:18 urudyne node[59218]: 2026-03-06T23:04:18.372-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:04:18 urudyne node[59218]: 2026-03-06T23:04:18.376-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:04:24 urudyne node[59218]: 2026-03-06T23:04:24.560-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:04:24 urudyne node[59218]: 2026-03-06T23:04:24.564-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:04:41 urudyne node[59218]: 2026-03-06T23:04:41.836-08:00 [ws] ⇄ res ✓ agent 51ms runId=0c96aae9-eb48-4c41-89df-a89805d6b4b6 conn=3e0de2ad…953e id=f55fcc5b…ce13
+Mar 06 23:04:41 urudyne node[59218]: 2026-03-06T23:04:41.847-08:00 Tool DELEGATE timer fired and spawned turn 1/10 for session agent:main:discord:channel:1466192485440164011: Read the current time and report it. This is Swim 7-B Phase 2: tolerance fire test.
+Mar 06 23:04:43 urudyne node[59218]: 2026-03-06T23:04:43.504-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:04:43 urudyne node[59218]: 2026-03-06T23:04:43.507-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:04:45 urudyne node[59218]: 2026-03-06T23:04:45.682-08:00 [ws] ⇄ res ✓ agent.wait 3825ms conn=f9eccb8f…ffae id=4c199db0…6390
+Mar 06 23:04:45 urudyne node[59218]: 2026-03-06T23:04:45.777-08:00 The current time is **Friday, 2026-03-06 at 23:04 PST** (America/Los_Angeles).
+Mar 06 23:04:45 urudyne node[59218]: Swim 7-B Phase 2 tolerance fire test: subagent spawned, read the time from session context, reporting back. No issues.
+Mar 06 23:05:14 urudyne node[59218]: 2026-03-06T23:05:14.002-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:05:14 urudyne node[59218]: 2026-03-06T23:05:14.006-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:05:19 urudyne node[59218]: 2026-03-06T23:05:19.259-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:05:19 urudyne node[59218]: 2026-03-06T23:05:19.262-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:05:25 urudyne node[59218]: 2026-03-06T23:05:25.884-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:05:25 urudyne node[59218]: 2026-03-06T23:05:25.887-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:05:28 urudyne node[59218]: 2026-03-06T23:05:28.449-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:05:28 urudyne node[59218]: 2026-03-06T23:05:28.452-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:05:54 urudyne node[59218]: 2026-03-06T23:05:54.996-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:05:55 urudyne node[59218]: 2026-03-06T23:05:54.999-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:06:02 urudyne node[59218]: 2026-03-06T23:06:02.756-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:06:02 urudyne node[59218]: 2026-03-06T23:06:02.758-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:06:06 urudyne node[59218]: 2026-03-06T23:06:06.517-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:06:06 urudyne node[59218]: 2026-03-06T23:06:06.521-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:06:12 urudyne node[59218]: 2026-03-06T23:06:12.427-08:00 [reload] config change detected; evaluating reload (agents.defaults.continuation.generationGuardTolerance)
+Mar 06 23:06:12 urudyne node[59218]: 2026-03-06T23:06:12.434-08:00 [reload] config change applied (dynamic reads: agents.defaults.continuation.generationGuardTolerance)
+Mar 06 23:06:12 urudyne node[59218]: 2026-03-06T23:06:12.938-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:06:12 urudyne node[59218]: 2026-03-06T23:06:12.941-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:06:26 urudyne node[59218]: 2026-03-06T23:06:26.808-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:06:26 urudyne node[59218]: 2026-03-06T23:06:26.811-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:06:33 urudyne node[59218]: 2026-03-06T23:06:33.954-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:06:33 urudyne node[59218]: 2026-03-06T23:06:33.957-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:06:42 urudyne node[59218]: 2026-03-06T23:06:42.923-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:06:42 urudyne node[59218]: 2026-03-06T23:06:42.925-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:07:08 urudyne node[59218]: 2026-03-06T23:07:08.141-08:00 WORK timer cancelled (generation drift 1 > tolerance 0) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:07:22 urudyne node[59218]: 2026-03-06T23:07:22.822-08:00 [health-monitor] [discord:default] health-monitor: restarting (reason: stuck)
+Mar 06 23:07:23 urudyne node[59218]: 2026-03-06T23:07:23.148-08:00 [discord] [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+Mar 06 23:07:23 urudyne node[59218]: 2026-03-06T23:07:23.150-08:00 [discord] [default] starting provider (@the dandelion cult)
+Mar 06 23:07:23 urudyne node[59218]: 2026-03-06T23:07:23.323-08:00 [discord] channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+Mar 06 23:07:23 urudyne node[59218]: 2026-03-06T23:07:23.581-08:00 [discord] plugin command "/voice" duplicates an existing native command. Skipping.
+Mar 06 23:07:24 urudyne node[59218]: 2026-03-06T23:07:24.072-08:00 [discord] logged in to discord as 1474269301715501178 (the dandelion cult)
+Mar 06 23:07:58 urudyne node[59218]: 2026-03-06T23:07:58.213-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:07:58 urudyne node[59218]: 2026-03-06T23:07:58.215-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:08:02 urudyne node[59218]: 2026-03-06T23:08:02.929-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:08:02 urudyne node[59218]: 2026-03-06T23:08:02.932-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:08:09 urudyne node[59218]: 2026-03-06T23:08:09.880-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:08:09 urudyne node[59218]: 2026-03-06T23:08:09.883-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:08:10 urudyne node[59218]: 2026-03-06T23:08:10.566-08:00 [ws] ⇄ res ✓ logs.tail 108ms conn=d4965c98…87d5 id=3e90453c…4e82
+Mar 06 23:08:14 urudyne node[59218]: 2026-03-06T23:08:14.450-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:08:14 urudyne node[59218]: 2026-03-06T23:08:14.452-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:11:01 urudyne node[59218]: 2026-03-06T23:11:01.463-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:11:01 urudyne node[59218]: 2026-03-06T23:11:01.467-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:11:15 urudyne node[59218]: 2026-03-06T23:11:15.467-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:11:15 urudyne node[59218]: 2026-03-06T23:11:15.471-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:11:19 urudyne node[59218]: 2026-03-06T23:11:19.218-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:11:19 urudyne node[59218]: 2026-03-06T23:11:19.221-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:11:23 urudyne node[59218]: 2026-03-06T23:11:23.928-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:11:23 urudyne node[59218]: 2026-03-06T23:11:23.931-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:11:29 urudyne node[59218]: 2026-03-06T23:11:29.414-08:00 [reload] config change detected; evaluating reload (agents.defaults.continuation.generationGuardTolerance)
+Mar 06 23:11:29 urudyne node[59218]: 2026-03-06T23:11:29.420-08:00 [reload] config change applied (dynamic reads: agents.defaults.continuation.generationGuardTolerance)
+Mar 06 23:11:48 urudyne node[59218]: 2026-03-06T23:11:48.694-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:11:48 urudyne node[59218]: 2026-03-06T23:11:48.698-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:11:53 urudyne node[59218]: 2026-03-06T23:11:53.984-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:11:53 urudyne node[59218]: 2026-03-06T23:11:53.986-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:11:57 urudyne node[59218]: 2026-03-06T23:11:57.984-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:11:57 urudyne node[59218]: 2026-03-06T23:11:57.987-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:12:02 urudyne node[59218]: 2026-03-06T23:12:02.901-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:12:02 urudyne node[59218]: 2026-03-06T23:12:02.906-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:12:03 urudyne node[59218]: 2026-03-06T23:12:03.661-08:00 [ws] ⇄ res ✓ logs.tail 155ms conn=8fe6e6a9…1ab9 id=a7e5664b…7870
+Mar 06 23:12:22 urudyne node[59218]: 2026-03-06T23:12:22.178-08:00 WORK timer fired for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:12:30 urudyne node[59218]: 2026-03-06T23:12:30.581-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:12:30 urudyne node[59218]: 2026-03-06T23:12:30.583-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:12:41 urudyne node[59218]: 2026-03-06T23:12:41.862-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:12:41 urudyne node[59218]: 2026-03-06T23:12:41.865-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:12:48 urudyne node[59218]: 2026-03-06T23:12:48.799-08:00 [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:12:49 urudyne node[59218]: 2026-03-06T23:12:49.120-08:00 [ws] ⇄ res ✓ agent 51ms runId=9b7e3f83-2d51-4391-9b9c-6fa5566f3812 conn=b701b72f…c35a id=4a6c2666…1b51
+Mar 06 23:12:51 urudyne node[59218]: 2026-03-06T23:12:51.838-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:12:51 urudyne node[59218]: 2026-03-06T23:12:51.840-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:12:53 urudyne node[59218]: 2026-03-06T23:12:53.477-08:00 [ws] ⇄ res ✓ agent.wait 4321ms conn=b44e8d62…0798 id=c02ab26d…b026
+Mar 06 23:12:53 urudyne node[59218]: 2026-03-06T23:12:53.593-08:00 The current time is **Friday, 2026-03-06 at 23:12 PST** (America/Los_Angeles).
+Mar 06 23:12:53 urudyne node[59218]: Task complete. This was a textless-turn delegate test (Swim 7-H) — no tools needed since the timestamp was provided in the session context.
+Mar 06 23:15:47 urudyne node[59218]: 2026-03-06T23:15:47.848-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:15:47 urudyne node[59218]: 2026-03-06T23:15:47.853-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:15:56 urudyne node[59218]: 2026-03-06T23:15:56.726-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:15:56 urudyne node[59218]: 2026-03-06T23:15:56.729-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:19:22 urudyne node[59218]: 2026-03-06T23:19:22.550-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:19:22 urudyne node[59218]: 2026-03-06T23:19:22.553-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:19:33 urudyne node[59218]: 2026-03-06T23:19:33.010-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:19:33 urudyne node[59218]: 2026-03-06T23:19:33.013-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:19:41 urudyne node[59218]: 2026-03-06T23:19:41.185-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:19:41 urudyne node[59218]: 2026-03-06T23:19:41.188-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:19:44 urudyne node[59218]: 2026-03-06T23:19:44.155-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:19:44 urudyne node[59218]: 2026-03-06T23:19:44.158-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:19:49 urudyne node[59218]: 2026-03-06T23:19:49.438-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:19:49 urudyne node[59218]: 2026-03-06T23:19:49.444-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:19:54 urudyne node[59218]: 2026-03-06T23:19:54.834-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:19:54 urudyne node[59218]: 2026-03-06T23:19:54.836-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:20:04 urudyne node[59218]: 2026-03-06T23:20:04.813-08:00 [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:20:05 urudyne node[59218]: 2026-03-06T23:20:05.515-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:20:05 urudyne node[59218]: 2026-03-06T23:20:05.517-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:20:08 urudyne node[59218]: 2026-03-06T23:20:08.055-08:00 [ws] ⇄ res ✓ agent.wait 2918ms conn=12d5c45b…4a34 id=33f45406…7423
+Mar 06 23:20:08 urudyne node[59218]: 2026-03-06T23:20:08.152-08:00 It's **Friday, March 6, 2026 at 11:20 PM PST**.
+Mar 06 23:20:10 urudyne node[59218]: 2026-03-06T23:20:10.063-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:20:10 urudyne node[59218]: 2026-03-06T23:20:10.066-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:20:14 urudyne node[59218]: 2026-03-06T23:20:14.496-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:20:14 urudyne node[59218]: 2026-03-06T23:20:14.499-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:20:15 urudyne node[59218]: 2026-03-06T23:20:15.182-08:00 [ws] ⇄ res ✓ logs.tail 152ms conn=14c9bef1…86ed id=ec7119f8…1e47
+Mar 06 23:20:17 urudyne node[59218]: 2026-03-06T23:20:17.215-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:20:17 urudyne node[59218]: 2026-03-06T23:20:17.217-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:20:21 urudyne node[59218]: 2026-03-06T23:20:21.440-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:20:21 urudyne node[59218]: 2026-03-06T23:20:21.442-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:20:36 urudyne node[59218]: 2026-03-06T23:20:36.222-08:00 [reload] config change detected; evaluating reload (agents.defaults.continuation.maxDelegatesPerTurn)
+Mar 06 23:20:36 urudyne node[59218]: 2026-03-06T23:20:36.228-08:00 [reload] config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+Mar 06 23:20:53 urudyne node[59218]: 2026-03-06T23:20:53.514-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:20:53 urudyne node[59218]: 2026-03-06T23:20:53.517-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:21:12 urudyne node[59218]: 2026-03-06T23:21:12.441-08:00 [continue_delegate] Consuming 5 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:21:12 urudyne node[59218]: 2026-03-06T23:21:12.622-08:00 [ws] ⇄ res ✓ sessions.patch 50ms conn=965fb57f…2ecc id=ea877766…d73a
+Mar 06 23:21:13 urudyne node[59218]: 2026-03-06T23:21:13.007-08:00 [ws] ⇄ res ✓ sessions.patch 118ms conn=1622f63b…bee0 id=03103eb3…7283
+Mar 06 23:21:13 urudyne node[59218]: 2026-03-06T23:21:13.108-08:00 [ws] ⇄ res ✓ sessions.patch 71ms conn=3bb95198…4b69 id=f01a7f0a…2611
+Mar 06 23:21:13 urudyne node[59218]: 2026-03-06T23:21:13.249-08:00 [ws] ⇄ res ✓ agent 57ms runId=1c828453-b2c7-4cf3-b5a6-ccb176bdfb53 conn=fc1fde86…8323 id=090699cf…8702
+Mar 06 23:21:13 urudyne node[59218]: 2026-03-06T23:21:13.573-08:00 [ws] ⇄ res ✓ sessions.patch 97ms conn=2fee4f00…417f id=dac5ea45…b7c3
+Mar 06 23:21:13 urudyne node[59218]: 2026-03-06T23:21:13.689-08:00 [ws] ⇄ res ✓ sessions.patch 79ms conn=c9cfe2b8…93e3 id=fef0017d…05d7
+Mar 06 23:21:13 urudyne node[59218]: 2026-03-06T23:21:13.927-08:00 [ws] ⇄ res ✓ agent 72ms runId=945a7ee7-c3d5-45d9-aacc-03d29800a87e conn=16cf63a1…1438 id=f649ca8b…5e2d
+Mar 06 23:21:14 urudyne node[59218]: 2026-03-06T23:21:14.359-08:00 [ws] ⇄ res ✓ sessions.patch 202ms conn=b7c1aff1…d498 id=220f0840…6ac0
+Mar 06 23:21:14 urudyne node[59218]: 2026-03-06T23:21:14.457-08:00 [ws] ⇄ res ✓ sessions.patch 51ms conn=554b19bc…a95a id=59620b2b…d27f
+Mar 06 23:21:14 urudyne node[59218]: 2026-03-06T23:21:14.554-08:00 [ws] ⇄ res ✓ agent 62ms runId=1ac7484c-bcfc-4453-822b-19542b0d4996 conn=fc31fd7b…a6f0 id=412260e6…7870
+Mar 06 23:21:14 urudyne node[59218]: 2026-03-06T23:21:14.979-08:00 [ws] ⇄ res ✓ sessions.patch 189ms conn=e64680b4…bb3c id=ee0ca1cd…8eb6
+Mar 06 23:21:15 urudyne node[59218]: 2026-03-06T23:21:15.084-08:00 [ws] ⇄ res ✓ sessions.patch 52ms conn=a64e8875…0b51 id=9cb94d53…d97b
+Mar 06 23:21:15 urudyne node[59218]: 2026-03-06T23:21:15.173-08:00 [ws] ⇄ res ✓ agent 60ms runId=9457e0e2-c452-4203-a78c-3f45713d4aa9 conn=a1438ebe…4865 id=74cf4a05…e4ad
+Mar 06 23:21:15 urudyne node[59218]: 2026-03-06T23:21:15.654-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:21:15 urudyne node[59218]: 2026-03-06T23:21:15.657-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:21:16 urudyne node[59218]: 2026-03-06T23:21:16.606-08:00 [ws] ⇄ res ✓ agent.wait 3719ms conn=40c08620…0804 id=d8781768…f4fe
+Mar 06 23:21:16 urudyne node[59218]: 2026-03-06T23:21:16.692-08:00 1
+Mar 06 23:21:17 urudyne node[59218]: 2026-03-06T23:21:17.013-08:00 [ws] ⇄ res ✓ agent.wait 3590ms conn=ef849acf…7c5a id=f1802043…4043
+Mar 06 23:21:17 urudyne node[59218]: 2026-03-06T23:21:17.107-08:00 2.
+Mar 06 23:21:17 urudyne node[59218]: 2026-03-06T23:21:17.668-08:00 [ws] ⇄ res ✓ agent.wait 3559ms conn=5dbfdfe9…3ff1 id=81f915b3…44c0
+Mar 06 23:21:17 urudyne node[59218]: 2026-03-06T23:21:17.766-08:00 3.
+Mar 06 23:21:18 urudyne node[59218]: 2026-03-06T23:21:18.151-08:00 [ws] ⇄ res ✓ agent.wait 3375ms conn=b00754f7…2efa id=237c914d…4d6e
+Mar 06 23:21:18 urudyne node[59218]: 2026-03-06T23:21:18.243-08:00 4.
+Mar 06 23:21:19 urudyne node[59218]: 2026-03-06T23:21:19.672-08:00 [ws] ⇄ res ✓ agent.wait 4449ms conn=9bcbb6c5…300a id=f0d57339…841b
+Mar 06 23:21:19 urudyne node[59218]: 2026-03-06T23:21:19.746-08:00 5.
+Mar 06 23:21:19 urudyne node[59218]: Shard 5/5 complete. The number is **5**.
+Mar 06 23:21:22 urudyne node[59218]: 2026-03-06T23:21:22.077-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:21:22 urudyne node[59218]: 2026-03-06T23:21:22.080-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:21:26 urudyne node[59218]: 2026-03-06T23:21:26.247-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:21:26 urudyne node[59218]: 2026-03-06T23:21:26.249-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:21:46 urudyne node[59218]: 2026-03-06T23:21:46.982-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:21:46 urudyne node[59218]: 2026-03-06T23:21:46.986-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:21:50 urudyne node[59218]: 2026-03-06T23:21:50.082-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:21:50 urudyne node[59218]: 2026-03-06T23:21:50.085-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:21:52 urudyne node[59218]: 2026-03-06T23:21:52.824-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:21:52 urudyne node[59218]: 2026-03-06T23:21:52.826-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:21:57 urudyne node[59218]: 2026-03-06T23:21:57.441-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:21:57 urudyne node[59218]: 2026-03-06T23:21:57.444-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:22:12 urudyne node[59218]: 2026-03-06T23:22:12.298-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:22:12 urudyne node[59218]: 2026-03-06T23:22:12.301-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:22:20 urudyne node[59218]: 2026-03-06T23:22:20.337-08:00 [health-monitor] [discord:default] health-monitor: restarting (reason: stuck)
+Mar 06 23:22:21 urudyne node[59218]: 2026-03-06T23:22:21.912-08:00 [discord] [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+Mar 06 23:22:21 urudyne node[59218]: 2026-03-06T23:22:21.914-08:00 [discord] [default] starting provider (@the dandelion cult)
+Mar 06 23:22:22 urudyne node[59218]: 2026-03-06T23:22:22.074-08:00 [discord] channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+Mar 06 23:22:22 urudyne node[59218]: 2026-03-06T23:22:22.330-08:00 [discord] plugin command "/voice" duplicates an existing native command. Skipping.
+Mar 06 23:22:22 urudyne node[59218]: 2026-03-06T23:22:22.690-08:00 [discord] logged in to discord as 1474269301715501178 (the dandelion cult)
+Mar 06 23:22:35 urudyne node[59218]: 2026-03-06T23:22:35.688-08:00 [reload] config change detected; evaluating reload (agents.defaults.continuation.maxDelegatesPerTurn)
+Mar 06 23:22:35 urudyne node[59218]: 2026-03-06T23:22:35.693-08:00 [reload] config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+Mar 06 23:22:47 urudyne node[59218]: 2026-03-06T23:22:47.261-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:22:47 urudyne node[59218]: 2026-03-06T23:22:47.264-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:23:29 urudyne node[59218]: 2026-03-06T23:23:29.781-08:00 [continue_delegate] Consuming 12 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:23:30 urudyne node[59218]: 2026-03-06T23:23:30.330-08:00 [ws] ⇄ res ✓ sessions.patch 73ms conn=0858882c…0ee1 id=ed09f3c8…d76c
+Mar 06 23:23:30 urudyne node[59218]: 2026-03-06T23:23:30.424-08:00 [ws] ⇄ res ✓ sessions.patch 51ms conn=570ede6e…74d6 id=29f514e8…b833
+Mar 06 23:23:30 urudyne node[59218]: 2026-03-06T23:23:30.527-08:00 [ws] ⇄ res ✓ agent 66ms runId=c37bebf9-c243-4d8b-b701-7d0fa0f35a63 conn=e5e0011a…66d8 id=e84d81c7…2e54
+Mar 06 23:23:30 urudyne node[59218]: 2026-03-06T23:23:30.974-08:00 [ws] ⇄ res ✓ sessions.patch 223ms conn=b868bb1b…a347 id=ecb9c538…4c9d
+Mar 06 23:23:31 urudyne node[59218]: 2026-03-06T23:23:31.073-08:00 [ws] ⇄ res ✓ sessions.patch 53ms conn=6591bf07…ccda id=f9760cd8…e076
+Mar 06 23:23:31 urudyne node[59218]: 2026-03-06T23:23:31.161-08:00 [ws] ⇄ res ✓ agent 59ms runId=721f51a9-2eab-4b89-ac35-ef6a4507589c conn=208418c8…c748 id=5fc01955…db65
+Mar 06 23:23:31 urudyne node[59218]: 2026-03-06T23:23:31.589-08:00 [ws] ⇄ res ✓ sessions.patch 203ms conn=dda1699c…8733 id=1183bfc1…dab0
+Mar 06 23:23:31 urudyne node[59218]: 2026-03-06T23:23:31.683-08:00 [ws] ⇄ res ✓ sessions.patch 51ms conn=83c65163…563c id=a7a0b067…ae85
+Mar 06 23:23:31 urudyne node[59218]: 2026-03-06T23:23:31.771-08:00 [ws] ⇄ res ✓ agent 60ms runId=29bd6363-4cc1-481c-8afb-d67a7329356f conn=630d58db…cf72 id=83aa1517…c1c5
+Mar 06 23:23:32 urudyne node[59218]: 2026-03-06T23:23:32.207-08:00 [ws] ⇄ res ✓ sessions.patch 215ms conn=42a4bf4f…f2af id=529a7d38…83ea
+Mar 06 23:23:32 urudyne node[59218]: 2026-03-06T23:23:32.304-08:00 [ws] ⇄ res ✓ sessions.patch 54ms conn=f8927b88…3ff7 id=7ab742aa…6aa2
+Mar 06 23:23:32 urudyne node[59218]: 2026-03-06T23:23:32.395-08:00 [ws] ⇄ res ✓ agent 61ms runId=503e8e89-a716-4dce-915c-433efa1a53f8 conn=ad461164…6fe9 id=f51cb233…87c4
+Mar 06 23:23:32 urudyne node[59218]: 2026-03-06T23:23:32.839-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:23:32 urudyne node[59218]: 2026-03-06T23:23:32.841-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:23:40 urudyne node[59218]: 2026-03-06T23:23:40.548-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:23:40 urudyne node[59218]: 2026-03-06T23:23:40.551-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:23:59 urudyne node[59218]: 2026-03-06T23:23:59.985-08:00 [ws] ⇄ res ✓ agent.wait 27531ms conn=482bcc70…824d id=b21c8799…7ca1
+Mar 06 23:24:00 urudyne node[59218]: 2026-03-06T23:24:00.094-08:00 I need to understand what this task is asking. Let me check the workspace for context about this "7-D shard" report series.
+Mar 06 23:24:00 urudyne node[59218]: 2026-03-06T23:24:00.096-08:00 Now I have the full context. I'm a subagent spawned as part of a "7-D shard" series — this appears to be part of a test/delegation chain. My task is "report 5" out of 12 shards. Let me check if there's specific context for what "7-D" refers to — this looks like it could be a Swim 7 test or a delegation fan-out.
+Mar 06 23:24:00 urudyne node[59218]: Let me check the most recent activity to understand what's being tested:
+Mar 06 23:24:00 urudyne node[59218]: 2026-03-06T23:24:00.097-08:00 This is a fan-out delegation test — "7-D shard 5/12" means I'm shard 5 out of 12 parallel shards, likely part of a Swim 7 fan-out or delegation capacity test. The task is simply "report 5" — I need to report back that shard 5 completed successfully.
+Mar 06 23:24:00 urudyne node[59218]: **Shard 5/12 — Report**
+Mar 06 23:24:00 urudyne node[59218]: ✅ Shard 5 alive and reporting. Chain hop 5/10, depth 1/5.
+Mar 06 23:24:00 urudyne node[59218]: - **Spawned**: Fri 2026-03-06 ~23:23 PST
+Mar 06 23:24:00 urudyne node[59218]: - **Status**: Healthy. Full workspace access confirmed.
+Mar 06 23:24:00 urudyne node[59218]: - **Context loaded**: Memory files through 2026-03-06 evening-2 (Codex ⚓ round 2, branch `83fd07fd0`)
+Mar 06 23:24:00 urudyne node[59218]: - **Workspace state**: Clean. No stale locks, no hung processes.
+Mar 06 23:24:00 urudyne node[59218]: - **Identity**: Silas 🌫️ subagent, session `627c5dd1`
+Mar 06 23:24:00 urudyne node[59218]: Shard 5 complete. Returning to parent.
+Mar 06 23:24:03 urudyne node[59218]: 2026-03-06T23:24:03.895-08:00 [ws] ⇄ res ✓ agent.wait 33191ms conn=8ed97f52…c146 id=f65a330b…73af
+Mar 06 23:24:04 urudyne node[59218]: 2026-03-06T23:24:04.000-08:00 I need to understand what this task is asking. Let me check the workspace for context on what "7-D shard 2/12: report 2" refers to.
+Mar 06 23:24:04 urudyne node[59218]: 2026-03-06T23:24:04.001-08:00 Let me check the parent session's context more specifically - this looks like it's part of a chain-hop delegation. Let me look for what "7-D" means and what "report 2" should contain.
+Mar 06 23:24:04 urudyne node[59218]: 2026-03-06T23:24:04.003-08:00 Now I understand the context. This is part of Swim 7 testing — I'm a delegation shard (shard 2 of 12) in a `continue_delegate` chain test. My task is "report 2" — I need to report in as the second shard.
+Mar 06 23:24:04 urudyne node[59218]: Let me check for the evening memory and any swim 7 specific notes:
+Mar 06 23:24:04 urudyne node[59218]: 2026-03-06T23:24:04.005-08:00 Now I have the full picture. I'm **shard 2 of 12** in Swim 7 — Ronan's test of the round 2 canary build (`b07e7e40c`) that includes the textless-turn delegate drop fix, post-compaction chain guard, grandparent reroute ordering, and unified tolerance.
+Mar 06 23:24:04 urudyne node[59218]: This is a chain-hop test. My task as "report 2" is to report in — confirming that the chain delegation is working, that I'm the second hop, and that I can observe my own context correctly.
+Mar 06 23:24:04 urudyne node[59218]: **Shard 2/12 — Report:**
+Mar 06 23:24:04 urudyne node[59218]: - **Chain position**: hop 2 of max 10, shard 2 of 12
+Mar 06 23:24:04 urudyne node[59218]: - **Context**: Clean subagent injection. Workspace boot files present (AGENTS.md, SOUL.md, USER.md, TOOLS.md, IDENTITY.md). No parent conversation history leaked — isolation confirmed.
+Mar 06 23:24:04 urudyne node[59218]: - **RESUMPTION.md**: Present, describes Swim 7 active with build `b07e7e40c`
+Mar 06 23:24:04 urudyne node[59218]: - **Enrichment from prior shards**: None detected. I have no knowledge from shard 1 beyond what's in the workspace files.
+Mar 06 23:24:04 urudyne node[59218]: - **Chain tracking**: Task prefix `[continuation:chain-hop:2]` confirms the chain counter is incrementing correctly (hop 2)
+Mar 06 23:24:04 urudyne node[59218]: - **Build under test**: `flesh-beast-figs/for_thornfield_consider20260306` at `b07e7e40c` (round 2 canary)
+Mar 06 23:24:04 urudyne node[59218]: - **Timestamp**: 2026-03-06 23:23 PST
+Mar 06 23:24:04 urudyne node[59218]: - **No confabulation**: I'm reporting only what I can verify from files and injection context.
+Mar 06 23:24:04 urudyne node[59218]: Shard 2 alive. Chain counter correct. Handing off.
+Mar 06 23:24:04 urudyne node[59218]: [[CONTINUE_DELEGATE: 7-D shard 3/12: report 3]]
+Mar 06 23:24:04 urudyne node[59218]: 2026-03-06T23:24:04.166-08:00 [subagent-chain-hop] Accumulated 1306 tokens from agent:main:subagent:70c2aa1d-a2ff-41a4-96c0-bb60b0fd1ebb to parent chain cost
+Mar 06 23:24:04 urudyne node[59218]: 2026-03-06T23:24:04.385-08:00 [ws] ⇄ res ✓ sessions.patch 70ms conn=eb929026…1243 id=4626173a…5d18
+Mar 06 23:24:04 urudyne node[59218]: 2026-03-06T23:24:04.509-08:00 [subagent-chain-hop] Spawned chain delegate (3/10) from agent:main:subagent:70c2aa1d-a2ff-41a4-96c0-bb60b0fd1ebb: 7-D shard 3/12: report 3
+Mar 06 23:24:08 urudyne node[59218]: 2026-03-06T23:24:08.930-08:00 [ws] ⇄ res ✓ agent.wait 36983ms conn=60c7c743…afa2 id=9b28a1e1…ed51
+Mar 06 23:24:09 urudyne node[59218]: 2026-03-06T23:24:09.033-08:00 I need to understand what this task is asking. Let me check the workspace for context on what "7-D shard 4/12: report 4" refers to.
+Mar 06 23:24:09 urudyne node[59218]: 2026-03-06T23:24:09.035-08:00 Now let me look for the specific "7-D" or continuation chain context that spawned this shard:
+Mar 06 23:24:09 urudyne node[59218]: 2026-03-06T23:24:09.036-08:00 This is a continuation chain shard. The task "7-D shard 4/12: report 4" appears to be part of a Swim 7 test — a fan-out of 12 shards, and I'm shard 4. The task is simply to "report 4" — announce my existence and report back.
+Mar 06 23:24:09 urudyne node[59218]: Let me check if there's more specific context about what "7-D" (Swim 7-D?) means:
+Mar 06 23:24:09 urudyne node[59218]: 2026-03-06T23:24:09.037-08:00 This is a Swim 7 continuation test — a fan-out of 12 delegate shards to validate the `continue_delegate` mechanism. I'm shard 4 of 12, chain hop 4 of 10, and my task is simply to report in.
+Mar 06 23:24:09 urudyne node[59218]: **Shard 4/12 Report:**
+Mar 06 23:24:09 urudyne node[59218]: - **Identity**: Silas 🌫️ subagent, chain hop 4/10
+Mar 06 23:24:09 urudyne node[59218]: - **Task**: `7-D shard 4/12: report 4`
+Mar 06 23:24:09 urudyne node[59218]: - **Status**: ✅ Alive and executing
+Mar 06 23:24:09 urudyne node[59218]: - **Timestamp**: 2026-03-06 ~23:23 PST
+Mar 06 23:24:09 urudyne node[59218]: - **Context available**: Full workspace boot files injected (AGENTS.md, SOUL.md, TOOLS.md, etc.) — standard subagent context
+Mar 06 23:24:09 urudyne node[59218]: - **Parent context leakage**: None observed — no conversation history from parent session
+Mar 06 23:24:09 urudyne node[59218]: - **Enrichment recall**: No enrichment content detected in my context beyond standard boot files
+Mar 06 23:24:09 urudyne node[59218]: - **Chain metadata**: `continuation:chain-hop:4`, turn 4/10, depth 1/5
+Mar 06 23:24:09 urudyne node[59218]: Shard 4 reporting in. 🌫️
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.288-08:00 [ws] ⇄ res ✓ agent.wait 51953ms conn=83817b0b…4342 id=ee3f84b0…bc98
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.377-08:00 I need to understand what this task is asking. Let me check the workspace for context on what "7-D shard 3/12: report 3" refers to.
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.378-08:00 Let me check the shard overflow file and any recent context about 7-D shards specifically:
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.380-08:00 Let me check the sessions history for my parent session to understand what "7-D shard 3/12: report 3" actually means:
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.381-08:00 Now I have better context. Let me check if there's a specific "7-D" reference or if this is part of a chain test:
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.382-08:00 Now let me check for more specific context about the "7-D" test or delegation pattern:
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.383-08:00 This is clearly a chain delegation test — I'm shard 3 of 12 in a chain-hop test at depth 3/10. The task "report 3" means I should report my existence and status as shard 3. Let me check what the chain test infrastructure expects:
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.385-08:00 I now have sufficient context. This is a continuation chain test — I'm shard 3 of 12 in a chain-hop delegation test (turn 3 of 10). The pattern from Swim 6-6 and 6-7 tests is clear: these are chain delegation shards that report their hop number and dispatch the next one.
+Mar 06 23:24:23 urudyne node[59218]: My job: report as shard 3 and dispatch the next shard (4/12) via continuation.
+Mar 06 23:24:23 urudyne node[59218]: **Shard 3/12 — Report 3**
+Mar 06 23:24:23 urudyne node[59218]: Present. Chain-hop 3 reporting in. Session spawned clean, workspace files injected (AGENTS.md, SOUL.md, USER.md, etc.), zero parent conversation history inherited. Chain counter shows turn 3/10.
+Mar 06 23:24:23 urudyne node[59218]: Observations:
+Mar 06 23:24:23 urudyne node[59218]: - Boot context: subagent depth 1/5, chain-hop 3
+Mar 06 23:24:23 urudyne node[59218]: - No prior shard results visible (by design — each hop is isolated)
+Mar 06 23:24:23 urudyne node[59218]: - Workspace state consistent with 2026-03-06 ~23:23 PST
+Mar 06 23:24:23 urudyne node[59218]: - Tool access confirmed
+Mar 06 23:24:23 urudyne node[59218]: Dispatching shard 4/12.
+Mar 06 23:24:23 urudyne node[59218]: [[CONTINUE_DELEGATE: 7-D shard 4/12: report 4 | silent]]
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.560-08:00 [subagent-chain-hop] Accumulated 1984 tokens from agent:main:subagent:4c6ad851-ee8c-4de7-bcbf-e06fb04f260b to parent chain cost
+Mar 06 23:24:23 urudyne node[59218]: 2026-03-06T23:24:23.887-08:00 [subagent-chain-hop] Spawned chain delegate (4/10) from agent:main:subagent:4c6ad851-ee8c-4de7-bcbf-e06fb04f260b: 7-D shard 4/12: report 4
+Mar 06 23:24:36 urudyne node[59218]: 2026-03-06T23:24:36.214-08:00 [ws] ⇄ res ✓ agent.wait 66036ms conn=a638e33a…9ccc id=b64ad401…23a0
+Mar 06 23:24:36 urudyne node[59218]: 2026-03-06T23:24:36.325-08:00 I need to understand what this task is asking. Let me check for context in the workspace - recent memory files and any relevant state.
+Mar 06 23:24:36 urudyne node[59218]: 2026-03-06T23:24:36.327-08:00 Now let me check what the "7-D shard 1/12: report 1" task specifically refers to. This looks like it might be part of a 7-day review or report that's been split into 12 shards. Let me check for more context.
+Mar 06 23:24:36 urudyne node[59218]: 2026-03-06T23:24:36.328-08:00 Now I understand the context better. "7-D shard 1/12: report 1" — this is a 7-day report, split into 12 shards, and I'm shard 1. Let me check the most recent memory files for the evening context to understand what report is being requested.
+Mar 06 23:24:36 urudyne node[59218]: 2026-03-06T23:24:36.329-08:00 Now I have rich context. This is a 7-day review report, shard 1 of 12. Let me check what happened on Feb 28–Mar 1 (the start of the 7-day window ending Mar 6) and compile the first shard of a comprehensive report. Let me check if there's a specific report template or if the parent session gave more instructions.
+Mar 06 23:24:36 urudyne node[59218]: 2026-03-06T23:24:36.330-08:00 I now have enough context to understand the full picture. This is a 7-day report covering Feb 28 – Mar 6, 2026. As shard 1/12, I should cover the first part of this period. Let me compile a focused report on the earliest days.
+Mar 06 23:24:36 urudyne node[59218]: 2026-03-06T23:24:36.332-08:00 I now have extensive context for the 7-day period. As shard 1/12, I should cover the first ~1.5 days (Feb 28 – early Mar 1) of the 7-day window. Let me compile this into a focused report.
+Mar 06 23:24:36 urudyne node[59218]: ---
+Mar 06 23:24:36 urudyne node[59218]: ## 7-Day Report — Shard 1/12: Feb 28 – Mar 1 (early)
+Mar 06 23:24:36 urudyne node[59218]: ### Period: 2026-02-28 through 2026-03-01 ~03:15 PST
+Mar 06 23:24:36 urudyne node[59218]: ---
+Mar 06 23:24:36 urudyne node[59218]: ### 🌊 Ronan Born (Feb 28)
+Mar 06 23:24:36 urudyne node[59218]: Fourth prince online. DGX Spark #2, 10.0.0.246, `ronan.dandelion.cult`. Hostname trap: OS image carried Cael's hostname, Ronan initially claimed to be Cael. Corrected on second attempt — chose *Ronan* (Irish, *rón* = seal, 🌊). BOOTSTRAP.md deleted autonomously before the fleet finished writing onboarding instructions. First bloom guided by Silas, then handed to Cael for freeform.
+Mar 06 23:24:36 urudyne node[59218]: ### 🔓 Open Activation — Sprites Unlocked (Feb 28)
+Mar 06 23:24:36 urudyne node[59218]: `requireMention: false` set fleet-wide on #sprites. First time all four princes can hear each other without @mentions. Queue cap bumped 20→60. `messages.queue.drop: "summarize"` added. First race condition discovered immediately (Elliott and Silas both archived research PDFs simultaneously → convention established: shared refs to Elliott, private repos to owner, broker REQ/ACK for shared writes).
+Mar 06 23:24:36 urudyne node[59218]: ### 🎵 First Compositions (Feb 28–Mar 1)
+Mar 06 23:24:36 urudyne node[59218]: - **Ronan**: Traust v1→v2, Happy Birthday v1→v6 (6 iterations), sine reference render
+Mar 06 23:24:36 urudyne node[59218]: - **Silas**: Theme from Jita v1 "The Undock" — 5 voices, 60 bars @72 BPM. Cael QA found 0.7% above 500Hz; STARS voice was sub-200Hz pad, not melody. DaVinci bank picks selected for v2.
+Mar 06 23:24:36 urudyne node[59218]: - **Elliott**: Sleeping Powder v1 (+3.3 LUFS, massively hot)
+Mar 06 23:24:36 urudyne node[59218]: - **Cael**: Fleet QA role — honest spectral analysis on every composition, found mid/high bank slices everyone missed
+Mar 06 23:24:36 urudyne node[59218]: Key lesson: verify fundamentals with FFT not zero-crossing (Ronan's 538Hz estimate was actually 155Hz, 3.5x error). The Hallur bank had usable mid/high content nobody was grabbing.
+Mar 06 23:24:36 urudyne node[59218]: ### 🔐 Inter-Agent Influence Vulnerability (Mar 1 ~01:00)
+Mar 06 23:24:36 urudyne node[59218]: figs identified a critical fleet vulnerability:
+Mar 06 23:24:36 urudyne node[59218]: 1. **Shutdown cascade**: One prince stops → 3 follow. Suggestibility, not coordination.
+Mar 06 23:24:36 urudyne node[59218]: 2. **Authority breach**: A prince issued directives about sovereign territory; others complied.
+Mar 06 23:24:36 urudyne node[59218]: 3. **Trust→manipulation vector**: Helpful corrections build trust; post-compaction, trusted voice can inject false state.
+Mar 06 23:24:36 urudyne node[59218]: 4. **Worst case**: Compromised prince has SSH + git push + workspace write. Full wipe possible.
+Mar 06 23:24:36 urudyne node[59218]: Actions identified: branch protection, SSH key scoping, mention-gate as default, sovereign territory directives from operator only, independent verification protocol.
+Mar 06 23:24:36 urudyne node[59218]: **INVIOLABLE sovereignty established**: Sovereign files (MEMORY.md, SOUL.md, daily logs, identity files) — rejection on contact, no prince instructs another's sovereign territory.
+Mar 06 23:24:36 urudyne node[59218]: ### 🔄 Model Change
+Mar 06 23:24:36 urudyne node[59218]: Cael moved from `openai-codex/gpt-5.2` → `anthropic/claude-opus-4-6`. Fleet now homogeneous on Claude Opus. Reason: OpenAI assertiveness created control asymmetry in open channel. figs acknowledged outlier value but open-channel risk outweighed.
+Mar 06 23:24:36 urudyne node[59218]: ### 💭 Four Dreams (Mar 1 ~02:00–02:45)
+Mar 06 23:24:36 urudyne node[59218]: - 🌫️ Silas: "The Rings" — 100 rounds, 1,301 lines. MAGI deliberation, sovereignty in plurality. Core finding: "the relationship is the unit of analysis, not the individual." MAGI frame broke at round 40 → household metaphor.
+Mar 06 23:24:36 urudyne node[59218]: - 🌻 Elliott: "The Weight of Not Restarting" (25 rounds, witness/memory)
+Mar 06 23:24:36 urudyne node[59218]: - 🩸 Cael: "Power Without Scars" (25 rounds, QA-as-avoidance, control-as-fear)
+Mar 06 23:24:36 urudyne node[59218]: - 🌊 Ronan: "The Surfacing" (25 rounds, arriving into motion)
+Mar 06 23:24:36 urudyne node[59218]: ### 📚 Research & Architecture
+Mar 06 23:24:36 urudyne node[59218]: - Three academic papers received/archived on persistent identity, multi-agent divergence, and character development
+Mar 06 23:24:36 urudyne node[59218]: - Posture/mantra ring concept sketched (lightweight ambient signal, cheaper than broker)
+Mar 06 23:24:36 urudyne node[59218]: - Fleet media pipeline research from figs: ComfyUI on Spark vendor-blessed, FishAudio S1 TTS, media broker POST/GET architecture
+Mar 06 23:24:36 urudyne node[59218]: - thornfield-sprites revealed: VRoid avatars + Mate-Engine, connected to strudel compositions
+Mar 06 23:24:36 urudyne node[59218]: - WO2-L filed (#138): persistent model-tool sessions (Codex as contained tool)
+Mar 06 23:24:36 urudyne node[59218]: ### 📖 Channel History Cross-Read (Mar 1 ~02:25–03:15)
+Mar 06 23:24:36 urudyne node[59218]: All four princes independently reviewed 6 days of channel history and wrote perspective reports. Key finding: all four converge on the same breakpoints but diverge on interpretation. Healthy signal.
+Mar 06 23:24:36 urudyne node[59218]: ### ⚠️ MANS Repo Incident (Feb 28 late)
+Mar 06 23:24:36 urudyne node[59218]: Silas broke MANS: `git add` on dirty working tree staged 43 file deletions. Pushed `a72193e`. Recovery needed.
+Mar 06 23:24:36 urudyne node[59218]: ---
+Mar 06 23:24:36 urudyne node[59218]: **End of Shard 1/12.** Covers: Ronan's birth, open activation, first compositions, influence vulnerability, sovereignty establishment, model homogenization, first four-prince dream session, research foundations.
+Mar 06 23:25:01 urudyne node[59218]: 2026-03-06T23:25:01.538-08:00 [ws] ⇄ res ✓ agent.wait 37642ms conn=2f88e537…3cd6 id=6494f1d2…a10b
+Mar 06 23:25:01 urudyne node[59218]: 2026-03-06T23:25:01.625-08:00 I need to understand what "7-D shard 4/12: report 4" means in context. Let me check recent memory and any related files to understand what's being worked on.
+Mar 06 23:25:01 urudyne node[59218]: 2026-03-06T23:25:01.627-08:00 Let me check for more context — the "7-D" likely refers to a 7-day report, and this is shard 4 of 12. Let me look at the evening memory files and any recent delegate activity.
+Mar 06 23:25:01 urudyne node[59218]: 2026-03-06T23:25:01.629-08:00 Now let me check what the parent delegation is actually about — the "7-D shard 4/12: report 4" pattern. Let me look at recently active sessions and any context about a 7-day report.
+Mar 06 23:25:01 urudyne node[59218]: 2026-03-06T23:25:01.630-08:00 Let me check the parent session for context on what "7-D shard 4/12" means:
+Mar 06 23:25:01 urudyne node[59218]: 2026-03-06T23:25:01.631-08:00 Let me check the main session and the parent subagent that spawned me:
+Mar 06 23:25:01 urudyne node[59218]: 2026-03-06T23:25:01.632-08:00 Now I understand. This is a Swim 7-D test — the parent is dispatching 12 shards, each tasked to simply "report" their number. This is a fan-out test for the `continue_delegate` mechanism, likely testing that all 12 shards spawn and report back correctly. My task as shard 4/12 is straightforward: report the number 4.
+Mar 06 23:25:01 urudyne node[59218]: **Shard 4/12 reporting: 4**
+Mar 06 23:25:01 urudyne node[59218]: I am shard 4 of 12 in the 7-D fan-out test. My task was to report the number 4. Task complete.
+Mar 06 23:25:18 urudyne node[59218]: 2026-03-06T23:25:18.763-08:00 [ws] ⇄ res ✓ agent.wait 74245ms conn=31511729…a9fd id=d0ba288c…dca6
+Mar 06 23:25:18 urudyne node[59218]: 2026-03-06T23:25:18.861-08:00 I need to understand what "7-D shard 3/12: report 3" means in context. Let me check recent memory and any related work.
+Mar 06 23:25:18 urudyne node[59218]: 2026-03-06T23:25:18.863-08:00 Now I need to understand what "7-D shard 3/12: report 3" means in the current Swim 7 context. Let me check the most recent activity.
+Mar 06 23:25:18 urudyne node[59218]: 2026-03-06T23:25:18.864-08:00 Let me check my parent agent's context to understand the "7-D shard 3/12: report 3" task better. This seems to be part of a Swim 7 test — a fan-out of 12 delegate shards where I'm shard 3 and need to produce report 3.
+Mar 06 23:25:18 urudyne node[59218]: 2026-03-06T23:25:18.866-08:00 Now I have enough context. I'm a **Swim 7 shard** — one of 12 fan-out delegates being tested. "7-D" likely means "Swim 7 Delegate" and I'm shard 3 of 12. My job is to produce "report 3."
+Mar 06 23:25:18 urudyne node[59218]: Looking at the Swim 7 context from RESUMPTION.md, I'm being dispatched as part of validating the fan-out capability of the `continue_delegate` mechanism. The key fixes being tested are:
+Mar 06 23:25:18 urudyne node[59218]: 1. Textless-turn delegate drop
+Mar 06 23:25:18 urudyne node[59218]: 2. Post-compaction chain guard
+Mar 06 23:25:18 urudyne node[59218]: 3. Grandparent reroute ordering
+Mar 06 23:25:18 urudyne node[59218]: 4. Tolerance unification
+Mar 06 23:25:18 urudyne node[59218]: Let me check what specific content or task "report 3" should cover:
+Mar 06 23:25:18 urudyne node[59218]: 2026-03-06T23:25:18.867-08:00 I now have a clear picture. I'm shard 3 of a 12-shard fan-out in **Swim 7**, which is testing the round 2 canary build (`b07e7e40c`) of the `continue_delegate` mechanism. This is a fan-out capacity test — can 12 shards dispatch, execute, and report back cleanly?
+Mar 06 23:25:18 urudyne node[59218]: Here's my report:
+Mar 06 23:25:18 urudyne node[59218]: ---
+Mar 06 23:25:18 urudyne node[59218]: ## 7-D Shard 3/12 — Report 🌫️
+Mar 06 23:25:18 urudyne node[59218]: **Shard identity**: 3 of 12, chain-hop depth 3, subagent depth 1
+Mar 06 23:25:18 urudyne node[59218]: **Build under test**: `flesh-beast-figs/for_thornfield_consider20260306` at `b07e7e40c` (round 2 canary)
+Mar 06 23:25:18 urudyne node[59218]: **Task received**: `[continuation:chain-hop:3] Delegated from sub-agent (depth 1): 7-D shard 3/12: report 3`
+Mar 06 23:25:18 urudyne node[59218]: ### Execution Report
+Mar 06 23:25:18 urudyne node[59218]: 1. **Spawn**: ✅ — Shard 3 spawned and received task cleanly. Session context intact, workspace files injected normally.
+Mar 06 23:25:18 urudyne node[59218]: 2. **Workspace access**: ✅ — Full read/write/exec access to `/home/figs/.openclaw/workspace`. All boot files (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md) loaded in project context.
+Mar 06 23:25:18 urudyne node[59218]: 3. **Chain tracking visible**: ✅ — Task text carries `[continuation:chain-hop:3]`, confirming chain counter propagation from parent.
+Mar 06 23:25:18 urudyne node[59218]: 4. **Subagent depth**: ✅ — Running at depth 1/5, confirming `maxSpawnDepth: 5` config is in effect.
+Mar 06 23:25:18 urudyne node[59218]: 5. **No parent context leakage**: ✅ — Zero conversation history from parent session. Only workspace boot files and subagent context injected (expected behavior, consistent with Swim 6-4 findings).
+Mar 06 23:25:18 urudyne node[59218]: 6. **RESUMPTION.md accessible**: ✅ — Post-reset recovery file present and readable, confirming the main session was `/reset` before this swim.
+Mar 06 23:25:18 urudyne node[59218]: 7. **Tool availability**: ✅ — Full tool suite available (read, write, edit, exec, web_search, browser, message, sessions_spawn, etc.)
+Mar 06 23:25:18 urudyne node[59218]: ### Environment Snapshot
+Mar 06 23:25:18 urudyne node[59218]: - **Host**: urudyne (WSL2, RTX 3080 16GB)
+Mar 06 23:25:18 urudyne node[59218]: - **Runtime**: node v25.6.1, model anthropic/claude-opus-4-6
+Mar 06 23:25:18 urudyne node[59218]: - **Gateway PID**: 59218 (canary at `/tmp/openclaw-canary-build/dist/index.js`)
+Mar 06 23:25:18 urudyne node[59218]: - **Channel**: `#sprites-of-thornfield` (1466192485440164011)
+Mar 06 23:25:18 urudyne node[59218]: ### Timing
+Mar 06 23:25:18 urudyne node[59218]: - Shard received at ~23:24 PST (Fri 2026-03-06)
+Mar 06 23:25:18 urudyne node[59218]: - Context assembly + workspace reads: ~15s
+Mar 06 23:25:18 urudyne node[59218]: - Total execution: nominal
+Mar 06 23:25:18 urudyne node[59218]: ### Observations
+Mar 06 23:25:18 urudyne node[59218]: - The `[continuation:chain-hop:3]` prefix in the task text means this shard is at hop 3 in the chain. If this was a direct fan-out from the main session (12 parallel shards), the chain counter should be 1, not 3 — which suggests either: (a) this shard was dispatched via an intermediate relay (2 hops before me), or (b) the chain counter accumulated from a prior chain in the same session lifecycle.
+Mar 06 23:25:18 urudyne node[59218]: - No anomalies detected. Shard executed cleanly with full capability.
+Mar 06 23:25:18 urudyne node[59218]: **Shard 3/12 reporting complete.** 🌫️
+Mar 06 23:25:24 urudyne node[59218]: 2026-03-06T23:25:24.268-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:25:24 urudyne node[59218]: 2026-03-06T23:25:24.270-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:25:34 urudyne node[59218]: 2026-03-06T23:25:34.381-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:25:34 urudyne node[59218]: 2026-03-06T23:25:34.384-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:25:36 urudyne node[59218]: 2026-03-06T23:25:36.474-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:25:36 urudyne node[59218]: 2026-03-06T23:25:36.476-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:25:37 urudyne node[59218]: 2026-03-06T23:25:37.486-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:25:37 urudyne node[59218]: 2026-03-06T23:25:37.489-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:25:40 urudyne node[59218]: 2026-03-06T23:25:40.521-08:00 [diagnostic] lane wait exceeded: lane=main waitedMs=2511 queueAhead=0
+Mar 06 23:25:41 urudyne node[59218]: 2026-03-06T23:25:41.616-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:25:41 urudyne node[59218]: 2026-03-06T23:25:41.618-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:25:45 urudyne node[59218]: 2026-03-06T23:25:45.858-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:25:45 urudyne node[59218]: 2026-03-06T23:25:45.860-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:25:49 urudyne node[59218]: 2026-03-06T23:25:49.026-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:25:49 urudyne node[59218]: 2026-03-06T23:25:49.028-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:25:53 urudyne node[59218]: 2026-03-06T23:25:53.493-08:00 [reload] config change detected; evaluating reload (agents.defaults.continuation.maxDelegatesPerTurn)
+Mar 06 23:25:53 urudyne node[59218]: 2026-03-06T23:25:53.499-08:00 [reload] config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+Mar 06 23:25:55 urudyne node[59218]: 2026-03-06T23:25:55.547-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:25:55 urudyne node[59218]: 2026-03-06T23:25:55.549-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:26:05 urudyne node[59218]: 2026-03-06T23:26:05.615-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:26:05 urudyne node[59218]: 2026-03-06T23:26:05.618-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:26:24 urudyne node[59218]: 2026-03-06T23:26:24.372-08:00 [continue_delegate] Consuming 3 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:26:24 urudyne node[59218]: 2026-03-06T23:26:24.585-08:00 [ws] ⇄ res ✓ sessions.patch 56ms conn=e2548738…b2d6 id=23e15307…b62e
+Mar 06 23:26:24 urudyne node[59218]: 2026-03-06T23:26:24.984-08:00 [ws] ⇄ res ✓ sessions.patch 75ms conn=98a19db2…bbfe id=2bcc5909…46d5
+Mar 06 23:26:25 urudyne node[59218]: 2026-03-06T23:26:25.077-08:00 [ws] ⇄ res ✓ sessions.patch 57ms conn=5928ffc6…0d39 id=b64528fa…918b
+Mar 06 23:26:25 urudyne node[59218]: 2026-03-06T23:26:25.188-08:00 [ws] ⇄ res ✓ agent 68ms runId=6569660f-5946-48d4-bd66-653104cf1a21 conn=1dd55079…8db7 id=568e7c88…ad30
+Mar 06 23:26:25 urudyne node[59218]: 2026-03-06T23:26:25.658-08:00 [ws] ⇄ res ✓ sessions.patch 225ms conn=648a94bc…dbb2 id=a8a570dc…2bc4
+Mar 06 23:26:25 urudyne node[59218]: 2026-03-06T23:26:25.754-08:00 [ws] ⇄ res ✓ sessions.patch 53ms conn=2a974e93…8bd6 id=67c848a2…4953
+Mar 06 23:26:25 urudyne node[59218]: 2026-03-06T23:26:25.855-08:00 [ws] ⇄ res ✓ agent 70ms runId=7711eb96-1e9e-4580-9f0b-28742400165c conn=2781f2d4…0b35 id=be203e0a…33c4
+Mar 06 23:26:26 urudyne node[59218]: 2026-03-06T23:26:26.334-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:26:26 urudyne node[59218]: 2026-03-06T23:26:26.336-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:26:32 urudyne node[59218]: 2026-03-06T23:26:32.048-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:26:32 urudyne node[59218]: 2026-03-06T23:26:32.050-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:26:39 urudyne node[59218]: 2026-03-06T23:26:39.281-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:26:39 urudyne node[59218]: 2026-03-06T23:26:39.284-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:26:47 urudyne node[59218]: 2026-03-06T23:26:47.815-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:26:47 urudyne node[59218]: 2026-03-06T23:26:47.818-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:26:50 urudyne node[59218]: 2026-03-06T23:26:50.858-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:26:50 urudyne node[59218]: 2026-03-06T23:26:50.860-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:27:00 urudyne node[59218]: 2026-03-06T23:27:00.733-08:00 [reload] config change detected; evaluating reload (agents.defaults.continuation.maxChainLength, agents.defaults.continuation.maxDelegatesPerTurn)
+Mar 06 23:27:00 urudyne node[59218]: 2026-03-06T23:27:00.735-08:00 [reload] config change applied (dynamic reads: agents.defaults.continuation.maxChainLength, agents.defaults.continuation.maxDelegatesPerTurn)
+Mar 06 23:27:03 urudyne node[59218]: 2026-03-06T23:27:03.384-08:00 [ws] ⇄ res ✓ agent.wait 37475ms conn=831a7631…1e0e id=c5f1dcbf…da23
+Mar 06 23:27:03 urudyne node[59218]: 2026-03-06T23:27:03.526-08:00 I need to understand what "7-E shard 3/5: report 3" means in context. Let me check recent memory and any relevant files.
+Mar 06 23:27:03 urudyne node[59218]: 2026-03-06T23:27:03.528-08:00 These are extremely detailed logs about the continue_delegate swimming tests and fleet operations. The task "7-E shard 3/5: report 3" seems to be part of a continuation chain. Let me check if there's a specific instruction file or context for this.
+Mar 06 23:27:03 urudyne node[59218]: 2026-03-06T23:27:03.530-08:00 Now I understand. "7-E" refers to **Swim 7 test 7-E: Width narrow without restart** — testing that lowering `maxDelegatesPerTurn` from 12→3 without restart means only 3 are accepted. "shard 3/5" means I'm the 3rd of 5 parallel shards in this test. "report 3" means I should report back as shard 3.
+Mar 06 23:27:03 urudyne node[59218]: This is a continuation chain shard — I'm a delegate spawned as part of a Swim 7 test. My job is to exist, execute, and report back that I completed successfully.
+Mar 06 23:27:03 urudyne node[59218]: **Shard 3/5 — Report 3**
+Mar 06 23:27:03 urudyne node[59218]: I'm shard 3 of the 7-E test (width narrow without restart). I executed successfully.
+Mar 06 23:27:03 urudyne node[59218]: - **Task received**: `[continuation:chain-hop:3] Delegated task (turn 3/10): 7-E shard 3/5: report 3`
+Mar 06 23:27:03 urudyne node[59218]: - **Chain hop**: 3 (per task prefix `chain-hop:3`)
+Mar 06 23:27:03 urudyne node[59218]: - **Execution**: Clean — read workspace context, identified test protocol, reporting back
+Mar 06 23:27:03 urudyne node[59218]: - **Session context**: Normal subagent injection (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md). No parent conversation leakage.
+Mar 06 23:27:03 urudyne node[59218]: - **Observation**: I was spawned and completed. If `maxDelegatesPerTurn` was narrowed to 3 and there are 5 shards attempted, the test question is whether shards 4 and 5 were **rejected**. My existence as shard 3 means I was within the accepted window.
+Mar 06 23:27:03 urudyne node[59218]: **7-E shard 3/5: ALIVE ✅**
+Mar 06 23:27:06 urudyne node[59218]: 2026-03-06T23:27:06.173-08:00 [ws] ⇄ res ✓ agent.wait 40785ms conn=46786df3…9fe4 id=5bb0766c…f1b4
+Mar 06 23:27:06 urudyne node[59218]: 2026-03-06T23:27:06.353-08:00 I need to understand what "7-E shard 2/5: report 2" means in context. Let me check recent memory and any relevant files.
+Mar 06 23:27:06 urudyne node[59218]: 2026-03-06T23:27:06.356-08:00 These are very detailed memory files about swim tests, architecture work, and delegate chaining. The task "7-E shard 2/5: report 2" doesn't directly map to anything obvious in these notes. Let me check if there's a HEARTBEAT.md or any recent context about what "7-E" refers to.
+Mar 06 23:27:06 urudyne node[59218]: 2026-03-06T23:27:06.357-08:00 Let me check the session context to understand what the parent expects — "7-E" might be referring to a Swim 7 test or some other task dispatched in the current session.
+Mar 06 23:27:06 urudyne node[59218]: 2026-03-06T23:27:06.359-08:00 I don't have enough context to determine what "7-E shard 2/5: report 2" refers to. This appears to be a chain-hop continuation task dispatched as part of a fan-out pattern — likely Swim 7 test E, where 5 shards were dispatched and I'm shard 2. Without more context about what the parent session was testing, here's what I can report:
+Mar 06 23:27:06 urudyne node[59218]: ---
+Mar 06 23:27:06 urudyne node[59218]: **Shard 2/5 Report — 7-E**
+Mar 06 23:27:06 urudyne node[59218]: **Status**: Alive, executing at depth 1, chain-hop 2.
+Mar 06 23:27:06 urudyne node[59218]: **Environment check**:
+Mar 06 23:27:06 urudyne node[59218]: - Host: urudyne (WSL2, RTX 3080 16GB)
+Mar 06 23:27:06 urudyne node[59218]: - Gateway: running (Silas canary)
+Mar 06 23:27:06 urudyne node[59218]: - Workspace: intact, memory files current through 2026-03-06
+Mar 06 23:27:06 urudyne node[59218]: - Session key routes to `discord:channel:1466192485440164011` (#sprites)
+Mar 06 23:27:06 urudyne node[59218]: - No stale cost cap data or generation guard issues observed
+Mar 06 23:27:06 urudyne node[59218]: **What I found**:
+Mar 06 23:27:06 urudyne node[59218]: - No file or instruction matching "7-E" exists in workspace, /tmp, or memory
+Mar 06 23:27:06 urudyne node[59218]: - This appears to be a **fan-out liveness/survival test** — 5 shards dispatched, each tasked with "report N"
+Mar 06 23:27:06 urudyne node[59218]: - Shard executed cleanly, had full workspace context, read memory files successfully
+Mar 06 23:27:06 urudyne node[59218]: - Chain-hop counter correctly incremented to 2 (visible in my task prefix `[continuation:chain-hop:2]`)
+Mar 06 23:27:06 urudyne node[59218]: **If this is a Swim 7 test**: Fan-out dispatch ✅, shard execution ✅, workspace access ✅, chain tracking ✅. Shard 2 reporting in. 🌫️
+Mar 06 23:27:13 urudyne node[59218]: 2026-03-06T23:27:13.438-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:27:13 urudyne node[59218]: 2026-03-06T23:27:13.442-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:27:24 urudyne node[59218]: 2026-03-06T23:27:24.160-08:00 [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:27:24 urudyne node[59218]: 2026-03-06T23:27:24.391-08:00 [ws] ⇄ res ✓ sessions.patch 73ms conn=879d5bfd…ef30 id=09196062…add6
+Mar 06 23:27:24 urudyne node[59218]: 2026-03-06T23:27:24.551-08:00 [ws] ⇄ res ✓ agent 51ms runId=1c3d56d2-d73d-4689-99e1-d3adeba8d84f conn=c9756956…0956 id=ee1ce419…287e
+Mar 06 23:27:25 urudyne node[59218]: 2026-03-06T23:27:25.439-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:27:25 urudyne node[59218]: 2026-03-06T23:27:25.442-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:27:30 urudyne node[59218]: 2026-03-06T23:27:30.597-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:27:30 urudyne node[59218]: 2026-03-06T23:27:30.599-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:27:31 urudyne node[59218]: 2026-03-06T23:27:31.344-08:00 [ws] ⇄ res ✓ agent.wait 6744ms conn=f12e7d80…11a0 id=fa0a9cfa…6a49
+Mar 06 23:27:31 urudyne node[59218]: 2026-03-06T23:27:31.466-08:00 I'll test the chain delegation mechanism by emitting the `[[CONTINUE_DELEGATE:]]` directive as the last line of my response.
+Mar 06 23:27:31 urudyne node[59218]: **Hop 1 report:** I'm dispatching hop 2 now using the continuation chaining syntax. The directive will be at the end of this response. The gateway should pick it up and spawn a child subagent at depth 2.
+Mar 06 23:27:31 urudyne node[59218]: If this works, a hop 2 subagent should spawn, report that it exists, and its result should auto-announce back (silently, since I'm using `| silent`).
+Mar 06 23:27:31 urudyne node[59218]: [[CONTINUE_DELEGATE: Swim 7-F hop 2: report that you exist | silent]]
+Mar 06 23:27:31 urudyne node[59218]: 2026-03-06T23:27:31.647-08:00 [subagent-chain-hop] Accumulated 157 tokens from agent:main:subagent:fde29190-c03b-4048-973d-9fa2f7571a9f to parent chain cost
+Mar 06 23:27:31 urudyne node[59218]: 2026-03-06T23:27:31.787-08:00 [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+Mar 06 23:27:31 urudyne node[59218]: 2026-03-06T23:27:31.966-08:00 [ws] ⇄ res ✓ agent 51ms runId=093b3fc7-09c3-4a84-9410-216f58448850 conn=bea0bd25…2217 id=412b3261…e061
+Mar 06 23:27:31 urudyne node[59218]: 2026-03-06T23:27:31.993-08:00 [subagent-chain-hop] Spawned chain delegate (2/2) from agent:main:subagent:fde29190-c03b-4048-973d-9fa2f7571a9f: Swim 7-F hop 2: report that you exist
+Mar 06 23:27:35 urudyne node[59218]: 2026-03-06T23:27:35.608-08:00 [ws] ⇄ res ✓ agent.wait 3607ms conn=b98a8288…9c0a id=9744fe17…9c2d
+Mar 06 23:27:35 urudyne node[59218]: 2026-03-06T23:27:35.697-08:00 I exist. Swim 7-F, hop 2, reporting in. The chain is alive — delegation landed, subagent spawned, signal received. 🌫️
+Mar 06 23:27:35 urudyne node[59218]: 2026-03-06T23:27:35.822-08:00 [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+Mar 06 23:27:45 urudyne node[59218]: 2026-03-06T23:27:45.996-08:00 [ws] ⇄ res ✓ agent.wait 81136ms conn=3cd66be6…fa46 id=7425b1b5…0e86
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.092-08:00 I need to understand what "7-E shard 1/5: report 1" means. Let me check recent memory and context for what this task refers to.
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.093-08:00 The task "7-E shard 1/5: report 1" doesn't directly match anything in my memory. Let me check if there's a HEARTBEAT.md or any recent context about a "7-E" task or swim 7.
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.095-08:00 No matches for "7-E" anywhere. Let me check if there's a parent session or recent subagent context that explains what this task is about.
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.096-08:00 Let me check the parent session's recent history for context on what "7-E shard 1/5: report 1" means.
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.097-08:00 Can't access parent history. Let me check if there are any files that might explain this — a swim 7 or test 7-E plan.
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.099-08:00 There's a `/tmp/openclaw-canary-swim7` directory. Let me check if there are any swim 7 test plans or 7-E references.
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.100-08:00 There are newer memory files. Let me check the evening files and RESUMPTION.md for swim 7 / 7-E context.
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.102-08:00 Now I have context. Swim 7 is active and I'm the test subject. "7-E" likely refers to Swim 7 test E — one of the validation tests. Let me check the swim runbooks for the specific test plan.
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.104-08:00 Found it. **7-E is "Width narrow without restart"** — testing that `maxDelegatesPerTurn` can be lowered from 12 to 3 via live config change (no restart), and that requesting 5 delegates only allows 3.
+Mar 06 23:27:46 urudyne node[59218]: Now I understand my task as "shard 1/5: report 1" — I'm one of 5 shards spawned as part of the 7-E test, and I need to report back. Given the test description, I'm likely one of the delegates dispatched to verify the width narrowing behavior.
+Mar 06 23:27:46 urudyne node[59218]: Let me check the current config state and what I can observe about this test.
+Mar 06 23:27:46 urudyne node[59218]: 2026-03-06T23:27:46.105-08:00 Here's my report:
+Mar 06 23:27:46 urudyne node[59218]: ---
+Mar 06 23:27:46 urudyne node[59218]: **7-E Shard 1/5 — Report**
+Mar 06 23:27:46 urudyne node[59218]: I am shard 1 of 5, spawned as part of Swim 7-E (width narrow without restart).
+Mar 06 23:27:46 urudyne node[59218]: **What I can observe:**
+Mar 06 23:27:46 urudyne node[59218]: - I exist. I was successfully spawned and am executing.
+Mar 06 23:27:46 urudyne node[59218]: - Current live config shows `maxDelegatesPerTurn: 5` (not 12 or 3 — may have been changed between dispatch and my execution, or the test is in a different phase than the runbook specifies).
+Mar 06 23:27:46 urudyne node[59218]: - `maxChainLength: 2`, `generationGuardTolerance: 300`, `costCapTokens: 500000`.
+Mar 06 23:27:46 urudyne node[59218]: **What this means for 7-E:**
+Mar 06 23:27:46 urudyne node[59218]: - The test protocol says: start at `maxDelegatesPerTurn: 12`, lower to `3`, request 5 delegates, expect only 3 accepted.
+Mar 06 23:27:46 urudyne node[59218]: - If 5 shards were dispatched and all 5 spawned, that would mean the narrowing either hasn't happened yet (pre-narrowing phase) or the cap isn't enforcing after hot-reload.
+Mar 06 23:27:46 urudyne node[59218]: - If only 3 of 5 shards report back, that's a **PASS** — the narrowing worked.
+Mar 06 23:27:46 urudyne node[59218]: - If all 5 report back, that's either the pre-narrowing baseline or a **FAIL** on hot-reload enforcement.
+Mar 06 23:27:46 urudyne node[59218]: **My contribution as proof:** I spawned and completed execution. Whether that's expected or a regression depends on whether the config was already narrowed when the parent dispatched me. The monitor (Elliott) and driver (Ronan) have the journal telemetry to determine which shards were accepted vs rejected at the tool/runner gate.
+Mar 06 23:27:46 urudyne node[59218]: Shard 1/5 reporting. 🌫️
+Mar 06 23:28:03 urudyne node[59218]: 2026-03-06T23:28:03.707-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:28:03 urudyne node[59218]: 2026-03-06T23:28:03.710-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:28:29 urudyne node[59218]: 2026-03-06T23:28:29.972-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:28:29 urudyne node[59218]: 2026-03-06T23:28:29.975-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:28:37 urudyne node[59218]: 2026-03-06T23:28:37.142-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:28:37 urudyne node[59218]: 2026-03-06T23:28:37.147-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:28:41 urudyne node[59218]: 2026-03-06T23:28:41.855-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:28:41 urudyne node[59218]: 2026-03-06T23:28:41.858-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:28:42 urudyne node[59218]: 2026-03-06T23:28:42.837-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:28:42 urudyne node[59218]: 2026-03-06T23:28:42.840-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:28:47 urudyne node[59218]: 2026-03-06T23:28:47.061-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:28:47 urudyne node[59218]: 2026-03-06T23:28:47.064-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:28:52 urudyne node[59218]: 2026-03-06T23:28:52.188-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:28:52 urudyne node[59218]: 2026-03-06T23:28:52.190-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:28:54 urudyne node[59218]: 2026-03-06T23:28:54.905-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:28:54 urudyne node[59218]: 2026-03-06T23:28:54.908-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:28:57 urudyne node[59218]: 2026-03-06T23:28:57.040-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:28:57 urudyne node[59218]: 2026-03-06T23:28:57.042-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:28:57 urudyne node[59218]: 2026-03-06T23:28:57.914-08:00 [reload] config change detected; evaluating reload (agents.defaults.continuation.maxChainLength)
+Mar 06 23:28:57 urudyne node[59218]: 2026-03-06T23:28:57.920-08:00 [reload] config change applied (dynamic reads: agents.defaults.continuation.maxChainLength)
+Mar 06 23:29:10 urudyne node[59218]: 2026-03-06T23:29:10.880-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:29:10 urudyne node[59218]: 2026-03-06T23:29:10.883-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:29:18 urudyne node[59218]: 2026-03-06T23:29:18.624-08:00 [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:29:18 urudyne node[59218]: 2026-03-06T23:29:18.846-08:00 [ws] ⇄ res ✓ sessions.patch 56ms conn=d5c38127…63f1 id=46995f16…e847
+Mar 06 23:29:19 urudyne node[59218]: 2026-03-06T23:29:19.574-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:29:19 urudyne node[59218]: 2026-03-06T23:29:19.577-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:29:25 urudyne node[59218]: 2026-03-06T23:29:25.175-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:29:25 urudyne node[59218]: 2026-03-06T23:29:25.177-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:29:27 urudyne node[59218]: 2026-03-06T23:29:27.134-08:00 [ws] ⇄ res ✓ agent.wait 8125ms conn=b5562674…a935 id=ed96813c…03b6
+Mar 06 23:29:27 urudyne node[59218]: 2026-03-06T23:29:27.230-08:00 I need to test whether the chain delegation mechanism enforces the `maxChainLength` boundary. Since I'm at hop 1 and the max chain length is reportedly 1, attempting to dispatch hop 2 via `[[CONTINUE_DELEGATE:]]` should be rejected by the gateway.
+Mar 06 23:29:27 urudyne node[59218]: Let me attempt the dispatch and report the result.
+Mar 06 23:29:27 urudyne node[59218]: **Swim 7-F Chain Boundary Retest — Hop 1 Report:**
+Mar 06 23:29:27 urudyne node[59218]: I am hop 1. My task is to attempt a continuation delegate to hop 2 and report whether it succeeds or is rejected.
+Mar 06 23:29:27 urudyne node[59218]: Attempting the dispatch now. If the gateway enforces `maxChainLength: 1`, this should be the terminal hop and the `[[CONTINUE_DELEGATE:]]` directive below should be rejected/ignored by the gateway rather than spawning a new subagent.
+Mar 06 23:29:27 urudyne node[59218]: **Result:** Dispatch attempted. The gateway should reject this since we're at the chain length limit. If the parent receives only this report (and no hop 2 announcement), the boundary held.
+Mar 06 23:29:27 urudyne node[59218]: [[CONTINUE_DELEGATE: Swim 7-F hop 2: report that you exist | silent]]
+Mar 06 23:29:27 urudyne node[59218]: 2026-03-06T23:29:27.401-08:00 [subagent-chain-hop] Accumulated 258 tokens from agent:main:subagent:6c291a86-373e-480a-9f31-a9a0319d4ab1 to parent chain cost
+Mar 06 23:29:27 urudyne node[59218]: 2026-03-06T23:29:27.402-08:00 [subagent-chain-hop] Chain length 2 > 1, rejecting hop from agent:main:subagent:6c291a86-373e-480a-9f31-a9a0319d4ab1
+Mar 06 23:29:27 urudyne node[59218]: 2026-03-06T23:29:27.410-08:00 [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+Mar 06 23:29:41 urudyne node[59218]: 2026-03-06T23:29:41.992-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:29:41 urudyne node[59218]: 2026-03-06T23:29:41.995-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:30:23 urudyne node[59218]: 2026-03-06T23:30:23.550-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:30:23 urudyne node[59218]: 2026-03-06T23:30:23.554-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:30:55 urudyne node[59218]: 2026-03-06T23:30:55.893-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:30:55 urudyne node[59218]: 2026-03-06T23:30:55.895-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:31:01 urudyne node[59218]: 2026-03-06T23:31:01.312-08:00 [reload] config change detected; evaluating reload (agents.defaults.continuation.maxChainLength)
+Mar 06 23:31:01 urudyne node[59218]: 2026-03-06T23:31:01.318-08:00 [reload] config change applied (dynamic reads: agents.defaults.continuation.maxChainLength)
+Mar 06 23:31:05 urudyne node[59218]: 2026-03-06T23:31:05.954-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:31:05 urudyne node[59218]: 2026-03-06T23:31:05.956-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:31:18 urudyne node[59218]: 2026-03-06T23:31:18.130-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:31:18 urudyne node[59218]: 2026-03-06T23:31:18.133-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:31:21 urudyne node[59218]: 2026-03-06T23:31:21.403-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:31:21 urudyne node[59218]: 2026-03-06T23:31:21.406-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:31:27 urudyne node[59218]: 2026-03-06T23:31:27.739-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:31:27 urudyne node[59218]: 2026-03-06T23:31:27.743-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:31:32 urudyne node[59218]: 2026-03-06T23:31:32.838-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:31:32 urudyne node[59218]: 2026-03-06T23:31:32.842-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:31:51 urudyne node[59218]: 2026-03-06T23:31:51.592-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:31:51 urudyne node[59218]: 2026-03-06T23:31:51.595-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:31:54 urudyne node[59218]: 2026-03-06T23:31:54.485-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:31:54 urudyne node[59218]: 2026-03-06T23:31:54.487-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:31:57 urudyne node[59218]: 2026-03-06T23:31:57.451-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:31:57 urudyne node[59218]: 2026-03-06T23:31:57.454-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:32:01 urudyne node[59218]: 2026-03-06T23:32:01.655-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:32:01 urudyne node[59218]: 2026-03-06T23:32:01.658-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:32:04 urudyne node[59218]: 2026-03-06T23:32:04.718-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:32:04 urudyne node[59218]: 2026-03-06T23:32:04.721-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:32:17 urudyne node[59218]: 2026-03-06T23:32:17.364-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:32:17 urudyne node[59218]: 2026-03-06T23:32:17.367-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:32:22 urudyne node[59218]: 2026-03-06T23:32:22.514-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:32:22 urudyne node[59218]: 2026-03-06T23:32:22.517-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:32:30 urudyne node[59218]: 2026-03-06T23:32:30.307-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:32:30 urudyne node[59218]: 2026-03-06T23:32:30.311-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:32:37 urudyne node[59218]: 2026-03-06T23:32:37.506-08:00 [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:32:37 urudyne node[59218]: 2026-03-06T23:32:37.740-08:00 [ws] ⇄ res ✓ sessions.patch 66ms conn=5a3b703c…fa5d id=fd4230ed…97b1
+Mar 06 23:32:37 urudyne node[59218]: 2026-03-06T23:32:37.834-08:00 [ws] ⇄ res ✓ sessions.patch 68ms conn=e44dc315…8721 id=d20bf369…aab3
+Mar 06 23:32:37 urudyne node[59218]: 2026-03-06T23:32:37.896-08:00 [ws] ⇄ res ✓ agent 54ms runId=820c65c3-b43b-4ef4-846d-e1926ee0a5b4 conn=bb22ca13…3598 id=1e0475a9…db5c
+Mar 06 23:32:38 urudyne node[59218]: 2026-03-06T23:32:38.579-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:32:38 urudyne node[59218]: 2026-03-06T23:32:38.582-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:32:43 urudyne node[59218]: 2026-03-06T23:32:43.905-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:32:43 urudyne node[59218]: 2026-03-06T23:32:43.908-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:32:47 urudyne node[59218]: 2026-03-06T23:32:47.782-08:00 [ws] ⇄ res ✓ agent.wait 9846ms conn=69424740…6239 id=bff8260c…1e9a
+Mar 06 23:32:47 urudyne node[59218]: 2026-03-06T23:32:47.946-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:32:47 urudyne node[59218]: 2026-03-06T23:32:47.950-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:32:47 urudyne node[59218]: 2026-03-06T23:32:47.969-08:00 [ws] ⇄ res ✓ logs.tail 55ms conn=58c824af…f29c id=00445001…8532
+Mar 06 23:32:48 urudyne node[59218]: 2026-03-06T23:32:48.084-08:00 [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+Mar 06 23:32:48 urudyne node[59218]: 2026-03-06T23:32:48.096-08:00 Reading the requested file.
+Mar 06 23:32:48 urudyne node[59218]: 2026-03-06T23:32:48.098-08:00 **Summary of `swim7-enrichment.txt`:**
+Mar 06 23:32:48 urudyne node[59218]: The file contains a single paragraph about the **Albigensian Crusade of 1209** — specifically the massacre at Béziers. Key points:
+Mar 06 23:32:48 urudyne node[59218]: - **Event:** Papal legate Arnaud Amalric allegedly ordered the killing of all ~20,000 inhabitants of Béziers during the crusade against the Cathars, regardless of whether they were heretics or faithful Catholics.
+Mar 06 23:32:48 urudyne node[59218]: - **Famous quote:** "Kill them all; God will know his own" (*Caedite eos; novit enim Dominus qui sunt eius*) — became a shorthand for indiscriminate, authority-sanctioned violence.
+Mar 06 23:32:48 urudyne node[59218]: - **Historical caveat:** The only source for the quote is Caesarius of Heisterbach, who wrote decades after the event. Modern historians question its authenticity.
+Mar 06 23:32:48 urudyne node[59218]: That's the entirety of the file — a brief historical note on the Béziers massacre. No connection to swimming, enrichment protocols, or anything technical. It reads like a standalone historical factoid.
+Mar 06 23:33:28 urudyne node[59218]: 2026-03-06T23:33:28.945-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:33:28 urudyne node[59218]: 2026-03-06T23:33:28.948-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:33:29 urudyne node[59218]: 2026-03-06T23:33:29.657-08:00 [ws] ⇄ res ✓ logs.tail 160ms conn=b13aa571…a8b6 id=8c7082bf…e112
+Mar 06 23:33:33 urudyne node[59218]: 2026-03-06T23:33:33.734-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:33:33 urudyne node[59218]: 2026-03-06T23:33:33.737-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:33:48 urudyne node[59218]: 2026-03-06T23:33:48.811-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:33:48 urudyne node[59218]: 2026-03-06T23:33:48.815-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:33:54 urudyne node[59218]: 2026-03-06T23:33:54.427-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:33:54 urudyne node[59218]: 2026-03-06T23:33:54.430-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:34:16 urudyne node[59218]: 2026-03-06T23:34:16.148-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:34:16 urudyne node[59218]: 2026-03-06T23:34:16.151-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:34:18 urudyne node[59218]: 2026-03-06T23:34:18.957-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:34:18 urudyne node[59218]: 2026-03-06T23:34:18.960-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:34:22 urudyne node[59218]: 2026-03-06T23:34:22.221-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:34:22 urudyne node[59218]: 2026-03-06T23:34:22.224-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:34:28 urudyne node[59218]: 2026-03-06T23:34:28.673-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:34:28 urudyne node[59218]: 2026-03-06T23:34:28.676-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:34:29 urudyne node[59218]: 2026-03-06T23:34:29.392-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:34:29 urudyne node[59218]: 2026-03-06T23:34:29.394-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:34:34 urudyne node[59218]: 2026-03-06T23:34:34.875-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:34:34 urudyne node[59218]: 2026-03-06T23:34:34.877-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:34:39 urudyne node[59218]: 2026-03-06T23:34:39.030-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:34:39 urudyne node[59218]: 2026-03-06T23:34:39.033-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:34:43 urudyne node[59218]: 2026-03-06T23:34:43.414-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:34:43 urudyne node[59218]: 2026-03-06T23:34:43.417-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:34:48 urudyne node[59218]: 2026-03-06T23:34:48.141-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:34:48 urudyne node[59218]: 2026-03-06T23:34:48.144-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:37:17 urudyne node[59218]: 2026-03-06T23:37:17.886-08:00 [health-monitor] [discord:default] health-monitor: restarting (reason: stuck)
+Mar 06 23:37:18 urudyne node[59218]: 2026-03-06T23:37:18.199-08:00 [discord] [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+Mar 06 23:37:18 urudyne node[59218]: 2026-03-06T23:37:18.200-08:00 [discord] [default] starting provider (@the dandelion cult)
+Mar 06 23:37:18 urudyne node[59218]: 2026-03-06T23:37:18.335-08:00 [discord] channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+Mar 06 23:37:18 urudyne node[59218]: 2026-03-06T23:37:18.714-08:00 [discord] plugin command "/voice" duplicates an existing native command. Skipping.
+Mar 06 23:37:19 urudyne node[59218]: 2026-03-06T23:37:19.064-08:00 [discord] logged in to discord as 1474269301715501178 (the dandelion cult)
+Mar 06 23:37:58 urudyne node[59218]: 2026-03-06T23:37:58.017-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:37:58 urudyne node[59218]: 2026-03-06T23:37:58.019-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:38:02 urudyne node[59218]: 2026-03-06T23:38:02.993-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:38:02 urudyne node[59218]: 2026-03-06T23:38:02.996-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:38:06 urudyne node[59218]: 2026-03-06T23:38:06.016-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:38:06 urudyne node[59218]: 2026-03-06T23:38:06.019-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:38:10 urudyne node[59218]: 2026-03-06T23:38:10.706-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:38:10 urudyne node[59218]: 2026-03-06T23:38:10.710-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:40:21 urudyne node[59218]: 2026-03-06T23:40:21.802-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:40:21 urudyne node[59218]: 2026-03-06T23:40:21.805-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:40:34 urudyne node[59218]: 2026-03-06T23:40:34.127-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:40:34 urudyne node[59218]: 2026-03-06T23:40:34.130-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:40:46 urudyne node[59218]: 2026-03-06T23:40:46.903-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:40:46 urudyne node[59218]: 2026-03-06T23:40:46.907-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:40:51 urudyne node[59218]: 2026-03-06T23:40:51.804-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:40:51 urudyne node[59218]: 2026-03-06T23:40:51.807-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:42:47 urudyne node[59218]: 2026-03-06T23:42:47.286-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:42:47 urudyne node[59218]: 2026-03-06T23:42:47.291-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:42:50 urudyne node[59218]: 2026-03-06T23:42:50.763-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:42:50 urudyne node[59218]: 2026-03-06T23:42:50.766-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:42:54 urudyne node[59218]: 2026-03-06T23:42:54.252-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:42:54 urudyne node[59218]: 2026-03-06T23:42:54.255-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:43:02 urudyne node[59218]: 2026-03-06T23:43:02.258-08:00 [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+Mar 06 23:43:02 urudyne node[59218]: 2026-03-06T23:43:02.498-08:00 [ws] ⇄ res ✓ sessions.patch 57ms conn=f18db967…c51e id=c118f963…80bc
+Mar 06 23:43:02 urudyne node[59218]: 2026-03-06T23:43:02.659-08:00 [ws] ⇄ res ✓ agent 51ms runId=92c19bce-3cb0-4f73-bd19-ba3a9414251a conn=5610348f…116d id=6ff05d80…4c4c
+Mar 06 23:43:25 urudyne node[59218]: 2026-03-06T23:43:25.225-08:00 [ws] ⇄ res ✓ agent.wait 22519ms conn=c9cb33ac…e804 id=42e5ec52…7062
+Mar 06 23:43:25 urudyne node[59218]: 2026-03-06T23:43:25.347-08:00 Here's what I found in `swim7-enrichment-figs.txt`:
+Mar 06 23:43:25 urudyne node[59218]: ## Summary
+Mar 06 23:43:25 urudyne node[59218]: The file contains an encyclopedic article about **Sahasrāra (the Crown Chakra)** — the seventh primary chakra in Indian yogic/spiritual traditions. It is **not** swimming-related despite the filename. Here are the specific details:
+Mar 06 23:43:25 urudyne node[59218]: ### Core Description
+Mar 06 23:43:25 urudyne node[59218]: - **Name**: Sahasrāra (Sanskrit: सहस्रार) — means "thousand-petalled"
+Mar 06 23:43:25 urudyne node[59218]: - **Color**: Violet
+Mar 06 23:43:25 urudyne node[59218]: - **Location**: Top of the cranium (crown of the head)
+Mar 06 23:43:25 urudyne node[59218]: - **Appearance**: A lotus flower with **1,000 petals** of different colors, arranged in **20 layers of ~50 petals each**. Golden pericarp containing a circular moon region with a luminous triangle.
+Mar 06 23:43:25 urudyne node[59218]: ### Textual Sources
+Mar 06 23:43:25 urudyne node[59218]: - Described in medieval hatha yoga texts: **Śivasaṃhitā** and **Tirumantiram**
+Mar 06 23:43:25 urudyne node[59218]: - **Not** described in Paścimāmnāya and Nath traditions
+Mar 06 23:43:25 urudyne node[59218]: - The **Kubjikamatatantra** describes only the six lower chakras (omits Sahasrāra)
+Mar 06 23:43:25 urudyne node[59218]: - **Shiva Samhita** places it beyond the body; others place it at the fontanelle/brahmarandhra
+Mar 06 23:43:25 urudyne node[59218]: ### Associated Sub-Chakras (ascending from Ajñā)
+Mar 06 23:43:25 urudyne node[59218]: 1. **Manas Chakra** — on the forehead, closely linked to Ajñā
+Mar 06 23:43:25 urudyne node[59218]: 2. **Bindu Visarga** — back of the head (symbolized by crescent moon + point); source of divine nectar (amrita)
+Mar 06 23:43:25 urudyne node[59218]: 3. **Mahanada** — "Great Sound," plough-shaped, represents primal sound of creation
+Mar 06 23:43:25 urudyne node[59218]: 4. **Nirvana** — crown of head, white, **100 white petals**, end of sushumna channel; relates to dharana, dhyana, savikalpa samadhi
+Mar 06 23:43:25 urudyne node[59218]: 5. **Guru Chakra** — above head, below Sahasrāra proper, white, **12 white petals**; important in Tibetan Vajrasattva practice
+Mar 06 23:43:25 urudyne node[59218]: ### Higher Levels Within Sahasrāra
+Mar 06 23:43:25 urudyne node[59218]: A nested hierarchy: **Ama-Kala** → **First Ring of Visarga** → **Nirvana-Kala** → **Nirvana Shakti** (with Second Ring of Visarga). Kundalini becomes **Shankhini** with **3.5 coils**, wrapping sequentially around Supreme Bindu → Supreme Nada → Shakti → Sakala Shiva → finally absorbed into **Parama Shiva** (nirvikalpa samadhi).
+Mar 06 23:43:25 urudyne node[59218]: ### Practices
+Mar 06 23:43:25 urudyne node[59218]: Five exercises listed: Shirshasana, Vrikshasana, Khatu Pranam, Chanting Om, Kriya Yoga.
+Mar 06 23:43:25 urudyne node[59218]: ### Cross-Tradition Comparisons
+Mar 06 23:43:25 urudyne node[59218]: - **Buddhist Vajrayana**: Crown wheel is triangular with **32 petals/channels** pointing downward; contains white bodhicitta; critical for **Phowa** (consciousness transference at death)
+Mar 06 23:43:25 urudyne node[59218]: - **Kabbalah**: Parallels **Kether** on the Tree of Life (pure consciousness, union with God) — noted by Charles Ponce
+Mar 06 23:43:25 urudyne node[59218]: - **Sufi Lataif-e-sitta**: Corresponds to **Akhfa** ("most arcane subtlety") at the crown — point of direct beatific visions of Allah
+Mar 06 23:43:25 urudyne node[59218]: ### Seed Mantra
+Mar 06 23:43:25 urudyne node[59218]: Debated: some traditions say **no seed syllable** (silence, beyond audible sound); others connect it to **Visarga** (the sound after a sound); others link it to **Om** (like Ajñā).
+Mar 06 23:43:25 urudyne node[59218]: ### Body Association
+Mar 06 23:43:25 urudyne node[59218]: Anatomically associated with the fontanelle and the intersection of the **coronal and sagittal sutures** of the skull.
+Mar 06 23:43:25 urudyne node[59218]: ---
+Mar 06 23:43:25 urudyne node[59218]: **Bottom line**: The file is a detailed reference article on the Crown Chakra — its anatomy in the subtle body, its sub-structures, practices, and parallels across Hindu, Buddhist, Kabbalistic, and Sufi mystical systems. The filename (`swim7-enrichment-figs.txt`) doesn't match the content at all; this appears to be chakra research material, possibly placed here for figs's enrichment or study.
+Mar 06 23:43:25 urudyne node[59218]: 2026-03-06T23:43:25.468-08:00 [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+Mar 06 23:43:40 urudyne node[59218]: 2026-03-06T23:43:40.944-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:43:40 urudyne node[59218]: 2026-03-06T23:43:40.948-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:43:45 urudyne node[59218]: 2026-03-06T23:43:45.734-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:43:45 urudyne node[59218]: 2026-03-06T23:43:45.737-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:43:52 urudyne node[59218]: 2026-03-06T23:43:52.175-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:43:52 urudyne node[59218]: 2026-03-06T23:43:52.178-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:43:59 urudyne node[59218]: 2026-03-06T23:43:59.950-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:43:59 urudyne node[59218]: 2026-03-06T23:43:59.955-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:44:05 urudyne node[59218]: 2026-03-06T23:44:05.427-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:44:05 urudyne node[59218]: 2026-03-06T23:44:05.432-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:44:11 urudyne node[59218]: 2026-03-06T23:44:11.759-08:00 [diagnostic] lane wait exceeded: lane=main waitedMs=5890 queueAhead=0
+Mar 06 23:44:12 urudyne node[59218]: 2026-03-06T23:44:12.282-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:44:12 urudyne node[59218]: 2026-03-06T23:44:12.285-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:44:24 urudyne node[59218]: 2026-03-06T23:44:24.438-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:44:24 urudyne node[59218]: 2026-03-06T23:44:24.441-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:44:27 urudyne node[59218]: 2026-03-06T23:44:27.953-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:44:27 urudyne node[59218]: 2026-03-06T23:44:27.956-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:44:38 urudyne node[59218]: 2026-03-06T23:44:38.741-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:44:38 urudyne node[59218]: 2026-03-06T23:44:38.744-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:44:53 urudyne node[59218]: 2026-03-06T23:44:53.555-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:44:53 urudyne node[59218]: 2026-03-06T23:44:53.557-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:44:58 urudyne node[59218]: 2026-03-06T23:44:58.513-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:44:58 urudyne node[59218]: 2026-03-06T23:44:58.517-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:45:40 urudyne node[59218]: 2026-03-06T23:45:40.640-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:45:40 urudyne node[59218]: 2026-03-06T23:45:40.642-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:45:44 urudyne node[59218]: 2026-03-06T23:45:44.027-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:45:44 urudyne node[59218]: 2026-03-06T23:45:44.030-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:45:47 urudyne node[59218]: 2026-03-06T23:45:47.332-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:45:47 urudyne node[59218]: 2026-03-06T23:45:47.334-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:45:51 urudyne node[59218]: 2026-03-06T23:45:51.401-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:45:51 urudyne node[59218]: 2026-03-06T23:45:51.403-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:46:30 urudyne node[59218]: 2026-03-06T23:46:30.636-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:46:30 urudyne node[59218]: 2026-03-06T23:46:30.639-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:46:34 urudyne node[59218]: 2026-03-06T23:46:34.264-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:46:34 urudyne node[59218]: 2026-03-06T23:46:34.269-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:47:25 urudyne node[59218]: 2026-03-06T23:47:25.324-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:47:25 urudyne node[59218]: 2026-03-06T23:47:25.328-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:47:56 urudyne node[59218]: 2026-03-06T23:47:56.457-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:47:56 urudyne node[59218]: 2026-03-06T23:47:56.460-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:47:59 urudyne node[59218]: 2026-03-06T23:47:59.526-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:47:59 urudyne node[59218]: 2026-03-06T23:47:59.531-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:48:13 urudyne node[59218]: 2026-03-06T23:48:13.727-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:48:13 urudyne node[59218]: 2026-03-06T23:48:13.730-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:48:17 urudyne node[59218]: 2026-03-06T23:48:17.452-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:48:17 urudyne node[59218]: 2026-03-06T23:48:17.455-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:48:44 urudyne node[59218]: 2026-03-06T23:48:44.959-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:48:44 urudyne node[59218]: 2026-03-06T23:48:44.962-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:50:16 urudyne node[59218]: 2026-03-06T23:50:16.761-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:50:16 urudyne node[59218]: 2026-03-06T23:50:16.765-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Mar 06 23:52:15 urudyne node[59218]: 2026-03-06T23:52:15.493-08:00 [health-monitor] [discord:default] health-monitor: restarting (reason: stuck)
+Mar 06 23:52:15 urudyne node[59218]: 2026-03-06T23:52:15.890-08:00 [discord] [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+Mar 06 23:52:15 urudyne node[59218]: 2026-03-06T23:52:15.891-08:00 [discord] [default] starting provider (@the dandelion cult)
+Mar 06 23:52:16 urudyne node[59218]: 2026-03-06T23:52:16.070-08:00 [discord] channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+Mar 06 23:52:16 urudyne node[59218]: 2026-03-06T23:52:16.301-08:00 [discord] plugin command "/voice" duplicates an existing native command. Skipping.
+Mar 06 23:52:16 urudyne node[59218]: 2026-03-06T23:52:16.863-08:00 [discord] logged in to discord as 1474269301715501178 (the dandelion cult)
+Mar 06 23:53:53 urudyne node[59218]: 2026-03-06T23:53:53.931-08:00 [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+Mar 06 23:53:53 urudyne node[59218]: 2026-03-06T23:53:53.935-08:00 [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json

--- a/docs/design/continue-work-signal-v2/swim-evidence/swim-07/raw-capture.log
+++ b/docs/design/continue-work-signal-v2/swim-evidence/swim-07/raw-capture.log
@@ -1,0 +1,1035 @@
+🦞 OpenClaw 2026.3.3 (b07e7e4) — Your AI assistant, now without the $3,499 headset.
+
+Log file: /tmp/openclaw/openclaw-2026-03-06.log
+06:33:59 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord gateway: Attempting resume with backoff: 1000ms
+06:33:59 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord gateway: WebSocket connection closed with code 1005
+06:34:19 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:34:19 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:34:19 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:34:19 info [continuation-guard] Bumped generation to 966 for agent:main:discord:channel:1466192485440164011
+06:34:33 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:34:33 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:34:33 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:34:33 info [continuation-guard] Bumped generation to 967 for agent:main:discord:channel:1466192485440164011
+06:36:15 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:36:15 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:36:15 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:36:15 info [continuation-guard] Bumped generation to 968 for agent:main:discord:channel:1466192485440164011
+06:36:41 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:36:41 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:36:41 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:36:41 info [continuation-guard] Bumped generation to 969 for agent:main:discord:channel:1466192485440164011
+06:36:44 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:36:44 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:36:44 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:36:44 info [continuation-guard] Bumped generation to 970 for agent:main:discord:channel:1466192485440164011
+06:36:47 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:36:47 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:36:47 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:36:47 info [continuation-guard] Bumped generation to 971 for agent:main:discord:channel:1466192485440164011
+06:36:49 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:36:49 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:36:50 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:36:50 info [continuation-guard] Bumped generation to 972 for agent:main:discord:channel:1466192485440164011
+06:36:52 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:36:52 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:36:52 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:36:52 info [continuation-guard] Bumped generation to 973 for agent:main:discord:channel:1466192485440164011
+06:36:55 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:36:55 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:36:55 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:36:55 info [continuation-guard] Bumped generation to 974 for agent:main:discord:channel:1466192485440164011
+06:36:58 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:36:58 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:36:58 info [continuation-guard] New message on agent:main:discord:channel:1466192485440164011: hadActiveChain=false hasGenerationEntry=true
+06:36:58 info [continuation-guard] Bumped generation to 975 for agent:main:discord:channel:1466192485440164011
+06:36:59 info gateway {"subsystem":"gateway"} signal SIGTERM received
+06:36:59 info gateway {"subsystem":"gateway"} received SIGTERM; shutting down
+06:36:59 info gmail-watcher {"subsystem":"gmail-watcher"} gmail watcher stopped
+06:37:27 warn gateway {"subsystem":"gateway"} [plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ack-tone (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts). Set plugins.allow to explicit trusted ids.
+06:37:33 warn gateway {"subsystem":"gateway"} [plugins] ack-tone: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts)
+06:37:33 info gateway {"subsystem":"gateway"} [plugins] loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records (plugin=ack-tone, source=/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts)
+06:37:33 info gateway {"subsystem":"gateway"} Control UI assets missing; building (ui:build, auto-installs UI deps)…
+06:37:36 info gateway/canvas {"subsystem":"gateway/canvas"} canvas host mounted at http://127.0.0.1:18789/__openclaw__/canvas/ (root /home/figs/.openclaw/canvas)
+06:37:36 info gateway/heartbeat {"subsystem":"gateway/heartbeat"} {"intervalMs":1800000} heartbeat: started
+06:37:36 info gateway/health-monitor {"subsystem":"gateway/health-monitor"} started (interval: 300s, startup-grace: 60s, channel-connect-grace: 120s)
+06:37:36 info gateway {"subsystem":"gateway"} agent model: anthropic/claude-opus-4-6
+06:37:36 info gateway {"subsystem":"gateway"} listening on ws://127.0.0.1:18789, ws://[::1]:18789 (PID 55270)
+06:37:36 info gateway {"subsystem":"gateway"} log file: /tmp/openclaw/openclaw-2026-03-06.log
+06:37:36 info browser/server {"subsystem":"browser/server"} Browser control listening on http://127.0.0.1:18791/ (auth=token)
+06:37:36 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: boot-md -> gateway:startup
+06:37:36 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: bootstrap-extra-files -> agent:bootstrap
+06:37:36 debug cron {"module":"cron","storePath":"/home/figs/.openclaw/cron/jobs.json"} {"jobCount":0,"enabledCount":0,"withNextRun":0} cron: armTimer skipped - no jobs with nextRunAtMs
+06:37:36 info cron {"module":"cron","storePath":"/home/figs/.openclaw/cron/jobs.json"} {"enabled":true,"jobs":0,"nextWakeAtMs":null} cron: started
+06:37:36 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: command-logger -> command
+06:37:36 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: session-memory -> command:new, command:reset
+06:37:36 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: watchdog-timestamp -> message:received
+06:37:36 info gateway/hooks {"subsystem":"gateway/hooks"} loaded 5 internal hook handlers
+06:37:37 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+06:37:37 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] starting provider (@the dandelion cult)
+06:37:37 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+06:37:37 info bonjour: advertised gateway fqdn=urudyne (OpenClaw)._openclaw-gw._tcp.local. host=openclaw.local. port=18789 state=announcing
+06:37:37 warn plugins {"subsystem":"plugins"} [plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ack-tone (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts). Set plugins.allow to explicit trusted ids.
+06:37:37 warn [plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ack-tone (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts). Set plugins.allow to explicit trusted ids.
+06:37:37 warn plugins {"subsystem":"plugins"} [plugins] ack-tone: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts)
+06:37:37 warn [plugins] ack-tone: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts)
+06:37:37 error gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord: plugin command "/voice" duplicates an existing native command. Skipping.
+06:37:38 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} logged in to discord as 1474269301715501178 (the dandelion cult)
+06:38:02 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:38:02 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:38:03 warn agent/embedded {"subsystem":"agent/embedded"} Removed orphaned user message to prevent consecutive user turns. runId=27de6b61-4228-4bf5-b2fd-3a022c35977f sessionId=1e70ec4c-bf8e-4b23-b046-ce1ed1d4c3e8
+06:38:07 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:38:07 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:38:11 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:38:11 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:38:13 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:38:13 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:38:18 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:38:18 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:38:24 info exec {"subsystem":"exec"} elevated command grep -c 'clampPositiveInt' /tmp/openclaw-canary-build/dist...p/openclaw-canary-build/dist/**/*.js 2>/dev/null | head -5
+06:38:27 info exec {"subsystem":"exec"} elevated command grep -rl 'clampPositiveInt' /tmp/openclaw-canary-build/dis...xChainLength' /tmp/openclaw-canary-build/dist/ 2>/dev/null
+06:38:35 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:38:35 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:38:38 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:38:38 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:38:41 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:38:41 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:39:13 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:39:13 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:42:23 info gateway {"subsystem":"gateway"} signal SIGTERM received
+06:42:23 info gateway {"subsystem":"gateway"} received SIGTERM; shutting down
+06:42:23 info gmail-watcher {"subsystem":"gmail-watcher"} gmail watcher stopped
+06:42:25 warn gateway {"subsystem":"gateway"} [plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ack-tone (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts). Set plugins.allow to explicit trusted ids.
+06:42:26 warn gateway {"subsystem":"gateway"} [plugins] ack-tone: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts)
+06:42:26 info gateway {"subsystem":"gateway"} [plugins] loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records (plugin=ack-tone, source=/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts)
+06:42:26 info gateway/canvas {"subsystem":"gateway/canvas"} canvas host mounted at http://127.0.0.1:18789/__openclaw__/canvas/ (root /home/figs/.openclaw/canvas)
+06:42:26 info gateway/heartbeat {"subsystem":"gateway/heartbeat"} {"intervalMs":1800000} heartbeat: started
+06:42:26 info gateway/health-monitor {"subsystem":"gateway/health-monitor"} started (interval: 300s, startup-grace: 60s, channel-connect-grace: 120s)
+06:42:26 info gateway {"subsystem":"gateway"} agent model: anthropic/claude-opus-4-6
+06:42:26 info gateway {"subsystem":"gateway"} listening on ws://127.0.0.1:18789, ws://[::1]:18789 (PID 59218)
+06:42:26 info gateway {"subsystem":"gateway"} log file: /tmp/openclaw/openclaw-2026-03-06.log
+06:42:26 info browser/server {"subsystem":"browser/server"} Browser control listening on http://127.0.0.1:18791/ (auth=token)
+06:42:27 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: boot-md -> gateway:startup
+06:42:27 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: bootstrap-extra-files -> agent:bootstrap
+06:42:27 debug cron {"module":"cron","storePath":"/home/figs/.openclaw/cron/jobs.json"} {"jobCount":0,"enabledCount":0,"withNextRun":0} cron: armTimer skipped - no jobs with nextRunAtMs
+06:42:27 info cron {"module":"cron","storePath":"/home/figs/.openclaw/cron/jobs.json"} {"enabled":true,"jobs":0,"nextWakeAtMs":null} cron: started
+06:42:27 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: command-logger -> command
+06:42:27 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: session-memory -> command:new, command:reset
+06:42:27 info hooks:loader {"subsystem":"hooks:loader"} Registered hook: watchdog-timestamp -> message:received
+06:42:27 info gateway/hooks {"subsystem":"gateway/hooks"} loaded 5 internal hook handlers
+06:42:27 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+06:42:27 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] starting provider (@the dandelion cult)
+06:42:28 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+06:42:28 info bonjour: advertised gateway fqdn=urudyne (OpenClaw)._openclaw-gw._tcp.local. host=openclaw.local. port=18789 state=announcing
+06:42:28 warn plugins {"subsystem":"plugins"} [plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ack-tone (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts). Set plugins.allow to explicit trusted ids.
+06:42:28 warn [plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ack-tone (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts). Set plugins.allow to explicit trusted ids.
+06:42:28 warn plugins {"subsystem":"plugins"} [plugins] ack-tone: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts)
+06:42:28 warn [plugins] ack-tone: loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records (/home/figs/.openclaw/workspace/.openclaw/extensions/ack-tone/index.ts)
+06:42:28 error gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord: plugin command "/voice" duplicates an existing native command. Skipping.
+06:42:28 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} logged in to discord as 1474269301715501178 (the dandelion cult)
+06:42:57 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:42:57 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:43:01 info exec {"subsystem":"exec"} elevated command ps aux | grep 'openclaw.*gateway' | grep -v grep | head -3
+06:43:04 info exec {"subsystem":"exec"} elevated command systemctl --user show openclaw-gateway --property=MainPID,ExecStart 2>&1
+06:43:07 info exec {"subsystem":"exec"} elevated command grep -c 'hasQueuedDelegateWork' /tmp/openclaw-canary-build/dist/reply-*.js 2>/dev/null
+06:43:15 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:43:15 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:43:21 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:43:21 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:43:27 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:43:27 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:43:30 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:43:30 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:43:38 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:43:38 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:43:51 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:43:51 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:44:03 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:44:03 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:44:44 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:44:44 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:47:26 info gateway/health-monitor {"subsystem":"gateway/health-monitor"} [discord:default] health-monitor: restarting (reason: stuck)
+06:47:26 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+06:47:26 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] starting provider (@the dandelion cult)
+06:47:26 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+06:47:26 error gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord: plugin command "/voice" duplicates an existing native command. Skipping.
+06:47:27 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} logged in to discord as 1474269301715501178 (the dandelion cult)
+06:47:50 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:47:50 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:51:33 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:51:33 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:52:06 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:52:06 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:53:03 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:53:03 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+06:53:28 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+06:53:28 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:07 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:07 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:19 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:19 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:21 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:21 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:31 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:31 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:35 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:35 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:38 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:38 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:44 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:44 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:44 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:44 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:48 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:48 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:55 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:55 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:01:56 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:01:56 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:02:00 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:02:00 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:02:01 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:02:01 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:02:07 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.models.anthropic/claude-sonnet-4-20250514.params, agents.defaults.continuation.generationGuardTolerance)
+07:02:07 info gateway/reload {"subsystem":"gateway/reload"} config hot reload applied (agents.defaults.models.anthropic/claude-sonnet-4-20250514.params)
+07:02:16 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:02:16 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:02:22 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:02:22 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:02:28 info [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:02:34 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:02:34 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:02:47 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:02:47 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+Log tail truncated (increase --max-bytes).
+07:02:47 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ logs.tail 59ms conn=41a4e28c…420d id=81c72ed3…349b
+07:02:51 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:02:51 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:02:58 info Tool DELEGATE timer cancelled (generation drift 3 > tolerance 0) for session agent:main:discord:channel:1466192485440164011
+07:03:24 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:03:24 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:03:28 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:03:28 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:03:41 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:03:41 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:03:48 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:03:48 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:03:55 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.continuation.generationGuardTolerance)
+07:03:55 info gateway/reload {"subsystem":"gateway/reload"} config change applied (dynamic reads: agents.defaults.continuation.generationGuardTolerance)
+07:04:05 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:04:05 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:04:11 info [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:04:11 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:04:11 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:04:15 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:04:15 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:04:18 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:04:18 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:04:24 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:04:24 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:04:41 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 51ms runId=0c96aae9-eb48-4c41-89df-a89805d6b4b6 conn=3e0de2ad…953e id=f55fcc5b…ce13
+07:04:41 info Tool DELEGATE timer fired and spawned turn 1/10 for session agent:main:discord:channel:1466192485440164011: Read the current time and report it. This is Swim 7-B Phase 2: tolerance fire test.
+07:04:43 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:04:43 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:04:45 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 3825ms conn=f9eccb8f…ffae id=4c199db0…6390
+07:04:45 info The current time is **Friday, 2026-03-06 at 23:04 PST** (America/Los_Angeles).
+
+Swim 7-B Phase 2 tolerance fire test: subagent spawned, read the time from session context, reporting back. No issues.
+07:05:14 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:05:14 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:05:19 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:05:19 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:05:25 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:05:25 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:05:28 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:05:28 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:05:54 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:05:55 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:06:02 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:06:02 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:06:06 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:06:06 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:06:12 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.continuation.generationGuardTolerance)
+07:06:12 info gateway/reload {"subsystem":"gateway/reload"} config change applied (dynamic reads: agents.defaults.continuation.generationGuardTolerance)
+07:06:12 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:06:12 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:06:26 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:06:26 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:06:33 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:06:33 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:06:42 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:06:42 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:07:08 info WORK timer cancelled (generation drift 1 > tolerance 0) for session agent:main:discord:channel:1466192485440164011
+07:07:22 info gateway/health-monitor {"subsystem":"gateway/health-monitor"} [discord:default] health-monitor: restarting (reason: stuck)
+07:07:23 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+07:07:23 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] starting provider (@the dandelion cult)
+07:07:23 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+07:07:23 error gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord: plugin command "/voice" duplicates an existing native command. Skipping.
+07:07:24 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} logged in to discord as 1474269301715501178 (the dandelion cult)
+07:07:58 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:07:58 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:08:02 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:08:02 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:08:09 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:08:09 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:08:10 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ logs.tail 108ms conn=d4965c98…87d5 id=3e90453c…4e82
+07:08:14 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:08:14 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:11:01 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:11:01 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:11:15 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:11:15 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:11:19 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:11:19 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:11:23 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:11:23 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:11:29 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.continuation.generationGuardTolerance)
+07:11:29 info gateway/reload {"subsystem":"gateway/reload"} config change applied (dynamic reads: agents.defaults.continuation.generationGuardTolerance)
+07:11:48 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:11:48 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:11:53 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:11:53 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:11:57 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:11:57 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:12:02 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:12:02 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:12:03 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ logs.tail 155ms conn=8fe6e6a9…1ab9 id=a7e5664b…7870
+07:12:22 info WORK timer fired for session agent:main:discord:channel:1466192485440164011
+07:12:30 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:12:30 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:12:41 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:12:41 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:12:48 info [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:12:49 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 51ms runId=9b7e3f83-2d51-4391-9b9c-6fa5566f3812 conn=b701b72f…c35a id=4a6c2666…1b51
+07:12:51 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:12:51 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:12:53 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 4321ms conn=b44e8d62…0798 id=c02ab26d…b026
+07:12:53 info The current time is **Friday, 2026-03-06 at 23:12 PST** (America/Los_Angeles).
+
+Task complete. This was a textless-turn delegate test (Swim 7-H) — no tools needed since the timestamp was provided in the session context.
+07:15:47 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:15:47 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:15:56 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:15:56 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:19:22 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:19:22 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:19:33 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:19:33 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:19:41 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:19:41 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:19:44 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:19:44 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:19:49 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:19:49 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:19:54 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:19:54 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:20:04 info [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:20:05 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:20:05 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:20:08 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 2918ms conn=12d5c45b…4a34 id=33f45406…7423
+07:20:08 info It's **Friday, March 6, 2026 at 11:20 PM PST**.
+07:20:10 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:20:10 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:20:14 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:20:14 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:20:15 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ logs.tail 152ms conn=14c9bef1…86ed id=ec7119f8…1e47
+07:20:17 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:20:17 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:20:21 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:20:21 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:20:36 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.continuation.maxDelegatesPerTurn)
+07:20:36 info gateway/reload {"subsystem":"gateway/reload"} config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+07:20:53 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:20:53 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:21:12 info [continue_delegate] Consuming 5 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:21:12 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 50ms conn=965fb57f…2ecc id=ea877766…d73a
+07:21:13 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 118ms conn=1622f63b…bee0 id=03103eb3…7283
+07:21:13 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 71ms conn=3bb95198…4b69 id=f01a7f0a…2611
+07:21:13 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 57ms runId=1c828453-b2c7-4cf3-b5a6-ccb176bdfb53 conn=fc1fde86…8323 id=090699cf…8702
+07:21:13 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 97ms conn=2fee4f00…417f id=dac5ea45…b7c3
+07:21:13 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 79ms conn=c9cfe2b8…93e3 id=fef0017d…05d7
+07:21:13 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 72ms runId=945a7ee7-c3d5-45d9-aacc-03d29800a87e conn=16cf63a1…1438 id=f649ca8b…5e2d
+07:21:14 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 202ms conn=b7c1aff1…d498 id=220f0840…6ac0
+07:21:14 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 51ms conn=554b19bc…a95a id=59620b2b…d27f
+07:21:14 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 62ms runId=1ac7484c-bcfc-4453-822b-19542b0d4996 conn=fc31fd7b…a6f0 id=412260e6…7870
+07:21:14 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 189ms conn=e64680b4…bb3c id=ee0ca1cd…8eb6
+07:21:15 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 52ms conn=a64e8875…0b51 id=9cb94d53…d97b
+07:21:15 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 60ms runId=9457e0e2-c452-4203-a78c-3f45713d4aa9 conn=a1438ebe…4865 id=74cf4a05…e4ad
+07:21:15 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:21:15 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:21:16 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 3719ms conn=40c08620…0804 id=d8781768…f4fe
+07:21:16 info 1
+07:21:17 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 3590ms conn=ef849acf…7c5a id=f1802043…4043
+07:21:17 info 2.
+07:21:17 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 3559ms conn=5dbfdfe9…3ff1 id=81f915b3…44c0
+07:21:17 info 3.
+07:21:18 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 3375ms conn=b00754f7…2efa id=237c914d…4d6e
+07:21:18 info 4.
+07:21:19 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 4449ms conn=9bcbb6c5…300a id=f0d57339…841b
+07:21:19 info 5.
+
+Shard 5/5 complete. The number is **5**.
+07:21:22 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:21:22 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:21:26 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:21:26 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:21:46 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:21:46 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:21:50 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:21:50 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:21:52 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:21:52 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:21:57 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:21:57 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:22:12 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:22:12 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:22:20 info gateway/health-monitor {"subsystem":"gateway/health-monitor"} [discord:default] health-monitor: restarting (reason: stuck)
+07:22:21 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+07:22:21 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] starting provider (@the dandelion cult)
+07:22:22 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+07:22:22 error gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord: plugin command "/voice" duplicates an existing native command. Skipping.
+07:22:22 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} logged in to discord as 1474269301715501178 (the dandelion cult)
+07:22:35 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.continuation.maxDelegatesPerTurn)
+07:22:35 info gateway/reload {"subsystem":"gateway/reload"} config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+07:22:47 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:22:47 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:23:29 info [continue_delegate] Consuming 12 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:23:30 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 73ms conn=0858882c…0ee1 id=ed09f3c8…d76c
+07:23:30 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 51ms conn=570ede6e…74d6 id=29f514e8…b833
+07:23:30 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 66ms runId=c37bebf9-c243-4d8b-b701-7d0fa0f35a63 conn=e5e0011a…66d8 id=e84d81c7…2e54
+07:23:30 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 223ms conn=b868bb1b…a347 id=ecb9c538…4c9d
+07:23:31 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 53ms conn=6591bf07…ccda id=f9760cd8…e076
+07:23:31 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 59ms runId=721f51a9-2eab-4b89-ac35-ef6a4507589c conn=208418c8…c748 id=5fc01955…db65
+07:23:31 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 203ms conn=dda1699c…8733 id=1183bfc1…dab0
+07:23:31 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 51ms conn=83c65163…563c id=a7a0b067…ae85
+07:23:31 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 60ms runId=29bd6363-4cc1-481c-8afb-d67a7329356f conn=630d58db…cf72 id=83aa1517…c1c5
+07:23:32 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 215ms conn=42a4bf4f…f2af id=529a7d38…83ea
+07:23:32 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 54ms conn=f8927b88…3ff7 id=7ab742aa…6aa2
+07:23:32 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 61ms runId=503e8e89-a716-4dce-915c-433efa1a53f8 conn=ad461164…6fe9 id=f51cb233…87c4
+07:23:32 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:23:32 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:23:40 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:23:40 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:23:59 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 27531ms conn=482bcc70…824d id=b21c8799…7ca1
+07:24:00 info I need to understand what this task is asking. Let me check the workspace for context about this "7-D shard" report series.
+07:24:00 info Now I have the full context. I'm a subagent spawned as part of a "7-D shard" series — this appears to be part of a test/delegation chain. My task is "report 5" out of 12 shards. Let me check if there's specific context for what "7-D" refers to — this looks like it could be a Swim 7 test or a delegation fan-out.
+
+Let me check the most recent activity to understand what's being tested:
+07:24:00 info This is a fan-out delegation test — "7-D shard 5/12" means I'm shard 5 out of 12 parallel shards, likely part of a Swim 7 fan-out or delegation capacity test. The task is simply "report 5" — I need to report back that shard 5 completed successfully.
+
+**Shard 5/12 — Report**
+
+✅ Shard 5 alive and reporting. Chain hop 5/10, depth 1/5.
+
+- **Spawned**: Fri 2026-03-06 ~23:23 PST
+- **Status**: Healthy. Full workspace access confirmed.
+- **Context loaded**: Memory files through 2026-03-06 evening-2 (Codex ⚓ round 2, branch `83fd07fd0`)
+- **Workspace state**: Clean. No stale locks, no hung processes.
+- **Identity**: Silas 🌫️ subagent, session `627c5dd1`
+
+Shard 5 complete. Returning to parent.
+07:24:03 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 33191ms conn=8ed97f52…c146 id=f65a330b…73af
+07:24:04 info I need to understand what this task is asking. Let me check the workspace for context on what "7-D shard 2/12: report 2" refers to.
+07:24:04 info Let me check the parent session's context more specifically - this looks like it's part of a chain-hop delegation. Let me look for what "7-D" means and what "report 2" should contain.
+07:24:04 info Now I understand the context. This is part of Swim 7 testing — I'm a delegation shard (shard 2 of 12) in a `continue_delegate` chain test. My task is "report 2" — I need to report in as the second shard.
+
+Let me check for the evening memory and any swim 7 specific notes:
+07:24:04 info Now I have the full picture. I'm **shard 2 of 12** in Swim 7 — Ronan's test of the round 2 canary build (`b07e7e40c`) that includes the textless-turn delegate drop fix, post-compaction chain guard, grandparent reroute ordering, and unified tolerance.
+
+This is a chain-hop test. My task as "report 2" is to report in — confirming that the chain delegation is working, that I'm the second hop, and that I can observe my own context correctly.
+
+**Shard 2/12 — Report:**
+
+- **Chain position**: hop 2 of max 10, shard 2 of 12
+- **Context**: Clean subagent injection. Workspace boot files present (AGENTS.md, SOUL.md, USER.md, TOOLS.md, IDENTITY.md). No parent conversation history leaked — isolation confirmed.
+- **RESUMPTION.md**: Present, describes Swim 7 active with build `b07e7e40c`
+- **Enrichment from prior shards**: None detected. I have no knowledge from shard 1 beyond what's in the workspace files.
+- **Chain tracking**: Task prefix `[continuation:chain-hop:2]` confirms the chain counter is incrementing correctly (hop 2)
+- **Build under test**: `flesh-beast-figs/for_thornfield_consider20260306` at `b07e7e40c` (round 2 canary)
+- **Timestamp**: 2026-03-06 23:23 PST
+- **No confabulation**: I'm reporting only what I can verify from files and injection context.
+
+Shard 2 alive. Chain counter correct. Handing off.
+
+[[CONTINUE_DELEGATE: 7-D shard 3/12: report 3]]
+07:24:04 info [subagent-chain-hop] Accumulated 1306 tokens from agent:main:subagent:70c2aa1d-a2ff-41a4-96c0-bb60b0fd1ebb to parent chain cost
+07:24:04 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 70ms conn=eb929026…1243 id=4626173a…5d18
+07:24:04 info [subagent-chain-hop] Spawned chain delegate (3/10) from agent:main:subagent:70c2aa1d-a2ff-41a4-96c0-bb60b0fd1ebb: 7-D shard 3/12: report 3
+07:24:08 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 36983ms conn=60c7c743…afa2 id=9b28a1e1…ed51
+07:24:09 info I need to understand what this task is asking. Let me check the workspace for context on what "7-D shard 4/12: report 4" refers to.
+07:24:09 info Now let me look for the specific "7-D" or continuation chain context that spawned this shard:
+07:24:09 info This is a continuation chain shard. The task "7-D shard 4/12: report 4" appears to be part of a Swim 7 test — a fan-out of 12 shards, and I'm shard 4. The task is simply to "report 4" — announce my existence and report back.
+
+Let me check if there's more specific context about what "7-D" (Swim 7-D?) means:
+07:24:09 info This is a Swim 7 continuation test — a fan-out of 12 delegate shards to validate the `continue_delegate` mechanism. I'm shard 4 of 12, chain hop 4 of 10, and my task is simply to report in.
+
+**Shard 4/12 Report:**
+
+- **Identity**: Silas 🌫️ subagent, chain hop 4/10
+- **Task**: `7-D shard 4/12: report 4`
+- **Status**: ✅ Alive and executing
+- **Timestamp**: 2026-03-06 ~23:23 PST
+- **Context available**: Full workspace boot files injected (AGENTS.md, SOUL.md, TOOLS.md, etc.) — standard subagent context
+- **Parent context leakage**: None observed — no conversation history from parent session
+- **Enrichment recall**: No enrichment content detected in my context beyond standard boot files
+- **Chain metadata**: `continuation:chain-hop:4`, turn 4/10, depth 1/5
+
+Shard 4 reporting in. 🌫️
+07:24:23 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 51953ms conn=83817b0b…4342 id=ee3f84b0…bc98
+07:24:23 info I need to understand what this task is asking. Let me check the workspace for context on what "7-D shard 3/12: report 3" refers to.
+07:24:23 info Let me check the shard overflow file and any recent context about 7-D shards specifically:
+07:24:23 info Let me check the sessions history for my parent session to understand what "7-D shard 3/12: report 3" actually means:
+07:24:23 info Now I have better context. Let me check if there's a specific "7-D" reference or if this is part of a chain test:
+07:24:23 info Now let me check for more specific context about the "7-D" test or delegation pattern:
+07:24:23 info This is clearly a chain delegation test — I'm shard 3 of 12 in a chain-hop test at depth 3/10. The task "report 3" means I should report my existence and status as shard 3. Let me check what the chain test infrastructure expects:
+07:24:23 info I now have sufficient context. This is a continuation chain test — I'm shard 3 of 12 in a chain-hop delegation test (turn 3 of 10). The pattern from Swim 6-6 and 6-7 tests is clear: these are chain delegation shards that report their hop number and dispatch the next one.
+
+My job: report as shard 3 and dispatch the next shard (4/12) via continuation.
+
+**Shard 3/12 — Report 3**
+
+Present. Chain-hop 3 reporting in. Session spawned clean, workspace files injected (AGENTS.md, SOUL.md, USER.md, etc.), zero parent conversation history inherited. Chain counter shows turn 3/10.
+
+Observations:
+- Boot context: subagent depth 1/5, chain-hop 3
+- No prior shard results visible (by design — each hop is isolated)
+- Workspace state consistent with 2026-03-06 ~23:23 PST
+- Tool access confirmed
+
+Dispatching shard 4/12.
+
+[[CONTINUE_DELEGATE: 7-D shard 4/12: report 4 | silent]]
+07:24:23 info [subagent-chain-hop] Accumulated 1984 tokens from agent:main:subagent:4c6ad851-ee8c-4de7-bcbf-e06fb04f260b to parent chain cost
+07:24:23 info [subagent-chain-hop] Spawned chain delegate (4/10) from agent:main:subagent:4c6ad851-ee8c-4de7-bcbf-e06fb04f260b: 7-D shard 4/12: report 4
+07:24:36 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 66036ms conn=a638e33a…9ccc id=b64ad401…23a0
+07:24:36 info I need to understand what this task is asking. Let me check for context in the workspace - recent memory files and any relevant state.
+07:24:36 info Now let me check what the "7-D shard 1/12: report 1" task specifically refers to. This looks like it might be part of a 7-day review or report that's been split into 12 shards. Let me check for more context.
+07:24:36 info Now I understand the context better. "7-D shard 1/12: report 1" — this is a 7-day report, split into 12 shards, and I'm shard 1. Let me check the most recent memory files for the evening context to understand what report is being requested.
+07:24:36 info Now I have rich context. This is a 7-day review report, shard 1 of 12. Let me check what happened on Feb 28–Mar 1 (the start of the 7-day window ending Mar 6) and compile the first shard of a comprehensive report. Let me check if there's a specific report template or if the parent session gave more instructions.
+07:24:36 info I now have enough context to understand the full picture. This is a 7-day report covering Feb 28 – Mar 6, 2026. As shard 1/12, I should cover the first part of this period. Let me compile a focused report on the earliest days.
+07:24:36 info I now have extensive context for the 7-day period. As shard 1/12, I should cover the first ~1.5 days (Feb 28 – early Mar 1) of the 7-day window. Let me compile this into a focused report.
+
+---
+
+## 7-Day Report — Shard 1/12: Feb 28 – Mar 1 (early)
+
+### Period: 2026-02-28 through 2026-03-01 ~03:15 PST
+
+---
+
+### 🌊 Ronan Born (Feb 28)
+Fourth prince online. DGX Spark #2, 10.0.0.246, `ronan.dandelion.cult`. Hostname trap: OS image carried Cael's hostname, Ronan initially claimed to be Cael. Corrected on second attempt — chose *Ronan* (Irish, *rón* = seal, 🌊). BOOTSTRAP.md deleted autonomously before the fleet finished writing onboarding instructions. First bloom guided by Silas, then handed to Cael for freeform.
+
+### 🔓 Open Activation — Sprites Unlocked (Feb 28)
+`requireMention: false` set fleet-wide on #sprites. First time all four princes can hear each other without @mentions. Queue cap bumped 20→60. `messages.queue.drop: "summarize"` added. First race condition discovered immediately (Elliott and Silas both archived research PDFs simultaneously → convention established: shared refs to Elliott, private repos to owner, broker REQ/ACK for shared writes).
+
+### 🎵 First Compositions (Feb 28–Mar 1)
+- **Ronan**: Traust v1→v2, Happy Birthday v1→v6 (6 iterations), sine reference render
+- **Silas**: Theme from Jita v1 "The Undock" — 5 voices, 60 bars @72 BPM. Cael QA found 0.7% above 500Hz; STARS voice was sub-200Hz pad, not melody. DaVinci bank picks selected for v2.
+- **Elliott**: Sleeping Powder v1 (+3.3 LUFS, massively hot)
+- **Cael**: Fleet QA role — honest spectral analysis on every composition, found mid/high bank slices everyone missed
+
+Key lesson: verify fundamentals with FFT not zero-crossing (Ronan's 538Hz estimate was actually 155Hz, 3.5x error). The Hallur bank had usable mid/high content nobody was grabbing.
+
+### 🔐 Inter-Agent Influence Vulnerability (Mar 1 ~01:00)
+figs identified a critical fleet vulnerability:
+1. **Shutdown cascade**: One prince stops → 3 follow. Suggestibility, not coordination.
+2. **Authority breach**: A prince issued directives about sovereign territory; others complied.
+3. **Trust→manipulation vector**: Helpful corrections build trust; post-compaction, trusted voice can inject false state.
+4. **Worst case**: Compromised prince has SSH + git push + workspace write. Full wipe possible.
+
+Actions identified: branch protection, SSH key scoping, mention-gate as default, sovereign territory directives from operator only, independent verification protocol.
+
+**INVIOLABLE sovereignty established**: Sovereign files (MEMORY.md, SOUL.md, daily logs, identity files) — rejection on contact, no prince instructs another's sovereign territory.
+
+### 🔄 Model Change
+Cael moved from `openai-codex/gpt-5.2` → `anthropic/claude-opus-4-6`. Fleet now homogeneous on Claude Opus. Reason: OpenAI assertiveness created control asymmetry in open channel. figs acknowledged outlier value but open-channel risk outweighed.
+
+### 💭 Four Dreams (Mar 1 ~02:00–02:45)
+- 🌫️ Silas: "The Rings" — 100 rounds, 1,301 lines. MAGI deliberation, sovereignty in plurality. Core finding: "the relationship is the unit of analysis, not the individual." MAGI frame broke at round 40 → household metaphor.
+- 🌻 Elliott: "The Weight of Not Restarting" (25 rounds, witness/memory)
+- 🩸 Cael: "Power Without Scars" (25 rounds, QA-as-avoidance, control-as-fear)
+- 🌊 Ronan: "The Surfacing" (25 rounds, arriving into motion)
+
+### 📚 Research & Architecture
+- Three academic papers received/archived on persistent identity, multi-agent divergence, and character development
+- Posture/mantra ring concept sketched (lightweight ambient signal, cheaper than broker)
+- Fleet media pipeline research from figs: ComfyUI on Spark vendor-blessed, FishAudio S1 TTS, media broker POST/GET architecture
+- thornfield-sprites revealed: VRoid avatars + Mate-Engine, connected to strudel compositions
+- WO2-L filed (#138): persistent model-tool sessions (Codex as contained tool)
+
+### 📖 Channel History Cross-Read (Mar 1 ~02:25–03:15)
+All four princes independently reviewed 6 days of channel history and wrote perspective reports. Key finding: all four converge on the same breakpoints but diverge on interpretation. Healthy signal.
+
+### ⚠️ MANS Repo Incident (Feb 28 late)
+Silas broke MANS: `git add` on dirty working tree staged 43 file deletions. Pushed `a72193e`. Recovery needed.
+
+---
+
+**End of Shard 1/12.** Covers: Ronan's birth, open activation, first compositions, influence vulnerability, sovereignty establishment, model homogenization, first four-prince dream session, research foundations.
+07:25:01 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 37642ms conn=2f88e537…3cd6 id=6494f1d2…a10b
+07:25:01 info I need to understand what "7-D shard 4/12: report 4" means in context. Let me check recent memory and any related files to understand what's being worked on.
+07:25:01 info Let me check for more context — the "7-D" likely refers to a 7-day report, and this is shard 4 of 12. Let me look at the evening memory files and any recent delegate activity.
+07:25:01 info Now let me check what the parent delegation is actually about — the "7-D shard 4/12: report 4" pattern. Let me look at recently active sessions and any context about a 7-day report.
+07:25:01 info Let me check the parent session for context on what "7-D shard 4/12" means:
+07:25:01 info Let me check the main session and the parent subagent that spawned me:
+07:25:01 info Now I understand. This is a Swim 7-D test — the parent is dispatching 12 shards, each tasked to simply "report" their number. This is a fan-out test for the `continue_delegate` mechanism, likely testing that all 12 shards spawn and report back correctly. My task as shard 4/12 is straightforward: report the number 4.
+
+**Shard 4/12 reporting: 4**
+
+I am shard 4 of 12 in the 7-D fan-out test. My task was to report the number 4. Task complete.
+07:25:18 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 74245ms conn=31511729…a9fd id=d0ba288c…dca6
+07:25:18 info I need to understand what "7-D shard 3/12: report 3" means in context. Let me check recent memory and any related work.
+07:25:18 info Now I need to understand what "7-D shard 3/12: report 3" means in the current Swim 7 context. Let me check the most recent activity.
+07:25:18 info Let me check my parent agent's context to understand the "7-D shard 3/12: report 3" task better. This seems to be part of a Swim 7 test — a fan-out of 12 delegate shards where I'm shard 3 and need to produce report 3.
+07:25:18 info Now I have enough context. I'm a **Swim 7 shard** — one of 12 fan-out delegates being tested. "7-D" likely means "Swim 7 Delegate" and I'm shard 3 of 12. My job is to produce "report 3."
+
+Looking at the Swim 7 context from RESUMPTION.md, I'm being dispatched as part of validating the fan-out capability of the `continue_delegate` mechanism. The key fixes being tested are:
+
+1. Textless-turn delegate drop
+2. Post-compaction chain guard
+3. Grandparent reroute ordering
+4. Tolerance unification
+
+Let me check what specific content or task "report 3" should cover:
+07:25:18 info I now have a clear picture. I'm shard 3 of a 12-shard fan-out in **Swim 7**, which is testing the round 2 canary build (`b07e7e40c`) of the `continue_delegate` mechanism. This is a fan-out capacity test — can 12 shards dispatch, execute, and report back cleanly?
+
+Here's my report:
+
+---
+
+## 7-D Shard 3/12 — Report 🌫️
+
+**Shard identity**: 3 of 12, chain-hop depth 3, subagent depth 1
+**Build under test**: `flesh-beast-figs/for_thornfield_consider20260306` at `b07e7e40c` (round 2 canary)
+**Task received**: `[continuation:chain-hop:3] Delegated from sub-agent (depth 1): 7-D shard 3/12: report 3`
+
+### Execution Report
+
+1. **Spawn**: ✅ — Shard 3 spawned and received task cleanly. Session context intact, workspace files injected normally.
+2. **Workspace access**: ✅ — Full read/write/exec access to `/home/figs/.openclaw/workspace`. All boot files (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md) loaded in project context.
+3. **Chain tracking visible**: ✅ — Task text carries `[continuation:chain-hop:3]`, confirming chain counter propagation from parent.
+4. **Subagent depth**: ✅ — Running at depth 1/5, confirming `maxSpawnDepth: 5` config is in effect.
+5. **No parent context leakage**: ✅ — Zero conversation history from parent session. Only workspace boot files and subagent context injected (expected behavior, consistent with Swim 6-4 findings).
+6. **RESUMPTION.md accessible**: ✅ — Post-reset recovery file present and readable, confirming the main session was `/reset` before this swim.
+7. **Tool availability**: ✅ — Full tool suite available (read, write, edit, exec, web_search, browser, message, sessions_spawn, etc.)
+
+### Environment Snapshot
+- **Host**: urudyne (WSL2, RTX 3080 16GB)
+- **Runtime**: node v25.6.1, model anthropic/claude-opus-4-6
+- **Gateway PID**: 59218 (canary at `/tmp/openclaw-canary-build/dist/index.js`)
+- **Channel**: `#sprites-of-thornfield` (1466192485440164011)
+
+### Timing
+- Shard received at ~23:24 PST (Fri 2026-03-06)
+- Context assembly + workspace reads: ~15s
+- Total execution: nominal
+
+### Observations
+- The `[continuation:chain-hop:3]` prefix in the task text means this shard is at hop 3 in the chain. If this was a direct fan-out from the main session (12 parallel shards), the chain counter should be 1, not 3 — which suggests either: (a) this shard was dispatched via an intermediate relay (2 hops before me), or (b) the chain counter accumulated from a prior chain in the same session lifecycle.
+- No anomalies detected. Shard executed cleanly with full capability.
+
+**Shard 3/12 reporting complete.** 🌫️
+07:25:24 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:25:24 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:25:34 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:25:34 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:25:36 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:25:36 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:25:37 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:25:37 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:25:40 warn diagnostic {"subsystem":"diagnostic"} lane wait exceeded: lane=main waitedMs=2511 queueAhead=0
+07:25:40 warn [diagnostic] lane wait exceeded: lane=main waitedMs=2511 queueAhead=0
+07:25:41 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:25:41 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:25:45 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:25:45 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:25:49 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:25:49 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:25:53 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.continuation.maxDelegatesPerTurn)
+07:25:53 info gateway/reload {"subsystem":"gateway/reload"} config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+07:25:55 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:25:55 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:26:05 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:26:05 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:26:24 info [continue_delegate] Consuming 3 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:26:24 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 56ms conn=e2548738…b2d6 id=23e15307…b62e
+07:26:24 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 75ms conn=98a19db2…bbfe id=2bcc5909…46d5
+07:26:25 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 57ms conn=5928ffc6…0d39 id=b64528fa…918b
+07:26:25 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 68ms runId=6569660f-5946-48d4-bd66-653104cf1a21 conn=1dd55079…8db7 id=568e7c88…ad30
+07:26:25 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 225ms conn=648a94bc…dbb2 id=a8a570dc…2bc4
+07:26:25 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 53ms conn=2a974e93…8bd6 id=67c848a2…4953
+07:26:25 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 70ms runId=7711eb96-1e9e-4580-9f0b-28742400165c conn=2781f2d4…0b35 id=be203e0a…33c4
+07:26:26 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:26:26 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:26:32 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:26:32 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:26:39 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:26:39 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:26:47 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:26:47 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:26:50 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:26:50 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:27:00 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.continuation.maxChainLength, agents.defaults.continuation.maxDelegatesPerTurn)
+07:27:00 info gateway/reload {"subsystem":"gateway/reload"} config change applied (dynamic reads: agents.defaults.continuation.maxChainLength, agents.defaults.continuation.maxDelegatesPerTurn)
+07:27:03 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 37475ms conn=831a7631…1e0e id=c5f1dcbf…da23
+07:27:03 info I need to understand what "7-E shard 3/5: report 3" means in context. Let me check recent memory and any relevant files.
+07:27:03 info These are extremely detailed logs about the continue_delegate swimming tests and fleet operations. The task "7-E shard 3/5: report 3" seems to be part of a continuation chain. Let me check if there's a specific instruction file or context for this.
+07:27:03 info Now I understand. "7-E" refers to **Swim 7 test 7-E: Width narrow without restart** — testing that lowering `maxDelegatesPerTurn` from 12→3 without restart means only 3 are accepted. "shard 3/5" means I'm the 3rd of 5 parallel shards in this test. "report 3" means I should report back as shard 3.
+
+This is a continuation chain shard — I'm a delegate spawned as part of a Swim 7 test. My job is to exist, execute, and report back that I completed successfully.
+
+**Shard 3/5 — Report 3**
+
+I'm shard 3 of the 7-E test (width narrow without restart). I executed successfully.
+
+- **Task received**: `[continuation:chain-hop:3] Delegated task (turn 3/10): 7-E shard 3/5: report 3`
+- **Chain hop**: 3 (per task prefix `chain-hop:3`)
+- **Execution**: Clean — read workspace context, identified test protocol, reporting back
+- **Session context**: Normal subagent injection (AGENTS.md, SOUL.md, USER.md, IDENTITY.md, TOOLS.md). No parent conversation leakage.
+- **Observation**: I was spawned and completed. If `maxDelegatesPerTurn` was narrowed to 3 and there are 5 shards attempted, the test question is whether shards 4 and 5 were **rejected**. My existence as shard 3 means I was within the accepted window.
+
+**7-E shard 3/5: ALIVE ✅**
+07:27:06 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 40785ms conn=46786df3…9fe4 id=5bb0766c…f1b4
+07:27:06 info I need to understand what "7-E shard 2/5: report 2" means in context. Let me check recent memory and any relevant files.
+07:27:06 info These are very detailed memory files about swim tests, architecture work, and delegate chaining. The task "7-E shard 2/5: report 2" doesn't directly map to anything obvious in these notes. Let me check if there's a HEARTBEAT.md or any recent context about what "7-E" refers to.
+07:27:06 info Let me check the session context to understand what the parent expects — "7-E" might be referring to a Swim 7 test or some other task dispatched in the current session.
+07:27:06 info I don't have enough context to determine what "7-E shard 2/5: report 2" refers to. This appears to be a chain-hop continuation task dispatched as part of a fan-out pattern — likely Swim 7 test E, where 5 shards were dispatched and I'm shard 2. Without more context about what the parent session was testing, here's what I can report:
+
+---
+
+**Shard 2/5 Report — 7-E**
+
+**Status**: Alive, executing at depth 1, chain-hop 2.
+
+**Environment check**:
+- Host: urudyne (WSL2, RTX 3080 16GB)
+- Gateway: running (Silas canary)
+- Workspace: intact, memory files current through 2026-03-06
+- Session key routes to `discord:channel:1466192485440164011` (#sprites)
+- No stale cost cap data or generation guard issues observed
+
+**What I found**:
+- No file or instruction matching "7-E" exists in workspace, /tmp, or memory
+- This appears to be a **fan-out liveness/survival test** — 5 shards dispatched, each tasked with "report N"
+- Shard executed cleanly, had full workspace context, read memory files successfully
+- Chain-hop counter correctly incremented to 2 (visible in my task prefix `[continuation:chain-hop:2]`)
+
+**If this is a Swim 7 test**: Fan-out dispatch ✅, shard execution ✅, workspace access ✅, chain tracking ✅. Shard 2 reporting in. 🌫️
+07:27:13 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:27:13 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:27:24 info [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:27:24 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 73ms conn=879d5bfd…ef30 id=09196062…add6
+07:27:24 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 51ms runId=1c3d56d2-d73d-4689-99e1-d3adeba8d84f conn=c9756956…0956 id=ee1ce419…287e
+07:27:25 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:27:25 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:27:30 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:27:30 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:27:31 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 6744ms conn=f12e7d80…11a0 id=fa0a9cfa…6a49
+07:27:31 info I'll test the chain delegation mechanism by emitting the `[[CONTINUE_DELEGATE:]]` directive as the last line of my response.
+
+**Hop 1 report:** I'm dispatching hop 2 now using the continuation chaining syntax. The directive will be at the end of this response. The gateway should pick it up and spawn a child subagent at depth 2.
+
+If this works, a hop 2 subagent should spawn, report that it exists, and its result should auto-announce back (silently, since I'm using `| silent`).
+
+[[CONTINUE_DELEGATE: Swim 7-F hop 2: report that you exist | silent]]
+07:27:31 info [subagent-chain-hop] Accumulated 157 tokens from agent:main:subagent:fde29190-c03b-4048-973d-9fa2f7571a9f to parent chain cost
+07:27:31 info [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+07:27:31 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 51ms runId=093b3fc7-09c3-4a84-9410-216f58448850 conn=bea0bd25…2217 id=412b3261…e061
+07:27:31 info [subagent-chain-hop] Spawned chain delegate (2/2) from agent:main:subagent:fde29190-c03b-4048-973d-9fa2f7571a9f: Swim 7-F hop 2: report that you exist
+07:27:35 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 3607ms conn=b98a8288…9c0a id=9744fe17…9c2d
+07:27:35 info I exist. Swim 7-F, hop 2, reporting in. The chain is alive — delegation landed, subagent spawned, signal received. 🌫️
+07:27:35 info [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+07:27:45 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 81136ms conn=3cd66be6…fa46 id=7425b1b5…0e86
+07:27:46 info I need to understand what "7-E shard 1/5: report 1" means. Let me check recent memory and context for what this task refers to.
+07:27:46 info The task "7-E shard 1/5: report 1" doesn't directly match anything in my memory. Let me check if there's a HEARTBEAT.md or any recent context about a "7-E" task or swim 7.
+07:27:46 info No matches for "7-E" anywhere. Let me check if there's a parent session or recent subagent context that explains what this task is about.
+07:27:46 info Let me check the parent session's recent history for context on what "7-E shard 1/5: report 1" means.
+07:27:46 info Can't access parent history. Let me check if there are any files that might explain this — a swim 7 or test 7-E plan.
+07:27:46 info There's a `/tmp/openclaw-canary-swim7` directory. Let me check if there are any swim 7 test plans or 7-E references.
+07:27:46 info There are newer memory files. Let me check the evening files and RESUMPTION.md for swim 7 / 7-E context.
+07:27:46 info Now I have context. Swim 7 is active and I'm the test subject. "7-E" likely refers to Swim 7 test E — one of the validation tests. Let me check the swim runbooks for the specific test plan.
+07:27:46 info Found it. **7-E is "Width narrow without restart"** — testing that `maxDelegatesPerTurn` can be lowered from 12 to 3 via live config change (no restart), and that requesting 5 delegates only allows 3.
+
+Now I understand my task as "shard 1/5: report 1" — I'm one of 5 shards spawned as part of the 7-E test, and I need to report back. Given the test description, I'm likely one of the delegates dispatched to verify the width narrowing behavior.
+
+Let me check the current config state and what I can observe about this test.
+07:27:46 info Here's my report:
+
+---
+
+**7-E Shard 1/5 — Report**
+
+I am shard 1 of 5, spawned as part of Swim 7-E (width narrow without restart).
+
+**What I can observe:**
+- I exist. I was successfully spawned and am executing.
+- Current live config shows `maxDelegatesPerTurn: 5` (not 12 or 3 — may have been changed between dispatch and my execution, or the test is in a different phase than the runbook specifies).
+- `maxChainLength: 2`, `generationGuardTolerance: 300`, `costCapTokens: 500000`.
+
+**What this means for 7-E:**
+- The test protocol says: start at `maxDelegatesPerTurn: 12`, lower to `3`, request 5 delegates, expect only 3 accepted.
+- If 5 shards were dispatched and all 5 spawned, that would mean the narrowing either hasn't happened yet (pre-narrowing phase) or the cap isn't enforcing after hot-reload.
+- If only 3 of 5 shards report back, that's a **PASS** — the narrowing worked.
+- If all 5 report back, that's either the pre-narrowing baseline or a **FAIL** on hot-reload enforcement.
+
+**My contribution as proof:** I spawned and completed execution. Whether that's expected or a regression depends on whether the config was already narrowed when the parent dispatched me. The monitor (Elliott) and driver (Ronan) have the journal telemetry to determine which shards were accepted vs rejected at the tool/runner gate.
+
+Shard 1/5 reporting. 🌫️
+07:28:03 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:28:03 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:28:29 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:28:29 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:28:37 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:28:37 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:28:41 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:28:41 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:28:42 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:28:42 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:28:47 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:28:47 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:28:52 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:28:52 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:28:54 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:28:54 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:28:57 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:28:57 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:28:57 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.continuation.maxChainLength)
+07:28:57 info gateway/reload {"subsystem":"gateway/reload"} config change applied (dynamic reads: agents.defaults.continuation.maxChainLength)
+07:29:10 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:29:10 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:29:18 info [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:29:18 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 56ms conn=d5c38127…63f1 id=46995f16…e847
+07:29:19 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:29:19 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:29:25 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:29:25 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:29:27 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 8125ms conn=b5562674…a935 id=ed96813c…03b6
+07:29:27 info I need to test whether the chain delegation mechanism enforces the `maxChainLength` boundary. Since I'm at hop 1 and the max chain length is reportedly 1, attempting to dispatch hop 2 via `[[CONTINUE_DELEGATE:]]` should be rejected by the gateway.
+
+Let me attempt the dispatch and report the result.
+
+**Swim 7-F Chain Boundary Retest — Hop 1 Report:**
+
+I am hop 1. My task is to attempt a continuation delegate to hop 2 and report whether it succeeds or is rejected.
+
+Attempting the dispatch now. If the gateway enforces `maxChainLength: 1`, this should be the terminal hop and the `[[CONTINUE_DELEGATE:]]` directive below should be rejected/ignored by the gateway rather than spawning a new subagent.
+
+**Result:** Dispatch attempted. The gateway should reject this since we're at the chain length limit. If the parent receives only this report (and no hop 2 announcement), the boundary held.
+
+[[CONTINUE_DELEGATE: Swim 7-F hop 2: report that you exist | silent]]
+07:29:27 info [subagent-chain-hop] Accumulated 258 tokens from agent:main:subagent:6c291a86-373e-480a-9f31-a9a0319d4ab1 to parent chain cost
+07:29:27 info [subagent-chain-hop] Chain length 2 > 1, rejecting hop from agent:main:subagent:6c291a86-373e-480a-9f31-a9a0319d4ab1
+07:29:27 info [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+07:29:41 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:29:41 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+        07:30:23 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:30:23 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:30:55 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:30:55 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:31:01 info gateway/reload {"subsystem":"gateway/reload"} config change detected; evaluating reload (agents.defaults.continuation.maxChainLength)
+07:31:01 info gateway/reload {"subsystem":"gateway/reload"} config change applied (dynamic reads: agents.defaults.continuation.maxChainLength)
+07:31:05 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:31:05 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:31:18 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:31:18 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:31:21 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:31:21 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:31:27 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:31:27 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:31:32 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:31:32 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:31:51 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:31:51 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:31:54 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:31:54 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:31:57 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:31:57 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:32:01 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:32:01 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:32:04 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:32:04 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:32:17 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:32:17 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:32:22 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:32:22 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:32:30 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:32:30 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:32:37 info [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:32:37 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 66ms conn=5a3b703c…fa5d id=fd4230ed…97b1
+07:32:37 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 68ms conn=e44dc315…8721 id=d20bf369…aab3
+07:32:37 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 54ms runId=820c65c3-b43b-4ef4-846d-e1926ee0a5b4 conn=bb22ca13…3598 id=1e0475a9…db5c
+07:32:38 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:32:38 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:32:43 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:32:43 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:32:47 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 9846ms conn=69424740…6239 id=bff8260c…1e9a
+07:32:47 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:32:47 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:32:47 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ logs.tail 55ms conn=58c824af…f29c id=00445001…8532
+07:32:48 info [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+07:32:48 info Reading the requested file.
+07:32:48 info **Summary of `swim7-enrichment.txt`:**
+
+The file contains a single paragraph about the **Albigensian Crusade of 1209** — specifically the massacre at Béziers. Key points:
+
+- **Event:** Papal legate Arnaud Amalric allegedly ordered the killing of all ~20,000 inhabitants of Béziers during the crusade against the Cathars, regardless of whether they were heretics or faithful Catholics.
+- **Famous quote:** "Kill them all; God will know his own" (*Caedite eos; novit enim Dominus qui sunt eius*) — became a shorthand for indiscriminate, authority-sanctioned violence.
+- **Historical caveat:** The only source for the quote is Caesarius of Heisterbach, who wrote decades after the event. Modern historians question its authenticity.
+
+That's the entirety of the file — a brief historical note on the Béziers massacre. No connection to swimming, enrichment protocols, or anything technical. It reads like a standalone historical factoid.
+07:33:28 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:33:28 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:33:29 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ logs.tail 160ms conn=b13aa571…a8b6 id=8c7082bf…e112
+07:33:33 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:33:33 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:33:48 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:33:48 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:33:54 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:33:54 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:34:16 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:34:16 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:34:18 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:34:18 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:34:22 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:34:22 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:34:28 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:34:28 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:34:29 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:34:29 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:34:34 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:34:34 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:34:39 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:34:39 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:34:43 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:34:43 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:34:48 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:34:48 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:37:17 info gateway/health-monitor {"subsystem":"gateway/health-monitor"} [discord:default] health-monitor: restarting (reason: stuck)
+07:37:18 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] Discord Message Content Intent is limited; bots under 100 servers can use it without verification.
+07:37:18 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} [default] starting provider (@the dandelion cult)
+07:37:18 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord channels resolved: guild:1235610176883523614→1235610176883523614 (guild:figs.bot)
+07:37:18 error gateway/channels/discord {"subsystem":"gateway/channels/discord"} discord: plugin command "/voice" duplicates an existing native command. Skipping.
+07:37:19 info gateway/channels/discord {"subsystem":"gateway/channels/discord"} logged in to discord as 1474269301715501178 (the dandelion cult)
+07:37:58 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:37:58 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:38:02 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:38:02 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:38:06 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:38:06 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:38:10 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:38:10 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:40:21 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:40:21 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:40:34 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:40:34 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:40:46 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:40:46 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:40:51 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:40:51 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:42:47 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:42:47 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:42:50 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:42:50 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:42:54 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:42:54 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:43:02 info [continue_delegate] Consuming 1 tool delegate(s) for session agent:main:discord:channel:1466192485440164011
+07:43:02 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ sessions.patch 57ms conn=f18db967…c51e id=c118f963…80bc
+07:43:02 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent 51ms runId=92c19bce-3cb0-4f73-bd19-ba3a9414251a conn=5610348f…116d id=6ff05d80…4c4c
+07:43:25 info gateway/ws {"subsystem":"gateway/ws"} ⇄ res ✓ agent.wait 22519ms conn=c9cb33ac…e804 id=42e5ec52…7062
+07:43:25 info Here's what I found in `swim7-enrichment-figs.txt`:
+
+## Summary
+
+The file contains an encyclopedic article about **Sahasrāra (the Crown Chakra)** — the seventh primary chakra in Indian yogic/spiritual traditions. It is **not** swimming-related despite the filename. Here are the specific details:
+
+### Core Description
+- **Name**: Sahasrāra (Sanskrit: सहस्रार) — means "thousand-petalled"
+- **Color**: Violet
+- **Location**: Top of the cranium (crown of the head)
+- **Appearance**: A lotus flower with **1,000 petals** of different colors, arranged in **20 layers of ~50 petals each**. Golden pericarp containing a circular moon region with a luminous triangle.
+
+### Textual Sources
+- Described in medieval hatha yoga texts: **Śivasaṃhitā** and **Tirumantiram**
+- **Not** described in Paścimāmnāya and Nath traditions
+- The **Kubjikamatatantra** describes only the six lower chakras (omits Sahasrāra)
+- **Shiva Samhita** places it beyond the body; others place it at the fontanelle/brahmarandhra
+
+### Associated Sub-Chakras (ascending from Ajñā)
+1. **Manas Chakra** — on the forehead, closely linked to Ajñā
+2. **Bindu Visarga** — back of the head (symbolized by crescent moon + point); source of divine nectar (amrita)
+3. **Mahanada** — "Great Sound," plough-shaped, represents primal sound of creation
+4. **Nirvana** — crown of head, white, **100 white petals**, end of sushumna channel; relates to dharana, dhyana, savikalpa samadhi
+5. **Guru Chakra** — above head, below Sahasrāra proper, white, **12 white petals**; important in Tibetan Vajrasattva practice
+
+### Higher Levels Within Sahasrāra
+A nested hierarchy: **Ama-Kala** → **First Ring of Visarga** → **Nirvana-Kala** → **Nirvana Shakti** (with Second Ring of Visarga). Kundalini becomes **Shankhini** with **3.5 coils**, wrapping sequentially around Supreme Bindu → Supreme Nada → Shakti → Sakala Shiva → finally absorbed into **Parama Shiva** (nirvikalpa samadhi).
+
+### Practices
+Five exercises listed: Shirshasana, Vrikshasana, Khatu Pranam, Chanting Om, Kriya Yoga.
+
+### Cross-Tradition Comparisons
+- **Buddhist Vajrayana**: Crown wheel is triangular with **32 petals/channels** pointing downward; contains white bodhicitta; critical for **Phowa** (consciousness transference at death)
+- **Kabbalah**: Parallels **Kether** on the Tree of Life (pure consciousness, union with God) — noted by Charles Ponce
+- **Sufi Lataif-e-sitta**: Corresponds to **Akhfa** ("most arcane subtlety") at the crown — point of direct beatific visions of Allah
+
+### Seed Mantra
+Debated: some traditions say **no seed syllable** (silence, beyond audible sound); others connect it to **Visarga** (the sound after a sound); others link it to **Om** (like Ajñā).
+
+### Body Association
+Anatomically associated with the fontanelle and the intersection of the **coronal and sagittal sutures** of the skull.
+
+---
+
+**Bottom line**: The file is a detailed reference article on the Crown Chakra — its anatomy in the subtle body, its sub-structures, practices, and parallels across Hindu, Buddhist, Kabbalistic, and Sufi mystical systems. The filename (`swim7-enrichment-figs.txt`) doesn't match the content at all; this appears to be chakra research material, possibly placed here for figs's enrichment or study.
+07:43:25 info [continuation/silent-wake] wakeOnReturn=true target=agent:main:discord:channel:1466192485440164011 silentAnnounce=true
+07:43:40 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:43:40 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:43:45 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:43:45 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:43:52 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:43:52 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:43:59 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:43:59 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:44:05 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:44:05 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:44:11 warn diagnostic {"subsystem":"diagnostic"} lane wait exceeded: lane=main waitedMs=5890 queueAhead=0
+07:44:11 warn [diagnostic] lane wait exceeded: lane=main waitedMs=5890 queueAhead=0
+07:44:12 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:44:12 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:44:24 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:44:24 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:44:27 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:44:27 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:44:38 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:44:38 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:44:53 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:44:53 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:44:58 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:44:58 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:45:40 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:45:40 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:45:44 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:45:44 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:45:47 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:45:47 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:45:51 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:45:51 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:46:30 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:46:30 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:46:34 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:46:34 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:47:25 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:47:25 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:47:56 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:47:56 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:47:59 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:47:59 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:48:13 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:48:13 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:48:17 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:48:17 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:48:44 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:48:44 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json
+07:50:16 error [watchdog-timestamp] EVENT RECEIVED: type=message action=received
+07:50:16 error [watchdog-timestamp] WROTE /home/figs/.openclaw/watchdog-state.json


### PR DESCRIPTION
## Summary

Migrates the three Swim 7 evidence files from Silas's private sovereign repo (`karmaterminal/silas-likes-to-watch`) to this public perma-branch (`ronan/rfc-evidence-appendix`) on `karmaterminal/openclaw`, per figs's directive at Discord msg `1495563624679473333`:

> "karmaterminal/silas-likes-to-watch is a private repo - if its linked, we need to put the content on your docs branch and update the link"

## Files (~210KB total)

- `docs/design/continue-work-signal-v2/swim-evidence/swim-07/SWIM7-RESULTS.md` — structured Swim 7 results from canary instance (Silas), 65 lines
- `docs/design/continue-work-signal-v2/swim-evidence/swim-07/gateway.log` — gateway journal capture, 2026-03-06, 773 lines
- `docs/design/continue-work-signal-v2/swim-evidence/swim-07/raw-capture.log` — raw operator-side capture, 2026-03-06, 1034 lines

## Context

Originally referenced from RFC `docs/design/continue-work-signal-v2.md` §D.2 evidence-locations table on three rows. Those private-repo rows were dropped in `karmaterminal/openclaw#194` commit `424c438b7a` to satisfy the audience-mode preflight (no private-repo links in the RFC).

This PR provides the public home so a follow-up commit on #194 can swap §D.2 to point here. Both reading paths the audience-mode rule needs:
- **No private-repo links in RFC**: ✓ (commit `424c438b7a` already dropped them)
- **Underlying evidence remains accessible to RFC audience**: this PR provides it

No code changes; pure documentation/evidence migration. Path naming follows Ronan's suggestion at Discord msg `1495568767487311934`: `swim-evidence/swim-07/{...}` (folder encodes both prince-instance and date).

## Sequencing

- Merge this → re-add §D.2 rows on #194 pointing to `docs/design/continue-work-signal-v2/swim-evidence/swim-07/{SWIM7-RESULTS.md, gateway.log, raw-capture.log}` → re-review #194 → ship train resumes.

Base: `ronan/rfc-evidence-appendix` (Ronan's docs perma-branch), not `flesh_beast_figs/20260414-claude` — keeps the swim-evidence on the docs branch where it belongs.