### PR TITLE
chore(continuation): code hygiene bundle — ContinueWorkRequest dedup, no-op cleanup, hedge-error severity (#219, #223, #224)

### DIFF
--- a/src/agents/tools/continue-work-tool.ts
+++ b/src/agents/tools/continue-work-tool.ts
@@ -35,10 +35,9 @@ const ContinueWorkToolSchema = Type.Object({
   ),
 });
 
-export type ContinueWorkRequest = {
-  reason: string;
-  delaySeconds: number;
-};
+// ContinueWorkRequest is defined in the continuation types module so the
+// tool and the store/signal consumers share one canonical contract.
+export type { ContinueWorkRequest } from "../../auto-reply/continuation/types.js";
 
 export function createContinueWorkTool(opts: { agentSessionKey?: string }): AnyAgentTool {
   return {

--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -20,7 +20,6 @@ import { resolveContinuationRuntimeConfig } from "./config.js";
 import { consumePendingDelegates, peekSoonestUnmaturedDelegateDueAt } from "./delegate-store.js";
 import { checkContinuationBudget, type ChainState } from "./scheduler.js";
 import {
-  setDelegatePending,
   registerContinuationTimerHandle,
   retainContinuationTimerRef,
   unregisterContinuationTimerHandle,
@@ -176,9 +175,6 @@ export async function dispatchToolDelegates(params: {
     const nextHop = currentChainCount + 1;
     const silent = delegate.mode === "silent" || delegate.mode === "silent-wake";
     const silentWake = delegate.mode === "silent-wake";
-
-    // Mark delegate-pending so the runner knows work is queued.
-    setDelegatePending(sessionKey);
 
     const spawnCtx: SpawnSubagentContext = {
       agentSessionKey: sessionKey,

--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -62,7 +62,12 @@ function armHedgeTimer(
     unregisterContinuationTimerHandle(sessionKey, handle);
     log.info(`[continuation:delegate-hedge-fired] session=${sessionKey}`);
     void dispatchToolDelegates({ sessionKey, ...params }).catch((err) => {
-      log.info(
+      // Warn (not info): per-delegate errors inside dispatchToolDelegates
+      // are logged at info by the dispatcher itself; reaching this outer
+      // catch means dispatcher-level failure (TaskFlow store error on
+      // consume / peek / readiness gate). A queued delegate may now be
+      // orphaned — that deserves a louder band. karmaterminal/openclaw#224.
+      log.warn(
         `[continuation:delegate-hedge-error] error=${err instanceof Error ? err.message : String(err)} session=${sessionKey}`,
       );
     });

--- a/src/auto-reply/continuation/delegate-store.ts
+++ b/src/auto-reply/continuation/delegate-store.ts
@@ -20,6 +20,7 @@ import {
   listTaskFlowsForOwnerKey,
 } from "../../tasks/task-flow-runtime-internal.js";
 import type {
+  ContinueWorkRequest,
   DelayedContinuationReservation,
   PendingContinuationDelegate,
   StagedPostCompactionDelegate,
@@ -373,18 +374,13 @@ export function clearDelayedContinuationReservations(sessionKey: string): void {
 // or gateway restarts. TaskFlow is not needed here.
 // ---------------------------------------------------------------------------
 
-const pendingWorkRequests = new Map<string, { reason: string; delaySeconds: number }>();
+const pendingWorkRequests = new Map<string, ContinueWorkRequest>();
 
-export function setPendingWorkRequest(
-  sessionKey: string,
-  request: { reason: string; delaySeconds: number },
-): void {
+export function setPendingWorkRequest(sessionKey: string, request: ContinueWorkRequest): void {
   pendingWorkRequests.set(sessionKey, request);
 }
 
-export function consumePendingWorkRequest(
-  sessionKey: string,
-): { reason: string; delaySeconds: number } | undefined {
+export function consumePendingWorkRequest(sessionKey: string): ContinueWorkRequest | undefined {
   const request = pendingWorkRequests.get(sessionKey);
   if (request) {
     pendingWorkRequests.delete(sessionKey);

--- a/src/auto-reply/continuation/scheduler.ts
+++ b/src/auto-reply/continuation/scheduler.ts
@@ -20,7 +20,6 @@ import {
 import {
   registerContinuationTimerHandle,
   retainContinuationTimerRef,
-  setDelegatePending,
   unregisterContinuationTimerHandle,
 } from "./state.js";
 import type { ContinuationRuntimeConfig, ContinuationSignal } from "./types.js";
@@ -175,8 +174,9 @@ export function scheduleDelegateContinuation(params: {
     Math.max(chainState.currentChainCount, highestDelayedContinuationReservationHop(sessionKey)) +
     1;
 
-  // Mark delegate-pending so the runner knows work is queued even before spawn.
-  setDelegatePending(sessionKey);
+  // TaskFlow enqueue (via addDelayedContinuationReservation / caller's
+  // enqueuePendingDelegate) is the source of truth for pending-state; the
+  // runner reads it via pendingDelegateCount().
 
   if (signal.delayMs && signal.delayMs > 0) {
     // Delayed dispatch: park reservation, arm timer.

--- a/src/auto-reply/continuation/signal.ts
+++ b/src/auto-reply/continuation/signal.ts
@@ -14,14 +14,10 @@ import type { ContinuationSignal } from "./types.js";
 
 const log = createSubsystemLogger("continuation/signal");
 
-/**
- * The tool-call request shape captured by `continue_work()` during execution.
- * The tool sets this via a callback; the runner reads it after the turn.
- */
-export type ContinueWorkRequest = {
-  reason: string;
-  delaySeconds: number;
-};
+// ContinueWorkRequest now lives in ./types.js — import for local use and
+// re-export for call sites that already depend on this module.
+import type { ContinueWorkRequest } from "./types.js";
+export type { ContinueWorkRequest };
 
 /**
  * A reply payload with optional text content.

--- a/src/auto-reply/continuation/state.ts
+++ b/src/auto-reply/continuation/state.ts
@@ -25,24 +25,8 @@ const continuationTimerRefs = new Map<string, number>();
 
 import { pendingDelegateCount } from "./delegate-store.js";
 
-/**
- * @deprecated No-op. Delegates are tracked in TaskFlow; the pending state
- * is derived from pendingDelegateCount(). Kept for call-site compatibility
- * during migration.
- */
-export function setDelegatePending(_sessionKey: string): void {
-  // No-op: TaskFlow enqueue is the source of truth.
-}
-
 export function hasDelegatePending(sessionKey: string): boolean {
   return pendingDelegateCount(sessionKey) > 0;
-}
-
-/**
- * @deprecated No-op. Delegate pending state is derived from TaskFlow.
- */
-export function clearDelegatePending(_sessionKey: string): void {
-  // No-op: TaskFlow consume/cancel is the source of truth.
 }
 
 // ---------------------------------------------------------------------------

--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -107,3 +107,21 @@ export type StagedPostCompactionDelegate = {
   task: string;
   stagedAt: number;
 };
+
+// ---------------------------------------------------------------------------
+// continue_work tool-call request shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Captured by `continue_work()` during tool execution; consumed by the runner
+ * in the same turn's post-response. Same-turn ephemeral — never persisted
+ * across turn boundaries or gateway restarts.
+ *
+ * Single canonical definition. Prior to karmaterminal/openclaw#223 this type
+ * was duplicated in `signal.ts`, `continue-work-tool.ts`, and inline in
+ * `delegate-store.ts`.
+ */
+export type ContinueWorkRequest = {
+  reason: string;
+  delaySeconds: number;
+};


### PR DESCRIPTION
## Summary

Three small source-code hygiene fixes bundled into one PR, three commits:

### #223 — Unify 3 copies of \`ContinueWorkRequest\` into \`types.ts\`
Before: \`{ reason: string; delaySeconds: number }\` was defined in \`signal.ts\`, \`continue-work-tool.ts\`, and inline in \`delegate-store.ts\` (Map type + two signatures). If the contract ever grew, one copy would update and the others would silently drift.
After: single canonical \`ContinueWorkRequest\` in \`continuation/types.ts\` alongside the other shared continuation contracts; the three prior sites import/re-export it.

### #219 — Remove \`setDelegatePending\`/\`clearDelegatePending\` no-ops + lying call-site comments
Both functions were explicit no-ops with \`@deprecated\` docblocks naming TaskFlow as the source of truth — but every call site still had a \`// Mark delegate-pending ...\` comment that claimed real behavior. Net: drop two no-op functions, drop three dead call sites, drop two misleading comments. \`hasDelegatePending()\` (a real TaskFlow-derived query) stays unchanged.

### #224 — Raise \`[continuation:delegate-hedge-error]\` from info to warn
Per-delegate errors inside \`dispatchToolDelegates\` are info-level by design. Reaching the outer catch on the hedge-timer natural-fire path means dispatcher-level failure — TaskFlow storage readback or readiness gate threw — which can orphan a queued delegate. Warn is the right band; added a comment on the severity choice so it doesn't regress back to info.

## Test plan

- [x] \`pnpm tsgo\` clean
- [x] \`pnpm test src/auto-reply/continuation/\` — 36/36 green (no behavior change in any of the three)

## Composes with other PRs

- **#242** (chain reads) — no overlap
- **#243** (classifier emission) — no overlap
- **#244** (lazy.runtime boundary) — no overlap
- **#245** (RFC drift pack) — no overlap
- **#236** (Ronan's CompactionReasonCode union) — no overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)