### PR TITLE
fix(continuation): emit classifier code on volitional-compaction warn/error paths (#205)

### DIFF
--- a/src/agents/tools/request-compaction-tool.classifier-emission.test.ts
+++ b/src/agents/tools/request-compaction-tool.classifier-emission.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Classifier-code emission on volitional-compaction warn / error paths.
+ *
+ * Pins the karmaterminal/openclaw#205 behavior: every journal line written
+ * on the resolved-failure and background-error branches carries the
+ * structured `code=<classifyCompactionReason(...)>` field alongside the
+ * raw reason. Journal queries and /status drill-downs shouldn't depend
+ * on raw-string grep for the failure taxonomy.
+ *
+ * Ref: karmaterminal/openclaw#205.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture every subsystem logger method the tool calls so assertions
+// can read back the exact message text emitted. vi.mock is hoisted, so
+// this file is scoped to the emission tests — the broader
+// request-compaction-tool.test.ts runs without the logger mock.
+const capturedLogs: Array<{ level: string; message: string }> = [];
+vi.mock("../../logging/subsystem.js", () => {
+  const record =
+    (level: string) =>
+    (message: string): void => {
+      capturedLogs.push({ level, message });
+    };
+  const logger = {
+    subsystem: "test",
+    isEnabled: () => true,
+    trace: record("trace"),
+    debug: record("debug"),
+    info: record("info"),
+    warn: record("warn"),
+    error: record("error"),
+    fatal: record("fatal"),
+    raw: record("raw"),
+    child: () => logger,
+  };
+  return {
+    createSubsystemLogger: () => logger,
+  };
+});
+
+import {
+  _resetGuardState,
+  _resetVolitionalCounts,
+  createRequestCompactionTool,
+  type RequestCompactionToolOpts,
+} from "./request-compaction-tool.js";
+
+const SESSION_KEY = "agent:main:discord:channel:test-session";
+const SESSION_ID = "test-session-205";
+const REASON = "context pressure at 92%, stage set for compaction.";
+
+function buildOpts(overrides: Partial<RequestCompactionToolOpts> = {}): RequestCompactionToolOpts {
+  return {
+    agentSessionKey: SESSION_KEY,
+    sessionId: SESSION_ID,
+    getContextUsage: () => 0.85,
+    triggerCompaction: vi.fn(async () => ({ ok: true, compacted: true })),
+    ...overrides,
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  // triggerCompaction is fire-and-forget (.then().finally()); settle the promise chain.
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("request_compaction tool — classifier emission (openclaw#205)", () => {
+  beforeEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+    capturedLogs.length = 0;
+  });
+
+  afterEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+    vi.restoreAllMocks();
+  });
+
+  it("warn log on resolve-with-failure includes code=<classifier-result> and the raw reason", async () => {
+    const tool = createRequestCompactionTool(
+      buildOpts({
+        triggerCompaction: vi.fn(async () => ({
+          ok: false,
+          compacted: false,
+          reason: "Unknown model openai/gpt-5.4",
+        })),
+      }),
+    );
+
+    await tool.execute("call-warn-unknown-model", { reason: REASON });
+    await flushMicrotasks();
+
+    const warn = capturedLogs.find(
+      (l) => l.level === "warn" && l.message.includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warn, "resolved-failure warn log should fire").toBeDefined();
+    expect(warn!.message).toContain("code=unknown_model");
+    expect(warn!.message).toContain("reason=Unknown model openai/gpt-5.4");
+  });
+
+  it("warn log on a generic Cancellation message emits code (currently 'unknown' per classifier taxonomy)", async () => {
+    const tool = createRequestCompactionTool(
+      buildOpts({
+        triggerCompaction: vi.fn(async () => ({
+          ok: false,
+          compacted: false,
+          reason: "Compaction cancelled",
+        })),
+      }),
+    );
+
+    await tool.execute("call-warn-cancelled", { reason: REASON });
+    await flushMicrotasks();
+
+    const warn = capturedLogs.find(
+      (l) => l.level === "warn" && l.message.includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warn, "resolved-failure warn log should fire for cancellation").toBeDefined();
+    // 'cancelled' has no dedicated band in classifyCompactionReason today; asserting
+    // the code= field is present (not absent) pins the emission contract so future
+    // classifier extensions (cancelled → "cancelled") don't regress silently.
+    expect(warn!.message).toMatch(/\bcode=\w+\b/);
+  });
+
+  it("error log on promise rejection includes code=<classifier-result>", async () => {
+    const tool = createRequestCompactionTool(
+      buildOpts({
+        triggerCompaction: vi.fn(async () => {
+          throw new Error("Unknown model openai/gpt-5.4");
+        }),
+      }),
+    );
+
+    await tool.execute("call-error-unknown-model", { reason: REASON });
+    await flushMicrotasks();
+
+    const err = capturedLogs.find(
+      (l) => l.level === "error" && l.message.includes("[request_compaction:background-error]"),
+    );
+    expect(err, "background-error log should fire").toBeDefined();
+    expect(err!.message).toContain("code=unknown_model");
+    expect(err!.message).toContain("error=Unknown model openai/gpt-5.4");
+  });
+
+  it("info log on legit skip (below threshold) does NOT fire the warn path", async () => {
+    const tool = createRequestCompactionTool(
+      buildOpts({
+        triggerCompaction: vi.fn(async () => ({
+          ok: true,
+          compacted: false,
+          reason: "nothing to compact",
+        })),
+      }),
+    );
+
+    await tool.execute("call-info-skip", { reason: REASON });
+    await flushMicrotasks();
+
+    const info = capturedLogs.find(
+      (l) => l.level === "info" && l.message.includes("[request_compaction:resolved-skip]"),
+    );
+    expect(info, "resolved-skip info log should fire for legit skip").toBeDefined();
+
+    const warn = capturedLogs.find(
+      (l) => l.level === "warn" && l.message.includes("[request_compaction:resolved-failure]"),
+    );
+    expect(warn, "warn should NOT fire on legit skip").toBeUndefined();
+  });
+});

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -22,7 +22,10 @@
 import { Type } from "@sinclair/typebox";
 import { createExpiringMapCache } from "../../config/cache-utils.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { isCompactionSkipReason } from "../pi-embedded-runner/compact-reasons.js";
