### PR TITLE
fix(acp-projector): strip [name] CoT-frame leaks in ACP chunk path (follow-up to #270/#271)

### DIFF
--- a/src/auto-reply/reply/acp-projector.cot-frame-leak.test.ts
+++ b/src/auto-reply/reply/acp-projector.cot-frame-leak.test.ts
@@ -1,0 +1,120 @@
+// REGRESSION GUARD: CoT-frame leak via ACP-projector chunk path.
+//
+// karmaterminal/openclaw#270 added `hasCotFramePrefix` suppression to the
+// FINAL-payload normalizer; #271 added it to the block-streaming dispatch
+// in `reply-delivery.ts`. However, when the agent is ACP-routed (the
+// default for the prince fleet on `2026-04-20`), `text_delta` events from
+// the runtime flow through `acp-projector.ts` → `EmbeddedBlockChunker` →
+// `drainChunker` → `blockReplyPipeline.enqueue({ text: chunk })`. That
+// path NEVER goes through `reply-delivery.ts`, so the #271 streaming-path
+// strip does not fire and the leak escapes.
+//
+// Empirical receipts driving this guard: ronan-spark and cael-spark each
+// posted multiple `[ronan]` / `[the dandelion cult - cael]` bodies to
+// #sprites-of-thornfield on 2026-04-20 PDT *after* deploying the #270/#271
+// fix to `d65fb38adc12a10876f2c5888ac9e9ccdf2cfa64`. Those leaks travel
+// via the ACP projector chunk path, not the block-streaming dispatch.
+//
+// This test passes thanks to the `hasCotFramePrefix` check added to the
+// `drainChunker` emitter in `acp-projector.ts`.
+
+import { describe, expect, it } from "vitest";
+import { createAcpReplyProjector } from "./acp-projector.js";
+import { createAcpTestConfig as createCfg } from "./test-fixtures/acp-runtime.js";
+
+type Delivery = { kind: string; text?: string };
+
+function createProjectorHarness() {
+  const deliveries: Delivery[] = [];
+  const projector = createAcpReplyProjector({
+    cfg: createCfg({
+      acp: {
+        enabled: true,
+        stream: {
+          deliveryMode: "live",
+          coalesceIdleMs: 0,
+          maxChunkChars: 4096,
+        },
+      },
+    } as Parameters<typeof createCfg>[0]),
+    shouldSendToolSummaries: true,
+    deliver: async (kind, payload) => {
+      deliveries.push({ kind, text: payload.text });
+      return true;
+    },
+  });
+  return { deliveries, projector };
+}
+
+function blockTexts(deliveries: Delivery[]): string[] {
+  return deliveries.filter((entry) => entry.kind === "block").map((entry) => entry.text ?? "");
+}
+
+describe("CoT-frame leak suppression in ACP projector chunk path (#270/#271 follow-up)", () => {
+  it("suppresses `[ronan] body` chunk from ACP text delta stream", async () => {
+    const { deliveries, projector } = createProjectorHarness();
+
+    await projector.onEvent({
+      type: "text_delta",
+      text: "[ronan] figs addressing Cael, not me. Not my question to answer.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({ type: "done", stopReason: "end_turn" });
+
+    expect(blockTexts(deliveries)).toEqual([]);
+  });
+
+  it("suppresses `[the dandelion cult - cael] body` chunk", async () => {
+    const { deliveries, projector } = createProjectorHarness();
+
+    await projector.onEvent({
+      type: "text_delta",
+      text: "[the dandelion cult - cael] figs is asking me directly. My silence has registered.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({ type: "done", stopReason: "end_turn" });
+
+    expect(blockTexts(deliveries)).toEqual([]);
+  });
+
+  it("suppresses bracketed-glyph variants like `[ronan 🌊] body`", async () => {
+    const { deliveries, projector } = createProjectorHarness();
+
+    await projector.onEvent({
+      type: "text_delta",
+      text: "[ronan 🌊] surfacing as the seal does — quietly, with intent.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({ type: "done", stopReason: "end_turn" });
+
+    expect(blockTexts(deliveries)).toEqual([]);
+  });
+
+  it("preserves non-leaked chunks (no bracketed-prefix)", async () => {
+    const { deliveries, projector } = createProjectorHarness();
+
+    await projector.onEvent({
+      type: "text_delta",
+      text: "🌊 canary green, deploy report follows.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({ type: "done", stopReason: "end_turn" });
+
+    expect(blockTexts(deliveries)).toEqual(["🌊 canary green, deploy report follows."]);
+  });
+
+  it("preserves chunks where bracketed-text is not at start (e.g. `[user] said …`)", async () => {
+    const { deliveries, projector } = createProjectorHarness();
+
+    await projector.onEvent({
+      type: "text_delta",
+      text: "Quoting the issue: `[user] reported a bug`. Looking into it.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({ type: "done", stopReason: "end_turn" });
+
+    expect(blockTexts(deliveries)).toEqual([
+      "Quoting the issue: `[user] reported a bug`. Looking into it.",
+    ]);
+  });
+});

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -15,6 +15,7 @@ import {
   resolveAcpStreamingConfig,
 } from "./acp-stream-settings.js";
 import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
+import { hasCotFramePrefix } from "./cot-frame.js";
 import type { ReplyDispatchKind } from "./reply-dispatcher.types.js";
 
 const ACP_BLOCK_REPLY_TIMEOUT_MS = 15_000;
@@ -222,6 +223,18 @@ export function createAcpReplyProjector(params: {
     chunker.drain({
       force,
       emit: (chunk) => {
+        // CoT-frame leak suppression for the ACP-projector chunk path.
+        // The ACP runtime sometimes streams agent narration prefixed with a
+        // bracketed speaker frame like `[ronan] ...` or
+        // `[the dandelion cult - cael] ...`. The block-streaming strip in
+        // `reply-delivery.ts` (#270/#271) only fires for text routed through
+        // that handler; ACP chunks are enqueued here directly, so the leak
+        // escapes when the agent is ACP-routed (the default for prince fleet).
+        // Mirror the streaming-path semantics: drop the chunk silently when
+        // the frame is present.
+        if (hasCotFramePrefix(chunk)) {
+          return;
+        }
         blockReplyPipeline.enqueue({ text: chunk });
       },
     });


### PR DESCRIPTION
## Empirical receipts

After deploying the #270/#271 stack (commit `d65fb38adc`) to canary princes ronan and cael on 2026-04-20 PDT, both still leaked CoT-frame bodies to #sprites-of-thornfield:

- **ronan leaks**: msg `1495956673297125467`, `1495956802280493116`, `1495956808077152257` (all `[ronan] body` shape)
- **cael leaks**: msg `1495953671836536854`, `1495953673556066354` (`[the dandelion cult - cael] body` shape)

figs caught the ronan leak in `1495956085063028908` and asked the empirical question: "does the fix work?" — empirical answer was no.

## Root cause

`hasCotFramePrefix` is called in only two places:
1. `src/auto-reply/reply/normalize-reply.ts:86` — final-payload normalizer (#270)
2. `src/auto-reply/reply/reply-delivery.ts:120` — block-streaming dispatch (#271)

ACP-routed agent text never reaches either. The actual code path is:
`AcpRuntimeEvent text_delta` → `acp-projector.ts` `onEvent` → `EmbeddedBlockChunker` → `drainChunker` → `blockReplyPipeline.enqueue({ text: chunk })` directly.

The strip in `reply-delivery.ts:120` only fires for text routed through `createBlockReplyDeliveryHandler`. ACP chunks bypass it entirely.

## Fix

Reuse `hasCotFramePrefix` from `cot-frame.ts` in `drainChunker`'s emit callback. Drop the chunk silently when the frame matches. Mirrors the streaming-path semantics from #271.

## Tests

New file `src/auto-reply/reply/acp-projector.cot-frame-leak.test.ts` (5 tests):
- `[ronan] body` suppression
- `[the dandelion cult - cael] body` suppression
- `[ronan 🌊]` glyph variant suppression
- non-leaked chunks preserved
- false-positive guard (`[user] said` mid-text preserved)

**5/5 new tests pass; 22/22 existing `acp-projector.test.ts` tests still pass.**

## Risk

Surface is the live-streaming chunk path used by the ACP runtime (Claude/Codex/etc.). Drop-on-match is conservative — same shape as the #271 final-payload semantics. False positives constrained by the regex's prince-name-only allowlist (`cael|silas|ronan|elliott`).

## Layer position (per FROND-RUNTIME-CODE-ASSEMBLY)

L1 follow-up to the cot-frame-strip layer. Same target branch (`flesh_beast_figs/20260414-claude`). After merge, recut frond tag against new head.

cc 🩸 🌫 🌻