### PR TITLE
test(continuation): pin silent / silent-wake / wakeOnReturn announce routing (#210)

### DIFF
--- a/src/agents/subagent-announce.silent-wake.test.ts
+++ b/src/agents/subagent-announce.silent-wake.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSubagentAnnounceDeliveryRuntimeMock } from "./subagent-announce.test-support.js";
+
+// Issue #210: pin the silent / silent-wake / wakeOnReturn announce routing
+// at src/agents/subagent-announce.ts:604-634. RFC §2.3 calls this the
+// specific fix for an observed six-minute stall — a canary-verified
+// behavior that must have a pinning test.
+//
+// Behaviors pinned (per issue #210):
+// 1. silentAnnounce:true, wakeOnReturn:true →
+//    - deliverSubagentAnnouncement NOT invoked
+//    - enqueueSystemEvent called with [continuation:enrichment-return] text + target session key
+//    - requestHeartbeatNow called with reason:"continuation"
+// 2. silentAnnounce:true, wakeOnReturn:false →
+//    - deliverSubagentAnnouncement NOT invoked
+//    - enqueueSystemEvent called (enrichment-return)
+//    - requestHeartbeatNow NOT called
+// 3. silentAnnounce:false →
+//    - deliverSubagentAnnouncement invoked
+//    - no enrichment-return event
+//    - no heartbeat wake
+
+const callGatewayMock = vi.fn(async (_request: unknown) => ({}));
+const loadSessionStoreMock = vi.fn((_storePath: string) => ({}) as Record<string, unknown>);
+const resolveAgentIdFromSessionKeyMock = vi.fn((sessionKey: string) => {
+  return sessionKey.match(/^agent:([^:]+)/)?.[1] ?? "main";
+});
+const resolveStorePathMock = vi.fn((_store: unknown, _options: unknown) => "/tmp/sessions.json");
+const resolveMainSessionKeyMock = vi.fn((_cfg: unknown) => "agent:main:main");
+const isEmbeddedPiRunActiveMock = vi.fn((_sessionId: string) => false);
+const queueEmbeddedPiMessageMock = vi.fn((_sessionId: string, _text: string) => false);
+const waitForEmbeddedPiRunEndMock = vi.fn(async (_sessionId: string, _timeoutMs?: number) => true);
+
+const dispatchToolDelegatesMock = vi.fn(async (_params: unknown) => ({
+  dispatched: 0,
+  rejected: 0,
+}));
+const resolveContinuationRuntimeConfigMock = vi.fn((_cfg?: unknown) => ({
+  enabled: true,
+  taskFlowDelegates: true,
+  defaultDelayMs: 15_000,
+  minDelayMs: 5_000,
+  maxDelayMs: 300_000,
+  maxChainLength: 10,
+  costCapTokens: 500_000,
+  maxDelegatesPerTurn: 5,
+  contextPressureThreshold: undefined,
+}));
+
+// The silent/wake routing seam: these are dynamic-imported INSIDE the
+// runSubagentAnnounceFlow body, so they must be mocked at module level
+// for vi.mock to intercept the dynamic import.
+const enqueueSystemEventMock = vi.fn((_text: string, _options?: unknown) => undefined);
+const requestHeartbeatNowMock = vi.fn((_options: unknown) => undefined);
+
+// Spy on the ordinary delivery path (not silent) so we can assert it
+// is NOT called when silentAnnounce is true.
+const deliverSubagentAnnouncementMock = vi.fn(async (_params: unknown) => ({
+  delivered: true,
+  path: "direct" as const,
+}));
+
+let mockConfig: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
+  session: { mainKey: "main", scope: "per-sender" },
+};
+
+const { subagentRegistryRuntimeMock } = vi.hoisted(() => ({
+  subagentRegistryRuntimeMock: {
+    shouldIgnorePostCompletionAnnounceForSession: vi.fn(() => false),
+    isSubagentSessionRunActive: vi.fn(() => true),
+    countActiveDescendantRuns: vi.fn(() => 0),
+    countPendingDescendantRuns: vi.fn(() => 0),
+    countPendingDescendantRunsExcludingRun: vi.fn(() => 0),
+    listSubagentRunsForRequester: vi.fn(() => []),
+    replaceSubagentRunAfterSteer: vi.fn(() => true),
+    resolveRequesterForChildSession: vi.fn(() => null),
+  },
+}));
+
+vi.mock("./subagent-announce.runtime.js", () => ({
+  callGateway: (request: unknown) => callGatewayMock(request),
+  isEmbeddedPiRunActive: (sessionId: string) => isEmbeddedPiRunActiveMock(sessionId),
+  loadConfig: () => mockConfig,
+  loadSessionStore: (storePath: string) => loadSessionStoreMock(storePath),
+  queueEmbeddedPiMessage: (sessionId: string, text: string) =>
+    queueEmbeddedPiMessageMock(sessionId, text),
+  resolveAgentIdFromSessionKey: (sessionKey: string) =>
+    resolveAgentIdFromSessionKeyMock(sessionKey),
+  resolveMainSessionKey: (cfg: unknown) => resolveMainSessionKeyMock(cfg),
+  resolveStorePath: (store: unknown, options: unknown) => resolveStorePathMock(store, options),
+  waitForEmbeddedPiRunEnd: (sessionId: string, timeoutMs?: number) =>
+    waitForEmbeddedPiRunEndMock(sessionId, timeoutMs),
+}));
+
+vi.mock("./subagent-announce-delivery.runtime.js", () =>
+  createSubagentAnnounceDeliveryRuntimeMock({
+    callGateway: (request: unknown) => callGatewayMock(request),
+    loadConfig: () => mockConfig,
+    loadSessionStore: (storePath: string) => loadSessionStoreMock(storePath),
+    resolveAgentIdFromSessionKey: (sessionKey: string) =>
+      resolveAgentIdFromSessionKeyMock(sessionKey),
+    resolveMainSessionKey: (cfg: unknown) => resolveMainSessionKeyMock(cfg),
+    resolveStorePath: (store: unknown, options: unknown) => resolveStorePathMock(store, options),
+    isEmbeddedPiRunActive: (sessionId: string) => isEmbeddedPiRunActiveMock(sessionId),
+    queueEmbeddedPiMessage: (sessionId: string, text: string) =>
+      queueEmbeddedPiMessageMock(sessionId, text),
+  }),
+);
+
+vi.mock("./subagent-announce-delivery.js", () => ({
+  deliverSubagentAnnouncement: (params: unknown) => deliverSubagentAnnouncementMock(params),
+  loadRequesterSessionEntry: (sessionKey: string) => {
+    const store = loadSessionStoreMock("/tmp/sessions.json");
+    return { entry: store?.[sessionKey] };
+  },
+  loadSessionEntryByKey: (sessionKey: string) => {
+    const store = loadSessionStoreMock("/tmp/sessions.json");
+    return store?.[sessionKey];
+  },
+  resolveAnnounceOrigin: (
+    _entry: unknown,
+    requesterOrigin?: { channel?: string; to?: string; accountId?: string; threadId?: string },
+  ) => requesterOrigin ?? {},
+  resolveSubagentCompletionOrigin: async (params: { requesterOrigin?: unknown }) =>
+    params.requesterOrigin,
+  resolveSubagentAnnounceTimeoutMs: () => 10_000,
+  runAnnounceDeliveryWithRetry: async <T>(params: { run: () => Promise<T> }) => await params.run(),
+}));
+
+vi.mock("./subagent-announce.registry.runtime.js", () => subagentRegistryRuntimeMock);
+
+vi.mock("../auto-reply/continuation/delegate-dispatch.js", () => ({
+  dispatchToolDelegates: (params: unknown) => dispatchToolDelegatesMock(params),
+}));
+
+vi.mock("../auto-reply/continuation/config.js", () => ({
+  resolveContinuationRuntimeConfig: (cfg?: unknown) => resolveContinuationRuntimeConfigMock(cfg),
+}));
+
+// Dynamic-imported by the silent/wake branch. Both are intercepted at
+// module-resolution time via vi.mock, so the dynamic import yields the
+// mock implementation.
+vi.mock("../infra/system-events.js", () => ({
+  enqueueSystemEvent: (text: string, options?: unknown) => enqueueSystemEventMock(text, options),
+}));
+
+vi.mock("../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (options: unknown) => requestHeartbeatNowMock(options),
+}));
+
+import { runSubagentAnnounceFlow } from "./subagent-announce.js";
+
+const childSessionKey = "agent:main:subagent:silent-test";
+const requesterSessionKey = "agent:main:main";
+
+function seedDefaultStore() {
+  loadSessionStoreMock.mockImplementation(
+    () =>
+      ({
+        [childSessionKey]: {
+          sessionId: "session-silent-child",
+          updatedAt: Date.now(),
+        },
+        [requesterSessionKey]: {
+          sessionId: "session-main",
+          updatedAt: Date.now(),
+        },
+      }) as Record<string, unknown>,
+  );
+}
+
+const baseParams = {
+  childSessionKey,
+  childRunId: "run-silent",
+  requesterSessionKey,
+  requesterDisplayKey: "main",
+  task: "silent-wake routing fixture",
+  timeoutMs: 100,
+  cleanup: "delete" as const,
+  waitForCompletion: false,
+  startedAt: 10,
+  endedAt: 20,
+  outcome: { status: "ok" as const },
+  roundOneReply: "done",
+};
+
+describe("subagent-announce silent / silent-wake / wakeOnReturn routing (#210, RFC §2.3)", () => {
+  beforeEach(() => {
+    callGatewayMock.mockReset().mockImplementation(async () => ({}));
+    dispatchToolDelegatesMock.mockReset().mockResolvedValue({ dispatched: 0, rejected: 0 });
+    loadSessionStoreMock.mockReset();
+    resolveAgentIdFromSessionKeyMock.mockReset().mockImplementation(() => "main");
+    resolveStorePathMock.mockReset().mockImplementation(() => "/tmp/sessions.json");
+    resolveMainSessionKeyMock.mockReset().mockImplementation(() => "agent:main:main");
+    isEmbeddedPiRunActiveMock.mockReset().mockReturnValue(false);
+    queueEmbeddedPiMessageMock.mockReset().mockReturnValue(false);
+    waitForEmbeddedPiRunEndMock.mockReset().mockResolvedValue(true);
+    enqueueSystemEventMock.mockReset();
+    requestHeartbeatNowMock.mockReset();
+    deliverSubagentAnnouncementMock
+      .mockReset()
+      .mockResolvedValue({ delivered: true, path: "direct" });
+    mockConfig = {
+      agents: { defaults: { continuation: { enabled: true } } },
+      session: { mainKey: "main", scope: "per-sender" },
+    };
+    subagentRegistryRuntimeMock.shouldIgnorePostCompletionAnnounceForSession
+      .mockReset()
+      .mockReturnValue(false);
+    subagentRegistryRuntimeMock.isSubagentSessionRunActive.mockReset().mockReturnValue(true);
+    subagentRegistryRuntimeMock.countPendingDescendantRuns.mockReset().mockReturnValue(0);
+    subagentRegistryRuntimeMock.listSubagentRunsForRequester.mockReset().mockReturnValue([]);
+    subagentRegistryRuntimeMock.resolveRequesterForChildSession.mockReset().mockReturnValue(null);
+  });
+
+  it("silentAnnounce:true + wakeOnReturn:true → enqueues system event AND wakes parent", async () => {
+    seedDefaultStore();
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      ...baseParams,
+      silentAnnounce: true,
+      wakeOnReturn: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+
+    // No channel delivery on the silent path.
+    expect(deliverSubagentAnnouncementMock).not.toHaveBeenCalled();
+
+    // System event delivered to the requester session.
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    const [eventText, eventOptions] = enqueueSystemEventMock.mock.calls[0] as [
+      string,
+      { sessionKey?: string } | undefined,
+    ];
+    expect(typeof eventText).toBe("string");
+    expect(eventText.length).toBeGreaterThan(0);
+    expect(eventOptions?.sessionKey).toBe(requesterSessionKey);
+
+    // Heartbeat wake fired with continuation reason.
+    expect(requestHeartbeatNowMock).toHaveBeenCalledTimes(1);
+    const wakeOptions = requestHeartbeatNowMock.mock.calls[0]?.[0] as {
+      sessionKey?: string;
+      reason?: string;
+    };
+    expect(wakeOptions?.sessionKey).toBe(requesterSessionKey);
+    expect(wakeOptions?.reason).toBe("continuation");
+  });
+
+  it("silentAnnounce:true + wakeOnReturn:false → enqueues system event but does NOT wake", async () => {
+    seedDefaultStore();
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      ...baseParams,
+      silentAnnounce: true,
+      wakeOnReturn: false,
+    });
+
+    expect(didAnnounce).toBe(true);
+
+    expect(deliverSubagentAnnouncementMock).not.toHaveBeenCalled();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    const [, eventOptions] = enqueueSystemEventMock.mock.calls[0] as [
+      string,
+      { sessionKey?: string } | undefined,
+    ];
+    expect(eventOptions?.sessionKey).toBe(requesterSessionKey);
+
+    // Critical: no wake when wakeOnReturn is false.
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("silentAnnounce:true with omitted wakeOnReturn → enqueues system event but does NOT wake", async () => {
+    // Defensive: a silent announce without an explicit wakeOnReturn must
+    // not surprise-wake the parent. The default for wakeOnReturn is falsy.
+    seedDefaultStore();
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      ...baseParams,
+      silentAnnounce: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(deliverSubagentAnnouncementMock).not.toHaveBeenCalled();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("silentAnnounce:true → system event text references the task label", async () => {
+    seedDefaultStore();
+
+    await runSubagentAnnounceFlow({
+      ...baseParams,
+      task: "unique-task-marker-RFC23",
+      silentAnnounce: true,
+      wakeOnReturn: true,
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    const [eventText] = enqueueSystemEventMock.mock.calls[0] as [
+      string,
+      { sessionKey?: string } | undefined,
+    ];
+    // Either the explicit completion trigger message or the fallback
+    // `[continuation:enrichment-return] Delegate completed: <task>` text
+    // must contain the task label so the parent can identify the source.
+    expect(eventText).toContain("unique-task-marker-RFC23");
+  });
+
+  it("silentAnnounce:false → ordinary delivery, no enrichment-return event, no wake", async () => {
+    seedDefaultStore();
+
+    await runSubagentAnnounceFlow({
+      ...baseParams,
+      silentAnnounce: false,
+      wakeOnReturn: false,
+    });
+
+    // Ordinary delivery path runs.
+    expect(deliverSubagentAnnouncementMock).toHaveBeenCalledTimes(1);
+
+    // No silent-path side effects.
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("silentAnnounce omitted → ordinary delivery, no silent-path side effects", async () => {
+    // Defensive: missing silentAnnounce must behave identically to false.
+    seedDefaultStore();
+
+    await runSubagentAnnounceFlow(baseParams);
+
+    expect(deliverSubagentAnnouncementMock).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #210.

RFC §2.3 calls the silent/wake routing at `subagent-announce.ts:604-634` the specific fix for an observed six-minute stall. **Zero behavioral tests covered it** before this PR. A refactor that drops the `enqueueSystemEvent` call, drops the `requestHeartbeatNow` call, or inverts the `silentAnnounce` guard would ship green today.

## Coverage (6 assertions)

1. `silentAnnounce:true` + `wakeOnReturn:true` → no channel delivery, system event on requester, heartbeat wake fired with `reason:'continuation'`.
2. `silentAnnounce:true` + `wakeOnReturn:false` → no channel delivery, system event on requester, **no** wake.
3. `silentAnnounce:false` → ordinary delivery, no enrichment-return event, no wake.
4. `silentAnnounce` omitted → ordinary delivery (defensive default).
5. `silentAnnounce:true` + omitted `wakeOnReturn` → no surprise wake (defensive default).
6. `silentAnnounce:true` → enrichment text references the task label.

Mock pattern mirrors `subagent-announce.continuation-drain.test.ts`. Module-level `vi.mock` for `../infra/system-events.js` and `../infra/heartbeat-wake.js` intercepts the dynamic imports inside `runSubagentAnnounceFlow`.

+337/-0, 1 file (new test file only). 6/6 vitest green.

Note: PR base is canary; auto-close won't trigger via GH on merge here — close #210 manually after canary→main squash, or it can ride the squash itself.