### PR TITLE
fix(commands): convert require() to ESM imports in status.command-report-data

### DIFF
--- a/src/commands/status.command-report-data.ts
+++ b/src/commands/status.command-report-data.ts
@@ -1,3 +1,8 @@
+import { resolveContinuationRuntimeConfig } from "../auto-reply/continuation/config.js";
+import {
+  pendingDelegateCount,
+  stagedPostCompactionDelegateCount,
+} from "../auto-reply/continuation/delegate-store.js";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
 import type { resolveOsSummary } from "../infra/os-summary.js";
 import type { Tone } from "../memory-host-sdk/status.js";
@@ -149,14 +154,6 @@ export async function buildStatusCommandReportData(params: {
     updateValue: params.updateValue,
     continuationValue: (() => {
       try {
-        const { resolveContinuationRuntimeConfig } =
-          require("../auto-reply/continuation/config.js") as {
-            resolveContinuationRuntimeConfig: () => {
-              enabled: boolean;
-              maxChainLength: number;
-              maxDelegatesPerTurn: number;
-            };
-          };
         const cfg = resolveContinuationRuntimeConfig();
 
         // RFC §6.3 — surface runtime continuation state. TaskFlow-backed
@@ -169,11 +166,6 @@ export async function buildStatusCommandReportData(params: {
         let stagedTotal = 0;
         if (cfg.enabled) {
           try {
-            const { pendingDelegateCount, stagedPostCompactionDelegateCount } =
-              require("../auto-reply/continuation/delegate-store.js") as {
-                pendingDelegateCount: (sessionKey: string) => number;
-                stagedPostCompactionDelegateCount: (sessionKey: string) => number;
-              };
             const seen = new Set<string>();
             for (const session of params.summary.sessions.recent) {
               if (!session.key || seen.has(session.key)) {


### PR DESCRIPTION
Closes #221

Drops two mid-file `require()` calls in `src/commands/status.command-report-data.ts` in favor of static top-level ESM imports. Net diff: +5/-13.

## Why
The continuationValue IIFE used `require()` to lazily load `continuation/config.js` and `continuation/delegate-store.js`. In an otherwise ESM TypeScript module this complicates tree-shaking and emits warnings under tsdown/rolldown. CLAUDE.md's architecture rules push ESM end-to-end.

## What changed
- Two static top-level imports added (`resolveContinuationRuntimeConfig`, `pendingDelegateCount`, `stagedPostCompactionDelegateCount`).
- Both `require()` call sites and their inline type assertions removed.
- Outer try/catch preserved (still guards `resolveContinuationRuntimeConfig()` throwing on config-load issues).
- Inner try/catch preserved (still guards TaskFlow lookup failures).

## Why static imports are safe here
- No back-edge from `continuation/config.js` or `continuation/delegate-store.js` to `commands/` (`pnpm check:import-cycles` and `pnpm check:madge-import-cycles` both clean: 0 cycles).
- Both modules are pure function exports with no top-level side effects (`delegate-store` declares a `Map` constant, no IO).
- No load-order constraints — `status.command-report-data.ts` is only imported from `status.command.ts` and tests.

## Verification
- `pnpm build` clean.
- `pnpm check` clean (no-conflict-markers, tool-display, host-env-policy, import-cycles, madge-import-cycles, tsgo, oxlint, webhook lint, auth lint).
- `pnpm vitest run src/commands/status.command-report-data.test.ts src/commands/status.continuation-banner.test.ts` → 7/7 pass.
- Scribe-pass via opus reviewer: PASS on circular-import risk, inner try/catch necessity, canary deployment risk, outer try/catch necessity.

## Acceptance criteria from #221
- [x] No `require()` in `src/commands/status.command-report-data.ts`
- [x] `pnpm build` clean; no bundler warnings about the affected module