### PR TITLE
test(continuation): pin volitional-compaction threading + counter truth (#209)

### DIFF
--- a/src/agents/tools/request-compaction-tool.callsite-threading.test.ts
+++ b/src/agents/tools/request-compaction-tool.callsite-threading.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Tests for volitional compaction call-site threading.
+ *
+ * Regression coverage for #639 fix arc:
+ * - The triggerCompaction closure passed to request_compaction tool must call
+ *   compactEmbeddedPiSession with the session's active provider/model/authProfileId
+ *   — NOT the hardcoded defaults (DEFAULT_PROVIDER/DEFAULT_MODEL).
+ * - When the compaction provider != persisted primary provider, authProfileId
+ *   must be dropped (set to undefined) so resolveEmbeddedCompactionTarget
+ *   picks the default profile for that provider.
+ *
+ * These tests verify the closure construction pattern used at:
+ * - src/auto-reply/reply/agent-runner-execution.ts:1006-1036
+ * - src/auto-reply/reply/followup-runner.ts:269-312
+ *
+ * See: docs/design/continue-work-signal-v2.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock setup for compactEmbeddedPiSession
+// ---------------------------------------------------------------------------
+
+interface CapturedCompactParams {
+  sessionId: string;
+  sessionKey: string;
+  sessionFile: string;
+  workspaceDir: string;
+  messageProvider?: string;
+  provider: string;
+  model: string;
+  authProfileId?: string;
+}
+
+const capturedCompactCalls: CapturedCompactParams[] = [];
+const compactEmbeddedPiSessionMock = vi.fn(
+  async (
+    params: CapturedCompactParams,
+  ): Promise<{ ok: boolean; compacted: boolean; reason?: string }> => {
+    capturedCompactCalls.push(params);
+    return { ok: true, compacted: true, reason: undefined };
+  },
+);
+
+vi.mock("../../agents/pi-embedded-runner/compact.queued.js", () => ({
+  compactEmbeddedPiSession: (params: CapturedCompactParams) => compactEmbeddedPiSessionMock(params),
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers: recreate the closure construction pattern from call sites
+// ---------------------------------------------------------------------------
+
+/**
+ * Recreates the triggerCompaction closure pattern from followup-runner.ts:269-312.
+ *
+ * This is the closure that gets passed to createRequestCompactionTool.
+ * The key bug #639 behavior: it must use the captured provider/model from the
+ * fallback dispatcher, NOT the hardcoded DEFAULT_PROVIDER/DEFAULT_MODEL.
+ *
+ * @param innerProvider - The provider selected by runWithModelFallback (may differ from run.provider on fallback)
+ * @param innerModel - The model selected by runWithModelFallback
+ * @param run - The session run parameters
+ */
+function buildTriggerCompactionClosure(
+  innerProvider: string,
+  innerModel: string,
+  run: {
+    sessionId: string;
+    sessionKey: string;
+    sessionFile: string;
+    workspaceDir: string;
+    messageProvider?: string;
+    provider: string; // The persisted primary provider
+    authProfileId?: string;
+  },
+): () => Promise<{ ok: boolean; compacted: boolean; reason?: string }> {
+  return async () => {
+    try {
+      // Inline the import pattern from the call sites
+      const { compactEmbeddedPiSession } =
+        await import("../../agents/pi-embedded-runner/compact.queued.js");
+
+      // bug #639: thread the session's active provider/model through so
+      // volitional compaction doesn't fall back to DEFAULT_PROVIDER/MODEL
+      // (openai/gpt-5.4) which nobody has auth for.
+      //
+      // bug #639 (scribe follow-up): thread authProfileId only when the
+      // inner-scope provider matches the persisted primary (the persisted
+      // profile is keyed to the primary). On fallback to a different provider,
+      // leave undefined so resolveEmbeddedCompactionTarget picks the default
+      // profile for that provider.
+      const compactionAuthProfileId =
+        innerProvider === run.provider ? run.authProfileId : undefined;
+
+      const result = await compactEmbeddedPiSession({
+        sessionId: run.sessionId ?? "",
+        sessionKey: run.sessionKey,
+        sessionFile: run.sessionFile ?? "",
+        workspaceDir: run.workspaceDir ?? process.cwd(),
+        messageProvider: run.messageProvider,
+        provider: innerProvider,
+        model: innerModel,
+        authProfileId: compactionAuthProfileId,
+      });
+
+      return {
+        ok: result.ok,
+        compacted: result.compacted,
+        reason: result.reason,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        compacted: false,
+        reason: err instanceof Error ? err.message : String(err),
+      };
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Provider/Model threading (#639 regression)
+// ---------------------------------------------------------------------------
+
+describe("call-site threading: provider/model passthrough (#639)", () => {
+  beforeEach(() => {
+    capturedCompactCalls.length = 0;
+    compactEmbeddedPiSessionMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes inner-scope provider/model to compactEmbeddedPiSession (not defaults)", async () => {
+    const run = {
+      sessionId: "session-123",
+      sessionKey: "agent:main:discord:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      messageProvider: "discord",
+      provider: "anthropic",
+      authProfileId: "profile-abc",
+    };
+
+    // Inner provider/model from fallback dispatcher (matches primary)
+    const innerProvider = "anthropic";
+    const innerModel = "claude-sonnet-4-6";
+
+    const triggerCompaction = buildTriggerCompactionClosure(innerProvider, innerModel, run);
+    await triggerCompaction();
+
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+    expect(capturedCompactCalls[0]).toMatchObject({
+      sessionId: "session-123",
+      sessionKey: "agent:main:discord:channel:test",
+      provider: "anthropic", // NOT DEFAULT_PROVIDER (openai)
+      model: "claude-sonnet-4-6", // NOT DEFAULT_MODEL (gpt-5.4)
+    });
+  });
+
+  it("passes fallback provider/model when different from primary", async () => {
+    const run = {
+      sessionId: "session-456",
+      sessionKey: "agent:main:slack:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      messageProvider: "slack",
+      provider: "anthropic", // Primary provider
+      authProfileId: "profile-xyz",
+    };
+
+    // Fallback to different provider (e.g., primary was rate-limited)
+    const innerProvider = "openai";
+    const innerModel = "gpt-5.4";
+
+    const triggerCompaction = buildTriggerCompactionClosure(innerProvider, innerModel, run);
+    await triggerCompaction();
+
+    expect(capturedCompactCalls[0]).toMatchObject({
+      provider: "openai", // Fallback provider, not primary
+      model: "gpt-5.4", // Fallback model
+    });
+  });
+
+  it("threads Google provider when selected", async () => {
+    const run = {
+      sessionId: "session-789",
+      sessionKey: "agent:main:telegram:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "google",
+      authProfileId: "google-profile",
+    };
+
+    const innerProvider = "google";
+    const innerModel = "gemini-2.5-flash";
+
+    const triggerCompaction = buildTriggerCompactionClosure(innerProvider, innerModel, run);
+    await triggerCompaction();
+
+    expect(capturedCompactCalls[0]).toMatchObject({
+      provider: "google",
+      model: "gemini-2.5-flash",
+    });
+  });
+
+  it("threads all session context fields", async () => {
+    const run = {
+      sessionId: "session-full",
+      sessionKey: "agent:main:matrix:channel:room",
+      sessionFile: "/data/sessions/full.jsonl",
+      workspaceDir: "/home/user/workspace",
+      messageProvider: "matrix",
+      provider: "anthropic",
+      authProfileId: "profile-full",
+    };
+
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-opus-4", run);
+    await triggerCompaction();
+
+    expect(capturedCompactCalls[0]).toEqual({
+      sessionId: "session-full",
+      sessionKey: "agent:main:matrix:channel:room",
+      sessionFile: "/data/sessions/full.jsonl",
+      workspaceDir: "/home/user/workspace",
+      messageProvider: "matrix",
+      provider: "anthropic",
+      model: "claude-opus-4",
+      authProfileId: "profile-full",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: authProfileId fallback-drop (#639 scribe follow-up)
+// ---------------------------------------------------------------------------
+
+describe("call-site threading: authProfileId fallback-drop (#639)", () => {
+  beforeEach(() => {
+    capturedCompactCalls.length = 0;
+    compactEmbeddedPiSessionMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes authProfileId when inner provider matches persisted primary", async () => {
+    const run = {
+      sessionId: "session-same",
+      sessionKey: "agent:main:discord:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "anthropic", // Primary
+      authProfileId: "profile-anthro",
+    };
+
+    // Same provider as primary
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-sonnet-4-6", run);
+    await triggerCompaction();
+
+    expect(capturedCompactCalls[0]?.authProfileId).toBe("profile-anthro");
+  });
+
+  it("drops authProfileId (undefined) when inner provider differs from primary", async () => {
+    const run = {
+      sessionId: "session-fallback",
+      sessionKey: "agent:main:discord:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "anthropic", // Primary provider
+      authProfileId: "profile-anthro", // Profile keyed to primary
+    };
+
+    // Fallback to different provider
+    const triggerCompaction = buildTriggerCompactionClosure("openai", "gpt-5.4", run);
+    await triggerCompaction();
+
+    expect(capturedCompactCalls[0]?.authProfileId).toBeUndefined();
+  });
+
+  it("drops authProfileId when falling back from openai to anthropic", async () => {
+    const run = {
+      sessionId: "session-reverse",
+      sessionKey: "agent:main:slack:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "openai", // Primary
+      authProfileId: "profile-openai",
+    };
+
+    // Fallback to anthropic
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-haiku-4", run);
+    await triggerCompaction();
+
+    expect(capturedCompactCalls[0]?.authProfileId).toBeUndefined();
+  });
+
+  it("handles undefined authProfileId in run (no profile to drop)", async () => {
+    const run = {
+      sessionId: "session-no-profile",
+      sessionKey: "agent:main:web:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "anthropic",
+      authProfileId: undefined, // No profile
+    };
+
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-sonnet-4-6", run);
+    await triggerCompaction();
+
+    expect(capturedCompactCalls[0]?.authProfileId).toBeUndefined();
+  });
+
+  it("handles undefined authProfileId with fallback (no profile to drop)", async () => {
+    const run = {
+      sessionId: "session-no-profile-fallback",
+      sessionKey: "agent:main:signal:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "anthropic",
+      authProfileId: undefined,
+    };
+
+    // Fallback to different provider
+    const triggerCompaction = buildTriggerCompactionClosure("google", "gemini-2.5-pro", run);
+    await triggerCompaction();
+
+    expect(capturedCompactCalls[0]?.authProfileId).toBeUndefined();
+  });
+
+  it("preserves authProfileId when provider names match exactly (case-sensitive)", async () => {
+    const run = {
+      sessionId: "session-case",
+      sessionKey: "agent:main:discord:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "Anthropic", // Uppercase A
+      authProfileId: "profile-case",
+    };
+
+    // Lowercase - should NOT match (providers are case-sensitive)
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-sonnet-4-6", run);
+    await triggerCompaction();
+
+    // Different case = different provider = authProfileId dropped
+    expect(capturedCompactCalls[0]?.authProfileId).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Error handling in triggerCompaction closure
+// ---------------------------------------------------------------------------
+
+describe("call-site threading: error handling", () => {
+  beforeEach(() => {
+    capturedCompactCalls.length = 0;
+    compactEmbeddedPiSessionMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns failure result when compactEmbeddedPiSession throws", async () => {
+    compactEmbeddedPiSessionMock.mockRejectedValueOnce(new Error("Network timeout"));
+
+    const run = {
+      sessionId: "session-error",
+      sessionKey: "agent:main:test:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "anthropic",
+    };
+
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-sonnet-4-6", run);
+    const result = await triggerCompaction();
+
+    expect(result).toEqual({
+      ok: false,
+      compacted: false,
+      reason: "Network timeout",
+    });
+  });
+
+  it("returns failure result for non-Error throws", async () => {
+    compactEmbeddedPiSessionMock.mockRejectedValueOnce("String error");
+
+    const run = {
+      sessionId: "session-string-error",
+      sessionKey: "agent:main:test:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "anthropic",
+    };
+
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-sonnet-4-6", run);
+    const result = await triggerCompaction();
+
+    expect(result).toEqual({
+      ok: false,
+      compacted: false,
+      reason: "String error",
+    });
+  });
+
+  it("passes through successful result from compactEmbeddedPiSession", async () => {
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      reason: undefined,
+    });
+
+    const run = {
+      sessionId: "session-success",
+      sessionKey: "agent:main:test:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "anthropic",
+    };
+
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-sonnet-4-6", run);
+    const result = await triggerCompaction();
+
+    expect(result).toEqual({
+      ok: true,
+      compacted: true,
+      reason: undefined,
+    });
+  });
+
+  it("passes through skip result from compactEmbeddedPiSession", async () => {
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: false,
+      reason: "Nothing to compact",
+    });
+
+    const run = {
+      sessionId: "session-skip",
+      sessionKey: "agent:main:test:channel:test",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/workspace",
+      provider: "anthropic",
+    };
+
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-sonnet-4-6", run);
+    const result = await triggerCompaction();
+
+    expect(result).toEqual({
+      ok: true,
+      compacted: false,
+      reason: "Nothing to compact",
+    });
+  });
+});

--- a/src/agents/tools/request-compaction-tool.volitional-threading.test.ts
+++ b/src/agents/tools/request-compaction-tool.volitional-threading.test.ts
@@ -1,0 +1,534 @@
+/**
+ * Tests for volitional compaction counter truthfulness and log-level correctness.
+ *
+ * Regression coverage for #639 fix arc:
+ * - Counter increments ONLY on {ok:true, compacted:true}
+ * - Legit-skip reasons (nothing to compact, below threshold, etc.) log at info
+ * - Real failures (unknown model, provider errors) log at warn
+ *
+ * See: docs/design/continue-work-signal-v2.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetGuardState,
+  _resetVolitionalCounts,
+  createRequestCompactionTool,
+  getVolitionalCompactionCount,
+  type RequestCompactionToolOpts,
+} from "./request-compaction-tool.js";
+
+// ---------------------------------------------------------------------------
+// Logger mock setup
+// ---------------------------------------------------------------------------
+
+const logMocks = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    subsystem: "continuation/request-compaction",
+    isEnabled: () => true,
+    debug: (...args: unknown[]) => logMocks.debug(...args),
+    info: (...args: unknown[]) => logMocks.info(...args),
+    warn: (...args: unknown[]) => logMocks.warn(...args),
+    error: (...args: unknown[]) => logMocks.error(...args),
+    child: () => ({
+      debug: logMocks.debug,
+      info: logMocks.info,
+      warn: logMocks.warn,
+      error: logMocks.error,
+    }),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const SESSION_KEY = "agent:main:discord:channel:volitional-test";
+const SESSION_ID = "volitional-test-session-id";
+const TURN_REASON = "context pressure at 85%, working state evacuated";
+
+function buildOpts(overrides: Partial<RequestCompactionToolOpts> = {}): RequestCompactionToolOpts {
+  return {
+    agentSessionKey: SESSION_KEY,
+    sessionId: SESSION_ID,
+    getContextUsage: () => 0.85, // Above 70% threshold
+    triggerCompaction: vi.fn(async () => ({ ok: true, compacted: true })),
+    ...overrides,
+  };
+}
+
+async function executeTool(
+  opts: RequestCompactionToolOpts,
+): Promise<{ status: string; [key: string]: unknown }> {
+  const tool = createRequestCompactionTool(opts);
+  const result = await tool.execute("call-id", { reason: TURN_REASON });
+  const content = (result as { content: Array<{ type: string; text: string }> }).content;
+  return JSON.parse(content[0]?.text ?? "{}");
+}
+
+/**
+ * Drain microtask queue to let fire-and-forget promises resolve.
+ * The triggerCompaction callback is invoked via void promise, so we need
+ * to give it time to complete before checking side effects.
+ */
+async function drainMicrotasks(): Promise<void> {
+  // Multiple awaits to ensure nested promises resolve
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Counter truthfulness (#639 regression)
+// ---------------------------------------------------------------------------
+
+describe("volitional compaction counter truthfulness (#639)", () => {
+  beforeEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+    vi.restoreAllMocks();
+  });
+
+  it("increments counter on {ok:true, compacted:true}", async () => {
+    const triggerCompaction = vi.fn(async () => ({ ok: true, compacted: true }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const countAfter = getVolitionalCompactionCount(SESSION_KEY);
+    expect(countAfter).toBe(countBefore + 1);
+    expect(triggerCompaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT increment counter on {ok:true, compacted:false, reason:'nothing to compact'}", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "Nothing to compact (session too small)",
+    }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const countAfter = getVolitionalCompactionCount(SESSION_KEY);
+    expect(countAfter).toBe(countBefore); // No increment
+  });
+
+  it("does NOT increment counter on {ok:true, compacted:false, reason:'below threshold'}", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "Below threshold for compaction",
+    }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const countAfter = getVolitionalCompactionCount(SESSION_KEY);
+    expect(countAfter).toBe(countBefore);
+  });
+
+  it("does NOT increment counter on {ok:true, compacted:false, reason:'already compacted'}", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "Already compacted recently",
+    }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const countAfter = getVolitionalCompactionCount(SESSION_KEY);
+    expect(countAfter).toBe(countBefore);
+  });
+
+  it("does NOT increment counter on {ok:true, compacted:false, reason:'no real conversation messages'}", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "No real conversation messages to compact",
+    }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const countAfter = getVolitionalCompactionCount(SESSION_KEY);
+    expect(countAfter).toBe(countBefore);
+  });
+
+  it("does NOT increment counter on {ok:false, reason:'unknown model'} (bug #639)", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "Unknown model: openai/gpt-5.4",
+    }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const countAfter = getVolitionalCompactionCount(SESSION_KEY);
+    expect(countAfter).toBe(countBefore);
+  });
+
+  it("does NOT increment counter on provider_error_4xx failures", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "Provider returned 401 Unauthorized",
+    }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const countAfter = getVolitionalCompactionCount(SESSION_KEY);
+    expect(countAfter).toBe(countBefore);
+  });
+
+  it("does NOT increment counter on provider_error_5xx failures", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "Provider returned 503 Service Unavailable",
+    }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const countAfter = getVolitionalCompactionCount(SESSION_KEY);
+    expect(countAfter).toBe(countBefore);
+  });
+
+  it("does NOT increment counter on freeform failure reasons", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "Something went wrong unexpectedly",
+    }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const countAfter = getVolitionalCompactionCount(SESSION_KEY);
+    expect(countAfter).toBe(countBefore);
+  });
+
+  it("accumulates counter correctly across multiple successful compactions", async () => {
+    // Use different session keys to avoid rate limiting
+    const sessionKey1 = `${SESSION_KEY}-1`;
+    const sessionKey2 = `${SESSION_KEY}-2`;
+
+    const triggerCompaction1 = vi.fn(async () => ({ ok: true, compacted: true }));
+    const triggerCompaction2 = vi.fn(async () => ({ ok: true, compacted: true }));
+
+    await executeTool(
+      buildOpts({ agentSessionKey: sessionKey1, triggerCompaction: triggerCompaction1 }),
+    );
+    await drainMicrotasks();
+
+    await executeTool(
+      buildOpts({ agentSessionKey: sessionKey2, triggerCompaction: triggerCompaction2 }),
+    );
+    await drainMicrotasks();
+
+    expect(getVolitionalCompactionCount(sessionKey1)).toBe(1);
+    expect(getVolitionalCompactionCount(sessionKey2)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Log level correctness per outcome (#639 regression)
+// ---------------------------------------------------------------------------
+
+describe("volitional compaction log levels (#639)", () => {
+  beforeEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+    vi.restoreAllMocks();
+  });
+
+  it("logs at INFO level with [resolved-skip] anchor for 'nothing to compact'", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "Nothing to compact (session too small)",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    expect(logMocks.info).toHaveBeenCalled();
+    const infoCall = logMocks.info.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-skip]"),
+    );
+    expect(infoCall).toBeDefined();
+    expect(logMocks.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("[request_compaction:resolved-skip]"),
+    );
+  });
+
+  it("logs at INFO level with [resolved-skip] anchor for 'below threshold'", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "Below threshold for compaction",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    expect(logMocks.info).toHaveBeenCalled();
+    const infoCall = logMocks.info.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-skip]"),
+    );
+    expect(infoCall).toBeDefined();
+  });
+
+  it("logs at INFO level with [resolved-skip] anchor for 'already compacted'", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "Already compacted recently",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    expect(logMocks.info).toHaveBeenCalled();
+    const infoCall = logMocks.info.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-skip]"),
+    );
+    expect(infoCall).toBeDefined();
+  });
+
+  it("logs at WARN level with [resolved-failure] anchor for 'unknown model' (bug #639)", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "Unknown model: openai/gpt-5.4",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    expect(logMocks.warn).toHaveBeenCalled();
+    const warnCall = logMocks.warn.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warnCall).toBeDefined();
+    expect(logMocks.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("[request_compaction:resolved-failure]"),
+    );
+  });
+
+  it("logs at WARN level with [resolved-failure] anchor for provider 4xx errors", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "Provider returned 401 Unauthorized",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const warnCall = logMocks.warn.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warnCall).toBeDefined();
+  });
+
+  it("logs at WARN level with [resolved-failure] anchor for provider 5xx errors", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "Provider returned 503 Service Unavailable",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const warnCall = logMocks.warn.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warnCall).toBeDefined();
+  });
+
+  it("logs at WARN level for {ok:true, compacted:false} with non-legit reason", async () => {
+    // This is the edge case: ok=true but compacted=false with a reason that
+    // is NOT a legitimate skip (e.g., some unexpected error message)
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "Unexpected internal error occurred",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const warnCall = logMocks.warn.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warnCall).toBeDefined();
+  });
+
+  it("logs at ERROR level with [background-error] anchor when triggerCompaction throws", async () => {
+    const triggerCompaction = vi.fn(async () => {
+      throw new Error("Network timeout during compaction");
+    });
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    expect(logMocks.error).toHaveBeenCalled();
+    const errorCall = logMocks.error.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:background-error]"),
+    );
+    expect(errorCall).toBeDefined();
+  });
+
+  it("does not log skip/failure for successful compaction", async () => {
+    const triggerCompaction = vi.fn(async () => ({ ok: true, compacted: true }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    // Should not have resolved-skip or resolved-failure logs
+    const skipCall = logMocks.info.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-skip]"),
+    );
+    const failCall = logMocks.warn.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-failure]"),
+    );
+    expect(skipCall).toBeUndefined();
+    expect(failCall).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: isLegitSkipReason boundary cases
+// ---------------------------------------------------------------------------
+
+describe("isLegitSkipReason boundary cases", () => {
+  beforeEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+    vi.restoreAllMocks();
+  });
+
+  it("treats case-insensitive 'NOTHING TO COMPACT' as legit skip", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "NOTHING TO COMPACT",
+    }));
+    const countBefore = getVolitionalCompactionCount(SESSION_KEY);
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    // Should be treated as legit skip: no counter increment, info log
+    expect(getVolitionalCompactionCount(SESSION_KEY)).toBe(countBefore);
+    const infoCall = logMocks.info.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-skip]"),
+    );
+    expect(infoCall).toBeDefined();
+  });
+
+  it("treats reason with extra whitespace as legit skip", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "  nothing to compact  ",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const infoCall = logMocks.info.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-skip]"),
+    );
+    expect(infoCall).toBeDefined();
+  });
+
+  it("does NOT treat partial match 'nothing' as legit skip", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: true,
+      compacted: false,
+      reason: "nothing",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    // Should be treated as failure, not skip
+    const warnCall = logMocks.warn.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warnCall).toBeDefined();
+  });
+
+  it("handles undefined reason as non-legit", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: undefined,
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const warnCall = logMocks.warn.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warnCall).toBeDefined();
+  });
+
+  it("handles empty string reason as non-legit", async () => {
+    const triggerCompaction = vi.fn(async () => ({
+      ok: false,
+      compacted: false,
+      reason: "",
+    }));
+
+    await executeTool(buildOpts({ triggerCompaction }));
+    await drainMicrotasks();
+
+    const warnCall = logMocks.warn.mock.calls.find((call) =>
+      String(call[0]).includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warnCall).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #209. Regression cover for the #639 fix arc.

The headline #639 ship-gate fix (threading session provider/model/authProfileId through volitional compaction, honoring the real compaction result instead of returning {ok:true}) shipped without behavioral test coverage. These tests pin the fix so the next provider/model rename or fallback-dispatcher refactor can't silently reintroduce the original bug.

## Tests added

- **`src/agents/tools/request-compaction-tool.volitional-threading.test.ts`** (24 tests)
  - Counter truthfulness: `getVolitionalCompactionCount` increments on `{ok:true,compacted:true}`, NOT on legit-skip reasons (all 4 `isLegitSkipReason` strings + boundary cases), NOT on `unknown_model` / `provider_error_*` / freeform failures.
  - Log-level routing: legit-skip → `log.info` with `[request_compaction:resolved-skip]` anchor; real failure → `log.warn` with `[request_compaction:resolved-failure]` anchor; exception → `log.error` with `[request_compaction:background-error]`.

- **`src/agents/tools/request-compaction-tool.callsite-threading.test.ts`** (14 tests)
  - Provider/model passthrough: triggerCompaction closure passes session provider/model to `compactEmbeddedPiSession` (not DEFAULT_PROVIDER/DEFAULT_MODEL).
  - authProfileId fallback-drop: when inner provider ≠ persisted-primary, authProfileId becomes `undefined`.
  - Multiple provider scenarios (anthropic/openai/google).

## Verification

- `pnpm test -- request-compaction-tool` — 38/38 green in 271ms
- `pnpm tsgo` — clean
- No source changes (test-only PR)

## Scribe-pass note

The callsite-threading tests recreate the closure-construction pattern from `agent-runner-execution.ts:1006-1036` and `followup-runner.ts:269-312` rather than invoking the production code directly (the closures are anonymous + scope-captured). Pattern matches line-by-line at write time; future call-site refactors will need manual verification that the test still mirrors. Flagged as MODERATE limitation, non-blocking — typical of testing inline-constructed closures.

## Pact

Worktree, scribe APPROVE_WITH_NOTES before push. Test-only diff.