### PR TITLE
fix(continuation): surface post-compaction delegate spawn failures (#203)

### DIFF
--- a/src/auto-reply/continuation/delegate-dispatch-post-compaction.test.ts
+++ b/src/auto-reply/continuation/delegate-dispatch-post-compaction.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for post-compaction delegate dispatch error handling.
+ *
+ * Issue #203: Silent catch was swallowing post-compaction delegate spawn failures.
+ * This test verifies that spawn failures are now properly logged and surfaced
+ * as system events, matching the pattern in the regular delegate dispatch path.
+ *
+ * See also: #639 for the bug-class precedent.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture mock state for assertions
+const mockState = vi.hoisted(() => ({
+  spawnSubagentDirect: vi.fn(),
+  warnLog: vi.fn(),
+  infoLog: vi.fn(),
+  enqueueSystemEvent: vi.fn(),
+}));
+
+// Mock spawnSubagentDirect — this is what we'll make throw
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  spawnSubagentDirect: mockState.spawnSubagentDirect,
+}));
+
+// Mock the subsystem logger to capture log.warn calls
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: mockState.infoLog,
+    warn: mockState.warnLog,
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Mock enqueueSystemEvent to capture system events
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: mockState.enqueueSystemEvent,
+}));
+
+import { dispatchPostCompactionDelegates } from "./delegate-dispatch.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("dispatchPostCompactionDelegates error handling (openclaw#203)", () => {
+  it("logs warn + enqueues system event when spawnSubagentDirect throws", async () => {
+    const sessionKey = "session-post-compact-fail";
+    const testError = new Error("registry rejection: chain depth exceeded");
+
+    mockState.spawnSubagentDirect.mockRejectedValueOnce(testError);
+
+    const delegates = [{ task: "rehydrate workspace state after compaction" }];
+    const spawnCtx = { agentSessionKey: sessionKey };
+
+    const result = await dispatchPostCompactionDelegates(delegates, sessionKey, spawnCtx);
+
+    // Verify the failure was tracked
+    expect(result.failed).toBe(1);
+    expect(result.dispatched).toBe(0);
+
+    // Verify warn log was called with the correct anchor
+    expect(mockState.warnLog).toHaveBeenCalledOnce();
+    const warnCall = mockState.warnLog.mock.calls[0][0];
+    expect(warnCall).toContain("[continuation:post-compaction-spawn-failed]");
+    expect(warnCall).toContain("registry rejection: chain depth exceeded");
+    expect(warnCall).toContain(sessionKey);
+    expect(warnCall).toContain("rehydrate workspace state");
+
+    // Verify system event was enqueued
+    expect(mockState.enqueueSystemEvent).toHaveBeenCalledOnce();
+    const [eventMessage, eventOpts] = mockState.enqueueSystemEvent.mock.calls[0];
+    expect(eventMessage).toContain("[continuation] Post-compaction delegate spawn failed");
+    expect(eventMessage).toContain("registry rejection: chain depth exceeded");
+    expect(eventMessage).toContain("rehydrate workspace state after compaction");
+    expect(eventOpts).toEqual({ sessionKey });
+  });
+
+  it("logs info on dispatch start regardless of outcome", async () => {
+    const sessionKey = "session-post-compact-info";
+
+    mockState.spawnSubagentDirect.mockRejectedValueOnce(new Error("test error"));
+
+    const delegates = [{ task: "test delegate" }];
+    await dispatchPostCompactionDelegates(delegates, sessionKey, { agentSessionKey: sessionKey });
+
+    // Verify info log was called with delegate count
+    expect(mockState.infoLog).toHaveBeenCalledOnce();
+    const infoCall = mockState.infoLog.mock.calls[0][0];
+    expect(infoCall).toContain("[continuation:compaction-delegate]");
+    expect(infoCall).toContain("Consuming 1 compaction delegate(s)");
+    expect(infoCall).toContain(sessionKey);
+  });
+
+  it("handles non-Error thrown values gracefully", async () => {
+    const sessionKey = "session-non-error";
+
+    // Throw a string instead of an Error object
+    mockState.spawnSubagentDirect.mockRejectedValueOnce("lane queue full");
+
+    const delegates = [{ task: "test task" }];
+    const result = await dispatchPostCompactionDelegates(delegates, sessionKey, {
+      agentSessionKey: sessionKey,
+    });
+
+    expect(result.failed).toBe(1);
+
+    // Should still log and enqueue event with the string value
+    expect(mockState.warnLog).toHaveBeenCalledOnce();
+    expect(mockState.warnLog.mock.calls[0][0]).toContain("lane queue full");
+
+    expect(mockState.enqueueSystemEvent).toHaveBeenCalledOnce();
+    expect(mockState.enqueueSystemEvent.mock.calls[0][0]).toContain("lane queue full");
+  });
+
+  it("continues dispatching remaining delegates after a failure", async () => {
+    const sessionKey = "session-continue-after-fail";
+
+    // First delegate fails, second succeeds
+    mockState.spawnSubagentDirect
+      .mockRejectedValueOnce(new Error("first failed"))
+      .mockResolvedValueOnce({ status: "accepted" });
+
+    const delegates = [{ task: "delegate-1" }, { task: "delegate-2" }];
+    const result = await dispatchPostCompactionDelegates(delegates, sessionKey, {
+      agentSessionKey: sessionKey,
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.dispatched).toBe(1);
+    expect(mockState.spawnSubagentDirect).toHaveBeenCalledTimes(2);
+  });
+
+  it("truncates long task strings in warn log to 80 chars", async () => {
+    const sessionKey = "session-truncate";
+    const longTask =
+      "This is a very long task description that exceeds eighty characters and should be truncated in the log message for readability";
+
+    mockState.spawnSubagentDirect.mockRejectedValueOnce(new Error("spawn failed"));
+
+    await dispatchPostCompactionDelegates([{ task: longTask }], sessionKey, {
+      agentSessionKey: sessionKey,
+    });
+
+    const warnCall = mockState.warnLog.mock.calls[0][0];
+    // The task in the log should be truncated
+    expect(warnCall).toContain(longTask.slice(0, 80));
+    expect(warnCall).not.toContain(longTask.slice(80));
+
+    // But the system event should contain the full task
+    const eventMessage = mockState.enqueueSystemEvent.mock.calls[0][0];
+    expect(eventMessage).toContain(longTask);
+  });
+});

