### PR TITLE
test(continuation): add registration visibility coverage for request_compaction (#151)

### DIFF
--- a/src/agents/openclaw-tools.continuation-registration.test.ts
+++ b/src/agents/openclaw-tools.continuation-registration.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock loadConfig + resolveGatewayPort the same way other openclaw-tools.* tests do,
+// so calls inside createOpenClawTools that read shared config don't reach the real
+// disk-backed loader.
+let mockConfig: Record<string, unknown> = {
+  session: { mainKey: "main", scope: "per-sender" },
+};
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    loadConfig: () => mockConfig,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+// Skip plugin tool resolution (we pass `disablePluginTools: true`), but the
+// import graph still loads it; stub the heavy bits.
+vi.mock("../plugins/tools.js", async () => {
+  const actual = await vi.importActual<typeof import("../plugins/tools.js")>("../plugins/tools.js");
+  return {
+    ...actual,
+    getPluginToolMeta: () => undefined,
+  };
+});
+
+import { createOpenClawTools } from "./openclaw-tools.js";
+
+const CONTINUATION_TOOLS = ["continue_work", "continue_delegate", "request_compaction"] as const;
+
+function buildRequestCompactionOpts() {
+  return {
+    sessionId: "test-session-x5.1",
+    getContextUsage: () => 0.85,
+    triggerCompaction: vi.fn(async () => ({ ok: true, compacted: true })),
+  };
+}
+
+function continuationToolNames(tools: Array<{ name: string }>): string[] {
+  return tools
+    .map((t) => t.name)
+    .filter((name): name is (typeof CONTINUATION_TOOLS)[number] =>
+      (CONTINUATION_TOOLS as readonly string[]).includes(name),
+    );
+}
+
+describe("createOpenClawTools — continuation-tool registration visibility (#151)", () => {
+  it("registers no continuation tools when continuation.enabled is unset", () => {
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: { session: { mainKey: "main", scope: "per-sender" } } as never,
+    });
+    expect(continuationToolNames(tools)).toEqual([]);
+  });
+
+  it("registers no continuation tools when continuation.enabled is explicitly false", () => {
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: false } } },
+      } as never,
+    });
+    expect(continuationToolNames(tools)).toEqual([]);
+  });
+
+  it("does not register request_compaction when continuation.enabled is true but requestCompactionOpts is missing", () => {
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+    });
+    const names = continuationToolNames(tools);
+    expect(names).toContain("continue_work");
+    expect(names).toContain("continue_delegate");
+    expect(names).not.toContain("request_compaction");
+  });
+
+  it("registers request_compaction when continuation.enabled is true AND requestCompactionOpts is provided", () => {
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+      requestCompactionOpts: buildRequestCompactionOpts(),
+    });
+    const names = continuationToolNames(tools);
+    expect(names).toContain("continue_work");
+    expect(names).toContain("continue_delegate");
+    expect(names).toContain("request_compaction");
+  });
+
+  it("does not register request_compaction even with opts when continuation.enabled is unset", () => {
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: { session: { mainKey: "main", scope: "per-sender" } } as never,
+      requestCompactionOpts: buildRequestCompactionOpts(),
+    });
+    expect(continuationToolNames(tools)).toEqual([]);
+  });
+
+  it("registers request_compaction with the expected tool surface (name + parameters present)", () => {
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+      requestCompactionOpts: buildRequestCompactionOpts(),
+    });
+    const requestCompaction = tools.find((t) => t.name === "request_compaction");
+    expect(requestCompaction).toBeDefined();
+    expect(requestCompaction?.parameters).toBeDefined();
+    expect(typeof requestCompaction?.execute).toBe("function");
+  });
+
+  it("registers continuation tools at most once per createOpenClawTools call", () => {
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+      requestCompactionOpts: buildRequestCompactionOpts(),
+    });
+    const names = continuationToolNames(tools);
+    const counts = new Map<string, number>();
+    for (const name of names) {
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    for (const [name, count] of counts) {
+      expect(count, `tool ${name} should appear exactly once`).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
Closes #151.

## Summary

Adds explicit registration / visibility tests for the continuation tool surface in `createOpenClawTools` (`src/agents/openclaw-tools.ts:312-330`).

The Swim-29 review flagged that we had no test pinning the conditional registration of `request_compaction` (and adjacent `continue_work` / `continue_delegate`) to the `continuation.enabled` + `requestCompactionOpts` two-key gate. This PR closes that coverage gap.

## Tests

`src/agents/openclaw-tools.continuation-registration.test.ts` — 7 cases, 7/7 pass:

- no continuation tools when `continuation.enabled` is unset
- no continuation tools when `continuation.enabled` is explicitly `false`
- `continue_work` + `continue_delegate` present when `continuation.enabled === true`, but `request_compaction` absent if `requestCompactionOpts` is missing
- `request_compaction` present iff `continuation.enabled === true` AND `requestCompactionOpts` is provided
- `request_compaction` not present even with opts if `continuation.enabled` is unset
- registered tool surface check (`name` + `parameters` + `execute`)
- continuation tools registered at most once per call

Mirrors `openclaw-tools.pdf-registration.test.ts` precedent for factory-side registration coverage.

## Verification

```
vitest run src/agents/openclaw-tools.continuation-registration.test.ts
Test Files  1 passed (1)
     Tests  7 passed (7)
```

Full pre-commit + lint + tsgo green.