### PR TITLE
refactor(continuation): PendingContinuationDelegate mode-only encoding (#227)

### DIFF
--- a/src/agents/tools/continue-delegate-tool.test.ts
+++ b/src/agents/tools/continue-delegate-tool.test.ts
@@ -102,11 +102,9 @@ describe("continue_delegate tool", () => {
     const queued = consumePendingDelegates(SESSION_KEY);
     expect(queued.length).toBe(1);
     expect(queued[0]?.task).toBe(TASK);
-    // No silent / silentWake / postCompaction flags on a normal-mode delegate.
+    // No mode on a normal-mode delegate; post-#227 the runtime shape carries
+    // mode only (silent/silentWake/postCompaction booleans no longer exist).
     expect(queued[0]?.mode).toBeUndefined();
-    expect(queued[0]?.silent).toBeUndefined();
-    expect(queued[0]?.silentWake).toBeUndefined();
-    expect(queued[0]?.postCompaction).toBeUndefined();
   });
 
   // (d cont) silent — also exercises delaySeconds → delayMs forwarding
@@ -141,7 +139,6 @@ describe("continue_delegate tool", () => {
     const queued = consumePendingDelegates(SESSION_KEY);
     expect(queued.length).toBe(1);
     expect(queued[0]?.mode).toBe("silent-wake");
-    expect(queued[0]?.silentWake).toBe(true);
   });
 
   // (d cont) zero-delay silent → consumable immediately, mode persists in queue
@@ -152,7 +149,6 @@ describe("continue_delegate tool", () => {
     const queued = consumePendingDelegates(SESSION_KEY);
     expect(queued.length).toBe(1);
     expect(queued[0]?.mode).toBe("silent");
-    expect(queued[0]?.silent).toBe(true);
     expect(queued[0]?.delayMs).toBeUndefined();
   });
 
@@ -188,7 +184,6 @@ describe("continue_delegate tool", () => {
     const staged = consumeStagedPostCompactionDelegates(SESSION_KEY);
     expect(staged.length).toBe(1);
     expect(staged[0]?.task).toBe(TASK);
-    expect(staged[0]?.postCompaction).toBe(true);
     expect(staged[0]?.mode).toBe("post-compaction");
   });
 

--- a/src/auto-reply/continuation/delegate-store.test.ts
+++ b/src/auto-reply/continuation/delegate-store.test.ts
@@ -111,7 +111,6 @@ describe("delegate store — TaskFlow-backed", () => {
     const delegates = consumePendingDelegates("session-1");
     expect(delegates[0]).toMatchObject({
       task: "silent task",
-      silentWake: true,
       mode: "silent-wake",
     });
   });
@@ -147,7 +146,7 @@ describe("post-compaction delegate staging", () => {
     const delegates = consumeStagedPostCompactionDelegates("session-1");
     expect(delegates).toHaveLength(1);
     expect(delegates[0].task).toBe("rehydrate state");
-    expect(delegates[0].postCompaction).toBe(true);
+    expect(delegates[0].mode).toBe("post-compaction");
     expect(stagedPostCompactionDelegateCount("session-1")).toBe(0);
   });
 

--- a/src/auto-reply/continuation/delegate-store.ts
+++ b/src/auto-reply/continuation/delegate-store.ts
@@ -57,29 +57,29 @@ type PendingDelegateState = z.infer<typeof PendingDelegateStateSchema>;
 
 function buildDelegateGoal(delegate: PendingContinuationDelegate): string {
   const task = delegate.task.trim();
+  const isPostCompaction = delegate.mode === "post-compaction";
   if (!task) {
-    return delegate.postCompaction
-      ? "Post-compaction continuation delegate"
-      : "Continuation delegate";
+    return isPostCompaction ? "Post-compaction continuation delegate" : "Continuation delegate";
   }
   const excerpt = task.length > 80 ? `${task.slice(0, 77)}...` : task;
-  return delegate.postCompaction
+  return isPostCompaction
     ? `Post-compaction delegate: ${excerpt}`
     : `Continuation delegate: ${excerpt}`;
 }
 
 function buildDelegateState(delegate: PendingContinuationDelegate): PendingDelegateState {
+  // karmaterminal/openclaw#227: `mode` is the sole runtime-surface encoding.
+  // Project it into the on-disk boolean flags so existing persisted records
+  // (which predate the mode-only runtime shape) keep their familiar schema
+  // and `decodeDelegateState` / `flowToDelegate` keep working unchanged for
+  // historical TaskFlow rows.
   return {
     kind: "continuation_delegate",
     task: delegate.task,
     ...(delegate.delayMs !== undefined ? { delayMs: delegate.delayMs } : {}),
-    ...(delegate.silent === true || delegate.mode === "silent" ? { silent: true } : {}),
-    ...(delegate.silentWake === true || delegate.mode === "silent-wake"
-      ? { silentWake: true }
-      : {}),
-    ...(delegate.postCompaction === true || delegate.mode === "post-compaction"
-      ? { postCompaction: true }
-      : {}),
+    ...(delegate.mode === "silent" ? { silent: true } : {}),
+    ...(delegate.mode === "silent-wake" ? { silentWake: true } : {}),
+    ...(delegate.mode === "post-compaction" ? { postCompaction: true } : {}),
   };
 }
 
@@ -114,14 +114,23 @@ function flowToDelegate(
   flow: TaskFlowRecord,
   state: PendingDelegateState,
 ): PendingContinuationDelegate {
+  // karmaterminal/openclaw#227: rehydrate runtime shape (mode-only) from
+  // the on-disk boolean flags. silentWake takes precedence over silent
+  // because on-disk rows may have both set (mode === "silent-wake" also
+  // wrote silent in earlier encoders), and silent-wake is the more
+  // specific mode.
+  let mode: PendingContinuationDelegate["mode"];
+  if (state.postCompaction === true) {
+    mode = "post-compaction";
+  } else if (state.silentWake === true) {
+    mode = "silent-wake";
+  } else if (state.silent === true) {
+    mode = "silent";
+  }
   return {
     task: state.task,
     ...(state.delayMs !== undefined ? { delayMs: state.delayMs } : {}),
-    ...(state.silent === true ? { silent: true, mode: "silent" as const } : {}),
-    ...(state.silentWake === true ? { silentWake: true, mode: "silent-wake" as const } : {}),
-    ...(state.postCompaction === true
-      ? { postCompaction: true, mode: "post-compaction" as const }
-      : {}),
+    ...(mode !== undefined ? { mode } : {}),
   };
 }
 
@@ -136,7 +145,7 @@ export function enqueuePendingDelegate(
   sessionKey: string,
   delegate: PendingContinuationDelegate,
 ): void {
-  const isPostCompaction = delegate.postCompaction === true || delegate.mode === "post-compaction";
+  const isPostCompaction = delegate.mode === "post-compaction";
   createManagedTaskFlow({
     ownerKey: sessionKey,
     controllerId: isPostCompaction
@@ -274,9 +283,6 @@ export function stagePostCompactionDelegate(
 ): void {
   enqueuePendingDelegate(sessionKey, {
     task: delegate.task,
-    silent: true,
-    silentWake: true,
-    postCompaction: true,
     mode: "post-compaction",
   });
 }

--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -43,15 +43,19 @@ export type ContinuationSignal =
  * A delegate waiting to be dispatched after the current turn completes.
  * Enqueued by the `continue_delegate` tool during execution, consumed by
  * the delegate dispatch module after the response finalizes.
+ *
+ * `mode` is the single source of truth for silent/silent-wake/post-compaction
+ * behaviour. Prior to karmaterminal/openclaw#227 this type also carried
+ * `silent`/`silentWake`/`postCompaction` booleans alongside `mode`, which
+ * the encoder resolved with an OR-fallback — creating a silent-disagreement
+ * hazard when the two encodings disagreed. The booleans still appear in the
+ * on-disk TaskFlow state payload (legacy persisted schema) but never on the
+ * runtime object.
  */
 export type PendingContinuationDelegate = {
   task: string;
   delayMs?: number;
   mode?: "normal" | "silent" | "silent-wake" | "post-compaction";
-  /** Convenience booleans for TaskFlow state serialization. */
-  silent?: boolean;
-  silentWake?: boolean;
-  postCompaction?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes karmaterminal/openclaw#227. Drops the redundant \`silent\` / \`silentWake\` / \`postCompaction\` booleans from the runtime \`PendingContinuationDelegate\` type. \`mode\` is now the single source of truth for silent / silent-wake / post-compaction behaviour.

Before this change the type carried **both** encodings and \`buildDelegateState\` reconciled them with an OR-fallback (\`delegate.silent === true || delegate.mode === \"silent\"\`). Callers that set \`mode\` and a disagreeing boolean got silently-different serialized state — the kind of drift only caught when on-disk rows start contradicting runtime behaviour.

## Scope

- **\`types.ts\`** \`PendingContinuationDelegate\` — drop three boolean fields; keep \`mode\`. Docblock updated to explain why the booleans still appear in the on-disk \`PendingDelegateStateSchema\` (legacy persisted shape).
- **\`delegate-store.ts\`** \`buildDelegateState\` — project \`mode\` → booleans on the way out (single direction, no OR-fallback). Existing on-disk rows that predate the mode-only runtime keep the same schema.
- **\`delegate-store.ts\`** \`flowToDelegate\` — rehydrate \`mode\` from on-disk booleans on the way in. \`silentWake\` wins over \`silent\` when both are set (some legacy rows wrote both; silent-wake is the more specific mode).
- **\`delegate-store.ts\`** \`enqueuePendingDelegate\` — \`isPostCompaction\` check simplified to \`mode === \"post-compaction\"\`.
- **\`delegate-store.ts\`** \`stagePostCompactionDelegate\` — drop redundant \`silent\` / \`silentWake\` / \`postCompaction\` flags at the construction site; \`mode\` alone is authoritative.
- **\`delegate-store.ts\`** \`buildDelegateGoal\` — replace \`delegate.postCompaction\` with \`delegate.mode === \"post-compaction\"\`.

## Test updates

- **\`delegate-store.test.ts\`**: assert \`mode\` only on the round-trip; drop the silent-wake boolean assertion (still written on disk but no longer exposed on the runtime object).
- **\`continue-delegate-tool.test.ts\`**: four places dropping \`silent\` / \`silentWake\` / \`postCompaction\` expectations on the runtime object; \`mode\` remains the assertion anchor.

## Verification

- [x] \`pnpm tsgo\` clean
- [x] 50/50 continuation tests green
- [x] 14/14 continue-delegate-tool tests green

## Back-compat

On-disk \`PendingDelegateStateSchema\` (SQLite TaskFlow rows) keeps the \`silent\` / \`silentWake\` / \`postCompaction\` booleans unchanged. Records written by prior gateway versions rehydrate cleanly via the updated \`flowToDelegate\`. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)