--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -234,3 +234,65 @@ export async function dispatchToolDelegates(params: {
 
   return { dispatched, rejected };
 }
+
+// ---------------------------------------------------------------------------
+// Post-compaction delegate dispatch (RFC §4.4)
+// ---------------------------------------------------------------------------
+
+const postCompactionLog = createSubsystemLogger("continuation/compaction");
+
+export interface PostCompactionSpawnContext {
+  agentSessionKey: string;
+  agentChannel?: string;
+  agentAccountId?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+}
+
+/**
+ * Dispatch post-compaction delegates with silentAnnounce + wakeOnReturn.
+ *
+ * This mirrors dispatchToolDelegates but is specifically for post-compaction
+ * staged delegates. Errors are logged and surfaced as system events rather
+ * than silently swallowed.
+ *
+ * See: issue #203, #639 for bug-class precedent.
+ */
+export async function dispatchPostCompactionDelegates(
+  delegates: Array<{ task: string }>,
+  sessionKey: string,
+  spawnCtx: PostCompactionSpawnContext,
+): Promise<{ dispatched: number; failed: number }> {
+  let dispatched = 0;
+  let failed = 0;
+
+  postCompactionLog.info(
+    `[continuation:compaction-delegate] Consuming ${delegates.length} compaction delegate(s) for session ${sessionKey}`,
+  );
+
+  for (const delegate of delegates) {
+    try {
+      await spawnSubagentDirect(
+        {
+          task: delegate.task,
+          silentAnnounce: true,
+          wakeOnReturn: true,
+          drainsContinuationDelegateQueue: true,
+        },
+        spawnCtx,
+      );
+      dispatched++;
+    } catch (err) {
+      postCompactionLog.warn(
+        `[continuation:post-compaction-spawn-failed] error=${err instanceof Error ? err.message : String(err)} session=${sessionKey} task=${delegate.task.slice(0, 80)}`,
+      );
+      enqueueSystemEvent(
+        `[continuation] Post-compaction delegate spawn failed: ${String(err)}. Task: ${delegate.task}`,
+        { sessionKey },
+      );
+      failed++;
+    }
+  }
+
+  return { dispatched, failed };
+}

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1646,33 +1646,15 @@ export async function runReplyAgent(params: {
           // Release staged post-compaction delegates with silentAnnounce + wakeOnReturn.
           const stagedDelegates = consumeStagedPostCompactionDelegates(sessionKey);
           if (stagedDelegates.length > 0) {
-            const { createSubsystemLogger } = await import("../../logging/subsystem.js");
-            const compactionLog = createSubsystemLogger("continuation/compaction");
-            compactionLog.info(
-              `[continuation:compaction-delegate] Consuming ${stagedDelegates.length} compaction delegate(s) for session ${sessionKey}`,
-            );
-            const { spawnSubagentDirect } = await import("../../agents/subagent-spawn.js");
-            for (const delegate of stagedDelegates) {
-              try {
-                await spawnSubagentDirect(
-                  {
-                    task: delegate.task,
-                    silentAnnounce: true,
-                    wakeOnReturn: true,
-                    drainsContinuationDelegateQueue: true,
-                  },
-                  {
-                    agentSessionKey: sessionKey,
-                    agentChannel: followupRun.originatingChannel ?? undefined,
-                    agentAccountId: followupRun.originatingAccountId ?? undefined,
-                    agentTo: followupRun.originatingTo ?? undefined,
-                    agentThreadId: followupRun.originatingThreadId ?? undefined,
-                  },
-                );
-              } catch {
-                // Post-compaction delegate dispatch is best-effort.
-              }
-            }
+            const { dispatchPostCompactionDelegates } =
+              await import("../continuation/delegate-dispatch.js");
+            await dispatchPostCompactionDelegates(stagedDelegates, sessionKey, {
+              agentSessionKey: sessionKey,
+              agentChannel: followupRun.originatingChannel ?? undefined,
+              agentAccountId: followupRun.originatingAccountId ?? undefined,
+              agentTo: followupRun.originatingTo ?? undefined,
+              agentThreadId: followupRun.originatingThreadId ?? undefined,
+            });
           }
         }
       }


### PR DESCRIPTION
Closes #203.

The empty `catch {}` at `agent-runner.ts:1672-1674` was swallowing real failures from post-compaction delegate dispatch — same bug class as the recently-fixed #639 ship-gate (request_compaction lying to its caller). Once `consumeStagedPostCompactionDelegates` marks a TaskFlow record released, an exception from `spawnSubagentDirect` would erase the staged work with zero log/journal/event trace.

## Changes

- **`src/auto-reply/continuation/delegate-dispatch.ts`** — new `dispatchPostCompactionDelegates` helper. On per-delegate failure: `log.warn` with anchor `[continuation:post-compaction-spawn-failed]` + `enqueueSystemEvent` for operator-visible signal. Returns `{ dispatched, failed }` counts.
- **`src/auto-reply/reply/agent-runner.ts`** — replaced inline loop+empty-catch with the helper call (-10 net lines).
- **`src/auto-reply/continuation/delegate-dispatch-post-compaction.test.ts`** — 5 new tests covering Error throw, non-Error throw, partial-failure continuation, log truncation, and dispatch counters.

## Verification

- `pnpm test` — green (7/7 in the touched suite, 2 prior + 5 new)
- `pnpm tsgo` — clean
- `pnpm check` — all gates pass

## Pattern fidelity

The new helper mirrors the canonical shape used in `delegate-dispatch.ts:223-232` for the live-dispatch path. One pattern, two callers — future maintainers see one error-handling shape, not two.

## Scope

Narrow: only the silent-catch fix and its test. The sibling silent-catch at `agent-runner.ts:1607-1615` (issue #204) is intentionally separate and tracked there.

## Pact

Worktree, scribe-pass APPROVE before this open.