### PR TITLE
test(continuation): update model constants in followup-runner.test.ts (#225)

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -279,8 +279,7 @@ async function loadFreshFollowupRunnerModuleForTest() {
     routeReply: (...args: unknown[]) => routeReplyMock(...args),
   }));
   vi.doMock("../continuation/delegate-dispatch.js", () => ({
-    dispatchToolDelegates: (...args: unknown[]) =>
-      dispatchToolDelegatesMock(...args),
+    dispatchToolDelegates: (...args: unknown[]) => dispatchToolDelegatesMock(...args),
   }));
   vi.doMock("../../cli/command-secret-gateway.js", () => ({
     resolveCommandSecretRefsViaGateway: (...args: unknown[]) =>
@@ -551,7 +550,7 @@ describe("createFollowupRunner compaction", () => {
       sessionStore,
       sessionKey: "main",
       storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
     });
 
     const queued = createQueuedRun({
@@ -603,7 +602,7 @@ describe("createFollowupRunner compaction", () => {
       sessionStore,
       sessionKey: "main",
       storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
     });
 
     const queued = createQueuedRun({
@@ -658,7 +657,7 @@ describe("createFollowupRunner compaction", () => {
       sessionStore,
       sessionKey: "main",
       storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
     });
 
     const queuedNext = createQueuedRun({
@@ -710,7 +709,7 @@ describe("createFollowupRunner compaction", () => {
       sessionStore,
       sessionKey: "main",
       storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
     });
 
     const queued = createQueuedRun({
@@ -857,7 +856,7 @@ describe("createFollowupRunner compaction", () => {
       sessionStore,
       sessionKey: "main",
       storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
       agentCfgContextTokens: 100_000,
     });
 
@@ -925,7 +924,7 @@ describe("createFollowupRunner bootstrap warning dedupe", () => {
       sessionEntry,
       sessionStore,
       sessionKey: "main",
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
     });
 
     await runner(baseQueuedRun());
@@ -960,7 +959,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
       opts: { onBlockReply },
       typing: createMockTypingController(),
       typingMode: "instant",
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
       sessionEntry: overrides.sessionEntry,
       sessionStore: overrides.sessionStore,
       sessionKey: overrides.sessionKey,
@@ -1025,7 +1024,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
           agentMeta: {
             usage: { input: 1_000, output: 50 },
             lastCallUsage: { input: 400, output: 20 },
-            model: "claude-opus-4-6",
+            model: "claude-sonnet-4-6",
             provider: "anthropic",
           },
         },
@@ -1044,12 +1043,12 @@ describe("createFollowupRunner messaging tool dedupe", () => {
       expect.objectContaining({
         storePath,
         sessionKey,
-        modelUsed: "claude-opus-4-6",
+        modelUsed: "claude-sonnet-4-6",
         providerUsed: "anthropic",
       }),
     );
     expect(sessionStore[sessionKey]?.totalTokens).toBe(400);
-    expect(sessionStore[sessionKey]?.model).toBe("claude-opus-4-6");
+    expect(sessionStore[sessionKey]?.model).toBe("claude-sonnet-4-6");
     // Accumulated usage is still stored for usage/cost tracking.
     expect(sessionStore[sessionKey]?.inputTokens).toBe(1_000);
     expect(sessionStore[sessionKey]?.outputTokens).toBe(50);
@@ -1074,7 +1073,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
         agentMeta: {
           usage: { input: 10, output: 5 },
           lastCallUsage: { input: 6, output: 3 },
-          model: "claude-opus-4-6",
+          model: "claude-sonnet-4-6",
         },
       },
     });
@@ -1083,7 +1082,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
       opts: { onBlockReply: createAsyncReplySpy() },
       typing: createMockTypingController(),
       typingMode: "instant",
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
       sessionEntry,
       sessionStore,
       sessionKey,
@@ -1122,7 +1121,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
         agentMeta: {
           usage: { input: 10, output: 5 },
           lastCallUsage: { input: 6, output: 3 },
-          model: "claude-opus-4-6",
+          model: "claude-sonnet-4-6",
           provider: "anthropic",
         },
       },
@@ -1132,7 +1131,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
       opts: { onBlockReply: createAsyncReplySpy() },
       typing: createMockTypingController(),
       typingMode: "instant",
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
       sessionEntry,
       sessionStore,
       sessionKey,
@@ -1240,7 +1239,7 @@ describe("createFollowupRunner typing cleanup", () => {
       opts: { onBlockReply: createAsyncReplySpy() },
       typing,
       typingMode: "instant",
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
     });
 
     await runner(baseQueuedRun());
@@ -1270,7 +1269,7 @@ describe("createFollowupRunner typing cleanup", () => {
       opts: { onBlockReply: vi.fn(async () => {}) },
       typing,
       typingMode: "instant",
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
     });
 
     await runner(baseQueuedRun());
@@ -1290,7 +1289,7 @@ describe("createFollowupRunner typing cleanup", () => {
       opts: { onBlockReply },
       typing,
       typingMode: "instant",
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
     });
 
     await runner(baseQueuedRun());
@@ -1368,7 +1367,7 @@ describe("createFollowupRunner agentDir forwarding", () => {
       opts: { onBlockReply },
       typing: createMockTypingController(),
       typingMode: "instant",
-      defaultModel: "anthropic/claude-opus-4-6",
+      defaultModel: "anthropic/claude-sonnet-4-6",
     });
     const agentDir = path.join("/tmp", "agent-dir");
     const queued = createQueuedRun();


### PR DESCRIPTION
## Summary

Closes karmaterminal/openclaw#225.

Per CLAUDE.md: *\"When tests need example Anthropic/OpenAI model constants, prefer \`sonnet-4.6\` and \`gpt-5.4\`; update older Anthropic/GPT examples when you touch those tests.\"*

\`followup-runner.test.ts\` is modified in the continuation PR train — the \"when you touch those tests\" clause triggers. 18 instances of \`claude-opus-4-6\` updated to \`claude-sonnet-4-6\`, keeping the hyphen form canonical in \`auto-reply/*\` tests (matches \`commands-status.thinking-default.test.ts\` and \`commands-models.test.ts\`).

No test behavior change: the model string flows through stubs and fixtures; no production code branches on the specific string.

## Test plan

- [x] \`pnpm tsgo\` clean
- [x] \`pnpm test src/auto-reply/reply/followup-runner.test.ts\` — 21/21 green

## Composes with other PRs

- No overlap with other in-flight karmafeast PRs.
- Does touch the same file Ronan's hypothetical #214-adjacent tests might extend; trivial conflict resolution if any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)