### PR TITLE
Add continuation/lazy.runtime.ts boundary; route dynamic imports through it (closes #220)

### DIFF
--- a/src/auto-reply/continuation/lazy.runtime.ts
+++ b/src/auto-reply/continuation/lazy.runtime.ts
@@ -1,0 +1,42 @@
+// Lazy-side boundary for the continuation/* singleton-bearing modules.
+//
+// CLAUDE.md rule: "Do not mix `await import('x')` and static `import ... from 'x'`
+// for the same module in production code paths." The continuation modules
+// (config, delegate-store, delegate-dispatch, state, context-pressure) carry
+// per-process singleton state (Maps, ref counts, TaskFlow handles) and were
+// being imported both statically (hot paths) and dynamically (cold paths) from
+// agent-runner / followup-runner / status / commands surface. Rolldown was
+// emitting them in two chunks with two separate Map identities — the bug
+// surfaced by #584 (continue_work tool calls silently dropped) and worked
+// around at tsdown.config.ts:147 by promoting agent-runner.runtime to a
+// unified-graph entry.
+//
+// This module is the dedicated lazy-side entry. Every cold-path consumer
+// (delayed dispatch, post-compaction drain, context-pressure trip,
+// chain-state persist, status-command CLI) routes its `await import(...)` /
+// `require(...)` through here instead of pulling the underlying module
+// directly. The static-side consumers (status.ts, agent-runner top-level,
+// continue-{work,delegate}-tool, subagent-announce.continuation.runtime) keep
+// their direct static imports.
+//
+// Boundary rule: NO file in src/ may statically import from this module —
+// that would defeat the lazy split. Enforced by the CLAUDE.md guardrail and
+// caught at review time. The static-side surface continues to import the
+// underlying modules directly; this entry exists only to give dynamic
+// consumers a single bundler-stable target so rolldown can dedupe the
+// singleton chunks.
+//
+// Registered as a tsdown bundler entry: `auto-reply/continuation/lazy.runtime`
+// in `tsdown.config.ts`.
+//
+// RFC: docs/design/continue-work-signal-v2.md §6.4 (lazy-side dedupe).
+
+export { resolveContinuationRuntimeConfig } from "./config.js";
+export { dispatchToolDelegates } from "./delegate-dispatch.js";
+export {
+  consumeStagedPostCompactionDelegates,
+  pendingDelegateCount,
+  stagedPostCompactionDelegateCount,
+} from "./delegate-store.js";
+export { checkContextPressure, clearContextPressureState } from "./context-pressure.js";
+export { loadContinuationChainState, persistContinuationChainState } from "./state.js";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1184,7 +1184,7 @@ export async function runReplyAgent(params: {
     // Fire before the agent turn so the agent can act on pressure in this turn.
     const continuationEnabledForPressure = cfg?.agents?.defaults?.continuation?.enabled === true;
     if (continuationEnabledForPressure && sessionKey && activeSessionEntry) {
-      const { checkContextPressure } = await import("../continuation/context-pressure.js");
+      const { checkContextPressure } = await import("../continuation/lazy.runtime.js");
       const pressureConfig = resolveContinuationRuntimeConfig(cfg);
       const threshold = pressureConfig.contextPressureThreshold;
       // Resolve context window for pressure calculation — agentCfgContextTokens
@@ -1618,10 +1618,11 @@ export async function runReplyAgent(params: {
         // --- Post-compaction continuation lifecycle (RFC §4.4) ---
         // Release staged post-compaction delegates and fire context-pressure event.
         if (continuationEnabledForPressure) {
-          const { consumeStagedPostCompactionDelegates } =
-            await import("../continuation/delegate-store.js");
-          const { clearContextPressureState, checkContextPressure } =
-            await import("../continuation/context-pressure.js");
+          const {
+            consumeStagedPostCompactionDelegates,
+            clearContextPressureState,
+            checkContextPressure,
+          } = await import("../continuation/lazy.runtime.js");
 
           // Clear pressure dedup so post-compaction lifecycle can fire fresh bands.
           clearContextPressureState(sessionKey);
@@ -1861,7 +1862,7 @@ export async function runReplyAgent(params: {
       const dispatchChainState = loadContinuationChainState(activeSessionEntry, {
         extraTokens: turnTokens,
       });
-      const { dispatchToolDelegates } = await import("../continuation/delegate-dispatch.js");
+      const { dispatchToolDelegates } = await import("../continuation/lazy.runtime.js");
       await dispatchToolDelegates({
         sessionKey,
         chainState: dispatchChainState,
@@ -1883,7 +1884,7 @@ export async function runReplyAgent(params: {
       sessionKey &&
       activeSessionEntry
     ) {
-      const { persistContinuationChainState } = await import("../continuation/state.js");
+      const { persistContinuationChainState } = await import("../continuation/lazy.runtime.js");
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
       const persistState = loadContinuationChainState(activeSessionEntry, {
         extraTokens: turnTokens,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -353,15 +353,11 @@ export function createFollowupRunner(params: {
       // (or any followup turn) stay in the queue until the NEXT inbound
       // message arrives to trigger the main-session dispatch. RFC §3.2.
       if (runtimeConfig?.agents?.defaults?.continuation?.enabled === true && sessionKey) {
-        const [
-          { dispatchToolDelegates },
-          { resolveContinuationRuntimeConfig },
-          { loadContinuationChainState },
-        ] = await Promise.all([
-          import("../continuation/delegate-dispatch.js"),
-          import("../continuation/config.js"),
-          import("../continuation/state.js"),
-        ]);
+        const {
+          dispatchToolDelegates,
+          resolveContinuationRuntimeConfig,
+          loadContinuationChainState,
+        } = await import("../continuation/lazy.runtime.js");
         const tailUsage = runResult.meta?.agentMeta?.usage;
         const turnTokens = (tailUsage?.input ?? 0) + (tailUsage?.output ?? 0);
         const tailEntry = (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -154,6 +154,14 @@ function buildCoreDistEntries(): Record<string, string> {
     "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
     "agents/subagent-announce.continuation.runtime":
       "src/agents/subagent-announce.continuation.runtime.ts",
+    // #220: continuation/lazy.runtime is the dedicated lazy-side boundary for
+    // continuation/{config,delegate-store,delegate-dispatch,state,context-pressure}.
+    // Promoting to a unified-graph entry guarantees rolldown dedupes the
+    // singleton-bearing modules between the lazy chunk and the static-side
+    // hot-path callers (status.ts, agent-runner top-level, continue-*-tool).
+    // Eliminates the same dual-chunk split class of bug that #584 worked around
+    // for agent-runner.runtime.
+    "auto-reply/continuation/lazy.runtime": "src/auto-reply/continuation/lazy.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",


### PR DESCRIPTION
Closes #220. **Stacked on PR #250** (silas/216-continuation-chain-state-helper) — review/merge that one first; this branch will re-target canary on merge.

## Summary

The continuation singleton-bearing modules (`config`, `delegate-store`, `delegate-dispatch`, `state`, `context-pressure`) were imported both **statically** (hot paths in `status.ts`, `agent-runner` top-level, `continue-{work,delegate}-tool`, `subagent-announce.continuation.runtime`) AND **dynamically** (cold paths in `agent-runner` conditional dispatch + chain-state persist + context-pressure trip, `followup-runner` tail dispatch).

This violates the CLAUDE.md rule against mixed static+dynamic imports of the same module — exactly the dual-chunk split that #584 worked around for `agent-runner.runtime` (silently dropped `continue_work` tool calls).

This change introduces a dedicated lazy-side boundary at `src/auto-reply/continuation/lazy.runtime.ts` that re-exports the symbols used on lazy paths. Every dynamic consumer in the auto-reply surface routes through it, giving rolldown a single bundler-stable target for the singleton-chunk dedupe.

## lazy.runtime.ts surface

```ts
export { resolveContinuationRuntimeConfig } from "./config.js";
export { dispatchToolDelegates } from "./delegate-dispatch.js";
export {
  consumeStagedPostCompactionDelegates,
  pendingDelegateCount,
  stagedPostCompactionDelegateCount,
} from "./delegate-store.js";
export { checkContextPressure, clearContextPressureState } from "./context-pressure.js";
export {
  loadContinuationChainState,
  persistContinuationChainState,
} from "./state.js";
```

## Call-site conversions

| File | Line | Before | After |
|---|---|---|---|
| `agent-runner.ts` | 1187 | `await import('../continuation/context-pressure.js')` | → `lazy.runtime.js` |
| `agent-runner.ts` | 1622 | two separate imports (delegate-store + context-pressure) | → single `lazy.runtime.js` destructure |
| `agent-runner.ts` | 1864 | `await import('../continuation/delegate-dispatch.js')` | → `lazy.runtime.js` |
| `agent-runner.ts` | 1886 | `await import('../continuation/state.js')` | → `lazy.runtime.js` |
| `followup-runner.ts` | 355 | `Promise.all` over 3 separate imports | → single `lazy.runtime.js` destructure |

## Bundler entry

`tsdown.config.ts` registers `auto-reply/continuation/lazy.runtime` as a unified-graph entry, mirroring the #584 pattern for `agent-runner.runtime`. Rolldown emits the singleton modules in the same chunk identity as the static-side hot-path callers.

## Boundary rule

NO file in `src/` statically imports from `lazy.runtime.js` — verified via `grep -rn 'from "[^"]*continuation/lazy\.runtime\.js"' src/` (empty). That would defeat the lazy split.

## Out of scope (covered by sibling PRs)

- **`src/commands/status.command-report-data.ts`** still uses `require()` of `config` + `delegate-store`. Cael's PR #247 (closes #221) converts those to **static** top-level imports — a different valid resolution of the same mixed-import case for the commands surface (CJS interop boundary, sync IIFE that can't easily go async). Stacking the two PRs leaves the commands surface fully static and the auto-reply surface fully boundary-routed.
- The pre-existing `agents/subagent-announce.continuation.runtime.ts` re-exporter (boundary for the subagent-announce → continuation cycle, documented at #473) is left alone. It serves a different purpose (cycle break, not lazy dedupe) and is correct as-is.
- The `#584` `coreDistEntries` workaround for `agent-runner.runtime` is **retained** — it targets a different dynamic-import site (`get-reply-run.ts:108`) that is not within #220's scope.

## Acceptance Criteria

- [x] `lazy.runtime.ts` created; re-exports the symbols used on lazy paths.
- [x] Every dynamic import of `continuation/{config,delegate-store,delegate-dispatch,state,context-pressure}.js` in the auto-reply surface routes through `lazy.runtime.js`.
- [x] No file statically imports from `lazy.runtime.js` (verified by grep).
- [x] `pnpm build` clean, no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings.
- [x] `pnpm check:import-cycles` + `pnpm check:madge-import-cycles` both 0 cycles.
- [ ] Commands-surface mixed-import resolved → covered by PR #247.

## Verification

- pnpm tsdown build: green.
- pnpm check:import-cycles: 0 cycles.
- pnpm check:madge-import-cycles: 0 cycles.
- Targeted vitest: **140/140 passed** across `continuation/`, `subagent-announce.continuation.runtime`, `status`, `followup-runner`.
- pre-commit hook (12 checks: no-conflict-markers, tool-display, host-env, import-cycles, madge, **tsgo**, prepare-boundary, lint, webhook, pairing): green.