### PR TITLE
refactor(continuation): close PressureBand union, drop -1 sentinel (#228)

### DIFF
--- a/src/auto-reply/continuation/context-pressure.test.ts
+++ b/src/auto-reply/continuation/context-pressure.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   checkContextPressure,
   clearContextPressureState,
+  type PressureBand,
   resetContextPressureForTests,
   resolveContextPressureBand,
 } from "./context-pressure.js";
@@ -21,6 +22,12 @@ describe("resolveContextPressureBand", () => {
     expect(resolveContextPressureBand(0.8)).toBe(80);
     expect(resolveContextPressureBand(0.9)).toBe(90);
     expect(resolveContextPressureBand(0.95)).toBe(95);
+  });
+
+  it("return type is the closed PressureBand union (#228)", () => {
+    // Compile-time assertion: assigning to PressureBand forces the closed union.
+    const band: PressureBand = resolveContextPressureBand(0.5);
+    expect(band).toBe(25);
   });
 
   it("returns highest crossed band", () => {

--- a/src/auto-reply/continuation/context-pressure.ts
+++ b/src/auto-reply/continuation/context-pressure.ts
@@ -11,11 +11,12 @@
  * Band dedup: equality-based. The same band doesn't fire twice consecutively,
  * but a new band (including a lower band after compaction) always fires.
  *
- * The dedup sentinel is -1, NOT 0. A first-time-seen session has previous=-1,
- * so even band=0 (ratio below the lowest hard-coded band) fires once. This
- * matters when the configured `contextPressureThreshold` is below the lowest
- * band (currently 25%): without the sentinel, every session's first crossing
- * collides band===previous===0 and is suppressed silently. (#580)
+ * First-fire is signalled by `lastFiredBand.has(sessionKey) === false`
+ * (previously a `-1` magic sentinel — replaced in #228 per CLAUDE.md). The
+ * #580 collision shape — first-crossing of a sub-lowest-band ratio being
+ * silently suppressed because `band===previous===0` — is now precluded by
+ * checking presence in the map before comparing. The behavior pinned by
+ * `context-pressure.test.ts` (#580 regression) is preserved.
  *
  * RFC: docs/design/continue-work-signal-v2.md §4.2
  */
@@ -28,17 +29,26 @@ const log = createSubsystemLogger("continuation/context-pressure");
 const PRESSURE_BANDS = [25, 80, 90, 95] as const;
 
 /**
+ * Closed union of pressure-band values returned by {@link resolveContextPressureBand}.
+ * `0` represents "below all hard-coded bands".
+ */
+export type PressureBand = 0 | (typeof PRESSURE_BANDS)[number];
+
+/**
  * Per-session dedup state: the last band that fired.
  * Reset when a new lifecycle begins (e.g., after compaction).
+ *
+ * Absence (`!map.has(sessionKey)`) means the session has never fired —
+ * it replaces the prior `-1` magic sentinel.
  */
-const lastFiredBand = new Map<string, number>();
+const lastFiredBand = new Map<string, PressureBand>();
 
 /**
  * Resolve which pressure band the current ratio falls into.
  * Returns 0 if below all bands.
  */
-export function resolveContextPressureBand(ratio: number): number {
-  let band = 0;
+export function resolveContextPressureBand(ratio: number): PressureBand {
+  let band: PressureBand = 0;
   for (const threshold of PRESSURE_BANDS) {
     if (ratio * 100 >= threshold) {
       band = threshold;
@@ -108,12 +118,15 @@ export function checkContextPressure(params: {
   const band = resolveContextPressureBand(ratio);
 
   // Dedup: same band as last time → suppress.
-  // Sentinel -1 ensures first-time-seen sessions fire once even when band===0
-  // (which happens for any ratio below the lowest hard-coded band, currently
-  // 25%). Using `?? 0` here would silently suppress every first crossing of
-  // sub-25% thresholds. See #580 for the bytes.
-  const previous = lastFiredBand.get(sessionKey) ?? -1;
-  if (band === previous) {
+  // First-fire is signalled by absence in the map (previously a `-1`
+  // sentinel — dropped in #228). The shape this protects against (#580):
+  // when `contextPressureThreshold` is below the lowest hard-coded band,
+  // a session's first crossing has band===0; comparing against `?? 0`
+  // silently suppressed it. Using `.has()` instead of a sentinel keeps
+  // the semantics intact without the magic number.
+  const previous = lastFiredBand.get(sessionKey);
+  const isFirstFire = previous === undefined;
+  if (!isFirstFire && band === previous) {
     if (log.isEnabled("debug")) {
       log.debug(
         `[context-pressure:noop] reason=band-dedup band=${band} previous=${previous} ratio=${percentUsed}% session=${sessionKey}`,
@@ -130,7 +143,7 @@ export function checkContextPressure(params: {
     `Consider evacuating working state to memory files or delegating remaining work.`;
 
   log.info(
-    `[context-pressure:fire] band=${band} previous=${previous} ratio=${percentUsed}% session=${sessionKey}`,
+    `[context-pressure:fire] band=${band} previous=${previous ?? "none"} ratio=${percentUsed}% session=${sessionKey}`,
   );
 
   return eventText;


### PR DESCRIPTION
Closes karmaterminal/openclaw#228.

## What

`resolveContextPressureBand` returned bare `number` when the value is always one of `0 | 25 | 80 | 90 | 95` (a `PRESSURE_BANDS` tuple declared `as const`). The closed-union just didn't flow out of the resolver.

`lastFiredBand: Map<string, number>` used `-1` as a magic 'never-fired' sentinel because `?? 0` would silently suppress every session's first crossing when `contextPressureThreshold` lives below the lowest hard-coded band (the #580 collision shape). Sentinel was correct but is exactly the kind of magic value CLAUDE.md discourages.

## How

- Export `PressureBand` closed union (`0 | 25 | 80 | 90 | 95`).
- Tighten `resolveContextPressureBand` return type to `PressureBand`; inner `band` accumulator typed `PressureBand`.
- Type `lastFiredBand` as `Map<string, PressureBand>`.
- Replace the `?? -1` sentinel with `previous === undefined` first-fire check on the result of `.get()`. Logic preserves the #580 semantics: first-fire never trips the dedup guard, regardless of band value.
- Update fire-log to print `previous=none` when first-fire (was printing `-1`).
- Refresh the file-header comment to describe the `.has()`-based approach instead of the dropped sentinel.

## Test coverage

Existing 11 tests (incl. the #580 sentinel-collision regression) all pass unchanged. Added one closed-union compile-time assertion case (`PressureBand` import + assignment).

```
$ pnpm exec vitest run src/auto-reply/continuation/context-pressure.test.ts
Test Files  1 passed (1)
     Tests  12 passed (12)
```

## Acceptance criteria

- [x] `PressureBand` union exported from `context-pressure.ts`
- [x] `resolveContextPressureBand` return type is `PressureBand`
- [x] `lastFiredBand` typed `Map<string, PressureBand>`; `-1` sentinel removed
- [x] Dedup logic uses presence-check (`previous === undefined`) instead of magic number
- [x] Existing `context-pressure.test.ts` still green (especially the #580 sentinel-collision regression)

## Risk

Low. Pure type-tightening + sentinel removal; the behavioral shape (first-fire always wins, same-band consecutive suppressed) is unchanged. `#580` regression test was the explicit guardrail and stays green.