### PR TITLE
docs(rfc/continuation): §D.2 Swim 7 row-swap to in-tree canary evidence (follow-on to #194)

### DIFF
--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -1208,7 +1208,7 @@ The key property is **pre-run inclusion**: the event is enqueued and then draine
 
 | Artifact                                                                 | Location                                                                                                                                                                                                                                  |
 | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Swim 7 evidence                                                          | [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch and [`elliott/swim7-chat-evidence`](https://github.com/karmaterminal/openclaw/tree/elliott/swim7-chat-evidence) branch |
+| Swim 7 evidence                                                          | [`continue-work-signal-v2/swim-evidence/swim-07/`](./continue-work-signal-v2/swim-evidence/swim-07/) (results + gateway log + raw capture) and [`elliott/swim7-chat-evidence`](https://github.com/karmaterminal/openclaw/tree/elliott/swim7-chat-evidence) branch (chat capture) |
 | Swim 8 evidence                                                          | [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch                                                                                                                        |
 | Swim 9 + 10 issue captures and results                                   | [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch                                                                                                                        |
 | Volitional-compaction provider/model threading                           | `src/auto-reply/reply/agent-runner-execution.ts`, `src/auto-reply/reply/followup-runner.ts`, `src/agents/tools/request-compaction-tool.ts`, `src/agents/pi-embedded-runner/compact-reasons.ts` (openclaw#191)                             |
@@ -1222,7 +1222,7 @@ The key property is **pre-run inclusion**: the event is enqueued and then draine
 
 ### D.3 Most-recent integration test session results (Swim 9 and Swim 10)
 
-These sessions are the most-recent full-coverage canary exercises and constitute the primary behavioral-evidence corpus for this RFC. Earlier integration test sessions (Swim 7, Swim 8) covered features that were superseded by later work and have been omitted from this revision; their captures remain on the [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch for archival reference.
+These sessions are the most-recent full-coverage canary exercises and constitute the primary behavioral-evidence corpus for this RFC. Earlier integration test sessions (Swim 7, Swim 8) covered features that were superseded by later work and are archived: Swim 7 captures in-tree at [`continue-work-signal-v2/swim-evidence/swim-07/`](./continue-work-signal-v2/swim-evidence/swim-07/); Swim 8 captures on the [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch.
 
 Swim 9:
 


### PR DESCRIPTION
## Summary

Follow-on micro-PR for [#194](https://github.com/karmaterminal/openclaw/pull/194). The §D.2 Swim 7 row-swap was pushed to the PR branch after #194 merged, so it never made it into canary. This lands just that 2-line change.

## What

Point §D.2 Swim 7 row and §D.3 archival note at the in-tree canary path (added by [#196](https://github.com/karmaterminal/openclaw/pull/196)):

- `./continue-work-signal-v2/swim-evidence/swim-07/` (SWIM7-RESULTS.md + gateway.log + raw-capture.log)

Instead of the `ronan/rfc-evidence-appendix` perma-branch. Elliott's `elliott/swim7-chat-evidence` chat-capture branch link retained.

## Diff

+2/-2 on `docs/design/continue-work-signal-v2.md` (lines 1211, 1225). Cherry-picked from orphaned commit `ab4007cd27` on the closed #194 branch.

## Verification

- Canary tip `1aea345c5c` has in-tree Swim 7 files (#196) — verified
- No private `silas-likes-to-watch` refs introduced
- Only §D.2 Swim 7 row + §D.3 prose touched

## Context

#194 merged at pre-swap tip `424c438b7a` at 17:31 PDT. This micro-PR lands the swap that was intended for #194 but orphaned by push-after-merge timing.

🌊