### PR TITLE
refactor(continuation): close CompactionReasonCode union + dedupe skip predicate (#214)

### DIFF
--- a/src/agents/pi-embedded-runner/compact-reasons.test.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { classifyCompactionReason, resolveCompactionFailureReason } from "./compact-reasons.js";
+import {
+  classifyCompactionReason,
+  type CompactionReasonCode,
+  isCompactionSkipCode,
+  isCompactionSkipReason,
+  resolveCompactionFailureReason,
+} from "./compact-reasons.js";
 
 describe("resolveCompactionFailureReason", () => {
   it("replaces generic compaction cancellation with the safeguard reason", () => {
@@ -30,6 +36,14 @@ describe("classifyCompactionReason", () => {
     );
   });
 
+  it('classifies "no real conversation messages" as a skip-like reason', () => {
+    // shape #214: this code is added to keep the existing-substring-match behavior
+    // of isLegitSkipReason / isCompactionSkipReason covered by the closed union.
+    expect(classifyCompactionReason("No real conversation messages to compact")).toBe(
+      "no_real_conversation_messages",
+    );
+  });
+
   it("classifies safeguard messages as guard-blocked", () => {
     expect(
       classifyCompactionReason(
@@ -43,5 +57,57 @@ describe("classifyCompactionReason", () => {
     // — e.g. volitional compaction without provider/model passed routes to openai/gpt-5.4
     expect(classifyCompactionReason("Unknown model: openai/gpt-5.4")).toBe("unknown_model");
     expect(classifyCompactionReason("unknown model: foo/bar")).toBe("unknown_model");
+  });
+
+  it("returns 'unknown' for an empty / missing reason", () => {
+    expect(classifyCompactionReason()).toBe("unknown");
+    expect(classifyCompactionReason("")).toBe("unknown");
+  });
+
+  it("return type is the closed CompactionReasonCode union (#214)", () => {
+    // Compile-time: assigning to CompactionReasonCode forces the union shape.
+    const code: CompactionReasonCode = classifyCompactionReason("nothing to compact");
+    expect(code).toBe("no_compactable_entries");
+  });
+});
+
+describe("isCompactionSkipCode (#214)", () => {
+  const ALL_CODES: ReadonlyArray<CompactionReasonCode> = [
+    "unknown",
+    "no_compactable_entries",
+    "no_real_conversation_messages",
+    "unknown_model",
+    "below_threshold",
+    "already_compacted_recently",
+    "live_context_still_exceeds_target",
+    "guard_blocked",
+    "summary_failed",
+    "timeout",
+    "provider_error_4xx",
+    "provider_error_5xx",
+  ];
+
+  const SKIP_CODES = new Set<CompactionReasonCode>([
+    "no_compactable_entries",
+    "no_real_conversation_messages",
+    "below_threshold",
+    "already_compacted_recently",
+  ]);
+
+  it.each(ALL_CODES)("classifies %s correctly as skip vs non-skip", (code) => {
+    expect(isCompactionSkipCode(code)).toBe(SKIP_CODES.has(code));
+  });
+
+  it("isCompactionSkipReason wraps classifier + isCompactionSkipCode", () => {
+    expect(isCompactionSkipReason("Nothing to compact")).toBe(true);
+    expect(isCompactionSkipReason("Below threshold")).toBe(true);
+    expect(isCompactionSkipReason("Already compacted recently")).toBe(true);
+    expect(isCompactionSkipReason("No real conversation messages to compact")).toBe(true);
+
+    expect(isCompactionSkipReason("Compaction timed out")).toBe(false);
+    expect(isCompactionSkipReason("Unknown model: openai/foo")).toBe(false);
+    expect(isCompactionSkipReason("guard_blocked")).toBe(false);
+    expect(isCompactionSkipReason()).toBe(false);
+    expect(isCompactionSkipReason("")).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-runner/compact-reasons.ts
+++ b/src/agents/pi-embedded-runner/compact-reasons.ts
@@ -1,5 +1,57 @@
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 
+/**
+ * Closed union of compaction-attempt outcomes returned by
+ * {@link classifyCompactionReason}. Replaces the prior bare `string` return,
+ * which forced consumers to substring-match on free-form messages.
+ *
+ * Add new variants here when the classifier learns a new shape.
+ *
+ * Ref: karmaterminal/openclaw#214 (closed-union refactor) and CLAUDE.md
+ *      *"Prefer closed error-code unions for recoverable runtime decisions."*
+ */
+export type CompactionReasonCode =
+  | "unknown"
+  | "no_compactable_entries"
+  | "no_real_conversation_messages"
+  | "unknown_model"
+  | "below_threshold"
+  | "already_compacted_recently"
+  | "live_context_still_exceeds_target"
+  | "guard_blocked"
+  | "summary_failed"
+  | "timeout"
+  | "provider_error_4xx"
+  | "provider_error_5xx";
+
+/**
+ * Reason codes that mean "compaction did not run, but for a legitimate
+ * non-error cause" — caller should treat the request as gracefully skipped
+ * rather than as a failure.
+ *
+ * Single source of truth shared by the request-compaction tool and the
+ * /compact command.
+ */
+const SKIP_CODES: ReadonlySet<CompactionReasonCode> = new Set([
+  "no_compactable_entries",
+  "no_real_conversation_messages",
+  "below_threshold",
+  "already_compacted_recently",
+]);
+
+export function isCompactionSkipCode(code: CompactionReasonCode): boolean {
+  return SKIP_CODES.has(code);
+}
+
+/**
+ * Convenience wrapper: classify a free-form reason string, then check whether
+ * the resulting code is a skip-class outcome. Replaces the duplicated
+ * `isLegitSkipReason` / `isCompactionSkipReason` substring helpers.
+ */
+export function isCompactionSkipReason(reason?: string): boolean {
+  return isCompactionSkipCode(classifyCompactionReason(reason));
+}
+
 function isGenericCompactionCancelledReason(reason: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(reason);
   return normalized === "compaction cancelled" || normalized === "error: compaction cancelled";
@@ -15,13 +67,16 @@ export function resolveCompactionFailureReason(params: {
   return params.reason;
 }
 
-export function classifyCompactionReason(reason?: string): string {
+export function classifyCompactionReason(reason?: string): CompactionReasonCode {
   const text = normalizeLowercaseStringOrEmpty(reason);
   if (!text) {
     return "unknown";
   }
   if (text.includes("nothing to compact")) {
     return "no_compactable_entries";
+  }
+  if (text.includes("no real conversation messages")) {
+    return "no_real_conversation_messages";
   }
   if (text.includes("unknown model")) {
     // bug #639: surfaced when DEFAULT_PROVIDER/DEFAULT_MODEL fallback hits

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -22,25 +22,11 @@
 import { Type } from "@sinclair/typebox";
 import { createExpiringMapCache } from "../../config/cache-utils.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { isCompactionSkipReason } from "../pi-embedded-runner/compact-reasons.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam, ToolInputError } from "./common.js";
 
 const log = createSubsystemLogger("continuation/request-compaction");
-
-/**
- * Mirrors `isCompactionSkipReason` from auto-reply/reply/commands-compact.ts.
- * Kept local to avoid cross-package coupling (agents/tools → auto-reply/reply);
- * the predicate is small and stable.
- */
-function isLegitSkipReason(reason?: string): boolean {
-  const text = (reason ?? "").toLowerCase().trim();
-  return (
-    text.includes("nothing to compact") ||
-    text.includes("below threshold") ||
-    text.includes("already compacted") ||
-    text.includes("no real conversation messages")
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Guards
@@ -175,7 +161,7 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
           (result) => {
             if (result.ok && result.compacted) {
               incrementVolitionalCompactionCount(sessionKey);
-            } else if (isLegitSkipReason(result.reason)) {
+            } else if (isCompactionSkipReason(result.reason)) {
               // bug #639: legitimate no-ops (below threshold, nothing to
               // compact, etc.) are expected outcomes — log at info to keep
               // journals readable.

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -1,9 +1,9 @@
 import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { isCompactionSkipReason } from "../../agents/pi-embedded-runner/compact-reasons.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import {
   normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
 import type { CommandHandler } from "./commands-types.js";
@@ -34,16 +34,6 @@ function extractCompactInstructions(params: {
     rest = rest.slice(1).trimStart();
   }
   return rest.length ? rest : undefined;
-}
-
-function isCompactionSkipReason(reason?: string): boolean {
-  const text = normalizeOptionalLowercaseString(reason) ?? "";
-  return (
-    text.includes("nothing to compact") ||
-    text.includes("below threshold") ||
-    text.includes("already compacted") ||
-    text.includes("no real conversation messages")
-  );
 }
 
 function formatCompactionReason(reason?: string): string | undefined {


### PR DESCRIPTION
Closes karmaterminal/openclaw#214.

## What

`classifyCompactionReason` returned a bare `string` while the closed set of ~11 outcomes lived only in the function body. CLAUDE.md explicitly calls for closed error-code unions on recoverable runtime decisions — textbook violation.

Two consumers (`request-compaction-tool.ts`, `commands-compact.ts`) each carried their own substring-matching skip-reason predicate (`isLegitSkipReason` / `isCompactionSkipReason`). Both copies existed because the taxonomy wasn't shared.

## How

In `src/agents/pi-embedded-runner/compact-reasons.ts`:

- Export `CompactionReasonCode` closed union (12 codes; adds `no_real_conversation_messages` to keep the prior substring skip-set covered by the union).
- Export `isCompactionSkipCode(code)`: single source of truth for skip-class outcomes.
- Export `isCompactionSkipReason(reason)`: convenience wrapper for callers still holding free-form strings.
- Tighten `classifyCompactionReason` return type from `string` to `CompactionReasonCode`.

Then:

- `src/agents/tools/request-compaction-tool.ts` — drop local `isLegitSkipReason`; import shared predicate.
- `src/auto-reply/reply/commands-compact.ts` — drop local `isCompactionSkipReason`; import shared predicate; drop now-unused `normalizeOptionalLowercaseString` import.

## Test coverage

`compact-reasons.test.ts` grows 4 → 21 cases:

- existing classifier cases preserved
- new `no_real_conversation_messages` code covered
- empty / missing-input case
- compile-time assert that classifier return is the closed union
- each-code parametrized table for `isCompactionSkipCode`
- `isCompactionSkipReason` wrapper coverage (positive + negative)

```
$ pnpm exec vitest run \
    src/agents/pi-embedded-runner/compact-reasons.test.ts \
    src/agents/tools/request-compaction-tool.test.ts \
    src/auto-reply/reply/commands-compact.test.ts
Test Files  3 passed (3)
     Tests  38 passed (38)
```

## Acceptance criteria

- [x] `classifyCompactionReason` return type is `CompactionReasonCode`, not `string`
- [x] `isCompactionSkipCode` exported from `compact-reasons.ts`; consumed by both tool sites
- [x] Local `isLegitSkipReason` and `isCompactionSkipReason` copies removed
- [x] Existing `compact-reasons.test.ts` updated for the new return type; new test covering `isCompactionSkipCode` across every code

## Risk

Low. Behavior of the consumer call sites preserved — the closed-union refactor adds the previously-implicit `no real conversation messages` substring-match into the typed taxonomy explicitly. Existing consumer tests (17 cases) all pass.