### PR TITLE
fix(compaction): inject Copilot IDE headers on summarization path

### DIFF
--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -28,6 +28,7 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
+import { buildCopilotIdeHeaders } from "../copilot-dynamic-headers.js";
 import { isTimeoutError } from "../failover-error.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -233,7 +234,11 @@ async function resolveModelAuth(
       reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
     };
   }
-  return { ok: true, apiKey: requestAuth.apiKey, headers: requestAuth.headers };
+  const headers =
+    model.provider === "github-copilot"
+      ? { ...buildCopilotIdeHeaders(), ...requestAuth.headers }
+      : requestAuth.headers;
+  return { ok: true, apiKey: requestAuth.apiKey, headers };
 }
 
 function clampNonNegativeInt(value: unknown, fallback: number): number {


### PR DESCRIPTION
Severability change-set 2 of #198 — clipping the Copilot IDE header injection in `compaction-safeguard.ts` off the continuation candidate branch into its own PR for clean upstream landing.

This is a cherry-pick of `b9186904e7` (originally Cael's #160 against the candidate branch), now retargeted at `main` so the continuation squash can exclude it.

## What this fixes

Compaction summarization HTTP calls were missing `Editor-Version` / `User-Agent` headers that GitHub Copilot now requires for IDE auth, causing fleet-wide compaction failure on Copilot-backed sessions. Mirrors the header injection already present in `anthropic-transport-stream.ts` and `openai-transport-stream.ts`.

## Diff

`src/agents/pi-hooks/compaction-safeguard.ts` — 1 file, +6/-1.

## Closes

karmaterminal/openclaw#159

## Severability ledger

Tracks against karmaterminal/openclaw#198 change-set 2/4.
