### PR TITLE
fix(continuation): centralize SessionEntry.continuationChain* reads (#216)

### DIFF
--- a/src/agents/subagent-announce.continuation.runtime.ts
+++ b/src/agents/subagent-announce.continuation.runtime.ts
@@ -17,3 +17,4 @@
 // in `tsdown.config.ts`.
 export { dispatchToolDelegates } from "../auto-reply/continuation/delegate-dispatch.js";
 export { resolveContinuationRuntimeConfig } from "../auto-reply/continuation/config.js";
+export { loadContinuationChainState } from "../auto-reply/continuation/state.js";

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -130,6 +130,19 @@ type ContinuationConfigModule = {
   resolveContinuationRuntimeConfig: (cfg?: unknown) => { maxChainLength: number };
 };
 
+type ContinuationChainSource = {
+  continuationChainCount?: number;
+  continuationChainStartedAt?: number;
+  continuationChainTokens?: number;
+};
+
+type ContinuationStateModule = {
+  loadContinuationChainState: (
+    source: ContinuationChainSource | undefined,
+    turnTokens?: number,
+  ) => ContinuationChainState;
+};
+
 /**
  * Drain the child session's continue_delegate queue after the subagent has
  * settled. Chain state is inherited from the child session entry so nested
@@ -163,7 +176,7 @@ async function drainChildContinuationQueue(params: {
     // with a literal path would pull `subagent-spawn.js` into a cycle via
     // `delegate-dispatch.js → subagent-spawn.js → subagent-registry.js →
     // subagent-announce.ts`.
-    const [dispatchModule, configModule] = await Promise.all([
+    const [dispatchModule, configModule, stateModule] = await Promise.all([
       importRuntimeModule<ContinuationDispatchModule>(import.meta.url, [
         "./subagent-announce.continuation.runtime",
         ".js",
@@ -172,24 +185,21 @@ async function drainChildContinuationQueue(params: {
         "./subagent-announce.continuation.runtime",
         ".js",
       ]),
+      importRuntimeModule<ContinuationStateModule>(import.meta.url, [
+        "./subagent-announce.continuation.runtime",
+        ".js",
+      ]),
     ]);
     const { dispatchToolDelegates } = dispatchModule;
     const { resolveContinuationRuntimeConfig } = configModule;
+    const { loadContinuationChainState } = stateModule;
     const childEntry = loadSessionEntryByKey(params.childSessionKey) as
-      | {
-          continuationChainCount?: number;
-          continuationChainStartedAt?: number;
-          continuationChainTokens?: number;
-        }
+      | ContinuationChainSource
       | undefined;
     const dispatchConfig = resolveContinuationRuntimeConfig(cfg);
     await dispatchToolDelegates({
       sessionKey: params.childSessionKey,
-      chainState: {
-        currentChainCount: childEntry?.continuationChainCount ?? 0,
-        chainStartedAt: childEntry?.continuationChainStartedAt ?? Date.now(),
-        accumulatedChainTokens: childEntry?.continuationChainTokens ?? 0,
-      },
+      chainState: loadContinuationChainState(childEntry),
       ctx: {
         sessionKey: params.childSessionKey,
         agentChannel: params.requesterOrigin?.channel,

--- a/src/auto-reply/continuation/lazy.runtime.ts
+++ b/src/auto-reply/continuation/lazy.runtime.ts
@@ -28,4 +28,4 @@ export {
   pendingDelegateCount,
   stagedPostCompactionDelegateCount,
 } from "./delegate-store.js";
-export { persistContinuationChainState } from "./state.js";
+export { loadContinuationChainState, persistContinuationChainState } from "./state.js";

--- a/src/auto-reply/continuation/scheduler.ts
+++ b/src/auto-reply/continuation/scheduler.ts
@@ -22,15 +22,11 @@ import {
   retainContinuationTimerRef,
   unregisterContinuationTimerHandle,
 } from "./state.js";
-import type { ContinuationRuntimeConfig, ContinuationSignal } from "./types.js";
+import type { ChainState, ContinuationRuntimeConfig, ContinuationSignal } from "./types.js";
 
 const log = createSubsystemLogger("continuation/scheduler");
 
-export type ChainState = {
-  currentChainCount: number;
-  chainStartedAt: number;
-  accumulatedChainTokens: number;
-};
+export type { ChainState } from "./types.js";
 
 export type ScheduleWorkResult =
   | { outcome: "scheduled"; timerHandle: ReturnType<typeof setTimeout>; nextChainCount: number }

--- a/src/auto-reply/continuation/state.test.ts
+++ b/src/auto-reply/continuation/state.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadContinuationChainState } from "./state.js";
+
+describe("loadContinuationChainState (openclaw#216)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-19T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns zeroed chain with chainStartedAt=now for undefined source", () => {
+    const state = loadContinuationChainState(undefined);
+    expect(state.currentChainCount).toBe(0);
+    expect(state.chainStartedAt).toBe(Date.now());
+    expect(state.accumulatedChainTokens).toBe(0);
+  });
+
+  it("reads chain fields directly when all three are present", () => {
+    const state = loadContinuationChainState({
+      continuationChainCount: 3,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: 42_000,
+    });
+    expect(state).toEqual({
+      currentChainCount: 3,
+      chainStartedAt: 1_700_000_000_000,
+      accumulatedChainTokens: 42_000,
+    });
+  });
+
+  it("folds turnTokens into accumulatedChainTokens", () => {
+    const state = loadContinuationChainState(
+      {
+        continuationChainCount: 1,
+        continuationChainStartedAt: 1_700_000_000_000,
+        continuationChainTokens: 1_000,
+      },
+      2_500,
+    );
+    expect(state.accumulatedChainTokens).toBe(3_500);
+    expect(state.currentChainCount).toBe(1);
+    expect(state.chainStartedAt).toBe(1_700_000_000_000);
+  });
+
+  it("defaults chainStartedAt to now when field is missing", () => {
+    const state = loadContinuationChainState({
+      continuationChainCount: 2,
+      continuationChainTokens: 100,
+    });
+    expect(state.chainStartedAt).toBe(Date.now());
+    expect(state.currentChainCount).toBe(2);
+    expect(state.accumulatedChainTokens).toBe(100);
+  });
+
+  it("treats missing count/tokens as zero (no undefined leak into arithmetic)", () => {
+    const state = loadContinuationChainState(
+      { continuationChainStartedAt: 1_700_000_000_000 },
+      500,
+    );
+    expect(state.currentChainCount).toBe(0);
+    expect(state.accumulatedChainTokens).toBe(500);
+    expect(state.chainStartedAt).toBe(1_700_000_000_000);
+  });
+
+  it("defaults turnTokens to 0 when not provided", () => {
+    const state = loadContinuationChainState({
+      continuationChainCount: 1,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: 777,
+    });
+    expect(state.accumulatedChainTokens).toBe(777);
+  });
+});

--- a/src/auto-reply/continuation/state.ts
+++ b/src/auto-reply/continuation/state.ts
@@ -116,6 +116,48 @@ export function clearTrackedContinuationTimers(sessionKey: string): void {
 // ---------------------------------------------------------------------------
 
 import type { SessionEntry } from "../../config/sessions/types.js";
+import type { ChainState } from "./types.js";
+
+/**
+ * Structural subset of `SessionEntry` covering only the fields the
+ * continuation-chain read path needs. Declared independently so callers
+ * that want to avoid a static edge into `src/config/sessions/types.js`
+ * (notably `subagent-announce.ts` — cycle-avoidance) can satisfy the
+ * helper signature without an extra type import.
+ */
+export type ContinuationChainSource = {
+  continuationChainCount?: number;
+  continuationChainStartedAt?: number;
+  continuationChainTokens?: number;
+};
+
+/**
+ * Read continuation chain state from a SessionEntry with safe defaults.
+ *
+ * Collapses the scattered `?? 0` / `?? Date.now()` sentinel pattern from
+ * 6+ call sites (agent-runner, followup-runner, subagent-announce) into
+ * one canonical adapter. The returned ChainState has `turnTokens` folded
+ * into `accumulatedChainTokens` so callers don't repeat the addition.
+ *
+ * - `undefined` source → zeroed chain, `chainStartedAt = Date.now()`
+ * - missing `continuationChainStartedAt` → `Date.now()` (the chain appears
+ *   to start fresh this turn; matches historical sentinel behavior).
+ *
+ * Accepts any shape compatible with `ContinuationChainSource`, including
+ * `SessionEntry` (structural compatibility).
+ *
+ * Ref: karmaterminal/openclaw#216.
+ */
+export function loadContinuationChainState(
+  source: ContinuationChainSource | undefined,
+  turnTokens = 0,
+): ChainState {
+  return {
+    currentChainCount: source?.continuationChainCount ?? 0,
+    chainStartedAt: source?.continuationChainStartedAt ?? Date.now(),
+    accumulatedChainTokens: (source?.continuationChainTokens ?? 0) + turnTokens,
+  };
+}
 
 /**
  * Persist continuation chain metadata to the session entry.

--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -126,3 +126,18 @@ export type ContinueWorkRequest = {
   reason: string;
   delaySeconds: number;
 };
+
+// ---------------------------------------------------------------------------
+// Chain state — passed into scheduler / dispatch / persistence entry points
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-session continuation chain state — depth, start time, accumulated tokens.
+ * Construct from a `SessionEntry` via `loadContinuationChainState(entry, turnTokens)`
+ * in `./state.ts` rather than hand-rolling `?? 0` / `?? Date.now()` at each site.
+ */
+export type ChainState = {
+  currentChainCount: number;
+  chainStartedAt: number;
+  accumulatedChainTokens: number;
+};

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1813,11 +1813,8 @@ export async function runReplyAgent(params: {
     if (effectiveContinuationSignal && sessionKey) {
       const continuationConfig = resolveContinuationRuntimeConfig(cfg);
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
-      const chainState = {
-        currentChainCount: activeSessionEntry?.continuationChainCount ?? 0,
-        chainStartedAt: activeSessionEntry?.continuationChainStartedAt ?? Date.now(),
-        accumulatedChainTokens: (activeSessionEntry?.continuationChainTokens ?? 0) + turnTokens,
-      };
+      const { loadContinuationChainState } = await import("../continuation/lazy.runtime.js");
+      const chainState = loadContinuationChainState(activeSessionEntry, turnTokens);
 
       if (effectiveContinuationSignal.kind === "work") {
         scheduleWorkContinuation({
@@ -1846,12 +1843,10 @@ export async function runReplyAgent(params: {
     // Consume and dispatch tool-dispatched delegates (continue_delegate tool).
     if (continuationFeatureEnabled && sessionKey) {
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
-      const dispatchChainState = {
-        currentChainCount: activeSessionEntry?.continuationChainCount ?? 0,
-        chainStartedAt: activeSessionEntry?.continuationChainStartedAt ?? Date.now(),
-        accumulatedChainTokens: (activeSessionEntry?.continuationChainTokens ?? 0) + turnTokens,
-      };
-      const { dispatchToolDelegates } = await import("../continuation/lazy.runtime.js");
+      const { dispatchToolDelegates, loadContinuationChainState } = await import(
+        "../continuation/lazy.runtime.js"
+      );
+      const dispatchChainState = loadContinuationChainState(activeSessionEntry, turnTokens);
       await dispatchToolDelegates({
         sessionKey,
         chainState: dispatchChainState,
@@ -1873,13 +1868,16 @@ export async function runReplyAgent(params: {
       sessionKey &&
       activeSessionEntry
     ) {
-      const { persistContinuationChainState } = await import("../continuation/lazy.runtime.js");
+      const { loadContinuationChainState, persistContinuationChainState } = await import(
+        "../continuation/lazy.runtime.js"
+      );
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
+      const nextState = loadContinuationChainState(activeSessionEntry, turnTokens);
       persistContinuationChainState({
         sessionEntry: activeSessionEntry,
-        count: activeSessionEntry.continuationChainCount ?? 0,
-        startedAt: activeSessionEntry.continuationChainStartedAt ?? Date.now(),
-        tokens: (activeSessionEntry.continuationChainTokens ?? 0) + turnTokens,
+        count: nextState.currentChainCount,
+        startedAt: nextState.chainStartedAt,
+        tokens: nextState.accumulatedChainTokens,
       });
     }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -358,17 +358,19 @@ export function createFollowupRunner(params: {
       // (or any followup turn) stay in the queue until the NEXT inbound
       // message arrives to trigger the main-session dispatch. RFC §3.2.
       if (runtimeConfig?.agents?.defaults?.continuation?.enabled === true && sessionKey) {
-        const [{ dispatchToolDelegates }, { resolveContinuationRuntimeConfig }] = await Promise.all(
-          [import("../continuation/delegate-dispatch.js"), import("../continuation/config.js")],
-        );
+        const [
+          { dispatchToolDelegates },
+          { resolveContinuationRuntimeConfig },
+          { loadContinuationChainState },
+        ] = await Promise.all([
+          import("../continuation/delegate-dispatch.js"),
+          import("../continuation/config.js"),
+          import("../continuation/state.js"),
+        ]);
         const tailUsage = runResult.meta?.agentMeta?.usage;
         const turnTokens = (tailUsage?.input ?? 0) + (tailUsage?.output ?? 0);
         const tailEntry = (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
-        const chainState = {
-          currentChainCount: tailEntry?.continuationChainCount ?? 0,
-          chainStartedAt: tailEntry?.continuationChainStartedAt ?? Date.now(),
-          accumulatedChainTokens: (tailEntry?.continuationChainTokens ?? 0) + turnTokens,
-        };
+        const chainState = loadContinuationChainState(tailEntry, turnTokens);
         await dispatchToolDelegates({
           sessionKey,
           chainState,


### PR DESCRIPTION
## Summary

Closes karmaterminal/openclaw#216. Collapses the scattered \`?? 0\` / \`?? Date.now()\` sentinel pattern across 6+ call sites into a single canonical adapter. No behavioral change — all historical sentinel semantics preserved.

## What changed

- **New helper** \`loadContinuationChainState(source, turnTokens = 0): ChainState\` in \`src/auto-reply/continuation/state.ts\`. Takes a structural subset of \`SessionEntry\` (\`ContinuationChainSource\`) so cycle-sensitive callers (notably \`subagent-announce.ts\`) can pass a structurally-typed value without importing \`SessionEntry\` and closing the \`delegate-dispatch → subagent-spawn → subagent-registry → subagent-announce\` cycle.
- **Type hoist**: \`ChainState\` moved from \`scheduler.ts\` into \`types.ts\` where the rest of the continuation shared types live. \`scheduler.ts\` re-exports it for backward compatibility so existing \`import { type ChainState } from \"./scheduler.js\"\` keeps working.
- **Runtime boundary**: \`subagent-announce.continuation.runtime.ts\` re-exports \`loadContinuationChainState\` alongside the existing \`dispatchToolDelegates\` / \`resolveContinuationRuntimeConfig\`. Consumed via the same \`importRuntimeModule\` pattern for post-bundle safety (same issue as #473 fix).
- **Call sites converted** (5 of 6):
  - \`agent-runner.ts:1829-1833\` (work-scheduling chainState)
  - \`agent-runner.ts:1862-1866\` (dispatch chainState)
  - \`agent-runner.ts:1889-1896\` (persist chain-state write-back)
  - \`followup-runner.ts:362-366\` (tail-entry chainState)
  - \`subagent-announce.ts:180-184\` (child-entry chainState) — also removes the inline \`Pick<SessionEntry>\`-equivalent cast at lines 170-176
- **Status row unchanged**: \`status.ts:925\` is a single-field read (\`.continuationChainCount ?? 0\`) for the banner, not full \`ChainState\` construction. Not part of the sprawl; intentionally left alone.
- **New test file** \`state.test.ts\` with 6 behavioral cases.

## Test plan

- [x] \`pnpm tsgo\` clean
- [x] New \`state.test.ts\` (6 cases): undefined source, full-field read, turnTokens folding, missing startedAt default, missing count/tokens as zero, default turnTokens
- [x] Continuation module tests: 42/42 passing
- [x] Subagent-announce tests: 8/8 passing
- [x] Followup-runner + agent-runner tests: 52/52 passing

## Acceptance criteria (from #216)

- [x] No \`?? 0\` / \`?? Date.now()\` on \`continuationChain*\` reads outside the new adapter (status.ts single-field read documented exception)
- [x] \`subagent-announce.ts:170-176\` no longer has inline \`Pick\`-equivalent duplicate (replaced with \`ContinuationChainSource\`)
- [x] All six call sites pass through the helper (or are documented as exempt)
- [x] Existing tests pass; new test covers the helper directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)