### PR TITLE
docs(rfc/continuation): fix §3.1/§6.1/§6.2/§6.3/§D.1 drift against real code (#217, #218, #229)

### DIFF
--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -283,7 +283,7 @@ The implementation hooks into existing gateway layers rather than adding a paral
 2. **Signal detection:** `runReplyAgent()` in `src/auto-reply/reply/agent-runner.ts` inspects finalized text payloads before follow-up finalization.
 3. **Turn scheduling:** `scheduleContinuationTurn()` in `src/auto-reply/reply/session-updates.ts` injects `[continuation:wake]` through the existing system-event queue.
 4. **Delegate queueing:** tool-path delegates are enqueued via `enqueuePendingDelegate()` and consumed after the response finishes.
-5. **Lifecycle dispatch:** post-compaction delegates are stored on `SessionEntry.pendingPostCompactionDelegates` and released in the compaction completion path.
+5. **Lifecycle dispatch:** post-compaction delegates are staged via `stagePostCompactionDelegate()` (TaskFlow-backed in `src/auto-reply/continuation/delegate-store.ts`) and released by `consumeStagedPostCompactionDelegates()` in the compaction completion path.
 
 No new transport layer is introduced. Continuation uses system events, existing sub-agent dispatch, and the standard inbound-message wake path.
 
@@ -701,8 +701,8 @@ The implementation emits stable log anchors for the major continuation lifecycle
 | `[context-pressure:noop]`          | `context-pressure.ts`       | pre-condition or guard suppressed the check (debug-level, see below) |
 | `[system:context-pressure]`        | system-event queue          | event included in the next system prompt                             |
 | `[continue_delegate:enqueue]`      | `continue-delegate-tool.ts` | tool call enqueued delegate work                                     |
-| `[continuation:delegate-pending]`  | `agent-runner.ts`           | delegate chain state registered                                      |
-| `[continuation:delegate-spawned]`  | `agent-runner.ts`           | child dispatched after delay or immediate acceptance                 |
+| `[continue_delegate]`              | `delegate-dispatch.ts`      | dispatcher begins consuming queued delegates for a session           |
+| `[continuation:delegate-spawned]`  | `delegate-dispatch.ts`      | child dispatched after delay or immediate acceptance                 |
 | `[continuation/silent-wake]`       | `subagent-announce.ts`      | silent return will wake the parent                                   |
 | `[continuation:enrichment-return]` | `subagent-announce.ts`      | silent return injected as system event                               |
 | `requestHeartbeatNow`              | heartbeat wake path         | generation cycle requested after a silent-wake return                |
@@ -727,9 +727,9 @@ Representative runtime traces are shown below.
 
 ```text
 [continue_delegate:enqueue] session=agent:main silent=false silentWake=true delayMs=60000 task=check CI status
-[continuation:delegate-pending] 1 delegate(s) registered for agent:main
+[continue_delegate] Consuming 1 tool delegate(s) for session agent:main
 ... 60s later ...
-[continuation:delegate-spawned] task=check CI status delay=60000ms session=agent:main
+[continuation:delegate-spawned] hop=1/10 mode=silent-wake session=agent:main task=check CI status
 ```
 
 **Silent return and wake:**
@@ -771,12 +771,12 @@ When continuation is enabled and at least one field is non-zero, `/status` surfa
 
 The Discord/agent path through `src/auto-reply/status.ts` was disconnected during an unrelated refactor and restored at openclaw#187. The render is gated on (a) continuation enabled in the resolved config, and (b) at least one of the four fields being non-zero — both gates are unit-tested in `src/auto-reply/status.test.ts`. The `volitional: N` field reflects an honest count of agent-initiated compactions only after openclaw#191 stopped the volitional path from incrementing the counter on phantom-successful (actually-failed) compactions; see §4.3.
 
-| Field                      | Source                                        | Meaning                                                   |
-| -------------------------- | --------------------------------------------- | --------------------------------------------------------- |
-| `chain X/Y`                | `continuationChainCount` and `maxChainLength` | current depth versus maximum                              |
-| `Z delegates pending`      | pending delegate store                        | delayed or not-yet-spawned work                           |
-| `W post-compaction staged` | `SessionEntry.pendingPostCompactionDelegates` | delegates waiting for the next compaction lifecycle event |
-| `volitional: N`            | request-compaction counter                    | count of agent-initiated compactions in the session       |
+| Field                      | Source                                                                          | Meaning                                                   |
+| -------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `chain X/Y`                | `continuationChainCount` and `maxChainLength`                                   | current depth versus maximum                              |
+| `Z delegates pending`      | pending delegate store                                                          | delayed or not-yet-spawned work                           |
+| `W post-compaction staged` | `stagedPostCompactionDelegateCount()` (TaskFlow-backed via `delegate-store.ts`) | delegates waiting for the next compaction lifecycle event |
+| `volitional: N`            | request-compaction counter                                                      | count of agent-initiated compactions in the session       |
 
 ### 6.4 Context-pressure telemetry and fleet evidence
 
@@ -1181,44 +1181,47 @@ These are not correctness bugs in continuation itself, but they materially shape
 
 ### D.1 Context-pressure inclusion sketch
 
-The pre-run inclusion path can be summarized as follows:
+The pre-run inclusion path in `src/auto-reply/reply/agent-runner.ts` (around lines 1183-1210) is summarized below. The sketch elides error handling and event-assembly details to keep the control flow visible; the field names match the real call site.
 
 ```typescript
-const threshold = cfg.agents?.defaults?.continuation?.contextPressureThreshold;
-if (threshold && sessionEntry.totalTokens && sessionEntry.totalTokensFresh) {
-  const contextWindow = resolveMemoryFlushContextWindowTokens({
-    modelId,
-    agentCfgContextTokens: agentCfg?.contextTokens,
-  });
-  if (contextWindow) {
-    const ratio = sessionEntry.totalTokens / contextWindow;
-    if (ratio >= threshold) {
-      enqueueSystemEvent(
-        sessionKey,
-        `[system:context-pressure] ${Math.round(ratio * 100)}% context consumed ...`,
-      );
+const continuationEnabledForPressure = cfg?.agents?.defaults?.continuation?.enabled === true;
+if (continuationEnabledForPressure && sessionKey && activeSessionEntry) {
+  const { checkContextPressure } = await import("../continuation/lazy.runtime.js");
+  const pressureConfig = resolveContinuationRuntimeConfig(cfg);
+  const threshold = pressureConfig.contextPressureThreshold;
+  const pressureContextWindow =
+    agentCfgContextTokens ?? activeSessionEntry.contextTokens ?? DEFAULT_CONTEXT_TOKENS;
+  if (threshold && activeSessionEntry.totalTokens && pressureContextWindow) {
+    const event = checkContextPressure({
+      sessionKey,
+      totalTokens: activeSessionEntry.totalTokens,
+      contextWindow: pressureContextWindow,
+      threshold,
+    });
+    if (event) {
+      enqueueSystemEvent(event, { sessionKey });
     }
   }
 }
 ```
 
-The key property is **pre-run inclusion**: the event is enqueued and then drained into the same upcoming system prompt.
+The key property is **pre-run inclusion**: the event is enqueued before the model call and then drained into the same upcoming system prompt, so the agent sees context-pressure state on the same turn it crosses the threshold.
 
 ### D.2 Evidence locations
 
-| Artifact                                                                 | Location                                                                                                                                                                                                                                  |
-| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Artifact                                                                 | Location                                                                                                                                                                                                                                                                         |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Swim 7 evidence                                                          | [`continue-work-signal-v2/swim-evidence/swim-07/`](./continue-work-signal-v2/swim-evidence/swim-07/) (results + gateway log + raw capture) and [`elliott/swim7-chat-evidence`](https://github.com/karmaterminal/openclaw/tree/elliott/swim7-chat-evidence) branch (chat capture) |
-| Swim 8 evidence                                                          | [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch                                                                                                                        |
-| Swim 9 + 10 issue captures and results                                   | [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch                                                                                                                        |
-| Volitional-compaction provider/model threading                           | `src/auto-reply/reply/agent-runner-execution.ts`, `src/auto-reply/reply/followup-runner.ts`, `src/agents/tools/request-compaction-tool.ts`, `src/agents/pi-embedded-runner/compact-reasons.ts` (openclaw#191)                             |
-| Hedge timer natural-fire unregister                                      | `src/auto-reply/continuation/delegate-dispatch.ts` (`armHedgeTimer`) + `src/auto-reply/continuation/delegate-dispatch.test.ts` (openclaw#193)                                                                                             |
-| `/status` continuation row (Discord/agent)                               | `src/auto-reply/status.ts` + `src/auto-reply/status.test.ts` (openclaw#187, #188)                                                                                                                                                         |
-| `request_compaction()` tool surface tests                                | `src/agents/tools/request-compaction-tool.test.ts` (openclaw#165, swim-34/X5.1)                                                                                                                                                           |
-| Context-pressure noop breadcrumbs + sentinel                             | `src/auto-reply/continuation/context-pressure.ts` (openclaw#164, #171, #172, #173)                                                                                                                                                        |
-| Singleton-state dedupe across rolldown chunks                            | `src/agents/agent-runner.runtime.ts` promoted to `coreDistEntries` (openclaw#162)                                                                                                                                                         |
-| Subagent-announce continuation runtime co-location                       | `src/agents/subagent-announce.continuation.runtime.ts` (openclaw#169)                                                                                                                                                                     |
-| F-NOISE delegate-path mirror (generation-guard absence on delegate path) | `src/auto-reply/continuation/scheduler.test.ts` (openclaw#170)                                                                                                                                                                            |
+| Swim 8 evidence                                                          | [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch                                                                                                                                                               |
+| Swim 9 + 10 issue captures and results                                   | [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch                                                                                                                                                               |
+| Volitional-compaction provider/model threading                           | `src/auto-reply/reply/agent-runner-execution.ts`, `src/auto-reply/reply/followup-runner.ts`, `src/agents/tools/request-compaction-tool.ts`, `src/agents/pi-embedded-runner/compact-reasons.ts` (openclaw#191)                                                                    |
+| Hedge timer natural-fire unregister                                      | `src/auto-reply/continuation/delegate-dispatch.ts` (`armHedgeTimer`) + `src/auto-reply/continuation/delegate-dispatch.test.ts` (openclaw#193)                                                                                                                                    |
+| `/status` continuation row (Discord/agent)                               | `src/auto-reply/status.ts` + `src/auto-reply/status.test.ts` (openclaw#187, #188)                                                                                                                                                                                                |
+| `request_compaction()` tool surface tests                                | `src/agents/tools/request-compaction-tool.test.ts` (openclaw#165, swim-34/X5.1)                                                                                                                                                                                                  |
+| Context-pressure noop breadcrumbs + sentinel                             | `src/auto-reply/continuation/context-pressure.ts` (openclaw#164, #171, #172, #173)                                                                                                                                                                                               |
+| Singleton-state dedupe across rolldown chunks                            | `src/agents/agent-runner.runtime.ts` promoted to `coreDistEntries` (openclaw#162)                                                                                                                                                                                                |
+| Subagent-announce continuation runtime co-location                       | `src/agents/subagent-announce.continuation.runtime.ts` (openclaw#169)                                                                                                                                                                                                            |
+| F-NOISE delegate-path mirror (generation-guard absence on delegate path) | `src/auto-reply/continuation/scheduler.test.ts` (openclaw#170)                                                                                                                                                                                                                   |
 
 ### D.3 Most-recent integration test session results (Swim 9 and Swim 10)
 

--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -99,7 +99,8 @@ export type ContinuationRuntimeConfig = {
 
 /**
  * A delegate staged for release after compaction completes.
- * Stored on `SessionEntry.pendingPostCompactionDelegates`.
+ * Serialized into the TaskFlow state payload by `buildDelegateState`
+ * (see `delegate-store.ts`) — no longer lives on `SessionEntry`.
  * Released in the after-compaction lifecycle path with
  * `silentAnnounce: true` and `wakeOnReturn: true`.
  */


### PR DESCRIPTION
## Summary

Closes karmaterminal/openclaw#217, #218, #229.

Three RFC-drift cleanups bundled as one docs-only PR (plus one source-doc comment rewrite). Each of the three issues is a pure text correction — no behavioral change.

## Changes

### #217 — \`SessionEntry.pendingPostCompactionDelegates\` references no longer accurate

The field doesn't exist anywhere in \`src/config/**\`; post-compaction delegates are staged via \`stagePostCompactionDelegate()\` in TaskFlow-backed \`delegate-store.ts\`.

- RFC §3.1 bullet 5: storage language rewritten to name the real functions
- RFC §6.3 field-source table: row now cites \`stagedPostCompactionDelegateCount()\` (TaskFlow)
- \`src/auto-reply/continuation/types.ts\` \`StagedPostCompactionDelegate\` comment: rewritten to reference the real serialization path

### #218 — \`[continuation:delegate-pending]\` anchor claim + \`[continuation:delegate-spawned]\` attribution

The \`[continuation:delegate-pending]\` anchor was listed in §6.1 as emitted by \`agent-runner.ts\`, but grep confirms it's never emitted anywhere. Separately \`[continuation:delegate-spawned]\` is real but attributed to the wrong file.

- Removed the vestigial \`[continuation:delegate-pending]\` row
- Added the real \`[continue_delegate]\` row (emitted by \`delegate-dispatch.ts:125-127\` — 'Consuming N tool delegate(s) for session X')
- Fixed \`[continuation:delegate-spawned]\` attribution to \`delegate-dispatch.ts\`
- §6.2 sample trace: replaced the non-existent \`delegate-pending\` line with the real \`[continue_delegate]\` consumption line; \`[continuation:delegate-spawned]\` format updated to match the real emission (\`hop=X/Y mode=... session=... task=...\`)

### #229 — §D.1 pressure-pre-run sketch referenced helpers not in real code

Sketch cited \`sessionEntry.totalTokensFresh\` and \`resolveMemoryFlushContextWindowTokens\`, neither of which is used on the real path. Real code at \`agent-runner.ts:1183-1210\` uses \`activeSessionEntry.totalTokens && pressureContextWindow\` and routes through \`lazy.runtime.js\`'s \`checkContextPressure\`. Sketch rewritten to match, with an explicit pointer to the source file + line range.

## Test plan

- [x] \`pnpm tsgo\` clean (types.ts comment change is the only code touch; no behavior affected)
- [x] Grep for \`pendingPostCompactionDelegates\` returns only generic 'delegate-pending' conceptual references (which correctly describe the state, not the anchor)

## Composes with pending PRs

- **#242** (#216 chain-state) — no file overlap
- **#243** (#205 classifier emission) — no file overlap
- **#244** (#220 lazy.runtime) — note: the §D.1 sketch references \`lazy.runtime.js\` which becomes the canonical continuation lazy-load boundary once #244 lands. If #244 lands first, the sketch is already accurate. If this PR lands first, the sketch anticipates #244 — either order fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)