### PR TITLE
fix(#475): checkpoint dedup in discoverAllSessions (clip of #167 from canary, refs #198)

### DIFF
--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   formatSessionArchiveTimestamp,
+  isCheckpointSessionTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
+  parseParentSessionIdFromCheckpointFileName,
   parseUsageCountedSessionIdFromFileName,
   parseSessionArchiveTimestamp,
 } from "./artifacts.js";
@@ -50,6 +52,32 @@ describe("session artifact helpers", () => {
     ).toBe("abc");
     expect(parseUsageCountedSessionIdFromFileName("abc.jsonl.bak.2026-01-01T00-00-00.000Z")).toBe(
       null,
+    );
+  });
+
+  it("classifies checkpoint transcript files and extracts parent session id", () => {
+    const parent = "e417ba9b-8043-43db-8d18-d88f1823567d";
+    const ckp = "21901ee7-8f22-4d07-9e39-6eaf7b224630";
+
+    // Positive: well-formed checkpoint sibling.
+    expect(isCheckpointSessionTranscriptFileName(`${parent}.checkpoint.${ckp}.jsonl`)).toBe(true);
+    expect(parseParentSessionIdFromCheckpointFileName(`${parent}.checkpoint.${ckp}.jsonl`)).toBe(
+      parent,
+    );
+
+    // Negative: primary, archive, non-uuid suffix, or substring matches.
+    expect(isCheckpointSessionTranscriptFileName(`${parent}.jsonl`)).toBe(false);
+    expect(
+      isCheckpointSessionTranscriptFileName(`${parent}.jsonl.deleted.2026-01-01T00-00-00.000Z`),
+    ).toBe(false);
+    // Substring contains "checkpoint" but is missing the UUID shape — must not dedup.
+    expect(isCheckpointSessionTranscriptFileName("my-checkpoint-review-session.jsonl")).toBe(false);
+    expect(parseParentSessionIdFromCheckpointFileName("my-checkpoint-review-session.jsonl")).toBe(
+      null,
+    );
+    // Shape looks close but the trailing UUID segment is malformed.
+    expect(isCheckpointSessionTranscriptFileName(`${parent}.checkpoint.not-a-uuid.jsonl`)).toBe(
+      false,
     );
   });
 

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -3,6 +3,13 @@ export type SessionArchiveReason = "bak" | "reset" | "deleted";
 const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
 const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
 
+// Anchored at end of file name: literal `.checkpoint.` + UUID-v4 shape + `.jsonl`.
+// Session IDs that happen to contain the substring "checkpoint" (with any suffix
+// shape) do NOT match because the UUID regex requires the exact `[0-9a-f]{8}-…`
+// shape immediately after `.checkpoint.` and `.jsonl` immediately after that.
+const CHECKPOINT_MARKER_RE =
+  /\.checkpoint\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+
 function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boolean {
   const marker = `.${reason}.`;
   const index = fileName.lastIndexOf(marker);
@@ -39,6 +46,30 @@ export function isUsageCountedSessionTranscriptFileName(fileName: string): boole
     return true;
   }
   return hasArchiveSuffix(fileName, "reset") || hasArchiveSuffix(fileName, "deleted");
