### PR TITLE
fix(continuation): honest "context_unknown" guard on followup path

### DIFF
--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -141,7 +141,7 @@ export type RunEmbeddedPiAgentParams = {
   /** Continuation: request_compaction tool opts (injected from execution context). */
   requestCompactionOpts?: {
     sessionId?: string;
-    getContextUsage: () => number;
+    getContextUsage: () => number | null;
     triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
   };
 };

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -321,7 +321,7 @@ export function createOpenClawCodingTools(options?: {
   /** Continuation: request_compaction tool opts (injected from execution context). */
   requestCompactionOpts?: {
     sessionId?: string;
-    getContextUsage: () => number;
+    getContextUsage: () => number | null;
     triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
   };
 }): AnyAgentTool[] {

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -150,7 +150,7 @@ export function resolveEffectiveToolInventory(
     requestCompactionOpts: continuationEnabled
       ? {
           sessionId: "<inventory-only>",
-          getContextUsage: () => 0,
+          getContextUsage: () => null,
           triggerCompaction: async () => ({
             ok: false,
             compacted: false,

--- a/src/agents/tools/request-compaction-tool.test.ts
+++ b/src/agents/tools/request-compaction-tool.test.ts
@@ -89,6 +89,22 @@ describe("request_compaction tool (swim-34/X5.1)", () => {
     expect(payload.guard).toBe("context_threshold");
   });
 
+  // (b2) context_unknown guard when getContextUsage returns null (Refs karmaterminal/openclaw#222).
+  // The followup-runner path has no live token count; returning null lets the
+  // tool surface that distinctly from the 70% floor instead of lying with `0`.
+  it("rejects with context_unknown guard when getContextUsage returns null", async () => {
+    const tool = createRequestCompactionTool(buildOpts({ getContextUsage: () => null }));
+    const result = await tool.execute("call-3c", { reason: TURN_REASON });
+    const payload = readJsonPayload(result);
+    expect(payload.status).toBe("rejected");
+    expect(payload.guard).toBe("context_unknown");
+    expect(payload.guard).not.toBe("context_threshold");
+    expect(payload.reason).toMatch(/not measurable/i);
+    // Should NOT carry a contextUsage / threshold field — we don't know.
+    expect(payload.contextUsage).toBeUndefined();
+    expect(payload.threshold).toBeUndefined();
+  });
+
   // (c) enqueue when >=70% no rate limit
   it("enqueues compaction when contextUsage >= MIN_CONTEXT_THRESHOLD and no rate limit", async () => {
     const triggerCompaction = vi.fn(async () => ({ ok: true, compacted: true }));

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -85,7 +85,14 @@ const RequestCompactionToolSchema = Type.Object({
 export type RequestCompactionToolOpts = {
   agentSessionKey?: string;
   sessionId?: string;
-  getContextUsage: () => number;
+  /**
+   * Returns context usage as a fraction in [0, 1], or `null` if the caller
+   * has no live token count to report (e.g. queued followup runs that don't
+   * receive `sessionTokenInfo`). When `null`, the tool replies with
+   * `guard: "context_unknown"` so callers learn the truth instead of
+   * tripping the 70% floor with a fake `0`. Refs karmaterminal/openclaw#222.
+   */
+  getContextUsage: () => number | null;
   triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
 };
 
@@ -130,6 +137,19 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
 
       // Guard: Context threshold
       const contextUsage = opts.getContextUsage();
+      // Honest "unknown" reply: callers without a live token count return
+      // `null`, and we surface that distinctly from the 70% floor rejection
+      // so the agent can route a follow-up turn to a path that has the data.
+      // (Refs karmaterminal/openclaw#222.)
+      if (contextUsage === null) {
+        log.debug(`[request_compaction:context-unknown] session=${sessionKey}`);
+        return jsonResult({
+          status: "rejected",
+          guard: "context_unknown",
+          reason:
+            "Context usage is not measurable on the current run path; request compaction from the main-session path where sessionTokenInfo is available.",
+        });
+      }
       if (contextUsage < MIN_CONTEXT_THRESHOLD) {
         log.debug(
           `[request_compaction:below-threshold] session=${sessionKey} usage=${(contextUsage * 100).toFixed(1)}%`,

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -95,7 +95,10 @@ export async function resolveCommandsSystemPromptBundle(
         requestCompactionOpts: continuationEnabled
           ? {
               sessionId: targetSessionEntry?.sessionId,
-              getContextUsage: () => 0,
+              // Inventory-only closure (no-op surface for /status & docs).
+              // Returning null is consistent with the new contract — never
+              // actually invoked. Refs karmaterminal/openclaw#222.
+              getContextUsage: () => null,
               triggerCompaction: async () => ({
                 ok: false,
                 compacted: false,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -262,9 +262,14 @@ export function createFollowupRunner(params: {
                     ? {
                         sessionId: run.sessionId,
                         getContextUsage: () => {
-                          // Followup path doesn't have a live token count yet —
-                          // the context-floor guard (70%) will reject premature calls.
-                          return 0;
+                          // Followup path doesn't have a live token count;
+                          // returning null makes request_compaction reply
+                          // with guard "context_unknown" instead of pretending
+                          // usage is 0% and tripping the 70% floor with a
+                          // misleading reason. Main-session callers (see
+                          // agent-runner-execution.ts) supply the real ratio
+                          // from sessionTokenInfo. Refs karmaterminal/openclaw#222.
+                          return null;
                         },
                         triggerCompaction: async () => {
                           try {


### PR DESCRIPTION
Closes karmaterminal/openclaw#222.

## Problem

`request_compaction` accepts a `getContextUsage: () => number` and applies a 70% floor before allowing compaction. The followup-runner path has no live token count yet, so it returned a hardcoded `0`. Result: every followup-path call to `request_compaction` was rejected with `guard: "context_threshold"` and a reason like *"Context usage (0%) is below the minimum threshold (70%)"*. The agent then learned the wrong fact: it thinks usage is too low when actually we have no measurement. Tool reply lies.

## Fix

Widen the contract from `() => number` to `() => number | null` and surface a distinct `guard: "context_unknown"` rejection when the caller has no measurement.

- **`agents/tools/request-compaction-tool.ts`**: type widen on `RequestCompactionToolOpts.getContextUsage`; new branch returning `status: "rejected", guard: "context_unknown", reason: "Context usage is not measurable on the current run path; request compaction from the main-session path where sessionTokenInfo is available."` (no fake `contextUsage`/`threshold` numbers).
- **`auto-reply/reply/followup-runner.ts`**: returns `null` with comment explaining why.
- **`auto-reply/reply/commands-system-prompt.ts`** + **`agents/tools-effective-inventory.ts`**: inventory closures return `null` for type consistency (never invoked at runtime).
- **`agents/pi-tools.ts`**, **`agents/pi-embedded-runner/run/params.ts`**: type signature widening.
- **Main-session caller** (`agent-runner-execution.ts`) is unchanged — it returns a real ratio from `sessionTokenInfo` and continues to hit the 70% floor honestly.

## Test

New case in `request-compaction-tool.test.ts`:
- `getContextUsage: () => null` →
  - `status === "rejected"`
  - `guard === "context_unknown"` (NOT `"context_threshold"`)
  - `reason` matches `/not measurable/i`
  - `contextUsage` and `threshold` are `undefined` (we don't know, don't make numbers up)

## Verify

```
pnpm test src/agents/tools/request-compaction-tool.test.ts   # 11/11 pass
pnpm test src/auto-reply/reply/followup-runner.test.ts        # 21/21 pass
pnpm exec tsc --noEmit -p tsconfig.json                       # clean
```

Pre-commit hooks (oxlint + webhook + auth lint + format) all green.

Refs karmaterminal/openclaw#222