### PR TITLE
fix(compaction): inject Copilot IDE headers on summarization path

### DIFF
--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -28,6 +28,7 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
+import { buildCopilotIdeHeaders } from "../copilot-dynamic-headers.js";
 import { isTimeoutError } from "../failover-error.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -233,7 +234,11 @@ async function resolveModelAuth(
       reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
     };
   }
-  return { ok: true, apiKey: requestAuth.apiKey, headers: requestAuth.headers };
+  const headers =
+    model.provider === "github-copilot"
+      ? { ...buildCopilotIdeHeaders(), ...requestAuth.headers }
+      : requestAuth.headers;
+  return { ok: true, apiKey: requestAuth.apiKey, headers };
 }
 
 function clampNonNegativeInt(value: unknown, fallback: number): number {


### PR DESCRIPTION
Cherry-picked from canary `b9186904e7` (Cael's original commit on the candidate branch). Targets `main` per #198 severability ask — clip change-set #2 off the candidate so the continuation squash stays clean.

Closes openclaw#159 (upstream needs the same fix; this lands ours, parity-track upstream after).

**Scope**: 1 file, +6/-1. Mirrors the Editor-Version / User-Agent header injection already present in `anthropic-transport-stream.ts` and `openai-transport-stream.ts` for the Copilot IDE auth path on the summarization HTTP call.

Part of #198 severability work:
- CS1 (session-key sweep, ~19 files) — figs
- **CS2 (Copilot IDE header) — this PR**
- CS3 (checkpoint transcript dedup) — open
- CS4 (truncate-after-compaction zod field) — open

Tests: cherry-pick is bit-identical to Cael's canary commit which CI'd green; no behavior delta vs that commit.

🌫️
