### PR TITLE
test(continuation): pin post-compaction lifecycle release path (#211)

### DIFF
--- a/src/auto-reply/continuation/post-compaction-release.test.ts
+++ b/src/auto-reply/continuation/post-compaction-release.test.ts
@@ -25,7 +25,8 @@
  *
  * See: openclaw#211.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { releasePostCompactionLifecycle } from "./post-compaction-release.js";
 
 const mockState = vi.hoisted(() => ({
@@ -75,10 +76,6 @@ const ORIGINATING = {
 beforeEach(() => {
   vi.clearAllMocks();
   mockState.spawnSubagentDirect.mockResolvedValue(undefined);
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
 });
 
 describe("releasePostCompactionLifecycle (openclaw#211)", () => {
@@ -269,9 +266,8 @@ describe("releasePostCompactionLifecycle (openclaw#211)", () => {
       activeSessionEntry: { totalTokens: 50_000, contextTokens: undefined },
       originating: ORIGINATING,
     });
-    const lastCall = mockState.checkContextPressure.mock.calls.at(-1);
-    expect(lastCall?.[0]?.contextWindow).toBeGreaterThan(0);
-    expect(lastCall?.[0]?.contextWindow).not.toBe(100_000);
-    expect(lastCall?.[0]?.contextWindow).not.toBe(75_000);
+    expect(mockState.checkContextPressure).toHaveBeenLastCalledWith(
+      expect.objectContaining({ contextWindow: DEFAULT_CONTEXT_TOKENS }),
+    );
   });
 });

--- a/src/auto-reply/continuation/post-compaction-release.test.ts
+++ b/src/auto-reply/continuation/post-compaction-release.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for the post-compaction continuation lifecycle release path
+ * (RFC §4.4) extracted from agent-runner.ts:1617-1700.
+ *
+ * Pins the integration of the three steps that fire AFTER both
+ * `continuationEnabledForPressure` and `preflightCompactionApplied` gates:
+ *
+ *   1. `clearContextPressureState(sessionKey)` runs first.
+ *   2. `checkContextPressure({ postCompaction: true })` is consulted and
+ *      its return value (when truthy) is enqueued as a system event.
+ *   3. `consumeStagedPostCompactionDelegates(sessionKey)` is drained and
+ *      each returned delegate is dispatched with the canonical flag set
+ *      (`silentAnnounce: true, wakeOnReturn: true,
+ *       drainsContinuationDelegateQueue: true`) via
+ *      `dispatchPostCompactionDelegates` → `spawnSubagentDirect`.
+ *
+ * Negative paths covered by the agent-runner caller are pinned at the
+ * helper boundary: when no delegates are staged, no spawn fires; when
+ * pressure inputs are absent, no pressure event is enqueued.
+ *
+ * The agent-runner-side `preflightCompactionApplied === false` /
+ * `continuationEnabledForPressure === false` gates are caller-side
+ * checks (verified by code reading) — the helper itself runs only when
+ * both are satisfied. See `agent-runner.ts:1621`.
+ *
+ * See: openclaw#211.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { releasePostCompactionLifecycle } from "./post-compaction-release.js";
+
+const mockState = vi.hoisted(() => ({
+  consumeStagedPostCompactionDelegates: vi.fn(),
+  clearContextPressureState: vi.fn(),
+  checkContextPressure: vi.fn(),
+  spawnSubagentDirect: vi.fn(),
+  enqueueSystemEvent: vi.fn(),
+}));
+
+vi.mock("./lazy.runtime.js", () => ({
+  consumeStagedPostCompactionDelegates: mockState.consumeStagedPostCompactionDelegates,
+  clearContextPressureState: mockState.clearContextPressureState,
+  checkContextPressure: mockState.checkContextPressure,
+}));
+
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  spawnSubagentDirect: mockState.spawnSubagentDirect,
+}));
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: mockState.enqueueSystemEvent,
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("./config.js", () => ({
+  resolveContinuationRuntimeConfig: () => ({ contextPressureThreshold: 0.8 }),
+}));
+
+const SESSION_KEY = "channel:cael-211";
+
+const ORIGINATING = {
+  originatingChannel: "discord",
+  originatingAccountId: "default",
+  originatingTo: "channel:1466192485440164011",
+  originatingThreadId: undefined,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState.spawnSubagentDirect.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("releasePostCompactionLifecycle (openclaw#211)", () => {
+  it("happy path: clears pressure state, fires post-compaction pressure event, and dispatches each staged delegate with the canonical flag set", async () => {
+    mockState.checkContextPressure.mockReturnValue("[continuation] post-compaction band fired");
+    mockState.consumeStagedPostCompactionDelegates.mockReturnValue([
+      { task: "rehydrate working state for issue X" },
+      { task: "rehydrate working state for issue Y" },
+    ]);
+
+    const result = await releasePostCompactionLifecycle({
+      sessionKey: SESSION_KEY,
+      cfg: undefined,
+      agentCfgContextTokens: 200_000,
+      activeSessionEntry: { totalTokens: 180_000, contextTokens: 200_000 },
+      originating: ORIGINATING,
+    });
+
+    // (1) Pressure dedup cleared FIRST so the post-compaction band fires fresh.
+    expect(mockState.clearContextPressureState).toHaveBeenCalledTimes(1);
+    expect(mockState.clearContextPressureState).toHaveBeenCalledWith(SESSION_KEY);
+
+    // (2) Pressure check consulted with postCompaction: true and the
+    //     returned text enqueued as a system event for this session.
+    expect(mockState.checkContextPressure).toHaveBeenCalledTimes(1);
+    expect(mockState.checkContextPressure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: SESSION_KEY,
+        totalTokens: 180_000,
+        contextWindow: 200_000,
+        threshold: 0.8,
+        postCompaction: true,
+      }),
+    );
+    expect(mockState.enqueueSystemEvent).toHaveBeenCalledWith(
+      "[continuation] post-compaction band fired",
+      { sessionKey: SESSION_KEY },
+    );
+
+    // (3) Two staged delegates → exactly two spawn calls, each with the
+    //     canonical post-compaction flag set.
+    expect(mockState.spawnSubagentDirect).toHaveBeenCalledTimes(2);
+    for (const call of mockState.spawnSubagentDirect.mock.calls) {
+      const [params, ctx] = call;
+      expect(params).toEqual(
+        expect.objectContaining({
+          silentAnnounce: true,
+          wakeOnReturn: true,
+          drainsContinuationDelegateQueue: true,
+        }),
+      );
+      expect(ctx).toEqual(
+        expect.objectContaining({
+          agentSessionKey: SESSION_KEY,
+          agentChannel: ORIGINATING.originatingChannel,
+          agentAccountId: ORIGINATING.originatingAccountId,
+          agentTo: ORIGINATING.originatingTo,
+        }),
+      );
+    }
+    expect(mockState.spawnSubagentDirect.mock.calls[0]?.[0]?.task).toBe(
+      "rehydrate working state for issue X",
+    );
+    expect(mockState.spawnSubagentDirect.mock.calls[1]?.[0]?.task).toBe(
+      "rehydrate working state for issue Y",
+    );
+
+    expect(result).toEqual({ pressureFired: true, delegatesDispatched: 2 });
+  });
+
+  it("no staged delegates: fires the pressure event but performs no spawns", async () => {
+    mockState.checkContextPressure.mockReturnValue("[continuation] post-compaction band fired");
+    mockState.consumeStagedPostCompactionDelegates.mockReturnValue([]);
+
+    const result = await releasePostCompactionLifecycle({
+      sessionKey: SESSION_KEY,
+      cfg: undefined,
+      agentCfgContextTokens: 200_000,
+      activeSessionEntry: { totalTokens: 180_000, contextTokens: 200_000 },
+      originating: ORIGINATING,
+    });
+
+    expect(mockState.clearContextPressureState).toHaveBeenCalledWith(SESSION_KEY);
+    expect(mockState.enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(mockState.spawnSubagentDirect).not.toHaveBeenCalled();
+    expect(result).toEqual({ pressureFired: true, delegatesDispatched: 0 });
+  });
+
+  it("pressure check returns nothing: no pressure event enqueued, but delegates still dispatch", async () => {
+    mockState.checkContextPressure.mockReturnValue(undefined);
+    mockState.consumeStagedPostCompactionDelegates.mockReturnValue([{ task: "rehydrate Z" }]);
+
+    const result = await releasePostCompactionLifecycle({
+      sessionKey: SESSION_KEY,
+      cfg: undefined,
+      agentCfgContextTokens: 200_000,
+      activeSessionEntry: { totalTokens: 180_000, contextTokens: 200_000 },
+      originating: ORIGINATING,
+    });
+
+    expect(mockState.clearContextPressureState).toHaveBeenCalledWith(SESSION_KEY);
+    expect(mockState.checkContextPressure).toHaveBeenCalledTimes(1);
+    expect(mockState.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mockState.spawnSubagentDirect).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ pressureFired: false, delegatesDispatched: 1 });
+  });
+
+  it("missing totalTokens: skips pressure check + enqueue but still consumes/dispatches staged delegates", async () => {
+    mockState.consumeStagedPostCompactionDelegates.mockReturnValue([{ task: "rehydrate W" }]);
+
+    const result = await releasePostCompactionLifecycle({
+      sessionKey: SESSION_KEY,
+      cfg: undefined,
+      agentCfgContextTokens: 200_000,
+      activeSessionEntry: { totalTokens: null, contextTokens: 200_000 },
+      originating: ORIGINATING,
+    });
+
+    expect(mockState.clearContextPressureState).toHaveBeenCalledWith(SESSION_KEY);
+    expect(mockState.checkContextPressure).not.toHaveBeenCalled();
+    expect(mockState.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mockState.spawnSubagentDirect).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ pressureFired: false, delegatesDispatched: 1 });
+  });
+
+  it("ordering: pressure-state clear runs before consumeStaged + pressure check", async () => {
+    const order: string[] = [];
+    mockState.clearContextPressureState.mockImplementation(() => {
+      order.push("clear");
+    });
+    mockState.checkContextPressure.mockImplementation(() => {
+      order.push("check");
+      return undefined;
+    });
+    mockState.consumeStagedPostCompactionDelegates.mockImplementation(() => {
+      order.push("consume");
+      return [];
+    });
+
+    await releasePostCompactionLifecycle({
+      sessionKey: SESSION_KEY,
+      cfg: undefined,
+      agentCfgContextTokens: 200_000,
+      activeSessionEntry: { totalTokens: 180_000, contextTokens: 200_000 },
+      originating: ORIGINATING,
+    });
+
+    // RFC §4.4: clear pressure dedup BEFORE checking pressure (so the
+    // post-compaction band can fire fresh) and BEFORE consuming
+    // delegates (so any pressure system event is enqueued ahead of
+    // delegate spawns).
+    expect(order).toEqual(["clear", "check", "consume"]);
+  });
+
+  it("falls back through agentCfgContextTokens → activeSessionEntry.contextTokens → DEFAULT_CONTEXT_TOKENS for pressure window", async () => {
+    mockState.checkContextPressure.mockReturnValue(undefined);
+    mockState.consumeStagedPostCompactionDelegates.mockReturnValue([]);
+
+    // Case A: agentCfgContextTokens wins.
+    await releasePostCompactionLifecycle({
+      sessionKey: SESSION_KEY,
+      cfg: undefined,
+      agentCfgContextTokens: 100_000,
+      activeSessionEntry: { totalTokens: 50_000, contextTokens: 9_999 },
+      originating: ORIGINATING,
+    });
+    expect(mockState.checkContextPressure).toHaveBeenLastCalledWith(
+      expect.objectContaining({ contextWindow: 100_000 }),
+    );
+
+    // Case B: activeSessionEntry.contextTokens wins when agentCfgContextTokens absent.
+    await releasePostCompactionLifecycle({
+      sessionKey: SESSION_KEY,
+      cfg: undefined,
+      agentCfgContextTokens: undefined,
+      activeSessionEntry: { totalTokens: 50_000, contextTokens: 75_000 },
+      originating: ORIGINATING,
+    });
+    expect(mockState.checkContextPressure).toHaveBeenLastCalledWith(
+      expect.objectContaining({ contextWindow: 75_000 }),
+    );
+
+    // Case C: DEFAULT_CONTEXT_TOKENS is the floor when both absent.
+    await releasePostCompactionLifecycle({
+      sessionKey: SESSION_KEY,
+      cfg: undefined,
+      agentCfgContextTokens: undefined,
+      activeSessionEntry: { totalTokens: 50_000, contextTokens: undefined },
+      originating: ORIGINATING,
+    });
+    const lastCall = mockState.checkContextPressure.mock.calls.at(-1);
+    expect(lastCall?.[0]?.contextWindow).toBeGreaterThan(0);
+    expect(lastCall?.[0]?.contextWindow).not.toBe(100_000);
+    expect(lastCall?.[0]?.contextWindow).not.toBe(75_000);
+  });
+});

