### PR TITLE
docs(pr-38780): rewrite description body without test counts or swim specifics

### DIFF
--- a/docs/pr-bodies/pr-38780-body.md
+++ b/docs/pr-bodies/pr-38780-body.md
@@ -1,0 +1,71 @@
+<!--
+Drafted body for openclaw/openclaw#38780 — replaces the existing PR description.
+Tracking issue: karmaterminal/openclaw#226
+Lives at: docs/pr-bodies/pr-38780-body.md
+-->
+## Agent Self-Elected Turn Continuation
+
+This PR adds a continuation system that lets persistent OpenClaw agents elect to continue working across turn boundaries, delegate follow-up work to sub-agents, and manage their own compaction lifecycle.
+
+### What it does
+
+Three new agent tools, available when `continuation.enabled: true`:
+
+| Tool | Purpose |
+|---|---|
+| `continue_work()` | Request another turn for the current session after an optional delay |
+| `continue_delegate()` | Dispatch work to a sub-agent with typed modes: normal, silent, silent-wake, post-compaction |
+| `request_compaction()` | Request volitional compaction after preparing working state |
+
+All three tools are also accessible via response-token fallback syntax (`CONTINUE_WORK`, `[[CONTINUE_DELEGATE: ...]]`) for environments where tools are disabled.
+
+### Why it matters
+
+Existing mechanisms for keeping agents active (heartbeat timers, cron scheduling, loop instructions) work by injecting external events on a fixed schedule. They solve liveness but not volition — the agent cannot say "I have more work to do" mid-turn. Over sustained operation, the repeated scheduling instructions accumulate as the dominant signal in the context window, biasing agent attention toward the polling task rather than the work at hand.
+
+`continue_work()` leaves zero injection footprint: the agent elects to continue from inside the turn, and the signal is stripped before the next context window is assembled.
+
+### Platform integration
+
+- **Context-pressure awareness**: system events notify the agent of rising context usage before compaction becomes unavoidable
+- **Volitional compaction**: `request_compaction()` lets the agent prepare (write memory files, stage recovery delegates) then elect compaction on its own schedule
+- **Post-compaction lifecycle dispatch**: delegates staged before compaction are released into the successor session alongside boot files
+- **TaskFlow backing**: durable delegate queue via the platform's managed-task infrastructure (ships enabled by default)
+
+### Scope
+
+This PR is **continuation-only**. Several ancillary fixes that landed on the same long-running candidate branch — the swim-35/A1 legacy session-key sweep, a checkpoint dedup, a Copilot IDE-header fix, and a truncate-after-compaction schema field — are being split into separate upstream PRs and should not appear in this diff. See the severability tracking issue for the file inventories.
+
+### Known issues addressed since the original draft
+
+- **Continuation tool provider/model threading**: earlier versions of `request_compaction()` did not propagate the source session's provider/model selection to the successor, and the chain-counter could under-report. The fix threads provider/model through the compaction request envelope and corrects the counter at the lifecycle release site. A regression test covering both behaviors is being added under a follow-up issue.
+- **Hedge-timer reference leak**: a delayed-continuation hedge could retain its scheduler entry past resolution under specific cancellation orderings, leaving stale entries in the timer map. Fixed; covered by `src/auto-reply/continuation/scheduler.test.ts`.
+- **`/status` continuation-row telemetry**: the continuation block on `/status` had drifted out of sync with the underlying counters during the squash. Restored, with the row populated from the same source the tools read.
+
+### Safety
+
+- Ships disabled by default (`continuation.enabled: false`)
+- Bounded by `maxChainLength`, `costCapTokens`, `maxDelegatesPerTurn`, and `generationGuardTolerance`
+- All configuration values are hot-reloadable without gateway restart
+- Interruptible: any generation drift cancels delayed work at the shipped tolerance
+
+### Test plan
+
+The relevant suites for a reviewer to run locally:
+
+- `pnpm test src/auto-reply/continuation/` — unit-level behaviors of the continuation modules (config, scheduler, signal, delegate-store, lifecycle)
+- `pnpm test src/agents/subagent-announce.continuation*` — subagent-announce integration: tool registration, drain semantics, silent / silent-wake / wakeOnReturn announce routing
+- `pnpm test src/agents/agent-runner-execution.test.ts` and `src/agents/agent-runner.test.ts` — end-to-end continuation lifecycle including post-compaction release
+- `pnpm test src/tools/continue-work-tool.test.ts src/tools/continue-delegate-tool.test.ts src/tools/request-compaction-tool.test.ts` — tool-surface coverage
+- `pnpm test:coverage` — repo-configured coverage threshold (≥70%)
+
+Coverage and CI gates are enforced by the existing repository configuration; no claim-counts are made here.
+
+### Evidence
+
+- RFC: [`docs/design/continue-work-signal-v2.md`](docs/design/continue-work-signal-v2.md) — design document covering problem statement, solution, implementation, platform integration, configuration, observability, safety, production use cases, and appendices.
+- In-tree integration test results: [`docs/design/continue-work-signal-v2/swim-evidence/swim-07/SWIM7-RESULTS.md`](docs/design/continue-work-signal-v2/swim-evidence/swim-07/SWIM7-RESULTS.md) — structured run report of the multi-agent integration session that exercised tool parity, chain-depth/width enforcement, and context-pressure integration on the candidate branch.
+
+---
+
+Upstream issue: openclaw/openclaw#32701


