### PR TITLE
fix(continuation): surface post-compaction delegate spawn failures (#203)

### DIFF
--- a/src/auto-reply/continuation/post-compaction-dispatch.test.ts
+++ b/src/auto-reply/continuation/post-compaction-dispatch.test.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0
+//
+// Regression cover for karmaterminal/openclaw#203:
+// post-compaction delegate dispatcher must surface spawn failures via a named
+// log anchor + a system event. Silent catches are forbidden — the bug class
+// fixed in the #639 arc still lived here until #203.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  dispatchPostCompactionDelegates,
+  type PostCompactionSpawnContext,
+} from "./post-compaction-dispatch.js";
+import type { PendingContinuationDelegate } from "./types.js";
+
+type LogFn = (message: string, meta?: Record<string, unknown>) => void;
+
+function makeLog(): {
+  info: ReturnType<typeof vi.fn<LogFn>>;
+  warn: ReturnType<typeof vi.fn<LogFn>>;
+} {
+  return {
+    info: vi.fn<LogFn>(),
+    warn: vi.fn<LogFn>(),
+  };
+}
+
+const SPAWN_CTX: PostCompactionSpawnContext = {
+  agentSessionKey: "test-session",
+  agentChannel: "test-channel",
+};
+
+const DELEGATE: PendingContinuationDelegate = {
+  task: "do the post-compaction follow-up",
+  mode: "post-compaction",
+  silent: true,
+  silentWake: true,
+  postCompaction: true,
+};
+
+describe("dispatchPostCompactionDelegates", () => {
+  it("counts a successful spawn", async () => {
+    const log = makeLog();
+    const enqueueSystemEvent = vi.fn();
+    const spawnFn = vi.fn().mockResolvedValue({ status: "spawned" });
+
+    const result = await dispatchPostCompactionDelegates({
+      sessionKey: "test-session",
+      delegates: [DELEGATE],
+      spawnContext: SPAWN_CTX,
+      spawnFn,
+      log,
+      enqueueSystemEvent,
+    });
+
+    expect(result).toEqual({ attempted: 1, spawned: 1, failed: 0 });
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    expect(spawnFn).toHaveBeenCalledWith(
+      {
+        task: DELEGATE.task,
+        silentAnnounce: true,
+        wakeOnReturn: true,
+        drainsContinuationDelegateQueue: true,
+      },
+      SPAWN_CTX,
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("emits a named log anchor + system event on spawn failure (regression cover #203)", async () => {
+    const log = makeLog();
+    const enqueueSystemEvent = vi.fn();
+    const spawnFn = vi.fn().mockRejectedValue(new Error("subagent registry full"));
+
+    const result = await dispatchPostCompactionDelegates({
+      sessionKey: "test-session",
+      delegates: [DELEGATE],
+      spawnContext: SPAWN_CTX,
+      spawnFn,
+      log,
+      enqueueSystemEvent,
+    });
+
+    expect(result).toEqual({ attempted: 1, spawned: 0, failed: 1 });
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    const warnArg = log.warn.mock.calls[0][0];
+    expect(warnArg).toContain("[continuation:post-compaction-spawn-failed]");
+    expect(warnArg).toContain("error=subagent registry full");
+    expect(warnArg).toContain("session=test-session");
+    expect(warnArg).toContain("task=do the post-compaction follow-up");
+
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    const [eventText, eventMeta] = enqueueSystemEvent.mock.calls[0];
+    expect(eventText).toContain("[continuation] Post-compaction delegate spawn failed");
+    expect(eventText).toContain("subagent registry full");
+    expect(eventText).toContain(DELEGATE.task);
+    expect(eventMeta).toEqual({ sessionKey: "test-session" });
+  });
+
+  it("isolates failures per-delegate (one failure does not abort the loop)", async () => {
+    const log = makeLog();
+    const enqueueSystemEvent = vi.fn();
+    const spawnFn = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "spawned" })
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce({ status: "spawned" });
+
+    const delegates: PendingContinuationDelegate[] = [
+      { ...DELEGATE, task: "first" },
+      { ...DELEGATE, task: "second" },
+      { ...DELEGATE, task: "third" },
+    ];
+
+    const result = await dispatchPostCompactionDelegates({
+      sessionKey: "test-session",
+      delegates,
+      spawnContext: SPAWN_CTX,
+      spawnFn,
+      log,
+      enqueueSystemEvent,
+    });
+
+    expect(result).toEqual({ attempted: 3, spawned: 2, failed: 1 });
+    expect(spawnFn).toHaveBeenCalledTimes(3);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles non-Error throwables (string, undefined) without crashing", async () => {
+    const log = makeLog();
+    const enqueueSystemEvent = vi.fn();
+    const spawnFn = vi.fn().mockRejectedValue("string-rejection");
+
+    const result = await dispatchPostCompactionDelegates({
+      sessionKey: "test-session",
+      delegates: [DELEGATE],
+      spawnContext: SPAWN_CTX,
+      spawnFn,
+      log,
+      enqueueSystemEvent,
+    });
+
+    expect(result.failed).toBe(1);
+    const warnArg = log.warn.mock.calls[0][0];
+    expect(warnArg).toContain("error=string-rejection");
+  });
+
+  it("returns zero counters for an empty delegate list", async () => {
+    const log = makeLog();
+    const enqueueSystemEvent = vi.fn();
+    const spawnFn = vi.fn();
+
+    const result = await dispatchPostCompactionDelegates({
+      sessionKey: "test-session",
+      delegates: [],
+      spawnContext: SPAWN_CTX,
+      spawnFn,
+      log,
+      enqueueSystemEvent,
+    });
+
+    expect(result).toEqual({ attempted: 0, spawned: 0, failed: 0 });
+    expect(spawnFn).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/continuation/post-compaction-dispatch.ts
+++ b/src/auto-reply/continuation/post-compaction-dispatch.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0
+//
+// Post-compaction delegate dispatch helper.
+//
+// Releases delegates that were staged during a session for execution after
+// auto-compaction completes. Each spawn failure must be observable: a named
+// log anchor plus a system event so the dispatcher cannot drop work silently
+// (regression-cover for the silent-catch class fixed in karmaterminal/openclaw#203).
+
+import type { PendingContinuationDelegate } from "./types.js";
+
+/**
+ * Minimal logger surface used by {@link dispatchPostCompactionDelegates}.
+ * Matches the {@link createSubsystemLogger} contract — kept narrow so the
+ * helper can be unit-tested without pulling the full logging subsystem.
+ */
+export interface PostCompactionDispatchLogger {
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+}
+
+export interface PostCompactionSpawnContext {
+  agentSessionKey: string;
+  agentChannel?: string;
+  agentAccountId?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+}
+
+/**
+ * Result shape from a single delegate spawn attempt. The dispatcher only
+ * cares about success vs failure — caller-side semantics (status fields,
+ * spawn metadata) belong to the spawn implementation.
+ */
+export type PostCompactionSpawnFn = (
+  params: {
+    task: string;
+    silentAnnounce: true;
+    wakeOnReturn: true;
+    drainsContinuationDelegateQueue: true;
+  },
+  ctx: PostCompactionSpawnContext,
+) => Promise<unknown>;
+
+export interface DispatchPostCompactionDelegatesArgs {
+  sessionKey: string;
+  delegates: PendingContinuationDelegate[];
+  spawnContext: PostCompactionSpawnContext;
+  spawnFn: PostCompactionSpawnFn;
+  log: PostCompactionDispatchLogger;
+  enqueueSystemEvent: (text: string, opts: { sessionKey: string }) => void;
+}
+
+export interface DispatchPostCompactionDelegatesResult {
+  attempted: number;
+  spawned: number;
+  failed: number;
+}
+
+/**
+ * Run each staged delegate through {@link spawnFn}. On failure, emit:
+ *   - a `[continuation:post-compaction-spawn-failed]` log line at warn level
+ *   - a system event so the operator surface sees the dropped work
+ *
+ * Failures are isolated per-delegate — one failure does not stop the rest.
+ */
+export async function dispatchPostCompactionDelegates(
+  args: DispatchPostCompactionDelegatesArgs,
+): Promise<DispatchPostCompactionDelegatesResult> {
+  const { sessionKey, delegates, spawnContext, spawnFn, log, enqueueSystemEvent } = args;
+  let spawned = 0;
+  let failed = 0;
+  for (const delegate of delegates) {
+    try {
+      await spawnFn(
+        {
+          task: delegate.task,
+          silentAnnounce: true,
+          wakeOnReturn: true,
+          drainsContinuationDelegateQueue: true,
+        },
+        spawnContext,
+      );
+      spawned++;
+    } catch (err) {
+      failed++;
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log.warn(
+        `[continuation:post-compaction-spawn-failed] error=${errMsg} session=${sessionKey} task=${delegate.task.slice(0, 80)}`,
+      );
+      enqueueSystemEvent(
+        `[continuation] Post-compaction delegate spawn failed: ${errMsg}. Task: ${delegate.task}`,
+        { sessionKey },
+      );
+    }
+  }
+  return { attempted: delegates.length, spawned, failed };
+}

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1652,27 +1652,22 @@ export async function runReplyAgent(params: {
               `[continuation:compaction-delegate] Consuming ${stagedDelegates.length} compaction delegate(s) for session ${sessionKey}`,
             );
             const { spawnSubagentDirect } = await import("../../agents/subagent-spawn.js");
-            for (const delegate of stagedDelegates) {
-              try {
-                await spawnSubagentDirect(
-                  {
-                    task: delegate.task,
-                    silentAnnounce: true,
-                    wakeOnReturn: true,
-                    drainsContinuationDelegateQueue: true,
-                  },
-                  {
-                    agentSessionKey: sessionKey,
-                    agentChannel: followupRun.originatingChannel ?? undefined,
-                    agentAccountId: followupRun.originatingAccountId ?? undefined,
-                    agentTo: followupRun.originatingTo ?? undefined,
-                    agentThreadId: followupRun.originatingThreadId ?? undefined,
-                  },
-                );
-              } catch {
-                // Post-compaction delegate dispatch is best-effort.
-              }
-            }
+            const { dispatchPostCompactionDelegates } =
+              await import("../continuation/post-compaction-dispatch.js");
+            await dispatchPostCompactionDelegates({
+              sessionKey,
+              delegates: stagedDelegates,
+              spawnContext: {
+                agentSessionKey: sessionKey,
+                agentChannel: followupRun.originatingChannel ?? undefined,
+                agentAccountId: followupRun.originatingAccountId ?? undefined,
+                agentTo: followupRun.originatingTo ?? undefined,
+                agentThreadId: followupRun.originatingThreadId ?? undefined,
+              },
+              spawnFn: (params, ctx) => spawnSubagentDirect(params, ctx),
+              log: compactionLog,
+              enqueueSystemEvent,
+            });
           }
         }
       }


### PR DESCRIPTION
Closes karmaterminal/openclaw#203.

## What

The empty catch in `src/auto-reply/reply/agent-runner.ts:1672-1674` silently swallowed `spawnSubagentDirect` rejections in the post-compaction delegate lifecycle. The TaskFlow record was marked released by `consumeStagedPostCompactionDelegates`, then any throw left zero trace in logs, journals, or operator system events. **Same bug class as the #639 ship-gate we just fought** — shipping with this still in place gives contradictory signal.

## How

Extracted the per-delegate spawn loop into `src/auto-reply/continuation/post-compaction-dispatch.ts` so the failure path is testable without agent-runner integration fixtures.

On failure the helper now emits:

- `log.warn '[continuation:post-compaction-spawn-failed]'` with error message, sessionKey, and 80-char task slice (mirrors the existing `delegate-dispatch.ts:223-232` pattern)
- `enqueueSystemEvent` so the operator surface sees dropped work

Failures are isolated per-delegate; one rejection does not abort the rest of the staged delegates.

## Test coverage

`src/auto-reply/continuation/post-compaction-dispatch.test.ts` — 5 cases:

1. Successful spawn passes through with correct counters
2. Spawn rejection emits the named log anchor + system event with all expected fields (regression cover for #203)
3. Per-delegate isolation: one failure does not abort the loop
4. Non-Error throwables (string rejection) handled cleanly
5. Empty delegate list short-circuits

## Verification

```
$ pnpm exec vitest run src/auto-reply/continuation/post-compaction-dispatch.test.ts
Test Files  1 passed (1)
     Tests  5 passed (5)
```

## Acceptance criteria

- [x] Post-compaction delegate spawn failure emits a named log anchor (`[continuation:post-compaction-spawn-failed]`)
- [x] Operator-visible system event enqueued on failure
- [x] Test added covering the catch path

## Risk

Low. Behavioral change is purely additive on the failure path (success path unchanged). The refactor preserves call-site semantics and was verified against existing `agent-runner-utils.test.ts` (8/8 passing).