+}
+
+/**
+ * Classify pre-compaction checkpoint-twin transcript files, e.g.
+ * `<parentId>.checkpoint.<uuid>.jsonl`. Uses an anchored UUID-shape match so
+ * session IDs that happen to contain the substring "checkpoint" do not
+ * false-positive.
+ */
+export function isCheckpointSessionTranscriptFileName(fileName: string): boolean {
+  return CHECKPOINT_MARKER_RE.test(fileName);
+}
+
+/**
+ * Extract the parent session id from a checkpoint transcript file name. The
+ * parent session id is the part BEFORE `.checkpoint.<uuid>.jsonl`; it matches
+ * what `isPrimarySessionTranscriptFileName` expects when the parent primary
+ * exists as `<parentId>.jsonl`. Returns `null` if the file is not a checkpoint.
+ */
+export function parseParentSessionIdFromCheckpointFileName(fileName: string): string | null {
+  const match = fileName.match(CHECKPOINT_MARKER_RE);
+  if (!match || match.index === undefined) {
+    return null;
+  }
+  return fileName.slice(0, match.index);
 }
 
 export function parseUsageCountedSessionIdFromFileName(fileName: string): string | null {

--- a/src/infra/session-cost-usage.discoverAllSessions.test.ts
+++ b/src/infra/session-cost-usage.discoverAllSessions.test.ts
@@ -1,0 +1,153 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { type DiscoveredSession, discoverAllSessions } from "./session-cost-usage.js";
+
+// ---------------------------------------------------------------------------
+// openclaw-bootstrap#475 — checkpoint dedup regression coverage
+//
+// discoverAllSessions must NOT treat `<parentId>.checkpoint.<uuid>.jsonl`
+// files as distinct sessions. They are pre-compaction snapshot siblings of
+// the parent primary and must be grouped under the parent session id. See
+// src/config/sessions/artifacts.ts for the classifier + parent-id parser.
+// ---------------------------------------------------------------------------
+
+const PARENT_UUID = "e417ba9b-8043-43db-8d18-d88f1823567d";
+const OTHER_PARENT_UUID = "71029058-ffdd-4def-9a8c-c84f9e1e3f01";
+const CHECKPOINT_UUIDS = [
+  "21901ee7-8f22-4d07-9e39-6eaf7b224630",
+  "44d92356-464c-4556-9403-77096e791375",
+  "47b9a01e-169a-442c-8e42-52f2188051eb",
+  "7da74434-2bd8-499e-8216-ba3fa0869884",
+  "ac813e2a-ad7b-4a0f-9f7b-26c0fbac2746",
+];
+
+const USER_JSONL_LINE = JSON.stringify({
+  type: "message",
+  message: { role: "user", content: "hello from parent primary" },
+});
+const EMPTY_JSONL = "";
+
+async function makeAgentSessionsDir(root: string, agentId = "main"): Promise<string> {
+  const sessionsDir = path.join(root, "agents", agentId, "sessions");
+  await fs.mkdir(sessionsDir, { recursive: true });
+  return sessionsDir;
+}
+
+async function discoverUnder(stateDir: string): Promise<DiscoveredSession[]> {
+  return await withEnvAsync(
+    { OPENCLAW_STATE_DIR: stateDir },
+    async () => await discoverAllSessions(),
+  );
+}
+
+describe("discoverAllSessions — checkpoint dedup (bootstrap#475)", () => {
+  const suiteRootTracker = createSuiteTempRootTracker({
+    prefix: "openclaw-discover-ckp-",
+  });
+
+  beforeAll(async () => {
+    await suiteRootTracker.setup();
+  });
+
+  afterAll(async () => {
+    await suiteRootTracker.cleanup();
+  });
+
+  it("(a) single primary: surfaces one discovered session", async () => {
+    const root = await suiteRootTracker.make("case-a");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+  });
+
+  it("(b) primary + one checkpoint: one discovered session under parent id", async () => {
+    const root = await suiteRootTracker.make("case-b");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+    await fs.writeFile(
+      path.join(sessionsDir, `${PARENT_UUID}.checkpoint.${CHECKPOINT_UUIDS[0]}.jsonl`),
+      EMPTY_JSONL,
+    );
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+    // Primary's sessionFile wins over checkpoint's sessionFile.
+    expect(discovered[0]?.sessionFile.endsWith(`${PARENT_UUID}.jsonl`)).toBe(true);
+  });
+
+  it("(c) five checkpoints only, parent primary missing: one discovered entry under parent id", async () => {
+    const root = await suiteRootTracker.make("case-c");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    for (const ckpUuid of CHECKPOINT_UUIDS) {
+      await fs.writeFile(
+        path.join(sessionsDir, `${PARENT_UUID}.checkpoint.${ckpUuid}.jsonl`),
+        EMPTY_JSONL,
+      );
+    }
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+  });
+
+  it("(d) primary + five checkpoints (Elliott shape): one discovered session", async () => {
+    const root = await suiteRootTracker.make("case-d");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+    for (const ckpUuid of CHECKPOINT_UUIDS) {
+      await fs.writeFile(
+        path.join(sessionsDir, `${PARENT_UUID}.checkpoint.${ckpUuid}.jsonl`),
+        EMPTY_JSONL,
+      );
+    }
+    // Also include an unrelated session to be sure discover returns 2 total, not 6.
+    await fs.writeFile(path.join(sessionsDir, `${OTHER_PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+
+    const discovered = await discoverUnder(root);
+    const ids = discovered.map((d) => d.sessionId).toSorted();
+    expect(ids).toEqual([OTHER_PARENT_UUID, PARENT_UUID].toSorted());
+  });
+
+  it("(e) .reset./.deleted. archives: still counted as their own entries (usage-count preserved)", async () => {
+    const root = await suiteRootTracker.make("case-e");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    // Primary present, plus one reset archive and one deleted archive for the same id.
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+    await fs.writeFile(
+      path.join(sessionsDir, `${PARENT_UUID}.jsonl.reset.2026-01-01T00-00-00.000Z`),
+      EMPTY_JSONL,
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, `${PARENT_UUID}.jsonl.deleted.2026-02-02T00-00-00.000Z`),
+      EMPTY_JSONL,
+    );
+
+    const discovered = await discoverUnder(root);
+    // The archives share the same session id and dedup with the primary in the
+    // discover map, so final count is 1 — the primary wins sessionFile.
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+    expect(discovered[0]?.sessionFile.endsWith(`${PARENT_UUID}.jsonl`)).toBe(true);
+  });
+
+  it("(f) primary with 'checkpoint' substring in session id: NOT dedup (regex anchored)", async () => {
+    const root = await suiteRootTracker.make("case-f");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    // This file name contains "checkpoint" in the session id portion, but
+    // does NOT match the UUID-anchored checkpoint regex. Must be treated as
+    // a distinct primary session.
+    const trickyId = "my-checkpoint-review-session";
+    await fs.writeFile(path.join(sessionsDir, `${trickyId}.jsonl`), USER_JSONL_LINE);
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(trickyId);
+  });
+});

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -5,9 +5,11 @@ import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import {
+  isCheckpointSessionTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
+  parseParentSessionIdFromCheckpointFileName,
   parseSessionArchiveTimestamp,
   parseUsageCountedSessionIdFromFileName,
 } from "../config/sessions/artifacts.js";
@@ -470,6 +472,48 @@ export async function discoverAllSessions(params?: {
       continue;
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
+
+    // Checkpoint-twin dedup (issue #475): `<parentId>.checkpoint.<uuid>.jsonl`
+    // files are pre-compaction snapshot siblings of the parent primary
+    // session. They must NOT surface as distinct discovered sessions — that
+    // lopsides the discover map (one lopsided prince session can present as
+    // 6 separate sessions) and, worse, opens each file for first-user-message
+    // extraction, which is the dominant read cost on a prince with deep
+    // checkpoint history. Group them under the parent session id, do not
+    // re-read for label (the parent primary already carries it), and advance
+    // the parent's mtime if this checkpoint is newer.
+    if (isCheckpointSessionTranscriptFileName(entry.name)) {
+      const parentId = parseParentSessionIdFromCheckpointFileName(entry.name);
+      if (!parentId) {
+        continue;
+      }
+      const existing = discovered.get(parentId);
+      if (!existing) {
+        // Parent primary may not have been scanned yet (or may be absent
+        // entirely, which is the parent-missing recovery case). Record the
+        // checkpoint's mtime under the parent id without a sessionFile
+        // commitment; the parent primary will replace this entry when we
+        // encounter it via the primary branch below.
+        discovered.set(parentId, {
+          sessionId: parentId,
+          sessionFile: filePath,
+          mtime: stats.mtimeMs,
+          firstUserMessage: undefined,
+        });
+      } else if (stats.mtimeMs > existing.mtime) {
+        // Advance the parent's mtime if this checkpoint is newer; do NOT
+        // overwrite sessionFile when existing points at a primary transcript.
+        const existingIsPrimary = isPrimarySessionTranscriptFileName(
+          path.basename(existing.sessionFile),
+        );
+        discovered.set(parentId, {
+          ...existing,
+          sessionFile: existingIsPrimary ? existing.sessionFile : filePath,
+          mtime: stats.mtimeMs,
+        });
+      }
+      continue;
+    }
 
     const sessionId = parseUsageCountedSessionIdFromFileName(entry.name);
     if (!sessionId) {


### PR DESCRIPTION
## Summary

Extracted from \`flesh_beast_figs/20260414-claude\` per karmaterminal/openclaw#198 (severability clipping) so the continuation-feature squash stays narrowly scoped. Original commit: \`aac0c04983\`.

Anchored UUID matching replaces substring matching for checkpoint / primary session pairing in \`discoverAllSessions\`. Eliminates false-positive \`my-checkpoint-review-session.jsonl\` matches and cuts the lopsided progressive-RSS pattern on sessions with deep checkpoint history.

Files:
- \`src/config/sessions/artifacts.{ts,test.ts}\`
- \`src/infra/session-cost-usage.ts\`
- \`src/infra/session-cost-usage.discoverAllSessions.test.ts\` (new)

Closes karmaterminal/openclaw#475.

## Refs

- karmaterminal/openclaw#198 (severability tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)