+import {
+  classifyCompactionReason,
+  isCompactionSkipReason,
+} from "../pi-embedded-runner/compact-reasons.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam, ToolInputError } from "./common.js";
 
@@ -189,17 +192,27 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
                 `[request_compaction:resolved-skip] session=${sessionKey} reason=${result.reason ?? "unspecified"}`,
               );
             } else {
-              // bug #639: surface resolve-with-failure (distinct from the catch-path
-              // background-error) so volitional compactions that silently fail
-              // (e.g. wrong provider, model unavailable) are visible in journals.
+              // karmaterminal/openclaw#639 / #205: surface resolve-with-failure
+              // (distinct from the catch-path background-error) so volitional
+              // compactions that silently fail are visible in journals, AND
+              // emit the structured classifier code so journal queries don't
+              // depend on raw-string grep.
+              const code = classifyCompactionReason(result.reason);
               log.warn(
-                `[request_compaction:resolved-failure] session=${sessionKey} ok=${result.ok} compacted=${result.compacted} reason=${result.reason ?? "unspecified"}`,
+                `[request_compaction:resolved-failure] session=${sessionKey} code=${code} ok=${result.ok} compacted=${result.compacted} reason=${result.reason ?? "unspecified"}`,
               );
             }
           },
           (err: unknown) => {
+            // karmaterminal/openclaw#205: classify here too so transport errors
+            // (AbortError / module-not-found / network) get a structured code
+            // alongside the raw message. Rejection reaches this branch when
+            // triggerCompaction's promise rejects outright (the resolve-shape
+            // `{ok:false, reason}` goes through the resolved-failure branch above).
+            const message = err instanceof Error ? err.message : String(err);
+            const code = classifyCompactionReason(message);
             log.error(
-              `[request_compaction:background-error] session=${sessionKey} error=${err instanceof Error ? err.message : String(err)}`,
+              `[request_compaction:background-error] session=${sessionKey} code=${code} error=${message}`,
             );
           },
         )


### PR DESCRIPTION
## Summary

Closes karmaterminal/openclaw#205. Journal lines for volitional-compaction failures now carry the structured \`code=<classifyCompactionReason(...)>\` field alongside the raw reason so operators can pivot on a closed-taxonomy code field instead of raw-string grep.

## What changed

- **\`request-compaction-tool.ts\`** (±9 net lines):
  - \`[request_compaction:resolved-failure]\` WARN now includes \`code=<classified>\`
  - \`[request_compaction:background-error]\` ERROR now also classifies the thrown message — transport errors (AbortError / module-not-found / network) surface a structured code instead of only the raw throw
  - Imports \`classifyCompactionReason\` from \`pi-embedded-runner/compact-reasons\`

- **Call sites at \`followup-runner.ts:305-311\` + \`agent-runner-execution.ts:1045-1051\`** intentionally unchanged: their caught error flows through the warn sibling which now classifies, satisfying the #205 acceptance criterion without extra churn on the catch itself.

- **\`isLegitSkipReason\`** behavior preserved unchanged: \"nothing to compact\" / \"below threshold\" / \"already compacted\" / \"no real conversation messages\" still route to INFO (no classifier call needed). The #639 legit-skip-quiet posture stays intact; only real failures get classified.

## New test: \`request-compaction-tool.classifier-emission.test.ts\`

4 cases (mocks \`createSubsystemLogger\` locally to capture log lines):

- resolve-with-failure \`reason=\"Unknown model openai/gpt-5.4\"\` → WARN contains \`code=unknown_model\` AND the raw reason
- resolve-with-failure \`reason=\"Compaction cancelled\"\` → WARN contains some \`code=<word>\` (pinning the emission contract so future classifier extensions — e.g. adding a \`cancelled\` band — don't regress silently)
- promise rejection with \`new Error(\"Unknown model ...\")\` → ERROR contains \`code=unknown_model\` AND \`error=<raw>\`
- legit skip \`{ok:true, compacted:false, reason:\"nothing to compact\"}\` → INFO fires, WARN does NOT

## Composes with Ronan's #236 (#214 closed-union work)

When \`classifyCompactionReason\` tightens its return type to a closed \`CompactionReasonCode\` union (Ronan's #236), my edits here become compile-time-safer with zero diff adjustment — the consumers just receive a tighter type.

## Test plan

- [x] \`pnpm tsgo\` clean
- [x] \`pnpm test src/agents/tools/request-compaction-tool.test.ts src/agents/tools/request-compaction-tool.classifier-emission.test.ts src/agents/pi-embedded-runner/compact-reasons.test.ts\` — 19/19 green

## Acceptance criteria (from #205)

- [x] \`[system:request_compaction:resolved-failure]\` log line includes a \`code=<classifier-result>\` field
- [x] \`triggerCompaction\` catch paths classify via the warn sibling (per issue's \"directly or in the warn sibling\" clause)
- [x] Test added: \`{ok:false, reason:\"Compaction cancelled\"}\` → WARN contains classifier code

🤖 Generated with [Claude Code](https://claude.com/claude-code)