### PR DESCRIPTION
Closes karmaterminal/openclaw#226.

Drafts a replacement description for upstream openclaw/openclaw#38780, kept in-tree at `docs/pr-bodies/pr-38780-body.md` so it can be reviewed before being copied onto the upstream PR body.

## What changed vs the existing PR body

**Stripped** (per issue acceptance checklist):
- `Validated across 6 structured integration test sessions (Swim 12-17)...`
- `Swim 17 achieved 5/5 PASS — first perfect swim`
- `5/5 PASS on Swim 17 (first perfect), 12/12 pass on tool parity, chain depth, ...`
- `1 bug found and fixed live (silent-wake persistence)`
- `Blind enrichment methodology validated accurate recall`
- `8 P0 candidates triaged → 3 real bugs found and fixed ... 4 false positives closed`
- `The fleet has been running continuation-enabled builds in daily production use since early March 2026`

**Kept** (per issue):
- Feature summary / tools table
- Why-it-matters narrative (volition vs liveness, zero injection footprint)
- Platform integration bullets (context-pressure, volitional compaction, post-compaction lifecycle, TaskFlow backing)
- Safety paragraph
- RFC link
- Upstream issue reference (now properly prefixed: `openclaw/openclaw#32701`)

**Added** (per issue):
- Scope note: continuation-only PR; ancillary fixes (swim-35/A1 legacy session-key sweep, checkpoint dedup, Copilot IDE-header fix, truncate-after-compaction schema field) split into separate upstream PRs
- Known-issues paragraph with substantive descriptions of three fix-arcs (provider/model threading, hedge-timer ref-leak, /status continuation-row telemetry) — described by behavior, not by fork-issue-number
- Test plan as a runnable checklist for the reviewer, not an achievement log
- Evidence pointer to the in-tree Swim 7 doc + RFC, with a one-line statement of what each contains

## Acceptance grep checks (all clean against the new body)

| Check | Result |
|---|---|
| `grep -E '[0-9]+/[0-9]+ PASS'` | none |
| `grep -i 'first perfect'` | none |
| `grep -E 'Swim [0-9]+\|Swim-[0-9]+'` | none (path `swim-evidence/swim-07/` is a real in-tree filepath the issue says to keep) |
| `grep -iE 'prince\|cult\|fleet\|figs\|goldeneye\|<named-contributor>\|dandelion'` | none |
| Bare `#N` references | none — all three are properly prefixed (`openclaw/openclaw#38780`, `karmaterminal/openclaw#226`, `openclaw/openclaw#32701`) |

## Next step

Once this is merged, the body at `docs/pr-bodies/pr-38780-body.md` should be copied onto the upstream PR body via `gh pr edit 38780 --repo openclaw/openclaw --body-file docs/pr-bodies/pr-38780-body.md`. (Out of scope for this PR — that's a one-shot copy, not a tracked artifact.)

Pairs with sibling karmaterminal/openclaw#199 (fork-only `#N` citation cleanup in source comments) and karmaterminal/openclaw#198 (severability — splitting ancillary fixes referenced by the new scope note).