### PR TITLE
fix(compaction): inject Copilot IDE headers on summarization path (clip of #160 from canary, refs #198)

### DIFF
--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -28,6 +28,7 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
+import { buildCopilotIdeHeaders } from "../copilot-dynamic-headers.js";
 import { isTimeoutError } from "../failover-error.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -233,7 +234,11 @@ async function resolveModelAuth(
       reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
     };
   }
-  return { ok: true, apiKey: requestAuth.apiKey, headers: requestAuth.headers };
+  const headers =
+    model.provider === "github-copilot"
+      ? { ...buildCopilotIdeHeaders(), ...requestAuth.headers }
+      : requestAuth.headers;
+  return { ok: true, apiKey: requestAuth.apiKey, headers };
 }
 
 function clampNonNegativeInt(value: unknown, fallback: number): number {


### PR DESCRIPTION
## Summary

Extracted from \`flesh_beast_figs/20260414-claude\` per karmaterminal/openclaw#198 (severability clipping) so the continuation-feature squash stays narrowly scoped. Original commit: \`b9186904e7\`.

Fixes \"Compaction fails fleet-wide: Copilot summarization endpoint rejects with 'missing …'\" — inject the \`Copilot-Integration-Id\` / \`Editor-Version\` / \`Editor-Plugin-Version\` headers on the summarization path so GitHub Copilot accepts the compaction request.

\`src/agents/pi-hooks/compaction-safeguard.ts\` only, 6-line addition.

Closes karmaterminal/openclaw#159.

## Refs

- karmaterminal/openclaw#198 (severability tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)