### PR TITLE
fix(continuation): surface silent-failure gaps with warn/error breadcrumbs (#206, #207, #208)

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -143,7 +143,15 @@ async function drainChildContinuationQueue(params: {
   let cfg: Awaited<ReturnType<typeof subagentAnnounceDeps.loadConfig>>;
   try {
     cfg = subagentAnnounceDeps.loadConfig();
-  } catch {
+  } catch (err) {
+    // karmaterminal/openclaw#208: config-load failure here silently drops
+    // the child's delegate drain — that's an F7-class stall at a different
+    // entry point. Surface it via the file's existing defaultRuntime.error
+    // pattern so operators can see why a chain stopped after a subagent
+    // settled.
+    defaultRuntime.error?.(
+      `[continuation:drain-config-load-failed] child=${params.childSessionKey} error=${err instanceof Error ? err.message : String(err)}`,
+    );
     return;
   }
   if (cfg?.agents?.defaults?.continuation?.enabled !== true) {

--- a/src/auto-reply/continuation/delegate-store.ts
+++ b/src/auto-reply/continuation/delegate-store.ts
@@ -11,6 +11,7 @@
  */
 
 import { z } from "zod";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { TaskFlowRecord } from "../../tasks/task-flow-registry.types.js";
 import {
   createManagedTaskFlow,
@@ -24,6 +25,8 @@ import type {
   PendingContinuationDelegate,
   StagedPostCompactionDelegate,
 } from "./types.js";
+
+const log = createSubsystemLogger("continuation/delegate-store");
 
 // ---------------------------------------------------------------------------
 // Controller IDs (exported for test assertions)
@@ -170,6 +173,12 @@ export function consumePendingDelegates(sessionKey: string): PendingContinuation
   for (const flow of listQueuedPendingFlows(sessionKey)) {
     const state = decodeDelegateState(flow);
     if (!state) {
+      // karmaterminal/openclaw#206: schema-drift / corrupt payload needs a
+      // live breadcrumb. failFlow alone leaves the record in SQLite where
+      // nobody looks until `openclaw status --deep`.
+      log.warn(
+        `[continuation:delegate-decode-failed] flowId=${flow.flowId} session=${sessionKey} raw=${JSON.stringify(flow.stateJson).slice(0, 200)}`,
+      );
       failFlow({
         flowId: flow.flowId,
         expectedRevision: flow.revision,
@@ -281,6 +290,12 @@ export function consumeStagedPostCompactionDelegates(
   for (const flow of listQueuedPostCompactionFlows(sessionKey)) {
     const state = decodeDelegateState(flow);
     if (!state) {
+      // karmaterminal/openclaw#206: mirror the pending-path breadcrumb on
+      // the post-compaction consume lane. Same schema-drift risk, same
+      // dropped-work consequence.
+      log.warn(
+        `[continuation:post-compaction-decode-failed] flowId=${flow.flowId} session=${sessionKey} raw=${JSON.stringify(flow.stateJson).slice(0, 200)}`,
+      );
       failFlow({
         flowId: flow.flowId,
         expectedRevision: flow.revision,

--- a/src/auto-reply/continuation/scheduler.test.ts
+++ b/src/auto-reply/continuation/scheduler.test.ts
@@ -173,3 +173,66 @@ describe("scheduleDelegateContinuation", () => {
     expect(onImmediateSpawn).not.toHaveBeenCalled();
   });
 });
+
+describe("scheduler timer callbacks swallow rejections (openclaw#207)", () => {
+  it("scheduleWorkContinuation: onFire throw does not propagate past the timer", async () => {
+    const onFire = vi.fn(() => {
+      throw new Error("enqueue-system-event exploded");
+    });
+
+    const result = scheduleWorkContinuation({
+      signal: { kind: "work", delayMs: 10_000 },
+      chainState: { currentChainCount: 0, chainStartedAt: 0, accumulatedChainTokens: 0 },
+      config: baseConfig,
+      sessionKey: "test-work-fire-throw",
+      onFire,
+    });
+    expect(result.outcome).toBe("scheduled");
+
+    // Under vitest fake timers, an unhandled exception thrown from a
+    // setTimeout callback would become a test-level failure. Advancing
+    // the timer without any custom unhandledException assertion is the
+    // regression check: the catch is in place iff this completes cleanly.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(onFire).toHaveBeenCalledTimes(1);
+  });
+
+  it("scheduleDelegateContinuation (delayed): onDelayedSpawn rejection does not propagate", async () => {
+    const onImmediateSpawn = vi.fn().mockResolvedValue(true);
+    const onDelayedSpawn = vi.fn().mockRejectedValue(new Error("spawn-failed"));
+
+    scheduleDelegateContinuation({
+      signal: { kind: "delegate", delayMs: 10_000, task: "probe" },
+      chainState: { currentChainCount: 0, chainStartedAt: 0, accumulatedChainTokens: 0 },
+      config: baseConfig,
+      sessionKey: "test-delayed-reject",
+      onImmediateSpawn,
+      onDelayedSpawn,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    // Drain the .catch microtask.
+    await vi.runAllTimersAsync();
+    expect(onDelayedSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("scheduleDelegateContinuation (immediate): onImmediateSpawn rejection does not propagate", async () => {
+    const onImmediateSpawn = vi.fn().mockRejectedValue(new Error("spawn-failed"));
+    const onDelayedSpawn = vi.fn().mockResolvedValue(true);
+
+    const result = scheduleDelegateContinuation({
+      signal: { kind: "delegate", task: "probe" }, // no delay → immediate
+      chainState: { currentChainCount: 0, chainStartedAt: 0, accumulatedChainTokens: 0 },
+      config: baseConfig,
+      sessionKey: "test-immediate-reject",
+      onImmediateSpawn,
+      onDelayedSpawn,
+    });
+    expect(result.outcome).toBe("scheduled-immediate");
+
+    // Microtask drain for the .catch branch.
+    await vi.runAllTimersAsync();
+    expect(onImmediateSpawn).toHaveBeenCalledTimes(1);
+    expect(onDelayedSpawn).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/continuation/scheduler.ts
+++ b/src/auto-reply/continuation/scheduler.ts
@@ -123,6 +123,14 @@ export function scheduleWorkContinuation(params: {
         chainState.accumulatedChainTokens,
         workReason,
       );
+    } catch (err) {
+      // karmaterminal/openclaw#207: the user-supplied onFire callback does
+      // enqueueSystemEvent + requestHeartbeatNow from agent-runner.ts; either
+      // can throw under bounded-queue / disk conditions. Without this catch
+      // the throw propagates to the event loop as an unhandled exception.
+      log.warn(
+        `[continuation:work-fire-failed] session=${sessionKey} error=${err instanceof Error ? err.message : String(err)}`,
+      );
     } finally {
       unregisterContinuationTimerHandle(sessionKey, timerHandle);
     }
@@ -204,13 +212,22 @@ export function scheduleDelegateContinuation(params: {
         log.info(
           `[continuation] DELEGATE timer fired: hop=${nextChainCount}/${config.maxChainLength} session=${sessionKey}`,
         );
-        void params.onDelayedSpawn({
-          plannedHop: nextChainCount,
-          task: signal.task,
-          silent: signal.silent,
-          silentWake: signal.silentWake,
-          startedAt: chainState.chainStartedAt,
-        });
+        // karmaterminal/openclaw#207: `.catch` replaces the previous bare
+        // `void` which discarded rejections and caused them to surface as
+        // unhandled rejections in the Node event loop.
+        params
+          .onDelayedSpawn({
+            plannedHop: nextChainCount,
+            task: signal.task,
+            silent: signal.silent,
+            silentWake: signal.silentWake,
+            startedAt: chainState.chainStartedAt,
+          })
+          .catch((err) => {
+            log.warn(
+              `[continuation:delayed-spawn-failed] hop=${nextChainCount}/${config.maxChainLength} session=${sessionKey} error=${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
       } finally {
         unregisterContinuationTimerHandle(sessionKey, timerHandle);
       }
@@ -225,11 +242,19 @@ export function scheduleDelegateContinuation(params: {
   log.info(
     `[continuation] DELEGATE immediate spawn: hop=${nextChainCount}/${config.maxChainLength} session=${sessionKey}`,
   );
-  void params.onImmediateSpawn(nextChainCount, signal.task, {
-    silent: signal.silent,
-    silentWake: signal.silentWake,
-    startedAt: chainState.chainStartedAt,
-  });
+  // karmaterminal/openclaw#207: same unhandled-rejection concern as the
+  // delayed branch. Catch + warn rather than `void` discard.
+  params
+    .onImmediateSpawn(nextChainCount, signal.task, {
+      silent: signal.silent,
+      silentWake: signal.silentWake,
+      startedAt: chainState.chainStartedAt,
+    })
+    .catch((err) => {
+      log.warn(
+        `[continuation:immediate-spawn-failed] hop=${nextChainCount}/${config.maxChainLength} session=${sessionKey} error=${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
 
   return { outcome: "scheduled-immediate", nextChainCount };
 }


### PR DESCRIPTION
## Summary

Three defensive log/try-catch fixes bundled. Each addresses a path where a failure previously surfaced as either a silent TaskFlow record transition or an unhandled rejection in the Node event loop.

### #206 — delegate-store zod-parse failure breadcrumbs
Both consume sites — pending delegates (\`consumePendingDelegates\` line 173) and staged post-compaction delegates (\`consumeStagedPostCompactionDelegates\` line 292) — now \`log.warn\` a named anchor with \`flowId\` + session key + truncated raw payload before calling \`failFlow\`. Schema-drift or partial-write corruption is now grep-able in live logs instead of only visible via \`openclaw status --deep\`. Added module-level logger alongside existing helpers.

### #207 — scheduler timer callback unhandled rejections
- \`scheduleWorkContinuation\` \`setTimeout\`: try/catch around \`onFire\` so a throw from the user-supplied callback (typically \`enqueueSystemEvent\` / \`requestHeartbeatNow\` from agent-runner.ts) warns instead of surfacing to the event loop.
- \`scheduleDelegateContinuation\` delayed branch: bare \`void params.onDelayedSpawn()\` replaced with \`.catch(log.warn)\`. Rejections no longer become unhandled rejections.
- Same treatment for the immediate branch (\`onImmediateSpawn\`).
- **3 new regression tests** in \`scheduler.test.ts\` that would flake on unhandled exceptions without the catches.

### #208 — \`drainChildContinuationQueue\` config-load silent return
Catch at \`subagent-announce.ts\` line 146 now emits a named \`defaultRuntime.error\` anchor (\`[continuation:drain-config-load-failed]\`) before returning. Matches the existing error-reporting style used later in the same function. A stalled chain now leaves a breadcrumb.

## Test plan

- [x] \`pnpm tsgo\` clean
- [x] \`pnpm test src/auto-reply/continuation/\` — 39/39 green (36 pre-existing + 3 new scheduler regression cases)
- [x] \`pnpm test src/agents/subagent-announce.continuation*\` — 8/8 green

## Composes with other PRs

- #242/#243/#244/#245/#246 — no file overlap with any of them.
- If #244 (lazy.runtime boundary) lands first, the new log imports in \`delegate-store.ts\` sit cleanly alongside existing imports; no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)