### PR TITLE
style(continuation): replace British 'initialised' with American 'initialized' in net additions

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -887,7 +887,7 @@ export function buildStatusMessage(args: StatusArgs): string {
  * Source modules are imported statically; no status<->continuation cycle
  * exists (verified — neither continuation/* nor request-compaction-tool.ts
  * imports auto-reply/status). Inner try/catch around each lookup keeps the
- * status row resilient if a counter store hasn't been initialised in a
+ * status row resilient if a counter store hasn't been initialized in a
  * particular runtime path (silently fall back to zero rather than failing
  * the whole status render).
  */
@@ -914,7 +914,7 @@ function formatContinuationStatusLine(params: {
       pending = pendingDelegateCount(sessionKey);
       staged = stagedPostCompactionDelegateCount(sessionKey);
     } catch {
-      // delegate-store not initialised — leave counts at zero.
+      // delegate-store not initialized — leave counts at zero.
     }
     try {
       volitional = getVolitionalCompactionCount(sessionKey);

--- a/src/commands/status.command-report-data.ts
+++ b/src/commands/status.command-report-data.ts
@@ -184,7 +184,7 @@ export async function buildStatusCommandReportData(params: {
               stagedTotal += stagedPostCompactionDelegateCount(session.key);
             }
           } catch {
-            // TaskFlow not initialised or lookup failed — fall back to
+            // TaskFlow not initialized or lookup failed — fall back to
             // config-only shape silently rather than hiding the whole row.
           }
         }


### PR DESCRIPTION
Closes karmaterminal/openclaw#201.

Three one-word comment edits across two files, all in net additions on the continuation candidate branch (`v2026.4.14..HEAD`):

- `src/auto-reply/status.ts:890` — jsdoc comment
- `src/auto-reply/status.ts:917` — inline comment
- `src/commands/status.command-report-data.ts:187` — inline comment

The review report listed two locations (`status.ts:890,917` and `status.command-report-data.ts:187`) but cited the wrong path for the first \u2014 the actual matches live in `src/auto-reply/status.ts`, not `src/commands/status.ts`. All three are in comments, not strings or code.

Pre-existing `initialised` in `src/gateway/auth.ts:347` is upstream code (no commits between `v2026.4.14` and the candidate branch touched it) and is left alone per the issue's 'in net additions' scope.

## Verification

```
$ git diff v2026.4.14...HEAD --name-only | xargs grep -ln 'initialised' 2>/dev/null
(none)
```