### PR TITLE
fix(#641): fail fast when compaction default lacks auth

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -44,6 +44,9 @@ export const resolveModelMock: Mock<
   authStorage: { setRuntimeApiKey: vi.fn() },
   modelRegistry: {},
 }));
+export const hasAvailableAuthForProviderMock: Mock<(params?: unknown) => Promise<boolean>> = vi.fn(
+  async () => true,
+);
 export const sessionCompactImpl = vi.fn(async () => ({
   summary: "summary",
   firstKeptEntryId: "entry-1",
@@ -174,6 +177,8 @@ export function resetCompactHooksHarnessMocks(): void {
     authStorage: { setRuntimeApiKey: vi.fn() },
     modelRegistry: {},
   });
+  hasAvailableAuthForProviderMock.mockReset();
+  hasAvailableAuthForProviderMock.mockResolvedValue(true);
 
   sessionCompactImpl.mockReset();
   sessionCompactImpl.mockResolvedValue({
@@ -306,6 +311,7 @@ export async function loadCompactHooksHarness(): Promise<{
     applyAuthHeaderOverride: vi.fn((model: unknown) => model),
     applyLocalNoAuthHeaderOverride: vi.fn((model: unknown) => model),
     getApiKeyForModel: vi.fn(async () => ({ apiKey: "test", mode: "env" })),
+    hasAvailableAuthForProvider: hasAvailableAuthForProviderMock,
     resolveModelAuthMode: vi.fn(() => "env"),
   }));
 

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -7,6 +7,7 @@ import {
   ensureRuntimePluginsLoaded,
   estimateTokensMock,
   getMemorySearchManagerMock,
+  hasAvailableAuthForProviderMock,
   hookRunner,
   loadCompactHooksHarness,
   registerProviderStreamForModelMock,
@@ -821,6 +822,43 @@ describe("compactEmbeddedPiSession hooks (ownsCompaction engine)", () => {
         }),
       }),
     );
+  });
+
+  it("fails fast when compaction falls back to the hardcoded default without auth", async () => {
+    hasAvailableAuthForProviderMock.mockResolvedValue(false);
+
+    const result = await compactEmbeddedPiSession(wrappedCompactionArgs());
+
+    expect(result).toMatchObject({
+      ok: false,
+      compacted: false,
+      reason:
+        "No auth profile available for compaction target openai/fake-model. Pass provider/model from active session context.",
+    });
+    expect(hasAvailableAuthForProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        preferredProfile: undefined,
+      }),
+    );
+    expect(resolveModelMock).not.toHaveBeenCalled();
+    expect(contextEngineCompactMock).not.toHaveBeenCalled();
+    expect(hookRunner.runBeforeCompaction).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit compaction targets on the existing path", async () => {
+    hasAvailableAuthForProviderMock.mockResolvedValue(false);
+
+    const result = await compactEmbeddedPiSession(
+      wrappedCompactionArgs({
+        provider: "openai",
+        model: "fake-model",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(resolveModelMock).toHaveBeenCalledWith("openai", "fake-model", "/tmp", undefined);
+    expect(contextEngineCompactMock).toHaveBeenCalled();
   });
 
   it("does not fire after_compaction when compaction fails", async () => {

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -18,6 +18,7 @@ import { resolveSessionAgentIds } from "../agent-scope.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { maybeCompactAgentHarnessSession } from "../harness/selection.js";
+import { hasAvailableAuthForProvider } from "../model-auth.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import type { CompactEmbeddedPiSessionParams } from "./compact.types.js";
 import { asCompactionHookRunner, runPostCompactionSideEffects } from "./compaction-hooks.js";
@@ -69,10 +70,32 @@ export async function compactEmbeddedPiSession(
           defaultProvider: DEFAULT_PROVIDER,
           defaultModel: DEFAULT_MODEL,
         });
+        const usingHardcodedDefaultFallback =
+          !(params.provider?.trim() || params.model?.trim()) &&
+          !params.config?.agents?.defaults?.compaction?.model?.trim() &&
+          resolvedCompactionTarget.provider === DEFAULT_PROVIDER &&
+          resolvedCompactionTarget.model === DEFAULT_MODEL;
         // Resolve token budget from the effective compaction model so engine-
         // owned /compact implementations see the same target as the runtime.
         const ceProvider = resolvedCompactionTarget.provider ?? DEFAULT_PROVIDER;
         const ceModelId = resolvedCompactionTarget.model ?? DEFAULT_MODEL;
+        if (
+          usingHardcodedDefaultFallback &&
+          !(await hasAvailableAuthForProvider({
+            provider: ceProvider,
+            cfg: params.config,
+            preferredProfile: resolvedCompactionTarget.authProfileId,
+            agentDir,
+          }))
+        ) {
+          return {
+            ok: false,
+            compacted: false,
+            reason:
+              `No auth profile available for compaction target ${ceProvider}/${ceModelId}. ` +
+              "Pass provider/model from active session context.",
+          };
+        }
         const { model: ceModel } = await resolveModelAsync(
           ceProvider,
           ceModelId,


### PR DESCRIPTION
Fixes karmaterminal/openclaw-bootstrap#641.

## Summary

Follow-up to #191 / bootstrap#639. When volitional compaction resolves to the hardcoded default target (`DEFAULT_PROVIDER` / `DEFAULT_MODEL`) and the active config has no auth profile for that provider, we now fail at target-resolution time instead of calling into the provider path and surfacing a later `Unknown model:` failure.

### What changed
- `compact.queued.ts`: detect the hardcoded-default fallback case and check `hasAvailableAuthForProvider(...)`
- return a structured failure reason before `resolveModelAsync(...)` / provider execution when no auth exists
- tests: cover the fail-fast branch and confirm explicit compaction targets still follow the old path unchanged
- harness: expose `hasAvailableAuthForProvider` mock for the new test coverage

## Why this shape

PR #191 made the existing failure legible and fixed the missing provider/model threading for the volitional path. This closes the sibling gap figs/Cael called out: if the call still lands on the hardcoded fallback with no auth, refuse immediately with the real root cause instead of letting the provider call fail downstream.

## Test

- `node scripts/run-vitest.mjs run src/agents/pi-embedded-runner/compact.hooks.test.ts src/agents/model-auth.profiles.test.ts`