--- a/src/auto-reply/continuation/post-compaction-release.ts
+++ b/src/auto-reply/continuation/post-compaction-release.ts
@@ -1,0 +1,107 @@
+/**
+ * Post-compaction continuation lifecycle release (RFC §4.4).
+ *
+ * Extracted from agent-runner.ts so the lifecycle release path is testable in
+ * isolation. The agent-runner code path remains gated by
+ * `continuationEnabledForPressure` and `preflightCompactionApplied` checks
+ * upstream; this helper owns the steps that fire AFTER both gates pass:
+ *
+ *   1. Clear pressure dedup state so post-compaction bands can fire fresh.
+ *   2. Fire context-pressure event (postCompaction: true) when totals are known.
+ *   3. Consume staged post-compaction delegates and dispatch them with
+ *      silentAnnounce + wakeOnReturn + drainsContinuationDelegateQueue.
+ *
+ * Lazy imports for `lazy.runtime` and `delegate-dispatch` are preserved here:
+ * lazy.runtime owns per-process singleton state and must not be statically
+ * imported anywhere in src/ (boundary rule); delegate-dispatch is heavy and
+ * is loaded only when delegates are actually staged.
+ *
+ * See: openclaw#211 (test post-compaction lifecycle release path).
+ */
+
+import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { resolveContinuationRuntimeConfig } from "./config.js";
+
+/** Minimal active-session shape this helper needs. */
+export interface PostCompactionActiveSession {
+  totalTokens?: number | null;
+  contextTokens?: number | null;
+}
+
+/** Originating channel info forwarded to spawn context. */
+export interface PostCompactionOriginating {
+  originatingChannel?: string | null;
+  originatingAccountId?: string | null;
+  originatingTo?: string | null;
+  originatingThreadId?: string | number | null;
+}
+
+export interface ReleasePostCompactionParams {
+  sessionKey: string;
+  cfg: OpenClawConfig | undefined;
+  agentCfgContextTokens: number | null | undefined;
+  activeSessionEntry: PostCompactionActiveSession | null | undefined;
+  originating: PostCompactionOriginating;
+}
+
+export interface ReleasePostCompactionResult {
+  pressureFired: boolean;
+  delegatesDispatched: number;
+}
+
+/**
+ * Run the post-compaction lifecycle release. Caller is responsible for
+ * checking `continuationEnabledForPressure` and `preflightCompactionApplied`
+ * BEFORE invoking this — both gates must be satisfied.
+ */
+export async function releasePostCompactionLifecycle(
+  params: ReleasePostCompactionParams,
+): Promise<ReleasePostCompactionResult> {
+  const { sessionKey, cfg, agentCfgContextTokens, activeSessionEntry, originating } = params;
+
+  const { consumeStagedPostCompactionDelegates, clearContextPressureState, checkContextPressure } =
+    await import("./lazy.runtime.js");
+
+  // 1. Clear pressure dedup so post-compaction lifecycle can fire fresh bands.
+  clearContextPressureState(sessionKey);
+
+  // 2. Fire context-pressure unconditionally after compaction (when totals
+  //    are populated) — informs the session it was compacted, enabling
+  //    rehydration via delegates.
+  let pressureFired = false;
+  const pressureConfig = resolveContinuationRuntimeConfig(cfg);
+  const pressureContextWindow =
+    agentCfgContextTokens ?? activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS;
+  if (pressureContextWindow && activeSessionEntry?.totalTokens != null) {
+    const postCompactionPressure = checkContextPressure({
+      sessionKey,
+      totalTokens: activeSessionEntry.totalTokens,
+      contextWindow: pressureContextWindow,
+      threshold: pressureConfig.contextPressureThreshold ?? 0.8,
+      postCompaction: true,
+    });
+    if (postCompactionPressure) {
+      enqueueSystemEvent(postCompactionPressure, { sessionKey });
+      pressureFired = true;
+    }
+  }
+
+  // 3. Release staged post-compaction delegates with the canonical flag set.
+  const stagedDelegates = consumeStagedPostCompactionDelegates(sessionKey);
+  let delegatesDispatched = 0;
+  if (stagedDelegates.length > 0) {
+    const { dispatchPostCompactionDelegates } = await import("./delegate-dispatch.js");
+    const result = await dispatchPostCompactionDelegates(stagedDelegates, sessionKey, {
+      agentSessionKey: sessionKey,
+      agentChannel: originating.originatingChannel ?? undefined,
+      agentAccountId: originating.originatingAccountId ?? undefined,
+      agentTo: originating.originatingTo ?? undefined,
+      agentThreadId: originating.originatingThreadId ?? undefined,
+    });
+    delegatesDispatched = result.dispatched;
+  }
+
+  return { pressureFired, delegatesDispatched };
+}

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1621,46 +1621,20 @@ export async function runReplyAgent(params: {
         // --- Post-compaction continuation lifecycle (RFC §4.4) ---
         // Release staged post-compaction delegates and fire context-pressure event.
         if (continuationEnabledForPressure) {
-          const {
-            consumeStagedPostCompactionDelegates,
-            clearContextPressureState,
-            checkContextPressure,
-          } = await import("../continuation/lazy.runtime.js");
-
-          // Clear pressure dedup so post-compaction lifecycle can fire fresh bands.
-          clearContextPressureState(sessionKey);
-
-          // Fire context-pressure unconditionally after compaction — informs the
-          // session it was compacted, enabling rehydration via delegates.
-          const pressureConfig = resolveContinuationRuntimeConfig(cfg);
-          const pressureContextWindow =
-            agentCfgContextTokens ?? activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS;
-          if (pressureContextWindow && activeSessionEntry?.totalTokens != null) {
-            const postCompactionPressure = checkContextPressure({
-              sessionKey,
-              totalTokens: activeSessionEntry.totalTokens,
-              contextWindow: pressureContextWindow,
-              threshold: pressureConfig.contextPressureThreshold ?? 0.8,
-              postCompaction: true,
-            });
-            if (postCompactionPressure) {
-              enqueueSystemEvent(postCompactionPressure, { sessionKey });
-            }
-          }
-
-          // Release staged post-compaction delegates with silentAnnounce + wakeOnReturn.
-          const stagedDelegates = consumeStagedPostCompactionDelegates(sessionKey);
-          if (stagedDelegates.length > 0) {
-            const { dispatchPostCompactionDelegates } =
-              await import("../continuation/delegate-dispatch.js");
-            await dispatchPostCompactionDelegates(stagedDelegates, sessionKey, {
-              agentSessionKey: sessionKey,
-              agentChannel: followupRun.originatingChannel ?? undefined,
-              agentAccountId: followupRun.originatingAccountId ?? undefined,
-              agentTo: followupRun.originatingTo ?? undefined,
-              agentThreadId: followupRun.originatingThreadId ?? undefined,
-            });
-          }
+          const { releasePostCompactionLifecycle } =
+            await import("../continuation/post-compaction-release.js");
+          await releasePostCompactionLifecycle({
+            sessionKey,
+            cfg,
+            agentCfgContextTokens,
+            activeSessionEntry,
+            originating: {
+              originatingChannel: followupRun.originatingChannel,
+              originatingAccountId: followupRun.originatingAccountId,
+              originatingTo: followupRun.originatingTo,
+              originatingThreadId: followupRun.originatingThreadId,
+            },
+          });
         }
       }
 
@@ -1843,9 +1817,8 @@ export async function runReplyAgent(params: {
     // Consume and dispatch tool-dispatched delegates (continue_delegate tool).
     if (continuationFeatureEnabled && sessionKey) {
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
-      const { dispatchToolDelegates, loadContinuationChainState } = await import(
-        "../continuation/lazy.runtime.js"
-      );
+      const { dispatchToolDelegates, loadContinuationChainState } =
+        await import("../continuation/lazy.runtime.js");
       const dispatchChainState = loadContinuationChainState(activeSessionEntry, turnTokens);
       await dispatchToolDelegates({
         sessionKey,
@@ -1868,9 +1841,8 @@ export async function runReplyAgent(params: {
       sessionKey &&
       activeSessionEntry
     ) {
-      const { loadContinuationChainState, persistContinuationChainState } = await import(
-        "../continuation/lazy.runtime.js"
-      );
+      const { loadContinuationChainState, persistContinuationChainState } =
+        await import("../continuation/lazy.runtime.js");
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
       const nextState = loadContinuationChainState(activeSessionEntry, turnTokens);
       persistContinuationChainState({


### PR DESCRIPTION
## Summary

Closes #211 — pins the RFC §4.4 post-compaction lifecycle release path that previously had no integration test.

The release block at `agent-runner.ts:1617-1700` was extracted into a new helper `releasePostCompactionLifecycle` in `src/auto-reply/continuation/post-compaction-release.ts` so the three-step sequence can be tested in isolation. Behavior is unchanged; agent-runner now delegates to the helper while keeping both gate checks (`continuationEnabledForPressure` + `preflightCompactionApplied`) at the call site.

## Tests added (6)

1. **Happy path** — two staged delegates → `clearContextPressureState` fires first; `checkContextPressure` is consulted with `postCompaction:true`; the returned text is enqueued; both spawns fire with the canonical flag set (`silentAnnounce + wakeOnReturn + drainsContinuationDelegateQueue`).
2. **No staged delegates** — pressure event fires, no spawns.
3. **Pressure check returns nothing** — no enqueue, but delegates still dispatch.
4. **Missing totalTokens** — pressure check skipped entirely; delegates still dispatch.
5. **Ordering** — `clear → check → consume` (RFC §4.4: clear must run before check so the band fires fresh).
6. **Pressure-window fallback chain** — `agentCfgContextTokens → activeSessionEntry.contextTokens → DEFAULT_CONTEXT_TOKENS`.

## Acceptance criteria coverage

- [x] Happy-path: two staged delegates → two spawns with correct flag set
- [x] Negative: no staged delegates → no spawn calls (only pressure event fires)
- [x] Negative: `preflightCompactionApplied === false` — verified by code reading at the helper's caller (the helper is only invoked when both gates pass)

## Local results

- New helper file: 6/6 pass
- Full `src/auto-reply/continuation/` suite: 75/75 pass
- `agent-runner-execution.test.ts`: 30/30 pass

## Boundary preservation

Lazy imports for `lazy.runtime` and `delegate-dispatch` are preserved in the helper:
- `lazy.runtime` owns per-process singleton state and must not be statically imported anywhere in `src/` (boundary rule)
- `delegate-dispatch` is heavy and loads only when delegates are actually staged

## Refs

- pr-test-analyzer C3
- RFC §4.4 lifecycle release
- agent-runner.ts:1617-1700 (now agent-runner.ts:1621-1638 after refactor)