### PR TITLE
fix(config): add truncateAfterCompaction to strict zod schema (clip of #166 from canary, refs #198)

### DIFF
--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -150,6 +150,7 @@ export const AgentDefaultsSchema = z
         postCompactionSections: z.array(z.string()).optional(),
         model: z.string().optional(),
         timeoutSeconds: z.number().int().positive().optional(),
+        truncateAfterCompaction: z.boolean().optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Extracted from \`flesh_beast_figs/20260414-claude\` per karmaterminal/openclaw#198 (severability clipping) so the continuation-feature squash stays narrowly scoped. Original commit: \`b07b23a856\`.

One-line addition to the strict zod schema for \`agents.defaults.compaction.truncateAfterCompaction\`. No behavior change — the runtime consumer and metadata layers already knew about the field.

Closes karmaterminal/openclaw#166.

## Refs

- karmaterminal/openclaw#198 (severability tracker)
- karmaterminal/openclaw-bootstrap#370 (original context per commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)