### PR TITLE
Centralize SessionEntry.continuationChain* reads (closes #216)

### DIFF
--- a/src/agents/subagent-announce.continuation.runtime.ts
+++ b/src/agents/subagent-announce.continuation.runtime.ts
@@ -17,3 +17,4 @@
 // in `tsdown.config.ts`.
 export { dispatchToolDelegates } from "../auto-reply/continuation/delegate-dispatch.js";
 export { resolveContinuationRuntimeConfig } from "../auto-reply/continuation/config.js";
+export { loadContinuationChainState } from "../auto-reply/continuation/state.js";

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -130,6 +130,19 @@ type ContinuationConfigModule = {
   resolveContinuationRuntimeConfig: (cfg?: unknown) => { maxChainLength: number };
 };
 
+type ContinuationStateModule = {
+  loadContinuationChainState: (
+    source:
+      | {
+          continuationChainCount?: number;
+          continuationChainStartedAt?: number;
+          continuationChainTokens?: number;
+        }
+      | undefined,
+    options?: { extraTokens?: number; now?: number },
+  ) => ContinuationChainState;
+};
+
 /**
  * Drain the child session's continue_delegate queue after the subagent has
  * settled. Chain state is inherited from the child session entry so nested
@@ -155,7 +168,7 @@ async function drainChildContinuationQueue(params: {
     // with a literal path would pull `subagent-spawn.js` into a cycle via
     // `delegate-dispatch.js → subagent-spawn.js → subagent-registry.js →
     // subagent-announce.ts`.
-    const [dispatchModule, configModule] = await Promise.all([
+    const [dispatchModule, configModule, stateModule] = await Promise.all([
       importRuntimeModule<ContinuationDispatchModule>(import.meta.url, [
         "./subagent-announce.continuation.runtime",
         ".js",
@@ -164,24 +177,19 @@ async function drainChildContinuationQueue(params: {
         "./subagent-announce.continuation.runtime",
         ".js",
       ]),
+      importRuntimeModule<ContinuationStateModule>(import.meta.url, [
+        "./subagent-announce.continuation.runtime",
+        ".js",
+      ]),
     ]);
     const { dispatchToolDelegates } = dispatchModule;
     const { resolveContinuationRuntimeConfig } = configModule;
-    const childEntry = loadSessionEntryByKey(params.childSessionKey) as
-      | {
-          continuationChainCount?: number;
-          continuationChainStartedAt?: number;
-          continuationChainTokens?: number;
-        }
-      | undefined;
+    const { loadContinuationChainState } = stateModule;
+    const childEntry = loadSessionEntryByKey(params.childSessionKey);
     const dispatchConfig = resolveContinuationRuntimeConfig(cfg);
     await dispatchToolDelegates({
       sessionKey: params.childSessionKey,
-      chainState: {
-        currentChainCount: childEntry?.continuationChainCount ?? 0,
-        chainStartedAt: childEntry?.continuationChainStartedAt ?? Date.now(),
-        accumulatedChainTokens: childEntry?.continuationChainTokens ?? 0,
-      },
+      chainState: loadContinuationChainState(childEntry),
       ctx: {
         sessionKey: params.childSessionKey,
         agentChannel: params.requesterOrigin?.channel,

--- a/src/auto-reply/continuation/state.ts
+++ b/src/auto-reply/continuation/state.ts
@@ -152,6 +152,50 @@ export function persistContinuationChainState(params: {
   params.sessionEntry.continuationChainTokens = params.tokens;
 }
 
+/**
+ * Subset of SessionEntry carrying continuation-chain metadata.
+ *
+ * Read sites can accept this shape instead of importing the full SessionEntry
+ * type — useful for callers that load entries via dynamic-typed helpers
+ * (e.g. subagent-announce.loadSessionEntryByKey).
+ */
+export type ContinuationChainSource = {
+  continuationChainCount?: number;
+  continuationChainStartedAt?: number;
+  continuationChainTokens?: number;
+};
+
+/**
+ * Resolved continuation-chain state — the shape every read site needs.
+ *
+ * Centralized here to (a) eliminate `?? 0` / `?? Date.now()` sentinel sprawl
+ * at six read sites, and (b) make the "all three fields rise/fall as a unit"
+ * invariant explicit. The on-disk shape (three flat optionals on SessionEntry)
+ * is preserved; this helper only normalizes the read path.
+ *
+ * If `extraTokens` is provided (representing the current turn's token usage),
+ * it is added to the persisted chain-token total. Pass `0` (or omit) for
+ * call sites that just want the persisted snapshot.
+ *
+ * Pass `now` to make timestamp defaulting deterministic in tests.
+ */
+export function loadContinuationChainState(
+  source: ContinuationChainSource | undefined,
+  options: { extraTokens?: number; now?: number } = {},
+): {
+  currentChainCount: number;
+  chainStartedAt: number;
+  accumulatedChainTokens: number;
+} {
+  const extraTokens = options.extraTokens ?? 0;
+  const nowFn = options.now ?? Date.now();
+  return {
+    currentChainCount: source?.continuationChainCount ?? 0,
+    chainStartedAt: source?.continuationChainStartedAt ?? nowFn,
+    accumulatedChainTokens: (source?.continuationChainTokens ?? 0) + extraTokens,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -35,6 +35,7 @@ import {
 } from "../continuation/delegate-store.js";
 import { scheduleWorkContinuation } from "../continuation/scheduler.js";
 import { extractContinuationSignal } from "../continuation/signal.js";
+import { loadContinuationChainState } from "../continuation/state.js";
 import {
   buildFallbackClearedNotice,
   buildFallbackNotice,
@@ -1826,11 +1827,9 @@ export async function runReplyAgent(params: {
     if (effectiveContinuationSignal && sessionKey) {
       const continuationConfig = resolveContinuationRuntimeConfig(cfg);
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
-      const chainState = {
-        currentChainCount: activeSessionEntry?.continuationChainCount ?? 0,
-        chainStartedAt: activeSessionEntry?.continuationChainStartedAt ?? Date.now(),
-        accumulatedChainTokens: (activeSessionEntry?.continuationChainTokens ?? 0) + turnTokens,
-      };
+      const chainState = loadContinuationChainState(activeSessionEntry, {
+        extraTokens: turnTokens,
+      });
 
       if (effectiveContinuationSignal.kind === "work") {
         scheduleWorkContinuation({
@@ -1859,11 +1858,9 @@ export async function runReplyAgent(params: {
     // Consume and dispatch tool-dispatched delegates (continue_delegate tool).
     if (continuationFeatureEnabled && sessionKey) {
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
-      const dispatchChainState = {
-        currentChainCount: activeSessionEntry?.continuationChainCount ?? 0,
-        chainStartedAt: activeSessionEntry?.continuationChainStartedAt ?? Date.now(),
-        accumulatedChainTokens: (activeSessionEntry?.continuationChainTokens ?? 0) + turnTokens,
-      };
+      const dispatchChainState = loadContinuationChainState(activeSessionEntry, {
+        extraTokens: turnTokens,
+      });
       const { dispatchToolDelegates } = await import("../continuation/delegate-dispatch.js");
       await dispatchToolDelegates({
         sessionKey,
@@ -1888,11 +1885,14 @@ export async function runReplyAgent(params: {
     ) {
       const { persistContinuationChainState } = await import("../continuation/state.js");
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
+      const persistState = loadContinuationChainState(activeSessionEntry, {
+        extraTokens: turnTokens,
+      });
       persistContinuationChainState({
         sessionEntry: activeSessionEntry,
-        count: activeSessionEntry.continuationChainCount ?? 0,
-        startedAt: activeSessionEntry.continuationChainStartedAt ?? Date.now(),
-        tokens: (activeSessionEntry.continuationChainTokens ?? 0) + turnTokens,
+        count: persistState.currentChainCount,
+        startedAt: persistState.chainStartedAt,
+        tokens: persistState.accumulatedChainTokens,
       });
     }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -353,17 +353,19 @@ export function createFollowupRunner(params: {
       // (or any followup turn) stay in the queue until the NEXT inbound
       // message arrives to trigger the main-session dispatch. RFC §3.2.
       if (runtimeConfig?.agents?.defaults?.continuation?.enabled === true && sessionKey) {
-        const [{ dispatchToolDelegates }, { resolveContinuationRuntimeConfig }] = await Promise.all(
-          [import("../continuation/delegate-dispatch.js"), import("../continuation/config.js")],
-        );
+        const [
+          { dispatchToolDelegates },
+          { resolveContinuationRuntimeConfig },
+          { loadContinuationChainState },
+        ] = await Promise.all([
+          import("../continuation/delegate-dispatch.js"),
+          import("../continuation/config.js"),
+          import("../continuation/state.js"),
+        ]);
         const tailUsage = runResult.meta?.agentMeta?.usage;
         const turnTokens = (tailUsage?.input ?? 0) + (tailUsage?.output ?? 0);
         const tailEntry = (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
-        const chainState = {
-          currentChainCount: tailEntry?.continuationChainCount ?? 0,
-          chainStartedAt: tailEntry?.continuationChainStartedAt ?? Date.now(),
-          accumulatedChainTokens: (tailEntry?.continuationChainTokens ?? 0) + turnTokens,
-        };
+        const chainState = loadContinuationChainState(tailEntry, { extraTokens: turnTokens });
         await dispatchToolDelegates({
           sessionKey,
           chainState,

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -60,6 +60,7 @@ import {
   pendingDelegateCount,
   stagedPostCompactionDelegateCount,
 } from "./continuation/delegate-store.js";
+import { loadContinuationChainState } from "./continuation/state.js";
 import { formatProviderModelRef, resolveSelectedAndActiveModel } from "./model-runtime.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
 
@@ -922,7 +923,7 @@ function formatContinuationStatusLine(params: {
       // request-compaction tool not loaded — leave at zero.
     }
   }
-  const chain = params.sessionEntry?.continuationChainCount ?? 0;
+  const chain = loadContinuationChainState(params.sessionEntry).currentChainCount;
   if (chain === 0 && pending === 0 && staged === 0 && volitional === 0) {
     return null;
   }


### PR DESCRIPTION
Closes #216.

## Summary

Six read sites of `SessionEntry.continuationChainCount` / `continuationChainStartedAt` / `continuationChainTokens` were each open-coding the same `?? 0` / `?? Date.now()` sentinel pattern, in violation of CLAUDE.md's rule against silent-meaning-change defaults. "Never been in a chain" and "chain at depth 0" were indistinguishable at every read site.

This is the lower-risk **Option B** from the issue: keep the on-disk shape (three flat optionals on `SessionEntry`) and centralize the read path in a single helper, `loadContinuationChainState`, which returns the resolved `ChainState` shape every caller already wanted.

## Changes

- `src/auto-reply/continuation/state.ts` — add `ContinuationChainSource` type + `loadContinuationChainState` helper (the single adapter the AC permits).
- `src/auto-reply/reply/agent-runner.ts` — three call sites switch to the helper (signal-driven schedule, tool-dispatch, write-back).
- `src/auto-reply/reply/followup-runner.ts` — tail-dispatch site switches via the dynamic-import group (cycle-safe).
- `src/agents/subagent-announce.ts` — child-session dispatch switches via the `importRuntimeModule` boundary; inline duplicate of `Pick<SessionEntry, 'continuationChain*'>` at the value cast is removed.
- `src/agents/subagent-announce.continuation.runtime.ts` — re-export `loadContinuationChainState` alongside the existing dispatch + config re-exports (preserves the bundle-cycle workaround documented in #473).
- `src/auto-reply/status.ts` — status line read switches to helper.

## Acceptance Criteria

- [x] No `?? 0` or `?? Date.now()` on `continuationChain*` reads outside one adapter (verified via `grep -rn 'continuationChain[A-Za-z]*\\s*??' src/` — only the helper itself remains).
- [x] `subagent-announce.ts` no longer holds an inline duplicate of the SessionEntry continuation fields at the value cast site (the runtime-import type signature is the unavoidable boundary type for the dynamic-import contract; removing it would require a static import that re-introduces the cycle #473 was fixing).
- [x] All six read sites pass via the new helper.
- [x] Existing tests pass.

## Verification

- `pnpm tsdown` build: green (full bundle).
- pre-commit hook (12 checks including `tsgo` full type-check, import-cycles, madge): green.
- Targeted vitest suites: 146/146 passed across touched modules:
  - `src/auto-reply/continuation/` — 54 tests
  - `src/agents/subagent-announce*.test.ts` — 10 tests
  - `src/auto-reply/status.test.ts` — 61 tests
  - `src/auto-reply/reply/followup-runner.test.ts` — 21 tests