### PR TITLE
fix(continuation): add lazy.runtime boundary for singleton dedupe (#220, folds #221)

### DIFF
--- a/src/auto-reply/continuation/lazy.runtime.ts
+++ b/src/auto-reply/continuation/lazy.runtime.ts
@@ -1,0 +1,31 @@
+// Lazy-load boundary for the continuation subsystem.
+//
+// Callers that need continuation helpers on a cold/lazy path import THIS
+// module via `await import("../continuation/lazy.runtime.js")` instead of
+// directly importing `./config.js`, `./delegate-store.js`, etc. That
+// routes every dynamic continuation load through a single module boundary
+// which the bundler can dedupe with the static graph — eliminating the
+// static+dynamic import mix that has bitten this tree multiple times
+// (karmaterminal/openclaw-bootstrap#584 silently-dropped continue_work
+// tool calls; `tsdown.config.ts` `coreDistEntries` promotion was the
+// first mitigation).
+//
+// Rule: never statically import from this file. A static `import`
+// defeats the boundary's purpose by re-entering the underlying modules
+// in the main chunk. Dynamic-only. `pnpm build` surfaces drift via
+// `INEFFECTIVE_DYNAMIC_IMPORT` warnings.
+//
+// Registered as a tsdown bundler entry:
+// `auto-reply/continuation/lazy.runtime` in `tsdown.config.ts`.
+//
+// Ref: karmaterminal/openclaw#220.
+
+export { resolveContinuationRuntimeConfig } from "./config.js";
+export { checkContextPressure, clearContextPressureState } from "./context-pressure.js";
+export { dispatchToolDelegates } from "./delegate-dispatch.js";
+export {
+  consumeStagedPostCompactionDelegates,
+  pendingDelegateCount,
+  stagedPostCompactionDelegateCount,
+} from "./delegate-store.js";
+export { persistContinuationChainState } from "./state.js";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1183,7 +1183,7 @@ export async function runReplyAgent(params: {
     // Fire before the agent turn so the agent can act on pressure in this turn.
     const continuationEnabledForPressure = cfg?.agents?.defaults?.continuation?.enabled === true;
     if (continuationEnabledForPressure && sessionKey && activeSessionEntry) {
-      const { checkContextPressure } = await import("../continuation/context-pressure.js");
+      const { checkContextPressure } = await import("../continuation/lazy.runtime.js");
       const pressureConfig = resolveContinuationRuntimeConfig(cfg);
       const threshold = pressureConfig.contextPressureThreshold;
       // Resolve context window for pressure calculation — agentCfgContextTokens
@@ -1617,10 +1617,11 @@ export async function runReplyAgent(params: {
         // --- Post-compaction continuation lifecycle (RFC §4.4) ---
         // Release staged post-compaction delegates and fire context-pressure event.
         if (continuationEnabledForPressure) {
-          const { consumeStagedPostCompactionDelegates } =
-            await import("../continuation/delegate-store.js");
-          const { clearContextPressureState, checkContextPressure } =
-            await import("../continuation/context-pressure.js");
+          const {
+            consumeStagedPostCompactionDelegates,
+            clearContextPressureState,
+            checkContextPressure,
+          } = await import("../continuation/lazy.runtime.js");
 
           // Clear pressure dedup so post-compaction lifecycle can fire fresh bands.
           clearContextPressureState(sessionKey);
@@ -1864,7 +1865,7 @@ export async function runReplyAgent(params: {
         chainStartedAt: activeSessionEntry?.continuationChainStartedAt ?? Date.now(),
         accumulatedChainTokens: (activeSessionEntry?.continuationChainTokens ?? 0) + turnTokens,
       };
-      const { dispatchToolDelegates } = await import("../continuation/delegate-dispatch.js");
+      const { dispatchToolDelegates } = await import("../continuation/lazy.runtime.js");
       await dispatchToolDelegates({
         sessionKey,
         chainState: dispatchChainState,
@@ -1886,7 +1887,7 @@ export async function runReplyAgent(params: {
       sessionKey &&
       activeSessionEntry
     ) {
-      const { persistContinuationChainState } = await import("../continuation/state.js");
+      const { persistContinuationChainState } = await import("../continuation/lazy.runtime.js");
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
       persistContinuationChainState({
         sessionEntry: activeSessionEntry,

--- a/src/commands/status.command-report-data.ts
+++ b/src/commands/status.command-report-data.ts
@@ -147,17 +147,14 @@ export async function buildStatusCommandReportData(params: {
     resolveMemoryFtsState: params.resolveMemoryFtsState,
     resolveMemoryCacheSummary: params.resolveMemoryCacheSummary,
     updateValue: params.updateValue,
-    continuationValue: (() => {
+    continuationValue: await (async () => {
       try {
-        const { resolveContinuationRuntimeConfig } =
-          require("../auto-reply/continuation/config.js") as {
-            resolveContinuationRuntimeConfig: () => {
-              enabled: boolean;
-              maxChainLength: number;
-              maxDelegatesPerTurn: number;
-            };
-          };
-        const cfg = resolveContinuationRuntimeConfig();
+        // karmaterminal/openclaw#220: route through the lazy-runtime boundary
+        // so continuation singletons (config, delegate-store) dedupe with the
+        // static graph and don't split across chunks. Also closes #221's ESM
+        // require() → await import migration at these two sites.
+        const lazy = await import("../auto-reply/continuation/lazy.runtime.js");
+        const cfg = lazy.resolveContinuationRuntimeConfig();
 
         // RFC §6.3 — surface runtime continuation state. TaskFlow-backed
         // counters are queryable cold-path from the CLI (SQLite persistent);
@@ -169,19 +166,14 @@ export async function buildStatusCommandReportData(params: {
         let stagedTotal = 0;
         if (cfg.enabled) {
           try {
-            const { pendingDelegateCount, stagedPostCompactionDelegateCount } =
-              require("../auto-reply/continuation/delegate-store.js") as {
-                pendingDelegateCount: (sessionKey: string) => number;
-                stagedPostCompactionDelegateCount: (sessionKey: string) => number;
-              };
             const seen = new Set<string>();
             for (const session of params.summary.sessions.recent) {
               if (!session.key || seen.has(session.key)) {
                 continue;
               }
               seen.add(session.key);
-              pendingTotal += pendingDelegateCount(session.key);
-              stagedTotal += stagedPostCompactionDelegateCount(session.key);
+              pendingTotal += lazy.pendingDelegateCount(session.key);
+              stagedTotal += lazy.stagedPostCompactionDelegateCount(session.key);
             }
           } catch {
             // TaskFlow not initialised or lookup failed — fall back to

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -149,6 +149,13 @@ function buildCoreDistEntries(): Record<string, string> {
     // dependencies (delegate-store, state, context-pressure) with the rest of the build,
     // eliminating the dual-chunk split that silently dropped continue_work tool calls.
     "auto-reply/reply/agent-runner.runtime": "src/auto-reply/reply/agent-runner.runtime.ts",
+    // karmaterminal/openclaw#220: single lazy-load boundary for the continuation
+    // subsystem. Every dynamic continuation import (agent-runner, status command,
+    // etc.) routes through this entry so the bundler can dedupe singleton-bearing
+    // modules (config, delegate-store, delegate-dispatch, context-pressure, state)
+    // across the main chunk and the lazy chunk. Replaces the need for individual
+    // coreDistEntries promotion per continuation module.
+    "auto-reply/continuation/lazy.runtime": "src/auto-reply/continuation/lazy.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
     "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",


### PR DESCRIPTION
## Summary

Closes karmaterminal/openclaw#220. Folds karmaterminal/openclaw#221 as a byproduct.

Creates \`src/auto-reply/continuation/lazy.runtime.ts\` as the single lazy-load boundary for the continuation subsystem. Every dynamic continuation import (agent-runner, status command, etc.) routes through this entry so rolldown can dedupe singleton-bearing modules (\`config\`, \`delegate-store\`, \`delegate-dispatch\`, \`context-pressure\`, \`state\`) across the main chunk and the lazy chunk.

This is the idiomatic replacement for the \`coreDistEntries\` promotion that the #584 fix leaned on (see \`tsdown.config.ts:147-151\`). The \`agent-runner.runtime\` promotion stays — it addresses a different site (\`get-reply-run.ts:108\`).

## What changed

**New file** \`src/auto-reply/continuation/lazy.runtime.ts\` — re-exports the 8 symbols consumed on lazy paths:
- \`resolveContinuationRuntimeConfig\` (from config.js)
- \`checkContextPressure\`, \`clearContextPressureState\` (from context-pressure.js)
- \`dispatchToolDelegates\` (from delegate-dispatch.js)
- \`consumeStagedPostCompactionDelegates\`, \`pendingDelegateCount\`, \`stagedPostCompactionDelegateCount\` (from delegate-store.js)
- \`persistContinuationChainState\` (from state.js)

**Bundler entry** in \`tsdown.config.ts\` — registers the new module alongside \`agent-runner.runtime\` with a comment tying back to #220.

**4 sites in \`src/auto-reply/reply/agent-runner.ts\`** converted to route through \`lazy.runtime\`:
- line 1186 (pre-turn context-pressure check)
- lines 1620-1623 (post-compaction consume + pressure fire) — collapsed 2 imports into 1
- line 1867 (tool-delegate dispatch)
- line 1889 (chain-state write-back)

**2 sites in \`src/commands/status.command-report-data.ts\`** converted — the \`require()\` → \`await import(...)\` migration folds in karmaterminal/openclaw#221 as a byproduct. The IIFE is now async (the enclosing \`buildStatusCommandReportData\` is already \`async\`, so \`await (async () => {})()\` cleanly fits).

## Verification

- [x] \`pnpm tsgo\` clean
- [x] \`pnpm build\` clean — **no \`INEFFECTIVE_DYNAMIC_IMPORT\` warnings**
- [x] \`pnpm check:import-cycles\` — 0 runtime value cycles
- [x] \`pnpm check:madge-import-cycles\` — 0 cycles
- [x] Continuation module tests: 36/36 green
- [x] Auto-reply integration tests: 88/88 green (across 6 test files)
- [x] Status continuation banner tests: 6/6 green

## Why this resolves the dual-chunk risk

The \`tsdown.config.ts:147-151\` comment flags the issue: \"dual-chunk split that silently dropped continue_work tool calls.\" With the lazy.runtime boundary, the bundler sees every dynamic continuation load resolving through one entry it tracks. Singletons (the session maps in \`delegate-store\`, the context-pressure dedup state, the config cache) cannot split into two parallel copies. Future lazy callers hitting the same modules either go through lazy.runtime (good — dedupe preserved) or add a direct dynamic import (\`pnpm build\` surfaces via \`INEFFECTIVE_DYNAMIC_IMPORT\`, which fails loudly).

## Acceptance criteria (from #220)

- [x] \`lazy.runtime.ts\` created; re-exports the symbols used on lazy paths
- [x] Every dynamic import of \`continuation/{config,delegate-store,delegate-dispatch,context-pressure,state}.js\` routes through \`lazy.runtime.js\`
- [x] No file statically imports from \`lazy.runtime.js\`
- [x] \`pnpm build\` clean, no \`[INEFFECTIVE_DYNAMIC_IMPORT]\` warnings
- [x] \`pnpm check:import-cycles\` + \`pnpm check:madge-import-cycles\` both green

## Composes with pending PRs

- **#242** (#216 centralize chain reads) — non-conflicting; #216 edits chain-state construction sites, #220 edits dynamic-import sites. If #216 lands first, one trivial merge conflict in \`agent-runner.ts\` around line 1889 (\`persistContinuationChainState\` import shape).
- **#243** (#205 classifier emission) — non-conflicting; touches \`request-compaction-tool.ts\` only.
- **Ronan's #236** (#214 closed union) — non-conflicting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)