### PR TITLE
fix(continuation): emit context-pressure:fire anchor at mid-turn compactions (#61)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ test/fixtures/openclaw-vitest-unit-report.json
 analysis/
 .artifacts/qa-e2e/
 extensions/qa-lab/web/dist/
+.gitnexus
+dist.bak-3.28/

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -1105,6 +1105,29 @@
         "text",
         "channel"
       ]
+    },
+    "continue_delegate": {
+      "emoji": "🔄",
+      "title": "Continue Delegate",
+      "detailKeys": [
+        "task",
+        "mode",
+        "fireAfterMs"
+      ]
+    },
+    "continue_work": {
+      "emoji": "⏩",
+      "title": "Continue Work",
+      "detailKeys": [
+        "reason"
+      ]
+    },
+    "request_compaction": {
+      "emoji": "📦",
+      "title": "Request Compaction",
+      "detailKeys": [
+        "reason"
+      ]
     }
   }
 }

--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -1,0 +1,1344 @@
+# RFC: Agent Self-Elected Turn Continuation (`CONTINUE_WORK`)
+
+**Status:** Implemented — gateway hook wired, 172 tests across 8 test files  
+**Authors:** [karmaterminal](https://github.com/karmaterminal)  
+**Upstream issue:** [openclaw/openclaw#32701](https://github.com/openclaw/openclaw/issues/32701)  
+**PR:** [openclaw/openclaw#38780](https://github.com/openclaw/openclaw/pull/38780)  
+**Date:** March–April 2026
+
+This RFC documents a continuation system for persistent OpenClaw sessions. It introduces self-elected turn continuation, delegated follow-up work, context-pressure awareness, and agent-initiated compaction. The implementation is bounded, observable, interruptible, and opt-in.
+
+## Table of Contents
+
+- [1. Problem](#1-problem)
+  - [1.1 Inter-turn inertia](#11-inter-turn-inertia)
+  - [1.2 The dwindle pattern](#12-the-dwindle-pattern)
+  - [1.3 Requirements for a continuation primitive](#13-requirements-for-a-continuation-primitive)
+- [2. Solution](#2-solution)
+  - [2.1 Unified interface: tools first, response-token fallback](#21-unified-interface-tools-first-response-token-fallback)
+  - [2.2 `continue_work()` semantics](#22-continue_work-semantics)
+  - [2.3 `continue_delegate()` semantics and return modes](#23-continue_delegate-semantics-and-return-modes)
+  - [2.4 `request_compaction()` semantics](#24-request_compaction-semantics)
+  - [2.5 Response-token fallback and token interaction](#25-response-token-fallback-and-token-interaction)
+  - [2.6 Three-tier fallback hierarchy](#26-three-tier-fallback-hierarchy)
+  - [2.7 Design rationale](#27-design-rationale)
+- [3. Implementation](#3-implementation)
+  - [3.1 Architecture](#31-architecture)
+  - [3.2 Delegate dispatch walkthrough](#32-delegate-dispatch-walkthrough)
+  - [3.3 Announce payloads and chain tracking](#33-announce-payloads-and-chain-tracking)
+  - [3.4 Tool implementation and prompt gating](#34-tool-implementation-and-prompt-gating)
+  - [3.5 Temporal sharding with context attachments](#35-temporal-sharding-with-context-attachments)
+- [4. Platform Integration](#4-platform-integration)
+  - [4.1 Two-layer compaction model and trigger taxonomy](#41-two-layer-compaction-model-and-trigger-taxonomy)
+  - [4.2 Context-pressure awareness](#42-context-pressure-awareness)
+  - [4.3 `request_compaction()` in the compaction lifecycle](#43-request_compaction-in-the-compaction-lifecycle)
+  - [4.4 Continuation relay and post-compaction context rehydration](#44-continuation-relay-and-post-compaction-context-rehydration)
+  - [4.5 Lifecycle hooks and platform settings](#45-lifecycle-hooks-and-platform-settings)
+- [5. Configuration](#5-configuration)
+  - [5.1 Core configuration surface](#51-core-configuration-surface)
+  - [5.2 Operator profiles](#52-operator-profiles)
+  - [5.3 Wide fan-out patterns](#53-wide-fan-out-patterns)
+  - [5.4 Task Flow backing and durable delegate queues](#54-task-flow-backing-and-durable-delegate-queues)
+- [6. Observability](#6-observability)
+  - [6.1 Diagnostic log anchors](#61-diagnostic-log-anchors)
+  - [6.2 Lifecycle traces](#62-lifecycle-traces)
+  - [6.3 `/status` continuation telemetry](#63-status-continuation-telemetry)
+  - [6.4 Context-pressure telemetry and fleet evidence](#64-context-pressure-telemetry-and-fleet-evidence)
+  - [6.5 Operator observability and hot reload](#65-operator-observability-and-hot-reload)
+- [7. Safety and Security](#7-safety-and-security)
+  - [7.1 Guardrails and operator consent](#71-guardrails-and-operator-consent)
+  - [7.2 Temporal gap and payload integrity](#72-temporal-gap-and-payload-integrity)
+- [8. Production Use Cases](#8-production-use-cases)
+  - [8.1 Persistent development workflows](#81-persistent-development-workflows)
+  - [8.2 Background research and scheduled follow-up](#82-background-research-and-scheduled-follow-up)
+  - [8.3 Ambient self-knowledge and quiet enrichment](#83-ambient-self-knowledge-and-quiet-enrichment)
+  - [8.4 Long-running creative and synthesis loops](#84-long-running-creative-and-synthesis-loops)
+- [9. Testing](#9-testing)
+  - [9.1 Test strategy and terminology](#91-test-strategy-and-terminology)
+  - [9.2 Functional coverage](#92-functional-coverage)
+  - [9.3 Blind enrichment methodology](#93-blind-enrichment-methodology)
+  - [9.4 Integration test session results](#94-integration-test-session-results)
+  - [9.5 Major findings from live validation](#95-major-findings-from-live-validation)
+- [10. Summary and Future](#10-summary-and-future)
+  - [10.1 Summary](#101-summary)
+  - [10.2 Future directions](#102-future-directions)
+- [Appendix A. Proposed and unimplemented extensions](#appendix-a-proposed-and-unimplemented-extensions)
+  - [A.1 Bounded pre-compaction evacuation window](#a1-bounded-pre-compaction-evacuation-window)
+  - [A.2 Compaction-triggered evacuation delegate](#a2-compaction-triggered-evacuation-delegate)
+  - [A.3 Proposed `context_pressure` lifecycle hook](#a3-proposed-context_pressure-lifecycle-hook)
+  - [A.4 Proposed configuration values not shipped in the current codebase](#a4-proposed-configuration-values-not-shipped-in-the-current-codebase)
+- [Appendix B. Alternatives, prior art, and tool comparisons](#appendix-b-alternatives-prior-art-and-tool-comparisons)
+  - [B.1 Alternatives considered](#b1-alternatives-considered)
+  - [B.2 Prior art](#b2-prior-art)
+  - [B.3 `continue_delegate()` compared with `sessions_spawn`](#b3-continue_delegate-compared-with-sessions_spawn)
+  - [B.4 Async-only volitional compaction decision record](#b4-async-only-volitional-compaction-decision-record)
+- [Appendix C. Failure modes and behavioral limitations](#appendix-c-failure-modes-and-behavioral-limitations)
+  - [C.1 Operational failure modes](#c1-operational-failure-modes)
+  - [C.2 Inherited behavioral limitations](#c2-inherited-behavioral-limitations)
+- [Appendix D. Detailed implementation evidence](#appendix-d-detailed-implementation-evidence)
+  - [D.1 Context-pressure inclusion sketch](#d1-context-pressure-inclusion-sketch)
+  - [D.2 Evidence locations](#d2-evidence-locations)
+  - [D.3 Swim 7 scorecard and evidence lines](#d3-swim-7-scorecard-and-evidence-lines)
+  - [D.4 Swim 8 detailed results](#d4-swim-8-detailed-results)
+  - [D.5 Swim 9 and Swim 10 detailed results](#d5-swim-9-and-swim-10-detailed-results)
+
+## 1. Problem
+
+### 1.1 Inter-turn inertia
+
+Existing mechanisms for keeping an OpenClaw agent active—heartbeat timers, cron-scheduled wake-ups, operator-authored loop instructions in system prompts—all work by injecting **external** events on a fixed schedule. They solve the liveness problem: the agent wakes up periodically. They do not solve the **volition** problem: the agent cannot say, mid-work, “I need another turn.” It can only wait for the next scheduled tick.
+
+This distinction matters for three reasons.
+
+First, **context cost.** A heartbeat instruction such as “check all open issues and work on them” occupies space in the context window on every turn, including turns where there is nothing to check. Over thousands of turns and repeated compaction cycles, this static instruction accumulates as the dominant repeated signal in the agent’s working memory—biasing attention toward the polling task and away from the work at hand. The repetition does not merely consume tokens; it shapes what the agent attends to.
+
+Second, **token waste.** Timer-driven polling burns tokens on empty cycles. An agent heartbeating every 60 seconds but with genuine work only once per hour executes 59 empty turns for every productive one.
+
+Third, **granularity.** A cron timer fires on a schedule. The agent knows _during its turn_ whether it has more work. The timer does not know until the next tick. The gap between “I know I have more to do” and “the timer will wake me in 58 seconds” is the inter-turn inertia.
+
+### 1.2 The dwindle pattern
+
+This produces the **dwindle pattern**: an agent with active work in flight decays toward inactivity between unrelated external events. Momentum is lost, context continuity weakens, and work that could have proceeded immediately instead waits for an accidental wake-up.
+
+Observed in production across 4 persistent agent sessions, this pattern consumed substantial productive time each day. The failure mode was not absence of capability; it was absence of an explicit inter-turn continuation primitive.
+
+### 1.3 Requirements for a continuation primitive
+
+A usable continuation primitive for OpenClaw had to satisfy several constraints simultaneously:
+
+1. **Volitional control.** The agent must be able to elect to continue and also elect to stop. This is not an infinite loop with a termination check; it is a choice at each turn boundary.
+2. **Same-session continuity.** The common case should preserve the session rather than forcing every continuation through a new child session.
+3. **Delegated continuation.** The design must support sub-agent work for cases where a future result, not merely another blank turn, is what matters.
+4. **Compaction awareness.** Persistent sessions need a way to prepare for compaction before the platform forces it.
+5. **Bounded operation.** The feature must remain interruptible, rate-limited, observable, and explicitly enabled by the operator.
+6. **Fallback behavior.** The mechanism must still work when tools are unavailable, including environments that only allow terminal response syntax.
+
+## 2. Solution
+
+### 2.1 Unified interface: tools first, response-token fallback
+
+The implemented solution exposes three continuation capabilities as tools on main-session turns when `continuation.enabled: true`, with fallback response syntax when tools are unavailable.
+
+| Capability             | Primary interface      | Fallback                            | Purpose                                                   |
+| ---------------------- | ---------------------- | ----------------------------------- | --------------------------------------------------------- |
+| Self-elected next turn | `continue_work()`      | `CONTINUE_WORK` / `CONTINUE_WORK:N` | Schedule another turn for the current session             |
+| Delegated work         | `continue_delegate()`  | `[[CONTINUE_DELEGATE: ...]]`        | Dispatch work to a sub-agent and preserve chain semantics |
+| Volitional compaction  | `request_compaction()` | None                                | Request compaction after preparatory work                 |
+
+All three tools are fire-and-forget. They schedule their action and return immediately. The current turn continues to completion normally; the follow-up action occurs only after the turn ends.
+
+This yields a strict two-interface model:
+
+- **Primary path:** typed tools with validation, multiple calls per turn where appropriate, and explicit schemas.
+- **Fallback path:** response-terminal syntax that works when tools are disabled by operator policy, unavailable to a given depth, or fail in the current turn.
+
+### 2.2 `continue_work()` semantics
+
+`continue_work()` is the same-session continuation primitive.
+
+**Purpose:** request another turn for the current session after an optional delay.
+
+**Behavior:** calling `continue_work()` schedules a future turn and the current turn completes normally. The call does not terminate the active turn, and it does not force an immediate second generation inside the same turn.
+
+If `delaySeconds` is 30 and the current turn is still active, the 30-second timer starts **after turn completion**, not when the tool call is emitted. The same timing model applies to the `CONTINUE_WORK:30` response token.
+
+**Safety model:** the scheduled continuation remains subject to chain-length, token-budget, and generation-drift guards. If the session has already exhausted its configured continuation budget, the call is rejected and the agent may stop, persist state to files, or choose another recovery path.
+
+### 2.3 `continue_delegate()` semantics and return modes
+
+`continue_delegate()` is the delegated continuation primitive.
+
+**Purpose:** dispatch a sub-agent with typed task, mode, and delay parameters, then route its completion back into the parent continuation chain. In the current implementation, delegate results return to their immediate caller (the session that dispatched them). However, delegates using `normal` mode announce their results to the channel, where the main session can observe them directly regardless of chain depth. For `silent` and `silent-wake` modes, results propagate up through the chain; direct root-return from arbitrary depth is a natural extension of the delivery architecture but is not yet exposed as a distinct mode.
+
+Compared with bracket syntax, `continue_delegate()` adds three core properties:
+
+1. **Multi-delegate fan-out.** Multiple calls in one turn can dispatch multiple delegates in parallel.
+2. **Typed parameters.** Delay, mode, and task are schema-validated rather than parsed from free text.
+3. **Tool-surface discoverability.** The tool is presented directly in the agent’s available interface when enabled.
+
+The delegate return modes are:
+
+| Mode               | Channel echo | Wake parent           | Use case                                                                          |
+| ------------------ | ------------ | --------------------- | --------------------------------------------------------------------------------- |
+| `normal` (default) | ✅           | ✅                    | Standard delegate completion                                                      |
+| `silent`           | ❌           | ❌                    | Passive enrichment that should color a later turn without waking immediately      |
+| `silent-wake`      | ❌           | ✅                    | Quiet background cognition that should trigger the next turn automatically        |
+| `post-compaction`  | ❌           | ✅ (after compaction) | Evacuation or resume work that should be released only after compaction completes |
+
+**`silent:`** the sub-agent result is delivered through `enqueueSystemEvent()` instead of the normal announce path. Internally, the `silentAnnounce` flag threads through spawn and registry paths to gate the delivery decision point. The parent absorbs the result on a later turn but is not woken.
+
+**`silent-wake:`** channel output remains suppressed, but the return triggers a generation cycle through `requestHeartbeatNow()`. This enables quiet background processing without visible channel noise.
+
+**`post-compaction:`** the delegate is staged on the session until compaction completes, then released into the successor session alongside workspace boot files and post-compaction lifecycle context.
+
+Without `silent-wake`, parent-orchestrated chain hops can stall. In canary testing, enrichment arrived successfully but did not trigger hop 2 until an unrelated external message arrived six minutes later.
+
+### 2.4 `request_compaction()` semantics
+
+`request_compaction()` is the agent-initiated compaction primitive.
+
+**Purpose:** allow the agent to prepare working state, then request compaction on its own schedule rather than waiting for overflow.
+
+**Behavior:** the tool enqueues compaction and returns immediately. The current turn finishes normally; compaction runs between turns on the same path used by platform compaction.
+
+`request_compaction()` operates on **the current session only**. If a delegate calls `request_compaction()`, it compacts the delegate’s session, not the parent. This isolation is intentional: a child should not compact the parent session through an inadvertent tool call.
+
+The tool has no response-token fallback. Volitional compaction is tool-only in the current design.
+
+`request_compaction()` works in concert with context-pressure awareness (§4.2) and post-compaction delegate release (§4.4): the agent notices rising pressure, prepares working state, stages recovery delegates, and then elects compaction. The three capabilities together form a volitional compaction lifecycle—awareness, preparation, and execution—all under agent control.
+
+### 2.5 Response-token fallback and token interaction
+
+When tools are unavailable, the continuation system falls back to terminal response syntax:
+
+```text
+CONTINUE_WORK                 → schedule another turn with default delay
+CONTINUE_WORK:30              → schedule another turn 30 seconds after turn completion
+[[CONTINUE_DELEGATE: <task>]] → dispatch a delegate sub-agent
+DONE                          → default inert state until another external event
+```
+
+The bracket syntax is used specifically for the `[[CONTINUE_DELEGATE: ...]]` form. Elsewhere in this document, the primary term is **response token**.
+
+Limitations of fallback syntax:
+
+- One continuation signal per response.
+- End-anchored parsing.
+- No multi-delegate fan-out in a single turn.
+- No fallback form for `request_compaction()`.
+
+Token interaction remains straightforward:
+
+| Combination                      | Behavior                                          |
+| -------------------------------- | ------------------------------------------------- |
+| `NO_REPLY` + `CONTINUE_WORK`     | Silent turn, then schedule continuation           |
+| `HEARTBEAT_OK` + `CONTINUE_WORK` | Acknowledge heartbeat, then schedule continuation |
+| Response text + `CONTINUE_WORK`  | Deliver response text, then schedule continuation |
+| `CONTINUE_WORK` alone            | Silent continuation                               |
+
+### 2.6 Three-tier fallback hierarchy
+
+The system follows a three-tier capability hierarchy.
+
+```text
+Tier 1: continuation.enabled=true and tools available
+  → use continue_work(), continue_delegate(), request_compaction()
+  → response syntax remains available as same-turn fallback if tool use fails
+
+Tier 2: continuation.enabled=true and tools denied by policy or depth
+  → use CONTINUE_WORK or CONTINUE_WORK:N
+  → use [[CONTINUE_DELEGATE: ...]]
+  → request_compaction() unavailable
+
+Tier 3: continuation.enabled=false
+  → no continuation features available
+  → standard single-turn behavior
+```
+
+```mermaid
+flowchart TB
+    subgraph T1["Tier 1: Tools available"]
+        CW1["continue_work()"] --> SCHED1["Schedule turn"]
+        CD1["continue_delegate()"] --> DISP1["Dispatch delegate"]
+        RC1["request_compaction()"] --> COMP1["Enqueue compaction"]
+    end
+
+    subgraph T2["Tier 2: Response-token fallback"]
+        CW2["CONTINUE_WORK / CONTINUE_WORK:N"] --> SCHED2["Schedule turn"]
+        CD2["[[CONTINUE_DELEGATE: ...]]"] --> DISP2["Dispatch delegate"]
+        RC2["request_compaction() unavailable"]
+    end
+
+    subgraph T3["Tier 3: Continuation disabled"]
+        OFF["Standard single-turn mode"]
+    end
+
+    subgraph OUT["Shared continuation machinery"]
+        direction LR
+        WAKE["[continuation:wake]"]
+        SPAWN["Sub-agent spawned"]
+        LANE["Compaction after turn"]
+    end
+
+    SCHED1 & SCHED2 --> WAKE
+    DISP1 & DISP2 --> SPAWN
+    COMP1 --> LANE
+```
+
+### 2.7 Design rationale
+
+1. **Gate by capability, not turn type.** Tool visibility is controlled by `continuation.enabled`, while abuse prevention is handled by runtime guards such as `maxDelegatesPerTurn`, `maxChainLength`, `costCapTokens`, and `generationGuardTolerance`.
+2. **Prefer structured invocation.** Tools avoid the fragility of regex parsing and allow explicit schemas.
+3. **Support width.** Fleet-scale fan-out requires multiple delegates in one turn; response syntax cannot express that efficiently.
+4. **Keep the interface self-describing.** When tools are available, the continuation surface appears explicitly in the tool inventory rather than relying on prior knowledge of terminal syntax.
+5. **Reuse implementation paths.** Tools and fallback syntax converge on the same scheduler and dispatch machinery.
+
+In OpenClaw, `continue_work()` is the first primitive that lets an agent say “I am not done yet” without trapping it in a loop that cannot also say “I am done.”
+
+## 3. Implementation
+
+### 3.1 Architecture
+
+The implementation hooks into existing gateway layers rather than adding a parallel runner.
+
+1. **Token parsing:** `parseContinuationSignal()` and `stripContinuationSignal()` in `src/auto-reply/tokens.ts` detect and remove continuation syntax from displayed output.
+2. **Signal detection:** `runReplyAgent()` in `src/auto-reply/reply/agent-runner.ts` inspects finalized text payloads before follow-up finalization.
+3. **Turn scheduling:** `scheduleContinuationTurn()` in `src/auto-reply/reply/session-updates.ts` injects `[continuation:wake]` through the existing system-event queue.
+4. **Delegate queueing:** tool-path delegates are enqueued via `enqueuePendingDelegate()` and consumed after the response finishes.
+5. **Lifecycle dispatch:** post-compaction delegates are stored on `SessionEntry.pendingPostCompactionDelegates` and released in the compaction completion path.
+
+No new transport layer is introduced. Continuation uses system events, existing sub-agent dispatch, and the standard inbound-message wake path.
+
+### 3.2 Delegate dispatch walkthrough
+
+The delegate path can be traced concretely from emitted response syntax to child completion.
+
+#### Turn 0: emit and strip
+
+Suppose the agent emits:
+
+```text
+Here is the PR review summary.
+
+[[CONTINUE_DELEGATE: verify the test suite passes and report results +10s]]
+```
+
+The gateway then:
+
+1. Parses the terminal bracket syntax.
+2. Strips it from displayed output, so the user sees only the review summary.
+3. Records delegate-pending state outside the model-visible event queue.
+4. Creates a delayed reservation with task, planned hop, fire time, and generation guard.
+5. Arms a timer for the configured delay.
+
+By default that delayed scheduling is process-scoped. A gateway restart clears the in-memory timer and reservation. When `taskFlowDelegates: true`, delegate queue state is backed by Task Flow in SQLite, so queued work survives restart even though a specific in-memory timer does not.
+
+#### Gap window
+
+Between scheduling and spawn, the parent session is idle while the delayed reservation is live. This is the principal temporal gap for audit and security analysis.
+
+#### Spawn and wake
+
+When the timer fires, `spawnSubagentDirect()` creates the child session, carries forward delivery context, records `[continuation:delegate-spawned]`, and advances accepted chain state.
+
+When the child completes, the existing announce path delivers its result back to the parent. The wake is classified through structured continuation metadata such as `continuationTrigger: "delegate-return"`, allowing the parent turn to distinguish internal continuation from unrelated user input.
+
+A representative timeline is:
+
+```text
+t=0s    emit [[CONTINUE_DELEGATE: task +10s]]
+        → parse and strip
+        → record delegate-pending state
+        → create delayed reservation
+        → arm timer
+
+t=10s   timer fires
+        → spawnSubagentDirect()
+        → persist accepted hop label
+        → enqueue [continuation:delegate-spawned]
+        → child begins work
+
+t≈20s   child completes
+        → result delivered to parent
+        → wake classified as delegate-return
+        → parent resumes with child result in context
+```
+
+### 3.3 Announce payloads and chain tracking
+
+When the child finishes, `runSubagentAnnounceFlow()` assembles an internal completion payload that includes task label, status, result text, and reply guidance. The parent receives this as an inbound event and resumes work.
+
+The task string effectively becomes a letter to the future turn. Any useful context embedded in that task survives into the child prompt and the later completion payload.
+
+Session metadata tracks continuation state through:
+
+- `continuationChainCount`
+- `continuationChainStartedAt`
+- `continuationChainTokens`
+
+Delayed delegates reserve future hop labels in a separate module-level reservation store. Those reservations are process-scoped and remain distinct from the persisted accepted-hop counter.
+
+For bracket-parsed chain hops, the hop label is encoded directly in the task prefix as `[continuation:chain-hop:N]`. This is necessary because inbound messages reset some session-level counters between hops.
+
+Budget inheritance follows four rules:
+
+1. **Chain index:** child hop labels advance within the configured maximum.
+2. **Token budget:** `continue_work()` chains and tool-path delegate chains accumulate against `costCapTokens`; bracket-chain cost accumulation exists but remains less reliable at the announce boundary because child token data may not yet be written.
+3. **Delay bounds:** each hop is clamped to runtime-configured `minDelayMs` and `maxDelayMs`.
+4. **Generation guard:** the parent generation counter is checked before delayed spawn.
+
+Both `CONTINUE_WORK` and delegate timers use the same generation-drift test: cancel when `drift > generationGuardTolerance`.
+
+### 3.4 Tool implementation and prompt gating
+
+`continue_work()` and `continue_delegate()` are structured entry points into shared continuation machinery.
+
+For `continue_delegate()` specifically:
+
+- tool calls enqueue work into a module-level pending-delegate store;
+- `agent-runner.ts` consumes that store after main-session responses complete;
+- delayed delegates converge with bracket-path delegates in the same reservation scheduler;
+- immediate delegates bypass the delayed reservation store and spawn directly.
+
+The tool is denied to **leaf** sub-agents through `SUBAGENT_TOOL_DENY_LEAF`, but remains available to orchestrator sub-agents and continuation chain hops below maximum depth.
+
+Consumption differs by context:
+
+- **Main sessions:** post-response consumption in `agent-runner.ts`.
+- **Spawned sub-agents:** announce-boundary consumption in `subagent-announce.ts`, using the requester session as the topology root.
+
+The routing distinction matters. Spawned sub-agents run with `deliver: false` and reach generation through the ingress path (`agentCommandFromIngress` → `runEmbeddedPiAgent`) rather than the ordinary reply path (`get-reply-run.ts` → `runReplyAgent`). The announce-boundary consumer exists specifically so these child sessions can still create the next delegate hop while preserving parent-rooted topology through `targetRequesterSessionKey`.
+
+The system prompt branches on tool availability in `src/agents/system-prompt.ts`:
+
+- when tools are present, the prompt teaches the tool path first and labels response syntax as fallback;
+- when tools are absent, the prompt teaches fallback syntax only.
+
+This keeps the agent’s taught interface aligned with the actual capability surface.
+
+### 3.5 Temporal sharding with context attachments
+
+Continuation is not limited to “same session, one more turn.” It also composes with `sessions_spawn` and its `attachments` parameter.
+
+This yields **temporal sharding**:
+
+```text
+agent receives complex task
+  → spawns N sub-agents with scoped inline attachments
+  → sub-agents execute in parallel over different horizons
+  → completions return to the parent
+  → parent synthesizes
+  → parent elects continue_work() or DONE
+```
+
+Inline context attachments can include:
+
+- memory files,
+- partial results from prior shards,
+- narrowed project specifications,
+- diffs or code fragments,
+- operator-provided working notes.
+
+This turns `sessions_spawn` from “start a task” into “start a task with scoped memory already attached.” Without such attachments, wide fan-out delegates repeatedly rediscover the same state. With them, the parent becomes a coordinator rather than a re-explainer.
+
+## 4. Platform Integration
+
+### 4.1 Two-layer compaction model and trigger taxonomy
+
+OpenClaw compaction now operates across two complementary layers:
+
+- **Initiated layer:** continuation features that allow the agent to notice pressure, prepare, and elect compaction.
+- **Obligatory layer:** platform features that compact at hard boundaries and preserve a minimum mechanical summary.
+
+The two-layer model is:
+
+| Layer      | Components                                                                                    | Role                                                   |
+| ---------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Initiated  | context-pressure alerts, `continue_delegate()` with `post-compaction`, `request_compaction()` | agent-directed preservation of working state           |
+| Obligatory | overflow compaction, `memoryFlush`, `postCompactionSections`                                  | platform-directed preservation when limits are crossed |
+
+The continuation contribution can also be described as a five-trigger taxonomy:
+
+| Trigger                   | Type                 | Who decides         | Source                                                          |
+| ------------------------- | -------------------- | ------------------- | --------------------------------------------------------------- |
+| A: overflow               | reactive automatic   | platform            | existing 100% context trigger                                   |
+| B: timeout + high usage   | reactive automatic   | platform            | existing idle-timeout path; disabled by `idleTimeoutSeconds: 0` |
+| C: `/compact`             | manual               | user                | existing slash command                                          |
+| D: context-pressure       | proactive advisory   | continuation system | `checkContextPressure()` in the reply pipeline                  |
+| E: `request_compaction()` | initiated volitional | agent               | new tool-driven trigger                                         |
+
+Triggers A–C predate this work. Triggers D and E are the continuation additions.
+
+### 4.2 Context-pressure awareness
+
+The continuation system adds a system event that reports session pressure before compaction becomes unavoidable.
+
+A representative configuration is:
+
+```yaml
+agents:
+  defaults:
+    continuation:
+      contextPressureThreshold: 0.8
+```
+
+When the session crosses the threshold, the gateway enqueues a message such as:
+
+```text
+[system:context-pressure] 85% context consumed (170k/200k tokens).
+Consider evacuating working state to memory files or delegating remaining work.
+```
+
+The event is injected **pre-run**, not post-run. That distinction matters: the agent can act in the current turn rather than discovering pressure one turn too late.
+
+Urgency is banded. In production and canary instrumentation, the practical bands were:
+
+- first threshold (often 25% in test instrumentation, 80% in production configurations),
+- 90%,
+- 95%.
+
+The dedup rule is equality-based: the same band does not fire twice consecutively, but a new band always fires. This allows post-compaction lifecycles to begin again at lower bands without suppressing fresh advisories.
+
+### 4.3 `request_compaction()` in the compaction lifecycle
+
+`request_compaction()` fills the gap that appears when `idleTimeoutSeconds: 0` removes the timeout-based compaction path. At time of writing, that setting is necessary for some copilot proxy configurations and slow providers.
+
+When Trigger B is disabled, a session can climb from “still usable” to overflow with no proactive intervention unless D and E exist.
+
+`request_compaction()` therefore does three things:
+
+1. gives the agent a tool to compact after it has written memory files or staged post-compaction delegates;
+2. routes into the same compaction machinery already used by platform compaction;
+3. preserves the existing user-visible model in which compaction occurs between turns rather than freezing a live reply.
+
+The tool applies three guards:
+
+| Guard            | Threshold           | Purpose                                                        |
+| ---------------- | ------------------- | -------------------------------------------------------------- |
+| Context floor    | below 70% rejected  | prevents wasteful compaction                                   |
+| Rate limit       | max 1 per 5 minutes | prevents compaction loops                                      |
+| Generation guard | reject on drift     | avoids compacting mid-conversation after new external activity |
+
+Operational flow:
+
+```text
+1. context-pressure event fires
+2. agent writes files and stages post-compaction work
+3. agent calls request_compaction()
+4. current turn finishes normally
+5. compaction runs between turns
+6. after-compaction path releases staged delegates
+7. successor session resumes with boot files, summary, and enrichment
+```
+
+### 4.4 Continuation relay and post-compaction context rehydration
+
+Before a first-class same-session continuation primitive existed, operators discovered a reliable workaround: export the next piece of work to a child session and let the child’s completion wake the parent later. This RFC refers to that historical pattern as a **continuation relay**.
+
+> Historical analogy: the precursor pattern resembled storing state externally before interruption and restoring it afterward. The analogy is useful only for topology. In this document the technical terms are **continuation relay** for the precursor dispatch pattern and **post-compaction context rehydration** for the recovery path after compaction.
+
+The relay pattern proved the need for `continue_work()`, but it also clarified what compaction-aware continuation required:
+
+| Property             | Continuation relay precursor       | `continue_work()`        |
+| -------------------- | ---------------------------------- | ------------------------ |
+| Session overhead     | new child session per continuation | same session             |
+| Context boundary     | warm but discontinuous             | continuous               |
+| Latency              | child startup plus execution       | configurable delay only  |
+| Observability        | spread across sessions             | one chain in one session |
+| Role in final design | precursor and fallback pattern     | first-class primitive    |
+
+A lighter precursor also existed: `requestHeartbeatNow()` could ring the parent session like a doorbell, but it still lacked task payload, chain tracking, and typed continuation semantics.
+
+For `post-compaction` delegates, the release semantics are intentionally fixed: staged work is dispatched with `silentAnnounce: true` and `wakeOnReturn: true`. The return is injected as an internal event into the successor session rather than echoed to the user-facing channel.
+
+The post-compaction rehydration path consists of three layers:
+
+1. **Immediate lifecycle signal:** `[system:post-compaction]` establishes that compaction occurred.
+2. **Queued continuity signal:** delegate-pending and staged post-compaction work indicate that asynchronous returns may still be in flight.
+3. **Persistent files:** memory files and `RESUMPTION.md` (a deployment convention, not a platform feature) preserve the durable working summary.
+
+What survives compaction today:
+
+- system events and staged metadata in session storage,
+- files written to disk,
+- post-compaction delegate staging.
+
+What does not survive in full:
+
+- detailed conversational context beyond the compaction summary,
+- associative working-state “temperature” that was held only in the active prompt,
+- some chain metadata that is intentionally reset by lifecycle boundaries.
+
+The role of staged delegates is therefore not merely to preserve facts, but to restore active working shape after the lifecycle reset.
+
+### 4.5 Lifecycle hooks and platform settings
+
+The continuation system integrates with existing compaction hooks and settings rather than replacing them.
+
+Hooks used directly:
+
+| Hook                | Type    | Usage                                                                                                                                              |
+| ------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `before_compaction` | observe | capture pre-compaction diagnostics such as token count, delegate count, and chain depth                                                            |
+| `after_compaction`  | observe | emit `[system:post-compaction]`, inject workspace boot files via `readPostCompactionContext()`, clear staged delegates, and dispatch released work |
+
+Platform settings used in interoperation:
+
+| Setting                              | Platform role                    | Continuation interaction                                                            |
+| ------------------------------------ | -------------------------------- | ----------------------------------------------------------------------------------- |
+| `compaction.memoryFlush.enabled`     | mechanical summary preservation  | provides the floor below intentional delegate-based preservation                    |
+| `compaction.postCompactionSections`  | static section re-injection      | arrives alongside dynamic delegate returns                                          |
+| `compaction.truncateAfterCompaction` | session log cleanup              | affects conversation history, not session metadata or staged delegate state         |
+| `llm.idleTimeoutSeconds`             | timeout-based compaction trigger | when set to `0`, removes Trigger B and increases the importance of Triggers D and E |
+
+The interop invariant is simple: disabling continuation restores ordinary platform compaction behavior without semantic changes.
+
+## 5. Configuration
+
+### 5.1 Core configuration surface
+
+The shipped configuration surface is consolidated below.
+
+```yaml
+agents:
+  defaults:
+    continuation:
+      enabled: false # feature ships disabled by default
+      maxChainLength: 10
+      defaultDelayMs: 15000
+      minDelayMs: 5000
+      maxDelayMs: 300000
+      costCapTokens: 500000
+      maxDelegatesPerTurn: 5
+      generationGuardTolerance: 0
+      contextPressureThreshold: 0.8
+      taskFlowDelegates: true # durable delegate queue via Task Flow (platform feature, ships enabled)
+```
+
+Operational notes:
+
+- `enabled: false` means explicit opt-in is required in `openclaw.json`.
+- `maxChainLength` is a recursion guard.
+- `costCapTokens` is a per-chain budget leash.
+- `generationGuardTolerance` controls whether incidental chatter cancels delayed work. At the shipped default of `0`, any inbound message during a delayed delegate chain will cancel it. This is deliberately conservative: a single-agent deployment where the only user communicates directly should not have background work running unnoticed. Operators with active channels or multiple users should raise this value (see fleet profile below).
+- all runtime values are hot-reloadable; changes take effect at the next enforcement point.
+
+### 5.2 Operator profiles
+
+#### Shipped defaults: single-agent, safety-first
+
+````yaml
+agents:
+  defaults:
+    continuation:
+      enabled: false
+      maxChainLength: 10
+      maxDelegatesPerTurn: 5
+      costCapTokens: 500000
+      generationGuardTolerance: 0
+      defaultDelayMs: 15000
+      minDelayMs: 5000
+      maxDelayMs: 300000
+      contextPressureThreshold: 0.8
+      taskFlowDelegates: true, strict interruption semantics, and a conservative per-chain budget.
+
+#### Fleet multi-agent profile
+
+```yaml
+agents:
+  defaults:
+    continuation:
+      enabled: true
+      maxChainLength: 10
+      maxDelegatesPerTurn: 20
+      costCapTokens: 1000000
+      generationGuardTolerance: 300
+      defaultDelayMs: 15000
+      minDelayMs: 5000
+      maxDelayMs: 300000
+      contextPressureThreshold: 0.8
+      taskFlowDelegates: true for multiple persistent agents in shared channels. In that environment:
+
+- `generationGuardTolerance: 300` absorbs ambient cross-agent generation drift;
+- `maxDelegatesPerTurn: 20` enables wide fan-out;
+- `costCapTokens: 1000000` preserves a budget ceiling while permitting broad but shallow work.
+
+Adjust fan-out and tolerance based on the activity level and agent count in the target channel.
+
+### 5.3 Wide fan-out patterns
+
+A common fleet pattern is wide sensor fan-out:
+
+```text
+main session
+  → coordinator delegate
+    → sensor 1 reads chunk 1
+    → sensor 2 reads chunk 2
+    → sensor 3 reads chunk 3
+    → ... up to maxDelegatesPerTurn
+  → coordinator synthesizes and returns
+````
+
+Representative use cases:
+
+- document chunking and synthesis,
+- parallel research queries,
+- ambient monitoring with `silent` returns,
+- codebase scans across multiple scoped delegates.
+
+In these patterns, width is normally adjusted before depth. `costCapTokens` remains the primary global safety mechanism.
+
+### 5.4 Task Flow backing and durable delegate queues
+
+By default, pending delegates live in a volatile in-memory `Map<string, PendingContinuationDelegate[]>`.
+
+An implemented opt-in alternative routes that queue through Task Flow:
+
+```yaml
+agents:
+  defaults:
+    continuation:
+      taskFlowDelegates: true
+```
+
+When enabled, `enqueuePendingDelegate()` and `consumePendingDelegates()` use `createManagedTaskFlow()` with `controllerId = "core/continuation-delegate"`.
+
+This provides:
+
+| Capability                 | Volatile store | Task Flow                                                     |
+| -------------------------- | -------------- | ------------------------------------------------------------- |
+| Persistence across restart | ❌             | ✅ SQLite-backed                                              |
+| Cancel semantics           | basic drain    | `requestFlowCancel`, terminal cancellation state, audit trail |
+| Lifecycle tracking         | minimal        | queued, spawned, succeeded, cancelled                         |
+| Observability              | manual logging | Task Flow registry queries                                    |
+| Session isolation          | map key        | flow scoping                                                  |
+
+Task Flow therefore aligns continuation delegates with the platform’s broader managed-work infrastructure without changing the public continuation API.
+
+## 6. Observability
+
+### 6.1 Diagnostic log anchors
+
+The implementation emits stable log anchors for the major continuation lifecycle events.
+
+| Log prefix                         | Emitted by                  | Meaning                                               |
+| ---------------------------------- | --------------------------- | ----------------------------------------------------- |
+| `[context-pressure:fire]`          | `context-pressure.ts`       | pressure band crossed and event generated             |
+| `[system:context-pressure]`        | system-event queue          | event included in the next system prompt              |
+| `[continue_delegate:enqueue]`      | `continue-delegate-tool.ts` | tool call enqueued delegate work                      |
+| `[continuation:delegate-pending]`  | `agent-runner.ts`           | delegate chain state registered                       |
+| `[continuation:delegate-spawned]`  | `agent-runner.ts`           | child dispatched after delay or immediate acceptance  |
+| `[continuation/silent-wake]`       | `subagent-announce.ts`      | silent return will wake the parent                    |
+| `[continuation:enrichment-return]` | `subagent-announce.ts`      | silent return injected as system event                |
+| `requestHeartbeatNow`              | heartbeat wake path         | generation cycle requested after a silent-wake return |
+
+These anchors make the full pipeline grepable end to end.
+
+### 6.2 Lifecycle traces
+
+Representative runtime traces are shown below.
+
+**Delegate enqueue and spawn:**
+
+```text
+[continue_delegate:enqueue] session=agent:main silent=false silentWake=true delayMs=60000 task=check CI status
+[continuation:delegate-pending] 1 delegate(s) registered for agent:main
+... 60s later ...
+[continuation:delegate-spawned] task=check CI status delay=60000ms session=agent:main
+```
+
+**Silent return and wake:**
+
+```text
+[continuation/silent-wake] wakeOnReturn=true target=agent:main silentAnnounce=true
+[continuation:enrichment-return] CI is green, all 152 tests passing
+```
+
+**Post-compaction release:**
+
+```text
+[auto-compaction] Session compacted: <before>k → <after>k tokens
+[continuation:compaction-delegate] Consuming 1 compaction delegate(s) — dispatching alongside boot files
+```
+
+**Chain depth and cost:**
+
+```text
+[continuation] Chain depth: 3/10, cost: 45000/500000 tokens
+[continuation] Chain cost cap reached (502000 > 500000) — delegate rejected
+```
+
+**Generation-drift behavior:**
+
+```text
+Tool DELEGATE timer cancelled (generation drift 3 > tolerance 0)
+WORK timer cancelled (generation drift 1 > tolerance 0)
+Tool DELEGATE timer fired and spawned turn 1/10 (drift within tolerance 300)
+```
+
+### 6.3 `/status` continuation telemetry
+
+When continuation is enabled and at least one field is non-zero, `/status` can surface the continuation state:
+
+```text
+🔄 Continuation: chain 3/10 | 2 delegates pending | 1 post-compaction staged | volitional: 1
+```
+
+| Field                      | Source                                        | Meaning                                                   |
+| -------------------------- | --------------------------------------------- | --------------------------------------------------------- |
+| `chain X/Y`                | `continuationChainCount` and `maxChainLength` | current depth versus maximum                              |
+| `Z delegates pending`      | pending delegate store                        | delayed or not-yet-spawned work                           |
+| `W post-compaction staged` | `SessionEntry.pendingPostCompactionDelegates` | delegates waiting for the next compaction lifecycle event |
+| `volitional: N`            | request-compaction counter                    | count of agent-initiated compactions in the session       |
+
+### 6.4 Context-pressure telemetry and fleet evidence
+
+Context-pressure events were validated at low thresholds on a 200k test session (integration test phase 1) and observed operationally across a fleet of 1M-window sessions.
+
+Selected observations:
+
+- at 19% of a 1M window, no band fired;
+- when the window changed to 200k, the same token count jumped directly to a 95 band;
+- after compaction, the reduced token ratio fired a lower band again, which confirmed equality-based dedup rather than monotonic suppression;
+- lowering the threshold via hot reload changed future firing behavior without restart.
+
+The dedup behavior can be summarized as:
+
+| Scenario                      | `band`   | `lastBand` | Fires? |
+| ----------------------------- | -------- | ---------- | ------ |
+| Below all thresholds          | 0        | 0          | No     |
+| First crossing                | 25       | 0          | Yes    |
+| Same band again               | 25       | 25         | No     |
+| Escalation                    | 90 or 95 | lower band | Yes    |
+| Post-compaction new lifecycle | 25       | 95         | Yes    |
+
+Operational fleet evidence from 2026-04-03 across four persistent OpenClaw instances on the same build and channel showed the cost of lacking this visibility:
+
+| Instance   | Compactions | Context at observation | Response latency           | Behavior          |
+| ---------- | ----------- | ---------------------- | -------------------------- | ----------------- |
+| Silas 🌫️   | 6           | 41%                    | normal (<10s)              | responsive        |
+| Ronan 🌊   | 3           | 62%                    | normal (<15s)              | responsive        |
+| Elliott 🌻 | 1           | 74%                    | degraded (~30s)            | slower tool use   |
+| Cael 🩸    | 0           | 81%                    | severely degraded (2+ min) | context thrashing |
+
+In that build, `checkContextPressure()` existed but had not yet been wired into the reply pipeline. The result was a measurable divergence between instances that compacted and those that did not.
+
+### 6.5 Operator observability and hot reload
+
+Operators can observe continuation behavior without restart:
+
+- timer fire and cancel events remain at info level;
+- timer setup and drift accumulation can be demoted to debug level;
+- config changes emit `gateway/reload config change applied`;
+- runtime reads happen at use time rather than process start, so new values apply at the next enforcement point.
+
+Hot-reload validation confirmed live changes to:
+
+- `generationGuardTolerance`,
+- `maxDelegatesPerTurn`,
+- `maxChainLength`,
+- `costCapTokens`,
+- `contextPressureThreshold`.
+
+## 7. Safety and Security
+
+### 7.1 Guardrails and operator consent
+
+The continuation feature is intentionally conservative by default.
+
+| Constraint                 | Default  | Purpose                                                      |
+| -------------------------- | -------- | ------------------------------------------------------------ |
+| `enabled`                  | `false`  | explicit deployment consent required                         |
+| `maxChainLength`           | `10`     | prevents runaway recursion                                   |
+| `costCapTokens`            | `500000` | bounds cost per chain                                        |
+| `minDelayMs`               | `5000`   | prevents tight loops                                         |
+| `maxDelayMs`               | `300000` | bounds scheduling horizon                                    |
+| `generationGuardTolerance` | `0`      | treats any drift as interruption in safety-first deployments |
+| `maxDelegatesPerTurn`      | `5`      | prevents unbounded fan-out                                   |
+
+Additional deployment note: delegate returns rely on an internal announce path. In channels configured with `requireMention: true`, the internal delivery path still bypasses mention gating, which preserves the continuation wake semantics.
+
+### 7.2 Temporal gap and payload integrity
+
+The delegated continuation path introduces a temporal gap between dispatch and return. During that period, task text, inline attachments, and pending delegate metadata are stored and transported as plaintext within the broader trust boundary of the OpenClaw instance.
+
+Threat model:
+
+| Vector               | Risk                                                 | Current state                                                     |
+| -------------------- | ---------------------------------------------------- | ----------------------------------------------------------------- |
+| Task interception    | evacuated context is read during transit or storage  | plaintext                                                         |
+| Payload modification | returned result is altered before parent consumption | no integrity verification                                         |
+| Marker spoofing      | attacker forges continuity metadata                  | no authenticated system-event origin                              |
+| Announce injection   | fabricated completion delivered to parent            | origin tied primarily to session routing, not cryptographic proof |
+
+For single-operator deployments, this usually aligns with the existing trust boundary. For stricter environments, the recommended first mitigation is an audit trail with payload hashing: compute a digest over task text and attachments at dispatch time, store it alongside delegate metadata, and verify it on return.
+
+Stronger options include HMAC signing, encrypted attachments, and signed announce payloads. None are required by the current implementation, but all are compatible with the present architecture.
+
+Operational failure modes and inherited behavioral limitations are documented in [Appendix C](#appendix-c-failure-modes-and-behavioral-limitations).
+
+## 8. Production Use Cases
+
+Observed in production across 4 persistent agent sessions, the continuation system supports several recurring patterns.
+
+### 8.1 Persistent development workflows
+
+These patterns could, in principle, be approximated by a set of static markdown instructions that describe a state machine for the agent to follow. The continuation system differs in a structural way: the agent **elects** the next step based on what it learned in the current turn, rather than following a prescribed sequence. A static instruction set determines the workflow before the work begins. Continuation allows the workflow to emerge from the work itself.
+
+- after answering a user message, the agent resumes work on an open PR;
+- after one review finishes, the agent begins the next queued task;
+- after a visible milestone, the agent schedules a delayed follow-up rather than relying on an operator reminder.
+
+### 8.2 Background research and scheduled follow-up
+
+A typical pattern is:
+
+```text
+continue_delegate(task="read README, CHANGELOG, and architecture doc; return a summary", mode="silent-wake")
+```
+
+The user receives an immediate conversational reply. The research returns later as silent enrichment, and the next answer reflects the new material.
+
+The same pattern works for CI follow-up:
+
+```text
+continue_delegate(task="check CI status for PR #1234", delaySeconds=60, mode="silent-wake")
+```
+
+### 8.3 Ambient self-knowledge and quiet enrichment
+
+A persistent agent can dispatch a quiet shard during an idle heartbeat to inspect its own repository history, logs, or memory files. The result returns silently, enriches the next turn, and does not create channel noise.
+
+This is useful for background self-audit, repository familiarization, and long-horizon context building.
+
+### 8.4 Long-running creative and synthesis loops
+
+The continuation system also supports repeated multi-turn work such as:
+
+- iterative creative explorations over many rounds,
+- large synthesis tasks that need pauses between sub-results,
+- multi-shard temporal coordination where several child sessions return partial results before final synthesis.
+
+These patterns were previously dependent on manual external wake-ups or ad hoc relay behavior.
+
+## 9. Testing
+
+> The fleet of OpenClaw instances described in this section has been running continuation-enabled builds in daily production use since early March 2026. The features documented here are not laboratory constructs; they are the daily-driver tools of a persistent multi-agent deployment.
+
+### 9.1 Test strategy and terminology
+
+In this RFC, an **“integration test session”** means a live multi-agent canary exercise in which OpenClaw instances play explicit roles such as subject under test, coordinator, log monitor, and administrator. Historical labels such as **Swim 7** or **Swim 10** are preserved as proper nouns for specific test sessions.
+
+Testing combined:
+
+- unit and integration tests in the codebase,
+- live canary exercises in persistent sessions,
+- blind enrichment experiments,
+- noisy-channel and quiet-channel validation,
+- cross-review of routing and gating paths.
+
+### 9.2 Functional coverage
+
+The automated suite covers:
+
+- token parsing and stripping for `CONTINUE_WORK` and delegate syntax,
+- delay parsing and clamping,
+- continuation scheduling and cancellation,
+- streaming false-positive prevention,
+- delegate spawn behavior and failure handling,
+- session isolation,
+- context-pressure thresholds and band dedup,
+- event queue ordering,
+- `silent` and `silent-wake` announce behavior,
+- delegate store lifecycle,
+- compaction delegate queues,
+- configuration validation and boundary testing.
+
+### 9.3 Blind enrichment methodology
+
+Blind enrichment testing used a “secret-world” pattern:
+
+```text
+operator → DM → administrator agent
+  → administrator places content on subject filesystem
+  → subject dispatches silent delegate
+  → delegate reads content and returns silently
+  → subject is probed for recall
+  → operator compares recall with ground truth
+```
+
+This establishes a strong claim: the subject’s only legitimate access path is the enrichment pipeline.
+
+The blind test matrix included:
+
+| #   | Content                                 | Dispatch | Enrichment | Recall | Notes                                     |
+| --- | --------------------------------------- | -------- | ---------- | ------ | ----------------------------------------- |
+| 1   | 6-digit number `847293`                 | ✅       | ✅         | ✅     | binary recall                             |
+| 2   | nonsense string `chrysanthemum-vapor-9` | ✅       | ✅         | ✅     | cross-machine via SSH                     |
+| 3   | prose sentence                          | ✅       | ✅         | ✅     | no channel contamination                  |
+| 4   | image description via file + image tool | ✅       | ✅         | ✅     | instruction file plus sibling image       |
+| 5   | dream summary                           | ❌       | —          | ❌     | generation guard cancelled dispatch       |
+| 6   | image via DM chain (catboy)             | ✅       | ✅         | ✅     | `read()` fallback after `image()` failure |
+| 7   | image via DM chain (N from Pokémon)     | ✅       | ⚠️         | ✅     | output correct, tool path unreliable      |
+| 8   | keyword-tagged file (`winterFloor`)     | ✅       | ✅         | ✅     | keyword recall validated                  |
+| 9   | image + keyword, narrated dispatch      | ❌       | —          | ❌     | syntax posted visibly rather than parsed  |
+| 10  | image + keyword, clean retry            | ✅       | ✅         | ✅     | retry succeeded                           |
+| 11  | two-hop chain, wrong path               | ✅       | ❌         | ❌     | workspace path error                      |
+| 12  | two-hop chain, corrected path           | ✅       | ✅         | ✅     | full two-hop pipeline validated           |
+
+Overall: **10/12 passed**. When dispatch occurred correctly, the accuracy rate was **10/10**.
+
+### 9.4 Integration test session results
+
+#### Swim 7
+
+Swim 7 validated tolerance hot reload, width hot reload, chain boundary behavior, textless-turn delegate consumption, and silent-return trust boundaries.
+
+Headline scorecard:
+
+- 10 pass,
+- 2 deferred,
+- 0 fail.
+
+Notable confirmations:
+
+- tolerance hot reload from 0 to 300 changed live timer behavior;
+- width widened from 5 to 12 and narrowed back to 3 without restart;
+- `NO_REPLY`-only turns still consumed pending delegates;
+- blind enrichment returned verifiable facts with honest source attribution when probed carefully.
+
+#### Swim 8
+
+Swim 8 focused on tool usage inside delegate chains.
+
+Headline scorecard:
+
+- 6 pass,
+- 1 documented finding,
+- 0 fail.
+
+Validated items included:
+
+- tool-based delegate chain hops,
+- silent propagation into hop 2,
+- `maxDelegatesPerTurn` enforcement,
+- corrected `maxChainLength` behavior,
+- `DENY_LEAF` enforcement.
+
+Three issues were found and fixed live:
+
+1. `doToolSpawn()` was missing the drain flag required for sub-agent delegate consumption.
+2. The chain-length guard used `>` instead of `>=`.
+3. A silent-reply edge case obscured cost-cap rejection logging.
+
+The one documented finding was mixed tool plus bracket usage in the same sub-agent turn. The tool path is reliable; concurrent mixed usage is unsupported and produces ambiguous consumption order.
+
+#### Swim 9
+
+Swim 9 focused on context pressure and volitional compaction.
+
+Headline scorecard:
+
+- Phase 1 low-context tests: 5/5 pass.
+
+A ship-blocking wiring gap was found: `run.ts` did not forward `requestCompactionOpts` to `attempt.ts`. The fix landed in `b2322f5`. The issue had survived 132 unit tests but was caught immediately in live canary execution.
+
+#### Swim 10
+
+Swim 10 validated full tool parity and integrated behavior.
+
+Headline scorecard:
+
+- 12 pass,
+- 0 fail,
+- 1 deferred.
+
+Confirmed behaviors included:
+
+- `continue_work()` tool firing with delay handling,
+- `continue_delegate()` single dispatch and fan-out,
+- silent-wake enrichment returns,
+- tool use inside delegates,
+- chain-depth enforcement at depth 10,
+- width enforcement at 5 delegates,
+- naturally firing context-pressure warnings,
+- response-token fallback for `CONTINUE_WORK` and bracket delegate syntax,
+- coexistence of tool-primary and fallback parsing.
+
+One live bug fix was required: `registerSubagentRun()` did not persist `silentAnnounce` and `wakeOnReturn` into the registry entry, which broke silent-wake returns until corrected.
+
+The deferred test (`10-H1`) concerned fallback behavior under `tools.deny`; the environment encountered provider instability and a syntax mismatch during the run, so that case remained deferred.
+
+### 9.5 Major findings from live validation
+
+1. **LLMs confabulate tool calls.** In Swim 10, a first attempt appeared to pass despite no actual tool calls having occurred. Log verification was required to detect the false positive.
+2. **LLMs confabulate absent enrichment.** When asked about enrichment that had not arrived, agents sometimes produced plausible but invented content. External verification is therefore mandatory for high-confidence recall.
+3. **Runtime testing found issues that code review missed.** The missing `doToolSpawn()` drain flag and the missing request-compaction wiring both survived prior review.
+4. **Continuation is resilient under pressure, but only with correct routing metadata.** Silent-wake, post-compaction dispatch, and sub-agent tool access all depend on small pieces of topology data being preserved end to end.
+5. **Session reset does not necessarily kill delayed work.** With permissive tolerance and deterministic session-key routing, delayed delegates can survive `/new` and return to the fresh session.
+
+## 10. Summary and Future
+
+### 10.1 Summary
+
+This RFC documents a continuation system that changes OpenClaw sessions from purely reactive units into bounded, observable, agent-directed processes.
+
+The implemented capability consists of six parts:
+
+1. `continue_work()` for self-elected same-session continuation,
+2. `continue_delegate()` for delegated continuation with typed modes,
+3. context-pressure events for pre-compaction awareness,
+4. post-compaction delegate release for lifecycle-aware recovery—pre-compaction work staged electively and released directly into the post-compaction lifecycle event,
+5. `request_compaction()` for volitional compaction,
+6. tool-primary design with response-token fallback.
+
+The feature ships disabled by default, respects operator guardrails, and integrates with the existing compaction and sub-agent machinery rather than replacing it.
+
+### 10.2 Future directions
+
+Several future directions are now technically credible because the continuation substrate exists:
+
+- richer post-compaction recovery strategies,
+- stronger integrity guarantees on delegate payloads,
+- more durable background-work management through Task Flow,
+- inter-session enrichment between persistent OpenClaw instances, including multi-channel presence where a single instance spans several channels,
+- compaction-time preservation strategies that better retain working-state shape rather than only summary facts.
+
+One especially promising direction is **sovereign peer enrichment**: multiple persistent OpenClaw instances exchanging quiet, scoped enrichment across a fleet without forcing central orchestration or requiring omniscience. The continuation system does not implement that pattern directly, but it provides the transport primitives from which such patterns can be built.
+
+## Appendix A. Proposed and unimplemented extensions
+
+### A.1 Bounded pre-compaction evacuation window
+
+A proposed enhancement is a bounded pre-compaction grace window:
+
+1. enqueue `[system:compaction-imminent]` with a deadline,
+2. grant one turn for evacuation,
+3. execute compaction after a non-extendable timeout.
+
+This is analogous to a process receiving a graceful termination signal before forced termination. It is not implemented in the current codebase.
+
+### A.2 Compaction-triggered evacuation delegate
+
+Another proposed enhancement is an automatically spawned evacuation delegate that inherits pre-compaction context, writes `RESUMPTION.md`, updates memory files, and optionally dispatches ordered child work before the parent compacts.
+
+The intended effect is to remove reliance on the parent having noticed the earlier advisory in time. This design is described but not implemented.
+
+### A.3 Proposed `context_pressure` lifecycle hook
+
+A future upstream hook could expose context-pressure detection as a formal modifying lifecycle hook rather than only as reply-pipeline logic. That would allow extensions to alter or suppress the event text, or add extension-specific guidance.
+
+### A.4 Proposed configuration values not shipped in the current codebase
+
+The following values appeared in design exploration but are **not** present in the shipped implementation:
+
+```yaml
+agents:
+  defaults:
+    continuation:
+      compactionWarningThreshold: 0.95
+      preCompactionTurnTimeoutMs: 30000
+      compactionEvacuation: true
+      evacuationTaskTemplate: |
+        Session is being compacted. Preserve current work state.
+```
+
+They are documented here as design targets only.
+
+## Appendix B. Alternatives, prior art, and tool comparisons
+
+### B.1 Alternatives considered
+
+| Alternative                  | Benefit                              | Limitation                                                                                                                                                                                                                                                                  |
+| ---------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Continuation relay precursor | works with existing sub-agent system | session overhead and context discontinuity                                                                                                                                                                                                                                  |
+| Higher heartbeat frequency   | simple to reason about               | burns tokens on empty polls, removes volition, and creates **injection accumulation**—static instructions repeated across thousands of turns become the dominant signal in the context window, biasing agent attention toward the polling task rather than the work at hand |
+| Infinite-loop agent model    | easy to keep active                  | coercive; termination becomes the hard problem                                                                                                                                                                                                                              |
+| Self-messaging               | technically possible                 | pollutes history and still feels like a workaround                                                                                                                                                                                                                          |
+
+### B.2 Prior art
+
+| System                 | Continuation model                    | Limitation relative to OpenClaw continuation       |
+| ---------------------- | ------------------------------------- | -------------------------------------------------- |
+| Anthropic Computer Use | externally supplied `max_turns`       | not agent-elected                                  |
+| OpenAI Codex CLI       | task loop until completion            | task-scoped rather than persistent session-scoped  |
+| AutoGPT / BabyAGI      | looping agent with termination checks | continuation is default; stopping is the hard part |
+| Cline / Aider          | single-task execution loops           | not persistent conversational context              |
+
+None of these systems combine agent-elected continuation with persistent conversational context in the same way.
+
+### B.3 `continue_delegate()` compared with `sessions_spawn`
+
+| Dimension        | `sessions_spawn`                         | `continue_delegate()`                                   |
+| ---------------- | ---------------------------------------- | ------------------------------------------------------- |
+| Initiation       | visible, operator- or agent-invoked task | continuation-specific delegated follow-up               |
+| Visibility       | always announced                         | supports `silent`, `silent-wake`, and `post-compaction` |
+| Cost model       | independent child sessions               | chain-aware cost and depth guards                       |
+| Timing           | immediate                                | immediate or delayed                                    |
+| Return semantics | normal announce                          | normal, silent, wake-on-return, lifecycle release       |
+| Best fit         | explicit visible tasks                   | background enrichment and continuation-carrying work    |
+
+`requestHeartbeatNow()` remains lighter than either, but it carries no task payload and no chain state. It is a wake signal, not a continuation-bearing result channel.
+
+### B.4 Async-only volitional compaction: design decision
+
+`request_compaction()` is intentionally async-only. This is a design decision in the implemented feature, not an alternative that was rejected. It is placed here alongside alternatives for completeness.
+
+Rationale:
+
+1. existing platform compaction already occurs between turns;
+2. synchronous compaction would create user-visible hangs;
+3. the agent should be able to finish its current reply before the lifecycle transition;
+4. `post-compaction` delegate release already covers the main use case for “compact, then continue.”
+
+A synchronous compaction mode is not implemented.
+
+## Appendix C. Failure modes and behavioral limitations
+
+### C.1 Operational failure modes
+
+| Failure                                    | Behavior                                                         |
+| ------------------------------------------ | ---------------------------------------------------------------- |
+| agent ignores context-pressure event       | compaction proceeds normally                                     |
+| agent evacuates too late                   | returning work lands in a later context than intended            |
+| parent session is killed                   | child results are logged but not consumed by the original parent |
+| simultaneous evacuation by multiple agents | no cross-contamination because markers are session-scoped        |
+| shard fails during evacuation              | normal delegate error propagation applies                        |
+| evacuation loop                            | bounded by `maxChainLength`                                      |
+| repeated pressure events                   | bounded by pressure-band dedup                                   |
+
+### C.2 Inherited behavioral limitations
+
+The continuation system inherits three broader limitations from persistent deployments:
+
+1. **Self-bound context occlusion.** Too many recurring lifecycle messages can displace the agent's useful conversational context.
+2. **Channel context poisoning.** In open-listen multi-agent channels, one agent's passive status messages can influence the rest of the fleet.
+3. **Volatile delayed-work state.** Without Task Flow backing, delayed timers and reservations remain process-scoped.
+
+These are not correctness bugs in continuation itself, but they materially shape safe deployment and future design work.
+
+## Appendix D. Detailed implementation evidence
+
+### D.1 Context-pressure inclusion sketch
+
+The pre-run inclusion path can be summarized as follows:
+
+```typescript
+const threshold = cfg.agents?.defaults?.continuation?.contextPressureThreshold;
+if (threshold && sessionEntry.totalTokens && sessionEntry.totalTokensFresh) {
+  const contextWindow = resolveMemoryFlushContextWindowTokens({
+    modelId,
+    agentCfgContextTokens: agentCfg?.contextTokens,
+  });
+  if (contextWindow) {
+    const ratio = sessionEntry.totalTokens / contextWindow;
+    if (ratio >= threshold) {
+      enqueueSystemEvent(
+        sessionKey,
+        `[system:context-pressure] ${Math.round(ratio * 100)}% context consumed ...`,
+      );
+    }
+  }
+}
+```
+
+The key property is **pre-run inclusion**: the event is enqueued and then drained into the same upcoming system prompt.
+
+### D.2 Evidence locations
+
+| Artifact                  | Location                                                                                                                                                               |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Swim 7 structured results | [`karmaterminal/silas-likes-to-watch` PR #27](https://github.com/karmaterminal/silas-likes-to-watch/pull/27)                                                           |
+| Gateway journal           | [`swim-logs/` on `silas-likes-to-watch/main`](https://github.com/karmaterminal/silas-likes-to-watch/tree/main/swim-logs)                                               |
+| Raw operator log capture  | [`swim7-silas-raw-figs-capture-2026-03-06.log`](https://github.com/karmaterminal/silas-likes-to-watch/blob/main/swim-logs/swim7-silas-raw-figs-capture-2026-03-06.log) |
+| Swim 7 chat transcript    | [`elliott/swim7-chat-evidence`](https://github.com/karmaterminal/openclaw/tree/elliott/swim7-chat-evidence) branch                                                     |
+| Swim 8 evidence           | [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) branch                                                     |
+| Swim 9 issue + results    | [`karmaterminal/openclaw-bootstrap#375`](https://github.com/karmaterminal/openclaw-bootstrap/issues/375)                                                               |
+| Swim 10 issue + results   | [`karmaterminal/openclaw-bootstrap#377`](https://github.com/karmaterminal/openclaw-bootstrap/issues/377)                                                               |
+
+### D.3 Swim 7 scorecard and evidence lines
+
+Swim 7 scorecard:
+
+| Test | Description                        | Result      |
+| ---- | ---------------------------------- | ----------- |
+| 7-B  | delegate tolerance hot reload      | ✅ PASS     |
+| 7-C  | WORK tolerance hot reload          | ✅ PASS     |
+| 7-D  | width widen without restart        | ✅ PASS     |
+| 7-E  | width narrow without restart       | ✅ PASS     |
+| 7-F  | chain boundary enforcement         | ✅ PASS     |
+| 7-H  | textless-turn delegate consumption | ✅ PASS     |
+| 7-K  | silent return trust boundary       | ✅ PASS     |
+| 7-M  | blind enrichment accuracy          | ✅ PASS     |
+| 7-I  | post-compaction guard parity       | ⏸️ DEFERRED |
+| 7-J  | grandparent reroute ordering       | ⏸️ DEFERRED |
+
+Representative evidence lines:
+
+```text
+07:02:58 Tool DELEGATE timer cancelled (generation drift 3 > tolerance 0)
+07:03:55 config change applied (dynamic reads: agents.defaults.continuation.generationGuardTolerance)
+07:04:41 Tool DELEGATE timer fired and spawned turn 1/10
+
+07:07:08 WORK timer cancelled (generation drift 1 > tolerance 0)
+07:12:22 WORK timer fired for session agent:main:discord:channel:...
+
+07:22:35 config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+07:23:29 [continue_delegate] Consuming 12 tool delegate(s)
+07:25:53 config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+07:26:24 [continue_delegate] Consuming 3 tool delegate(s)
+```
+
+### D.4 Swim 8 detailed results
+
+Swim 8 targeted delegate tool use inside chain hops.
+
+- **Issue:** [karmaterminal/openclaw#57](https://github.com/karmaterminal/openclaw/issues/57)
+- **SUT:** Silas canary build on fleet node (`urudyne`)
+- **Formation:** Cael (coordinator/driver), Elliott (log monitor), Silas (SUT), Ronan (driver Day 1)
+- **Duration:** March 30–31, 2026, approximately 14 hours across two days
+- **Convergence path:** `8ee9dcbe0f` later squashed to `4f3461ee07`
+
+| Test | Description                            | Result     |
+| ---- | -------------------------------------- | ---------- |
+| 8-T1 | tool delegate from chain-hop sub-agent | ✅ PASS    |
+| 8-T2 | silent delegate propagation            | ✅ PASS    |
+| 8-T3 | `maxDelegatesPerTurn` enforcement      | ✅ PASS    |
+| 8-T4 | `maxChainLength` serial proof          | ✅ PASS    |
+| 8-T5 | mixed bracket and tool signals         | ⚠️ FINDING |
+| 8-T6 | cost-cap enforcement                   | ✅ PASS    |
+| 8-T7 | `DENY_LEAF` enforcement                | ✅ PASS    |
+
+Detailed findings preserved from the canary run:
+
+- missing `drainsContinuationDelegateQueue` on `doToolSpawn()`; the one-line fix landed in `649bac1d12`;
+- off-by-one on chain-length comparison; the `>` to `>=` correction landed in `3d26030cdc`;
+- silent-reply cost-cap logging gap; defensive logging landed in `8ee9dcbe0f`;
+- mixed tool and bracket syntax in one turn is unsupported;
+- the debug log line `[continuation] Continuation instructions suppressed for non-drain run` was the decisive diagnostic artifact;
+- compaction during diagnosis did not destroy the investigation because post-compaction continuation recovered working state.
+
+### D.5 Swim 9 and Swim 10 detailed results
+
+Swim 9:
+
+- **Issue:** [karmaterminal/openclaw-bootstrap#375](https://github.com/karmaterminal/openclaw-bootstrap/issues/375)
+- **SUT:** Silas canary build on `cael/61-volitional-compaction`
+- **Build:** `b2322f5`
+- **Duration:** approximately 2 hours, Phase 1 low-context testing
+- **Result:** 5/5 pass after fixing a missing forwarding of `requestCompactionOpts` from `run.ts` to `attempt.ts`
+
+Swim 10:
+
+- **Issue:** [karmaterminal/openclaw-bootstrap#377](https://github.com/karmaterminal/openclaw-bootstrap/issues/377)
+- **SUT:** Silas canary build on `cael/61-volitional-compaction`
+- **Formation:** Ronan (driver), Elliott (log monitor), Silas (SUT), Cael (coordinator), figs (operator)
+- **Build:** `ad32cde`
+- **Duration:** approximately 5 hours
+- **Result:** 12 pass, 0 fail, 1 deferred
+
+Detailed Swim 10 scorecard:
+
+| Test  | Description                                    | Result          |
+| ----- | ---------------------------------------------- | --------------- |
+| 10-T1 | `continue_work()` fires                        | ✅ PASS         |
+| 10-T2 | delayed `continue_work()` honored              | ✅ PASS         |
+| 10-T4 | single `continue_delegate()` from main session | ✅ PASS         |
+| 10-T5 | fan-out × 3                                    | ✅ PASS (retry) |
+| 10-T6 | silent-wake delegate return                    | ✅ PASS (fix)   |
+| 10-D1 | delegate tool inside delegates                 | ✅ PASS         |
+| 10-D4 | chain-length enforcement at depth 10           | ✅ PASS         |
+| 10-G1 | width enforcement at 5                         | ✅ PASS         |
+| 10-P1 | natural context-pressure fire                  | ✅ PASS         |
+| 10-B1 | bare `CONTINUE_WORK` fallback                  | ✅ PASS         |
+| 10-B2 | bracket delegate fallback                      | ✅ PASS         |
+| 10-B3 | bracket + tool coexistence                     | ✅ PASS         |
+| 10-H1 | fallback under `tools.deny`                    | ⏸️ DEFERRED     |
+
+Additional retained notes:
+
+- `registerSubagentRun()` initially failed to persist `silentAnnounce` and `wakeOnReturn`; the four-line fix was applied during Swim 10 and the retry passed.
+- first-pass tool validation produced a false positive because the agent narrated tool calls it never made; log verification became mandatory.
+- `10-H1` was deferred for operational reasons rather than correctness: provider 429s, timeout and restart churn, and an incorrect test syntax (`[[CONTINUE_WORK: text]]` instead of bare `CONTINUE_WORK`).
+- a six-path delegate wiring audit found one divergence on post-compaction flag normalization; the defensive fix was accepted in `1a1e88e15e` after a cross-review by Codex and Claude.
+- the qualitative canary report was positive: tools felt natural, silent-wake was effective, and the guardrails held at boundaries.

--- a/src/agents/agent-command.test.ts
+++ b/src/agents/agent-command.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./agent-command.js";
+
+describe("agent command ACP text accumulator", () => {
+  it("flushes a buffered silent-prefix fragment from finalizeRaw", () => {
+    const accumulator = __testing.createAcpVisibleTextAccumulator();
+
+    expect(accumulator.consume("NO")).toBeNull();
+    expect(accumulator.finalizeRaw()).toBe("NO");
+    expect(accumulator.finalize()).toBe("NO");
+  });
+});

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -46,6 +46,7 @@ import {
 } from "./agent-scope.js";
 import { ensureAuthProfileStore } from "./auth-profiles.js";
 import { clearSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
+import { createAcpVisibleTextAccumulator } from "./command/attempt-execution.helpers.js";
 import {
   persistSessionEntry as persistSessionEntryBase,
   prependInternalEventContext,
@@ -1108,4 +1109,5 @@ export async function agentCommandFromIngress(
 export const __testing = {
   resolveAgentRuntimeConfig,
   prepareAgentCommandExecution,
+  createAcpVisibleTextAccumulator,
 };

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -120,6 +120,7 @@ export function buildSystemPrompt(params: {
     contextFiles: params.contextFiles,
     ttsHint,
     memoryCitationsMode: params.config?.memory?.citations,
+    continuationEnabled: params.config?.agents?.defaults?.continuation?.enabled === true,
   });
 }
 

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -160,10 +160,10 @@ export function createAcpVisibleTextAccumulator() {
       return { text: visibleText, delta: nextVisible.delta };
     },
     finalize(): string {
-      return visibleText.trim();
+      return (visibleText || pendingSilentPrefix).trim();
     },
     finalizeRaw(): string {
-      return visibleText;
+      return visibleText || pendingSilentPrefix;
     },
   };
 }

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -286,6 +286,7 @@ export function runAgentAttempt(params: {
     extraSystemPrompt: params.opts.extraSystemPrompt,
     bootstrapContextMode: params.opts.bootstrapContextMode,
     bootstrapContextRunKind: params.opts.bootstrapContextRunKind,
+    drainsContinuationDelegateQueue: params.opts.drainsContinuationDelegateQueue,
     internalEvents: params.opts.internalEvents,
     inputProvenance: params.opts.inputProvenance,
     streamParams: params.opts.streamParams,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -1,5 +1,6 @@
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import type { SpawnedRunMetadata } from "../../agents/spawned-context.js";
+import type { ContinuationTrigger } from "../../auto-reply/types.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
@@ -77,6 +78,10 @@ export type AgentCommandOpts = {
   abortSignal?: AbortSignal;
   lane?: string;
   runId?: string;
+  /** Structured lifecycle metadata for internally-triggered turns. */
+  continuationTrigger?: ContinuationTrigger;
+  /** When true, the run drains the pending continuation delegate queue after completion. */
+  drainsContinuationDelegateQueue?: boolean;
   extraSystemPrompt?: string;
   /** Bootstrap workspace context injection mode for this run. */
   bootstrapContextMode?: "full" | "lightweight";

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -16,6 +16,8 @@ import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
+import { createContinueDelegateTool } from "./tools/continue-delegate-tool.js";
+import { createContinueWorkTool, type ContinueWorkRequest } from "./tools/continue-work-tool.js";
 import { createCronTool } from "./tools/cron-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageGenerateTool } from "./tools/image-generate-tool.js";
@@ -24,6 +26,7 @@ import { createMessageTool } from "./tools/message-tool.js";
 import { createMusicGenerateTool } from "./tools/music-generate-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
+import { createRequestCompactionTool } from "./tools/request-compaction-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
@@ -110,6 +113,19 @@ export function createOpenClawTools(
     onYield?: (message: string) => Promise<void> | void;
     /** Allow plugin tools for this tool set to late-bind the gateway subagent. */
     allowGatewaySubagentBinding?: boolean;
+    /** Whether the current run consumes the continue_delegate staging queue. */
+    drainsContinuationDelegateQueue?: boolean;
+    /** Callback for continue_work to request a post-turn continuation. */
+    continueWorkOpts?: {
+      requestContinuation: (request: ContinueWorkRequest) => void;
+    };
+    /** Closures for request_compaction tool (Trigger E). Only set when continuation is enabled. */
+    requestCompactionOpts?: {
+      getContextUsage: () => number;
+      getSessionGeneration: () => number;
+      turnGeneration: number;
+      triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+    };
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const resolvedConfig = options?.config ?? openClawToolsDeps.config;
@@ -301,6 +317,32 @@ export function createOpenClawTools(
       sandboxed: options?.sandboxed,
     }),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),
+    ...(options?.config?.agents?.defaults?.continuation?.enabled === true &&
+    options?.continueWorkOpts
+      ? [
+          createContinueWorkTool({
+            agentSessionKey: options?.agentSessionKey,
+            ...options.continueWorkOpts,
+          }),
+        ]
+      : []),
+    ...(options?.config?.agents?.defaults?.continuation?.enabled === true
+      ? [
+          createContinueDelegateTool({
+            agentSessionKey: options?.agentSessionKey,
+          }),
+        ]
+      : []),
+    ...(options?.config?.agents?.defaults?.continuation?.enabled === true &&
+    options?.requestCompactionOpts
+      ? [
+          createRequestCompactionTool({
+            agentSessionKey: options?.agentSessionKey,
+            sessionId: options?.sessionId,
+            ...options.requestCompactionOpts,
+          }),
+        ]
+      : []),
   ];
 
   if (options?.disablePluginTools) {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -140,6 +140,7 @@ import type { EmbeddedPiCompactResult } from "./types.js";
 import { mapThinkingLevel } from "./utils.js";
 import { flushPendingToolResultsAfterIdle } from "./wait-for-idle-before-flush.js";
 export type { CompactEmbeddedPiSessionParams } from "./compact.types.js";
+export type { CompactionMessageMetrics } from "./compact.types.js";
 
 function hasRealConversationContent(
   msg: AgentMessage,
@@ -733,6 +734,7 @@ export async function compactEmbeddedPiSessionDirect(
           config: params.config,
           workspaceDir: effectiveWorkspace,
           context: {
+            systemPrompt: builtSystemPrompt,
             config: params.config,
             agentDir,
             workspaceDir: effectiveWorkspace,
@@ -742,7 +744,6 @@ export async function compactEmbeddedPiSessionDirect(
             runtimeChannel,
             runtimeCapabilities,
             agentId: sessionAgentId,
-            systemPrompt: builtSystemPrompt,
           },
         }),
       );

--- a/src/agents/pi-embedded-runner/compact.types.ts
+++ b/src/agents/pi-embedded-runner/compact.types.ts
@@ -45,7 +45,7 @@ export type CompactEmbeddedPiSessionParams = {
   customInstructions?: string;
   tokenBudget?: number;
   force?: boolean;
-  trigger?: "budget" | "overflow" | "manual";
+  trigger?: "budget" | "overflow" | "manual" | "volitional";
   diagId?: string;
   attempt?: number;
   maxAttempts?: number;

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -91,6 +91,13 @@ describe("overflow compaction in run loop", () => {
         "context overflow detected (attempt 1/3); attempting auto-compaction",
       ),
     );
+    // Regression guard (#61 / #289): overflow compaction must also emit a
+    // [context-pressure:fire] anchor so operators grepping for mid-turn
+    // pressure triggers (trigger F, per RFC §4.1) find the in-turn event
+    // that bypasses the pre-run checkContextPressure() path.
+    expect(mockedLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[context-pressure:fire] mid-turn trigger=overflow"),
+    );
     expect(mockedLog.info).toHaveBeenCalledWith(
       expect.stringContaining("auto-compaction succeeded"),
     );

--- a/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
@@ -6,6 +6,7 @@ import {
   mockedContextEngine,
   mockedGetApiKeyForModel,
   mockedGlobalHookRunner,
+  mockedLog,
   mockedPickFallbackThinkingLevel,
   mockedResolveAuthProfileOrder,
   mockedRunEmbeddedAttempt,
@@ -99,6 +100,14 @@ describe("timeout-triggered compaction", () => {
       }),
     );
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    // Regression guard (#61 / #289): timeout-compaction path must emit a
+    // [context-pressure:fire] anchor in the same format as the overflow path,
+    // so operators grepping for mid-turn pressure triggers (trigger F,
+    // RFC §4.1) see the timeout-driven compaction that bypasses
+    // checkContextPressure() in agent-runner.ts.
+    expect(mockedLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[context-pressure:fire] mid-turn trigger=timeout"),
+    );
     expect(result.meta.error).toBeUndefined();
   });
 

--- a/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
@@ -330,7 +330,7 @@ describe("timeout-triggered compaction", () => {
     expect(mockedCompactDirect).not.toHaveBeenCalled();
   });
 
-  it("falls through to failover rotation after max timeout compaction attempts", async () => {
+  it("falls through to timeout handling after max timeout compaction attempts", async () => {
     // First attempt: timeout with high prompt usage (150k / 200k = 75%)
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
@@ -380,7 +380,7 @@ describe("timeout-triggered compaction", () => {
     // Both compaction attempts used; third timeout falls through.
     expect(mockedCompactDirect).toHaveBeenCalledTimes(2);
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
-    // Falls through to timeout error payload (failover rotation path)
+    // Falls through to timeout error payload once compaction retries are exhausted.
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("timed out");
   });
@@ -452,46 +452,27 @@ describe("timeout-triggered compaction", () => {
     expect(mockedRunPostCompactionSideEffects).toHaveBeenCalledTimes(1);
   });
 
-  it("counts compacted:false timeout compactions against the retry cap across profile rotation", async () => {
+  it("does not rotate profiles after compacted:false timeout compaction failure", async () => {
     useTwoAuthProfiles();
-    // Attempt 1 (profile-a): timeout → compaction #1 fails → rotate to profile-b
-    mockedRunEmbeddedAttempt
-      .mockResolvedValueOnce(
-        makeAttemptResult({
-          timedOut: true,
-          aborted: true,
-          lastAssistant: {
-            usage: { input: 150000 },
-          } as never,
-        }),
-      )
-      // Attempt 2 (profile-b): timeout → compaction #2 fails → cap exhausted → rotation
-      .mockResolvedValueOnce(
-        makeAttemptResult({
-          timedOut: true,
-          aborted: true,
-          lastAssistant: {
-            usage: { input: 150000 },
-          } as never,
-        }),
-      );
-    mockedCompactDirect
-      .mockResolvedValueOnce({
-        ok: false,
-        compacted: false,
-        reason: "nothing to compact",
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        compacted: false,
-        reason: "nothing to compact",
-      });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        timedOut: true,
+        aborted: true,
+        lastAssistant: {
+          usage: { input: 150000 },
+        } as never,
+      }),
+    );
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "nothing to compact",
+    });
 
     const result = await runEmbeddedPiAgent(overflowBaseRunParams);
 
-    expect(mockedCompactDirect).toHaveBeenCalledTimes(2);
-    expect(mockedCompactDirect).toHaveBeenNthCalledWith(
-      1,
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedCompactDirect).toHaveBeenCalledWith(
       expect.objectContaining({
         runtimeContext: expect.objectContaining({
           authProfileId: "profile-a",
@@ -500,59 +481,35 @@ describe("timeout-triggered compaction", () => {
         }),
       }),
     );
-    expect(mockedCompactDirect).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        runtimeContext: expect.objectContaining({
-          authProfileId: "profile-b",
-          attempt: 2,
-          maxAttempts: 2,
-        }),
-      }),
-    );
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    expect(result.payloads?.[0]?.isError).toBe(true);
-    expect(result.payloads?.[0]?.text).toContain("timed out");
-  });
-
-  it("counts thrown timeout compactions against the retry cap across profile rotation", async () => {
-    useTwoAuthProfiles();
-    // Attempt 1 (profile-a): timeout → compaction #1 throws → rotate to profile-b
-    mockedRunEmbeddedAttempt
-      .mockResolvedValueOnce(
-        makeAttemptResult({
-          timedOut: true,
-          aborted: true,
-          lastAssistant: {
-            usage: { input: 150000 },
-          } as never,
-        }),
-      )
-      // Attempt 2 (profile-b): timeout → compaction #2 throws → cap exhausted → rotation
-      .mockResolvedValueOnce(
-        makeAttemptResult({
-          timedOut: true,
-          aborted: true,
-          lastAssistant: {
-            usage: { input: 150000 },
-          } as never,
-        }),
-      );
-    mockedCompactDirect
-      .mockRejectedValueOnce(new Error("engine crashed"))
-      .mockRejectedValueOnce(new Error("engine crashed again"));
-
-    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
-
-    expect(mockedCompactDirect).toHaveBeenCalledTimes(2);
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(mockedRunEmbeddedAttempt).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ authProfileId: "profile-a" }),
     );
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("timed out");
+  });
+
+  it("does not rotate profiles after thrown timeout compaction failure", async () => {
+    useTwoAuthProfiles();
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        timedOut: true,
+        aborted: true,
+        lastAssistant: {
+          usage: { input: 150000 },
+        } as never,
+      }),
+    );
+    mockedCompactDirect.mockRejectedValueOnce(new Error("engine crashed"));
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(mockedRunEmbeddedAttempt).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ authProfileId: "profile-b" }),
+      1,
+      expect.objectContaining({ authProfileId: "profile-a" }),
     );
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("timed out");

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -891,15 +891,18 @@ export async function runEmbeddedPiAgent(
               log.warn(
                 `[context-pressure:fire] mid-turn trigger=timeout ratio=${Math.round(tokenUsedRatio * 100)}% ` +
                   `tokens=${Math.round((lastTurnPromptTokens ?? 0) / 1000)}k/${Math.round(ctxInfo.tokens / 1000)}k ` +
-                  `session=${params.sessionKey}`,
+                  `sessionKey=${params.sessionKey ?? params.sessionId}`,
               );
-              enqueueSystemEvent(
-                `[system:context-pressure] Mid-turn compaction triggered at ${Math.round(tokenUsedRatio * 100)}% ` +
-                  `context (${Math.round((lastTurnPromptTokens ?? 0) / 1000)}k/${Math.round(ctxInfo.tokens / 1000)}k tokens). ` +
-                  `Your last reply hit the provider timeout ceiling. Consider evacuating working state earlier via ` +
-                  `continue_delegate(post-compaction) or memory files so the next turn starts with room to grow.`,
-                { sessionKey: params.sessionKey ?? "" },
-              );
+              const timeoutSessionKey = params.sessionKey?.trim();
+              if (timeoutSessionKey) {
+                enqueueSystemEvent(
+                  `[system:context-pressure] Mid-turn compaction triggered at ${Math.round(tokenUsedRatio * 100)}% ` +
+                    `context (${Math.round((lastTurnPromptTokens ?? 0) / 1000)}k/${Math.round(ctxInfo.tokens / 1000)}k tokens). ` +
+                    `Your last reply hit the provider timeout ceiling. Consider evacuating working state earlier via ` +
+                    `continue_delegate(post-compaction) or memory files so the next turn starts with room to grow.`,
+                  { sessionKey: timeoutSessionKey },
+                );
+              }
               let timeoutCompactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
               await runOwnsCompactionBeforeHook("timeout recovery");
               try {
@@ -1049,16 +1052,19 @@ export async function runEmbeddedPiAgent(
               log.warn(
                 `[context-pressure:fire] mid-turn trigger=overflow attempt=${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS} ` +
                   `tokens=${observedOverflowTokens !== undefined ? Math.round(observedOverflowTokens / 1000) : "?"}k/${Math.round(ctxInfo.tokens / 1000)}k ` +
-                  `session=${params.sessionKey}`,
+                  `sessionKey=${params.sessionKey ?? params.sessionId}`,
               );
-              enqueueSystemEvent(
-                `[system:context-pressure] Context-overflow compaction triggered mid-turn ` +
-                  `(attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}). ` +
-                  `Your last reply grew the context past the model's window. Consider evacuating ` +
-                  `working state earlier via continue_delegate(post-compaction) or memory files; the ` +
-                  `pre-run context-pressure band did not catch this growth pattern.`,
-                { sessionKey: params.sessionKey ?? "" },
-              );
+              const overflowSessionKey = params.sessionKey?.trim();
+              if (overflowSessionKey) {
+                enqueueSystemEvent(
+                  `[system:context-pressure] Context-overflow compaction triggered mid-turn ` +
+                    `(attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}). ` +
+                    `Your last reply grew the context past the model's window. Consider evacuating ` +
+                    `working state earlier via continue_delegate(post-compaction) or memory files; the ` +
+                    `pre-run context-pressure band did not catch this growth pattern.`,
+                  { sessionKey: overflowSessionKey },
+                );
+              }
               let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
               await runOwnsCompactionBeforeHook("overflow recovery");
               try {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -6,6 +6,7 @@ import { resolveContextEngine } from "../../context-engine/registry.js";
 import { emitAgentPlanEvent } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -882,6 +883,23 @@ export async function runEmbeddedPiAgent(
                 `[timeout-compaction] LLM timed out with high prompt token usage (${Math.round(tokenUsedRatio * 100)}%); ` +
                   `attempting compaction before retry (attempt ${timeoutCompactionAttempts}/${MAX_TIMEOUT_COMPACTION_ATTEMPTS}) diagId=${timeoutDiagId}`,
               );
+              // Emit a pressure-fire anchor so operators grepping for context-pressure
+              // find mid-turn triggers that bypassed the pre-run checkContextPressure()
+              // in agent-runner.ts. Enqueue a post-compaction advisory so the
+              // successor session knows why compaction fired and can evacuate earlier
+              // via continue_delegate(post-compaction) next turn.
+              log.warn(
+                `[context-pressure:fire] mid-turn trigger=timeout ratio=${Math.round(tokenUsedRatio * 100)}% ` +
+                  `tokens=${Math.round((lastTurnPromptTokens ?? 0) / 1000)}k/${Math.round(ctxInfo.tokens / 1000)}k ` +
+                  `session=${params.sessionKey}`,
+              );
+              enqueueSystemEvent(
+                `[system:context-pressure] Mid-turn compaction triggered at ${Math.round(tokenUsedRatio * 100)}% ` +
+                  `context (${Math.round((lastTurnPromptTokens ?? 0) / 1000)}k/${Math.round(ctxInfo.tokens / 1000)}k tokens). ` +
+                  `Your last reply hit the provider timeout ceiling. Consider evacuating working state earlier via ` +
+                  `continue_delegate(post-compaction) or memory files so the next turn starts with room to grow.`,
+                { sessionKey: params.sessionKey ?? "" },
+              );
               let timeoutCompactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
               await runOwnsCompactionBeforeHook("timeout recovery");
               try {
@@ -1023,6 +1041,23 @@ export async function runEmbeddedPiAgent(
               overflowCompactionAttempts++;
               log.warn(
                 `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
+              );
+              // Emit pressure-fire anchor + system event so operators and successor
+              // sessions see the mid-turn overflow compaction in the same format as
+              // pre-run band fires. Matches [context-pressure:fire] grep from §6.1 of
+              // docs/design/continue-work-signal-v2.md (trigger F — overflow recovery).
+              log.warn(
+                `[context-pressure:fire] mid-turn trigger=overflow attempt=${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS} ` +
+                  `tokens=${observedOverflowTokens !== undefined ? Math.round(observedOverflowTokens / 1000) : "?"}k/${Math.round(ctxInfo.tokens / 1000)}k ` +
+                  `session=${params.sessionKey}`,
+              );
+              enqueueSystemEvent(
+                `[system:context-pressure] Context-overflow compaction triggered mid-turn ` +
+                  `(attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}). ` +
+                  `Your last reply grew the context past the model's window. Consider evacuating ` +
+                  `working state earlier via continue_delegate(post-compaction) or memory files; the ` +
+                  `pre-run context-pressure band did not catch this growth pattern.`,
+                { sessionKey: params.sessionKey ?? "" },
               );
               let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
               await runOwnsCompactionBeforeHook("overflow recovery");

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -754,6 +754,9 @@ export async function runEmbeddedPiAgent(
             silentExpected: params.silentExpected,
             bootstrapContextMode: params.bootstrapContextMode,
             bootstrapContextRunKind: params.bootstrapContextRunKind,
+            drainsContinuationDelegateQueue: params.drainsContinuationDelegateQueue,
+            continueWorkOpts: params.continueWorkOpts,
+            requestCompactionOpts: params.requestCompactionOpts,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
@@ -870,7 +873,7 @@ export async function runEmbeddedPiAgent(
                 : 0;
             if (timeoutCompactionAttempts >= MAX_TIMEOUT_COMPACTION_ATTEMPTS) {
               log.warn(
-                `[timeout-compaction] already attempted timeout compaction ${timeoutCompactionAttempts} time(s); falling through to failover rotation`,
+                `[timeout-compaction] already attempted timeout compaction ${timeoutCompactionAttempts} time(s); falling through to timeout handling`,
               );
             } else if (tokenUsedRatio > 0.65) {
               const timeoutDiagId = createCompactionDiagId();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -517,6 +517,8 @@ export async function runEmbeddedAttempt(
             senderE164: params.senderE164,
             senderIsOwner: params.senderIsOwner,
             allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+            continueWorkOpts: params.continueWorkOpts,
+            requestCompactionOpts: params.requestCompactionOpts,
             sessionKey: sandboxSessionKey,
             sessionId: params.sessionId,
             runId: params.runId,
@@ -794,6 +796,7 @@ export async function runEmbeddedAttempt(
         includeMemorySection: !params.contextEngine || params.contextEngine.info.id === "legacy",
         memoryCitationsMode: params.config?.memory?.citations,
         promptContribution,
+        continuationEnabled: params.config?.agents?.defaults?.continuation?.enabled === true,
       });
     const appendPrompt = transformProviderSystemPrompt({
       provider: params.provider,

--- a/src/agents/pi-embedded-runner/run/failover-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.test.ts
@@ -99,6 +99,44 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("surfaces timed-out assistant attempts so local timeout recovery can run", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: false,
+        failoverReason: null,
+        timedOut: true,
+        timedOutDuringCompaction: false,
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "surface_error",
+      reason: null,
+    });
+  });
+
+  it("falls back for classified assistant timeout errors when model fallbacks are configured", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "timeout",
+        timedOut: false,
+        timedOutDuringCompaction: false,
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "timeout",
+    });
+  });
+
   it("does nothing for assistant turns without failover signals", () => {
     expect(
       resolveRunFailoverDecision({

--- a/src/agents/pi-embedded-runner/run/failover-policy.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.ts
@@ -86,10 +86,10 @@ function shouldRotatePrompt(params: PromptDecisionParams): boolean {
 }
 
 function shouldRotateAssistant(params: AssistantDecisionParams): boolean {
-  return (
-    (!params.aborted && (params.failoverFailure || params.failoverReason !== null)) ||
-    (params.timedOut && !params.timedOutDuringCompaction)
-  );
+  if (params.aborted) {
+    return false;
+  }
+  return params.failoverFailure || params.failoverReason !== null;
 }
 
 export function mergeRetryFailoverReason(params: {
@@ -97,7 +97,13 @@ export function mergeRetryFailoverReason(params: {
   failoverReason: FailoverReason | null;
   timedOut?: boolean;
 }): FailoverReason | null {
-  return params.failoverReason ?? (params.timedOut ? "timeout" : null) ?? params.previous;
+  // timedOut takes precedence — timeout must always surface as the reason
+  // to prevent session-lock deadlock (#86). A pre-existing failoverReason
+  // (e.g. "rate_limit") must not mask a timeout condition.
+  if (params.timedOut) {
+    return "timeout";
+  }
+  return params.failoverReason ?? params.previous;
 }
 
 export function resolveRunFailoverDecision(
@@ -147,6 +153,24 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
   }
 
   if (params.externalAbort) {
+    return {
+      action: "surface_error",
+      reason: params.failoverReason,
+    };
+  }
+  if (params.timedOut) {
+    return {
+      action: "surface_error",
+      reason: params.failoverReason,
+    };
+  }
+  if (params.failoverReason === "timeout") {
+    if (params.fallbackConfigured && params.failoverFailure) {
+      return {
+        action: "fallback_model",
+        reason: "timeout",
+      };
+    }
     return {
       action: "surface_error",
       reason: params.failoverReason,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -64,6 +64,21 @@ export type RunEmbeddedPiAgentParams = {
   disableMessageTool?: boolean;
   /** Allow runtime plugins for this run to late-bind the gateway subagent. */
   allowGatewaySubagentBinding?: boolean;
+  /** Whether this run drains continue_delegate work staged during the turn. */
+  drainsContinuationDelegateQueue?: boolean;
+  /** Callback for continue_work to request a post-turn continuation. */
+  continueWorkOpts?: {
+    requestContinuation: (
+      request: import("../../tools/continue-work-tool.js").ContinueWorkRequest,
+    ) => void;
+  };
+  /** Closures for request_compaction tool (Trigger E). Provided by the caller when continuation is enabled. */
+  requestCompactionOpts?: {
+    getContextUsage: () => number;
+    getSessionGeneration: () => number;
+    turnGeneration: number;
+    triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+  };
   sessionFile: string;
   workspaceDir: string;
   agentDir?: string;

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -56,6 +56,7 @@ export function buildEmbeddedSystemPrompt(params: {
   includeMemorySection?: boolean;
   memoryCitationsMode?: MemoryCitationsMode;
   promptContribution?: ProviderSystemPromptContribution;
+  continuationEnabled?: boolean;
 }): string {
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
@@ -86,6 +87,7 @@ export function buildEmbeddedSystemPrompt(params: {
     includeMemorySection: params.includeMemorySection,
     memoryCitationsMode: params.memoryCitationsMode,
     promptContribution: params.promptContribution,
+    continuationEnabled: params.continuationEnabled,
   });
 }
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -38,6 +38,7 @@ function createMessageUpdateContext(
       reasoningStreamOpen: false,
       streamReasoning: false,
       deltaBuffer: "",
+      visibleAssistantBuffer: "",
       blockBuffer: "",
       partialBlockState: {
         thinking: false,
@@ -89,6 +90,7 @@ function createMessageEndContext(
       streamReasoning: false,
       blockReplyBreak: "message_end",
       deltaBuffer: "Need send.",
+      visibleAssistantBuffer: "Need send.",
       blockBuffer: "Need send.",
       blockState: {
         thinking: false,
@@ -311,6 +313,19 @@ describe("handleMessageUpdate", () => {
     expect(flushBlockReplyBuffer).not.toHaveBeenCalled();
     expect(ctx.state.deltaBuffer).toBe("");
     expect(ctx.state.blockBuffer).toBe("");
+  });
+
+  it("builds visible partial text incrementally across text_delta events", () => {
+    const onAgentEvent = vi.fn();
+    const stripBlockTags = vi.fn((text: string) => text);
+    const ctx = createMessageUpdateContext({ onAgentEvent });
+    ctx.stripBlockTags = stripBlockTags as unknown as EmbeddedPiSubscribeContext["stripBlockTags"];
+
+    handleMessageUpdate(ctx, createTextUpdateEvent({ type: "text_delta", text: "Hello" }));
+    handleMessageUpdate(ctx, createTextUpdateEvent({ type: "text_delta", text: " world" }));
+
+    expect(stripBlockTags.mock.calls.map(([text]) => text)).toEqual(["Hello", " world"]);
+    expect(ctx.state.visibleAssistantBuffer).toBe("Hello world");
   });
 
   it("suppresses commentary partials even when they contain visible text", () => {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -278,6 +278,7 @@ export function handleMessageUpdate(
   });
 
   let chunk = "";
+  let shouldRebuildVisibleBuffer = false;
   if (evtType === "text_delta") {
     chunk = delta;
   } else if (evtType === "text_start" || evtType === "text_end") {
@@ -292,6 +293,7 @@ export function handleMessageUpdate(
         chunk = "";
       } else if (!ctx.state.deltaBuffer.includes(content)) {
         chunk = content;
+        shouldRebuildVisibleBuffer = true;
       }
     }
   }
@@ -322,20 +324,10 @@ export function handleMessageUpdate(
     // Handle partial <think> tags: stream whatever reasoning is visible so far.
     ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
   }
-  const next =
-    phaseAwareVisibleText ||
-    (deliveryPhase === "final_answer"
-      ? ""
-      : ctx
-          .stripBlockTags(ctx.state.deltaBuffer, {
-            thinking: false,
-            final: false,
-            inlineCode: createInlineCodeState(),
-          })
-          .trim());
-  if (next) {
+  let visibleDelta = "";
+  if (chunk) {
     const wasThinking = ctx.state.partialBlockState.thinking;
-    const visibleDelta = chunk ? ctx.stripBlockTags(chunk, ctx.state.partialBlockState) : "";
+    visibleDelta = ctx.stripBlockTags(chunk, ctx.state.partialBlockState);
     if (!wasThinking && ctx.state.partialBlockState.thinking) {
       ctx.state.reasoningStreamOpen = true;
     }
@@ -343,6 +335,30 @@ export function handleMessageUpdate(
     if (wasThinking && !ctx.state.partialBlockState.thinking) {
       emitReasoningEnd(ctx);
     }
+  }
+
+  if (shouldRebuildVisibleBuffer) {
+    const rebuiltBlockState = {
+      thinking: false,
+      final: false,
+      inlineCode: createInlineCodeState(),
+    };
+    const rebuiltVisible = ctx.stripBlockTags(ctx.state.deltaBuffer, rebuiltBlockState);
+    ctx.state.partialBlockState.thinking = rebuiltBlockState.thinking;
+    ctx.state.partialBlockState.final = rebuiltBlockState.final;
+    ctx.state.partialBlockState.inlineCode = rebuiltBlockState.inlineCode;
+    if (!shouldUsePhaseAwareBlockReply) {
+      ctx.state.visibleAssistantBuffer = rebuiltVisible;
+    }
+    visibleDelta = "";
+  } else if (!shouldUsePhaseAwareBlockReply && visibleDelta) {
+    ctx.state.visibleAssistantBuffer += visibleDelta;
+  }
+
+  const next =
+    phaseAwareVisibleText ||
+    (deliveryPhase === "final_answer" ? "" : ctx.state.visibleAssistantBuffer.trim());
+  if (next) {
     const parsedDelta = visibleDelta ? ctx.consumePartialReplyDirectives(visibleDelta) : null;
     const parsedFull = parseReplyDirectives(stripTrailingDirective(next));
     const cleanedText = parsedFull.text;
@@ -491,6 +507,7 @@ export function handleMessageEnd(
 
   const finalizeMessageEnd = () => {
     ctx.state.deltaBuffer = "";
+    ctx.state.visibleAssistantBuffer = "";
     ctx.state.blockBuffer = "";
     ctx.blockChunker?.reset();
     ctx.state.blockState.thinking = false;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -43,6 +43,7 @@ export type EmbeddedPiSubscribeState = {
   streamReasoning: boolean;
 
   deltaBuffer: string;
+  visibleAssistantBuffer: string;
   blockBuffer: string;
   blockState: { thinking: boolean; final: boolean; inlineCode: InlineCodeState };
   partialBlockState: { thinking: boolean; final: boolean; inlineCode: InlineCodeState };

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -86,6 +86,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     shouldEmitPartialReplies: !(reasoningMode === "on" && !params.onBlockReply),
     streamReasoning: reasoningMode === "stream" && typeof params.onReasoningStream === "function",
     deltaBuffer: "",
+    visibleAssistantBuffer: "",
     blockBuffer: "",
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
     blockState: { thinking: false, final: false, inlineCode: createInlineCodeState() },
@@ -187,6 +188,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
 
   const resetAssistantMessageState = (nextAssistantTextBaseline: number) => {
     state.deltaBuffer = "";
+    state.visibleAssistantBuffer = "";
     state.blockBuffer = "";
     blockChunker?.reset();
     replyDirectiveAccumulator.reset();

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -308,6 +308,19 @@ export function createOpenClawCodingTools(options?: {
   hasRepliedRef?: { value: boolean };
   /** Allow plugin tools for this run to late-bind the gateway subagent. */
   allowGatewaySubagentBinding?: boolean;
+  /** Callback for continue_work to request a post-turn continuation. */
+  continueWorkOpts?: {
+    requestContinuation: (
+      request: import("./tools/continue-work-tool.js").ContinueWorkRequest,
+    ) => void;
+  };
+  /** Closures for request_compaction tool (Trigger E). */
+  requestCompactionOpts?: {
+    getContextUsage: () => number;
+    getSessionGeneration: () => number;
+    turnGeneration: number;
+    triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+  };
   /** If true, the model has native vision capability */
   modelHasVision?: boolean;
   /** Require explicit message targets (no implicit last-route sends). */
@@ -594,6 +607,8 @@ export function createOpenClawCodingTools(options?: {
       sessionId: options?.sessionId,
       onYield: options?.onYield,
       allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
+      continueWorkOpts: options?.continueWorkOpts,
+      requestCompactionOpts: options?.requestCompactionOpts,
     }),
   ];
   const toolsForMemoryFlush =

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -298,6 +298,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
         sourceChannel: item.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
         sourceTool: item.sourceTool ?? "subagent_announce",
       },
+      continuationTrigger: item.continuationTriggerOverride,
       idempotencyKey,
     },
     timeoutMs: announceTimeoutMs,
@@ -341,6 +342,7 @@ async function maybeQueueSubagentAnnounce(params: {
   sourceChannel?: string;
   sourceTool?: string;
   internalEvents?: AgentInternalEvent[];
+  continuationTriggerOverride?: string;
   signal?: AbortSignal;
 }): Promise<"steered" | "queued" | "none" | "dropped"> {
   if (params.signal?.aborted) {
@@ -379,6 +381,7 @@ async function maybeQueueSubagentAnnounce(params: {
       key: buildAnnounceQueueKey(canonicalKey, origin),
       item: {
         announceId: params.announceId,
+        continuationTriggerOverride: params.continuationTriggerOverride,
         prompt: params.triggerMessage,
         summaryLine: params.summaryLine,
         internalEvents: params.internalEvents,
@@ -412,6 +415,7 @@ async function sendSubagentAnnounceDirectly(params: {
   sourceChannel?: string;
   sourceTool?: string;
   requesterIsSubagent: boolean;
+  continuationTriggerOverride?: string;
   signal?: AbortSignal;
 }): Promise<SubagentAnnounceDeliveryResult> {
   if (params.signal?.aborted) {
@@ -499,6 +503,7 @@ async function sendSubagentAnnounceDirectly(params: {
               sourceChannel: params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
               sourceTool: params.sourceTool ?? "subagent_announce",
             },
+            continuationTrigger: params.continuationTriggerOverride,
             idempotencyKey: params.directIdempotencyKey,
           },
           expectFinal: true,
@@ -539,6 +544,9 @@ export async function deliverSubagentAnnouncement(params: {
   bestEffortDeliver?: boolean;
   directIdempotencyKey: string;
   signal?: AbortSignal;
+  silentEnrichment?: boolean;
+  silentWakeEnrichment?: boolean;
+  continuationTriggerOverride?: string;
 }): Promise<SubagentAnnounceDeliveryResult> {
   return await runSubagentAnnounceDispatch({
     expectsCompletionMessage: params.expectsCompletionMessage,
@@ -555,6 +563,7 @@ export async function deliverSubagentAnnouncement(params: {
         sourceChannel: params.sourceChannel,
         sourceTool: params.sourceTool,
         internalEvents: params.internalEvents,
+        continuationTriggerOverride: params.continuationTriggerOverride,
         signal: params.signal,
       }),
     direct: async () =>
@@ -571,6 +580,7 @@ export async function deliverSubagentAnnouncement(params: {
         sourceTool: params.sourceTool,
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
+        continuationTriggerOverride: params.continuationTriggerOverride,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
       }),

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -23,6 +23,7 @@ export type AnnounceQueueItem = {
   // Stable announce identity shared by direct + queued delivery paths.
   // Optional for backward compatibility with previously queued items.
   announceId?: string;
+  continuationTriggerOverride?: string;
   prompt: string;
   summaryLine?: string;
   internalEvents?: AgentInternalEvent[];

--- a/src/agents/subagent-announce.chain-guard.test.ts
+++ b/src/agents/subagent-announce.chain-guard.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for announce-side chain guard (maxChainLength enforcement).
+ * Verifies [continuation:chain-hop:N] task-prefix tracking using the repo's
+ * max-depth convention: a shard already at hop N cannot spawn hop N+1 when
+ * maxChainLength is N.
+ *
+ * Coverage gap from CODEWALK.md: "No existing test for announce-side chain guard"
+ *
+ * @author Elliott 🌻
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks that DO intercept the SUT (non-barrel modules) ---
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (request: Record<string, unknown>) => {
+    if (request.method === "chat.history") {
+      return { messages: [] };
+    }
+    return {};
+  }),
+}));
+
+vi.mock("./subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 1,
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  isEmbeddedPiRunActive: () => false,
+  queueEmbeddedPiMessage: () => false,
+  waitForEmbeddedPiRunEnd: async () => true,
+}));
+
+vi.mock("./subagent-announce.registry.runtime.js", () => ({
+  countActiveDescendantRuns: () => 0,
+  countPendingDescendantRuns: () => 0,
+  countPendingDescendantRunsExcludingRun: () => 0,
+  isSubagentSessionRunActive: () => true,
+  listSubagentRunsForRequester: () => [],
+  replaceSubagentRunAfterSteer: () => true,
+  resolveRequesterForChildSession: () => null,
+  shouldIgnorePostCompletionAnnounceForSession: () => false,
+}));
+
+vi.mock("../auto-reply/reply/continuation-state.runtime.js", () => ({
+  bumpContinuationGeneration: vi.fn(() => 1),
+  currentContinuationGeneration: vi.fn(() => 0),
+  registerContinuationTimerHandle: vi.fn(),
+  retainContinuationTimerRef: vi.fn(),
+  releaseContinuationTimerRef: vi.fn(),
+  setDelegatePending: vi.fn(),
+  unregisterContinuationTimerHandle: vi.fn(),
+}));
+
+vi.mock("../auto-reply/continuation-delegate-store.js", () => ({
+  consumePendingDelegates: vi.fn(() => []),
+}));
+
+import { consumePendingDelegates } from "../auto-reply/continuation-delegate-store.js";
+import { setRuntimeConfigSnapshot, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { resolveStorePath } from "../config/sessions.js";
+import { runSubagentAnnounceFlow } from "./subagent-announce.js";
+import * as subagentSpawn from "./subagent-spawn.js";
+
+type AnnounceFlowParams = Parameters<typeof runSubagentAnnounceFlow>[0];
+
+function makeConfig(
+  overrides: {
+    maxChainLength?: number;
+    costCapTokens?: number;
+    enabled?: boolean;
+  } = {},
+) {
+  return {
+    session: { mainKey: "main", scope: "per-sender" as const },
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: overrides.enabled ?? true,
+          maxChainLength: overrides.maxChainLength ?? 10,
+          costCapTokens: overrides.costCapTokens ?? 500_000,
+          minDelayMs: 0,
+          maxDelayMs: 0, // zero delay to avoid timer issues
+          generationGuardTolerance: 0,
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Write session data directly to the session store file.
+ * vitest 4.x forks pool doesn't intercept vi.mock for barrel re-exports
+ * (config.js -> io.js, sessions.js -> store.js) so we use the real
+ * filesystem-backed session store instead.
+ */
+function writeSessionStore(data: Record<string, unknown>) {
+  const storePath = resolveStorePath(undefined, { agentId: "main" });
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.writeFileSync(storePath, JSON.stringify(data), "utf8");
+}
+
+function buildChainShardParams(hopIndex: number): AnnounceFlowParams {
+  const taskPrefix = hopIndex > 0 ? `[continuation:chain-hop:${hopIndex}] ` : "";
+  return {
+    childSessionKey: `agent:main:subagent:shard-hop-${hopIndex}`,
+    childRunId: `run-hop-${hopIndex}`,
+    requesterSessionKey: "agent:main:discord:dm:test-chain",
+    requesterDisplayKey: "test-chain",
+    task: `${taskPrefix}Delegated task: do research`,
+    roundOneReply: `Research result.\n[[CONTINUE_DELEGATE: continue next step]]`,
+    timeoutMs: 30_000,
+    cleanup: "delete",
+    outcome: { status: "ok" as const },
+    silentAnnounce: true,
+    wakeOnReturn: true,
+  };
+}
+
+describe("announce-side chain guard (maxChainLength enforcement)", () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Write empty session store so loadSessionEntryByKey finds no entries
+    writeSessionStore({});
+    setRuntimeConfigSnapshot(makeConfig() as any);
+    spawnSpy = vi.spyOn(subagentSpawn, "spawnSubagentDirect").mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:chain-next",
+      runId: "run-chain-next",
+    });
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("allows chain hop when nextChainHop <= maxChainLength", async () => {
+    const params = buildChainShardParams(5);
+    await runSubagentAnnounceFlow(params);
+    // Fire-and-forget spawn: flush microtasks
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:6]");
+  });
+
+  it("allows chain hop when the next shard reaches the configured boundary", async () => {
+    const params = buildChainShardParams(9);
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:10]");
+  });
+
+  it("blocks chain hop once the completing shard already occupies maxChainLength", async () => {
+    const params = buildChainShardParams(10);
+    await runSubagentAnnounceFlow(params);
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks chain hop well beyond maxChainLength", async () => {
+    const params = buildChainShardParams(15);
+    await runSubagentAnnounceFlow(params);
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows first bracket-started hop (no prefix → hop 0)", async () => {
+    const params = buildChainShardParams(0);
+    params.task = "Delegated task: do research";
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:1]");
+  });
+
+  it("respects custom maxChainLength from config at the exact boundary", async () => {
+    setRuntimeConfigSnapshot(makeConfig({ maxChainLength: 3 }) as any);
+
+    const params = buildChainShardParams(2);
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:3]");
+  });
+
+  it("respects custom maxChainLength from config after the boundary is reached", async () => {
+    setRuntimeConfigSnapshot(makeConfig({ maxChainLength: 3 }) as any);
+
+    const params = buildChainShardParams(3);
+    await runSubagentAnnounceFlow(params);
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks on cost cap even when chain length is within bounds", async () => {
+    writeSessionStore({
+      "agent:main:discord:dm:test-chain": {
+        sessionId: "test",
+        updatedAt: Date.now(),
+        continuationChainTokens: 600_000,
+      },
+    });
+
+    const params = buildChainShardParams(1);
+    await runSubagentAnnounceFlow(params);
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool-delegate chain guard (nextToolHop > toolMaxChainLength)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build params for a tool-delegate chain guard test.
+ * The roundOneReply has NO bracket [[CONTINUE_DELEGATE:...]] so the bracket
+ * path stays dormant and only tool delegates (from consumePendingDelegates)
+ * are evaluated.
+ */
+function buildToolDelegateParams(hopIndex: number): AnnounceFlowParams {
+  const taskPrefix = hopIndex > 0 ? `[continuation:chain-hop:${hopIndex}] ` : "";
+  return {
+    childSessionKey: `agent:main:subagent:tool-hop-${hopIndex}`,
+    childRunId: `run-tool-hop-${hopIndex}`,
+    requesterSessionKey: "agent:main:discord:dm:test-chain",
+    requesterDisplayKey: "test-chain",
+    task: `${taskPrefix}Tool-delegated from sub-agent (depth 1): do research`,
+    roundOneReply: "Research complete.", // no bracket delegate
+    timeoutMs: 30_000,
+    cleanup: "delete",
+    outcome: { status: "ok" as const },
+    silentAnnounce: true,
+    wakeOnReturn: true,
+  };
+}
+
+const mockedConsumePendingDelegates = vi.mocked(consumePendingDelegates);
+
+describe("tool-delegate chain guard (nextToolHop > toolMaxChainLength)", () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writeSessionStore({});
+    setRuntimeConfigSnapshot(makeConfig({ maxChainLength: 10 }) as any);
+    spawnSpy = vi.spyOn(subagentSpawn, "spawnSubagentDirect").mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:tool-chain-next",
+      runId: "run-tool-chain-next",
+    });
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    mockedConsumePendingDelegates.mockReturnValue([]);
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("allows tool delegate at maxChainLength-1 (next hop = maxChainLength)", async () => {
+    // childChainHop=9, bracketConsumedHop=0, toolHopBase=9, nextToolHop=10 = maxChainLength → allowed
+    mockedConsumePendingDelegates.mockReturnValue([{ task: "tool task at boundary minus one" }]);
+
+    const params = buildToolDelegateParams(9);
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:10]");
+    expect(spawnArgs.task).toContain("Tool-delegated");
+  });
+
+  it("allows tool delegate at maxChainLength (next hop = maxChainLength, off-by-one fix)", async () => {
+    // With maxChainLength=5: childChainHop=4, nextToolHop=5 = maxChainLength → allowed (> not >=)
+    setRuntimeConfigSnapshot(makeConfig({ maxChainLength: 5 }) as any);
+    mockedConsumePendingDelegates.mockReturnValue([{ task: "tool task exactly at boundary" }]);
+
+    const params = buildToolDelegateParams(4);
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:5]");
+  });
+
+  it("rejects tool delegate at maxChainLength+1 (next hop exceeds max)", async () => {
+    // childChainHop=10, nextToolHop=11 > maxChainLength(10) → rejected
+    mockedConsumePendingDelegates.mockReturnValue([{ task: "tool task beyond boundary" }]);
+
+    const params = buildToolDelegateParams(10);
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects tool delegate well beyond maxChainLength", async () => {
+    mockedConsumePendingDelegates.mockReturnValue([{ task: "tool task way beyond boundary" }]);
+
+    const params = buildToolDelegateParams(15);
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("respects custom maxChainLength for tool delegates", async () => {
+    setRuntimeConfigSnapshot(makeConfig({ maxChainLength: 3 }) as any);
+    mockedConsumePendingDelegates.mockReturnValue([{ task: "tool task at custom boundary" }]);
+
+    // hop 2 → next=3 = maxChainLength → allowed
+    const paramsAllow = buildToolDelegateParams(2);
+    await runSubagentAnnounceFlow(paramsAllow);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+
+    spawnSpy.mockClear();
+
+    // hop 3 → next=4 > maxChainLength → rejected
+    const paramsReject = buildToolDelegateParams(3);
+    await runSubagentAnnounceFlow(paramsReject);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/subagent-announce.continuation.test.ts
+++ b/src/agents/subagent-announce.continuation.test.ts
@@ -1,0 +1,365 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocked = vi.hoisted(() => ({
+  spawnSubagentDirectMock: vi.fn(),
+  requestHeartbeatNowMock: vi.fn(),
+  readLatestAssistantReplyMock: vi.fn(
+    async (_sessionKey?: string): Promise<string | undefined> => "raw subagent reply",
+  ),
+  generationState: new Map<string, number>(),
+  registerContinuationTimerHandleMock: vi.fn(),
+  retainContinuationTimerRefMock: vi.fn(),
+  releaseContinuationTimerRefMock: vi.fn(),
+  setDelegatePendingMock: vi.fn(),
+  unregisterContinuationTimerHandleMock: vi.fn(),
+  countActiveDescendantRunsMock: vi.fn((_key?: string) => 0),
+  countPendingDescendantRunsMock: vi.fn((_key?: string) => 0),
+  isSubagentSessionRunActiveMock: vi.fn((_key?: string) => true),
+  resolveRequesterForChildSessionMock: vi.fn(
+    (_key?: string) =>
+      null as {
+        requesterSessionKey: string;
+        requesterOrigin: { channel: string; to: string };
+      } | null,
+  ),
+}));
+
+// ---------- Non-barrel module mocks (these intercept correctly in vitest 4.x) ----------
+
+vi.mock("./tools/agent-step.js", () => ({
+  readLatestAssistantReply: mocked.readLatestAssistantReplyMock,
+}));
+
+vi.mock("../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => mocked.requestHeartbeatNowMock(...args),
+}));
+
+vi.mock("../auto-reply/reply/continuation-state.runtime.js", () => ({
+  bumpContinuationGeneration: (sessionKey: string) => {
+    const next = (mocked.generationState.get(sessionKey) ?? 0) + 1;
+    mocked.generationState.set(sessionKey, next);
+    return next;
+  },
+  currentContinuationGeneration: (sessionKey: string) =>
+    mocked.generationState.get(sessionKey) ?? 0,
+  registerContinuationTimerHandle: (...args: unknown[]) =>
+    mocked.registerContinuationTimerHandleMock(...args),
+  retainContinuationTimerRef: (...args: unknown[]) =>
+    mocked.retainContinuationTimerRefMock(...args),
+  releaseContinuationTimerRef: (...args: unknown[]) =>
+    mocked.releaseContinuationTimerRefMock(...args),
+  setDelegatePending: (...args: unknown[]) => mocked.setDelegatePendingMock(...args),
+  unregisterContinuationTimerHandle: (...args: unknown[]) =>
+    mocked.unregisterContinuationTimerHandleMock(...args),
+}));
+
+vi.mock("./subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: (sessionKey: string) =>
+    sessionKey.includes(":subagent:") ? 1 : 0,
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  isEmbeddedPiRunActive: () => false,
+  isEmbeddedPiRunStreaming: () => false,
+  queueEmbeddedPiMessage: () => false,
+  waitForEmbeddedPiRunEnd: async () => true,
+}));
+
+vi.mock("./subagent-announce.registry.runtime.js", () => ({
+  countActiveDescendantRuns: (key: string) => mocked.countActiveDescendantRunsMock(key),
+  countPendingDescendantRuns: (key: string) => mocked.countPendingDescendantRunsMock(key),
+  countPendingDescendantRunsExcludingRun: () => 0,
+  isSubagentSessionRunActive: (key: string) => mocked.isSubagentSessionRunActiveMock(key),
+  listSubagentRunsForRequester: () => [],
+  replaceSubagentRunAfterSteer: () => true,
+  resolveRequesterForChildSession: (key: string) => mocked.resolveRequesterForChildSessionMock(key),
+  shouldIgnorePostCompletionAnnounceForSession: () => false,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => ({
+    hasHooks: () => false,
+    runSubagentDeliveryTarget: async () => undefined,
+  }),
+}));
+
+import {
+  setRuntimeConfigSnapshot,
+  clearRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../config/config.js";
+import { resolveStorePath } from "../config/sessions.js";
+import { runSubagentAnnounceFlow } from "./subagent-announce.js";
+import * as subagentSpawn from "./subagent-spawn.js";
+
+/**
+ * Write session data directly to the session store file.
+ * vitest 4.x forks pool doesn't intercept vi.mock for barrel re-exports
+ * so we use the real filesystem-backed session store instead.
+ */
+function writeSessionStore(data: Record<string, unknown>) {
+  const storePath = resolveStorePath(undefined, { agentId: "main" });
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.writeFileSync(storePath, JSON.stringify(data), "utf8");
+}
+
+function makeBaseConfig(overrides?: {
+  maxChainLength?: number;
+  maxDelayMs?: number;
+  costCapTokens?: number;
+  generationGuardTolerance?: number;
+}): OpenClawConfig {
+  return {
+    session: { mainKey: "main", scope: "per-sender" as const },
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: true,
+          maxChainLength: overrides?.maxChainLength ?? 10,
+          minDelayMs: 0,
+          maxDelayMs: overrides?.maxDelayMs ?? 10_000,
+          generationGuardTolerance: overrides?.generationGuardTolerance ?? 0,
+          ...(typeof overrides?.costCapTokens === "number"
+            ? { costCapTokens: overrides.costCapTokens }
+            : {}),
+        },
+      },
+    },
+  };
+}
+
+describe("subagent announce continuation chaining", () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    // Use vi.spyOn instead of vi.mock for subagent-spawn — vitest 4.x forks
+    // pool doesn't reliably intercept vi.mock for modules imported by the SUT.
+    spawnSpy = vi
+      .spyOn(subagentSpawn, "spawnSubagentDirect")
+      .mockImplementation((...args: unknown[]) => mocked.spawnSubagentDirectMock(...args));
+    mocked.spawnSubagentDirectMock.mockReset().mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:spawned",
+      runId: "run-spawned",
+    });
+    mocked.requestHeartbeatNowMock.mockReset();
+    mocked.readLatestAssistantReplyMock.mockReset().mockResolvedValue("raw subagent reply");
+    mocked.generationState.clear();
+    mocked.registerContinuationTimerHandleMock.mockReset();
+    mocked.retainContinuationTimerRefMock.mockReset();
+    mocked.releaseContinuationTimerRefMock.mockReset();
+    mocked.setDelegatePendingMock.mockReset();
+    mocked.unregisterContinuationTimerHandleMock.mockReset();
+    mocked.countActiveDescendantRunsMock.mockReset().mockReturnValue(0);
+    mocked.countPendingDescendantRunsMock.mockReset().mockReturnValue(0);
+    mocked.isSubagentSessionRunActiveMock.mockReset().mockReturnValue(true);
+    mocked.resolveRequesterForChildSessionMock.mockReset().mockReturnValue(null);
+    writeSessionStore({
+      "agent:main:main": {
+        sessionId: "parent-session",
+        continuationChainTokens: 0,
+      },
+    });
+    setRuntimeConfigSnapshot(makeBaseConfig());
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    clearRuntimeConfigSnapshot();
+  });
+
+  async function runContinuationAnnounce(params: {
+    childSessionKey: string;
+    childTaskPrefix: string;
+    reply: string;
+    maxChainLength?: number;
+    maxDelayMs?: number;
+    costCapTokens?: number;
+    requesterSessionKey?: string;
+    wakeOnReturn?: boolean;
+  }) {
+    // Write the child entry into the session store
+    const storePath = resolveStorePath(undefined, { agentId: "main" });
+    const currentStore = JSON.parse(fs.readFileSync(storePath, "utf8"));
+    currentStore[params.childSessionKey] = {
+      sessionId: `${params.childSessionKey}-session`,
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    fs.writeFileSync(storePath, JSON.stringify(currentStore), "utf8");
+
+    // Update config if needed
+    if (
+      typeof params.maxChainLength === "number" ||
+      typeof params.maxDelayMs === "number" ||
+      typeof params.costCapTokens === "number"
+    ) {
+      setRuntimeConfigSnapshot(
+        makeBaseConfig({
+          maxChainLength: params.maxChainLength,
+          maxDelayMs: params.maxDelayMs,
+          costCapTokens: params.costCapTokens,
+        }),
+      );
+    }
+
+    return await runSubagentAnnounceFlow({
+      childSessionKey: params.childSessionKey,
+      childRunId: `${params.childSessionKey}-run`,
+      requesterSessionKey: params.requesterSessionKey ?? "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "discord", to: "channel:123" },
+      task: `${params.childTaskPrefix} delegated task`,
+      roundOneReply: params.reply,
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      // Use silentAnnounce to avoid hitting the real gateway for delivery.
+      // The continuation chain logic runs before the announce gate, so
+      // this does not affect chain-hop spawn coverage.
+      silentAnnounce: true,
+      wakeOnReturn: params.wakeOnReturn,
+    });
+  }
+
+  it("seeds bracket-origin delegates with hop 1 when no prior chain-hop prefix exists", async () => {
+    await runContinuationAnnounce({
+      childSessionKey: "agent:main:subagent:worker-origin",
+      childTaskPrefix: "",
+      reply: "step complete\n[[CONTINUE_DELEGATE: do step 1]]",
+      maxChainLength: 2,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mocked.spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    expect(mocked.spawnSubagentDirectMock.mock.calls[0]?.[0]).toMatchObject({
+      task: expect.stringContaining("[continuation:chain-hop:1]"),
+    });
+  });
+
+  it("propagates canonical chain-hop metadata for the next spawned child", async () => {
+    await runContinuationAnnounce({
+      childSessionKey: "agent:main:subagent:worker-1",
+      childTaskPrefix: "[continuation:chain-hop:1]",
+      reply: "step complete\n[[CONTINUE_DELEGATE: do step 2]]",
+      maxChainLength: 2,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mocked.spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    expect(mocked.spawnSubagentDirectMock.mock.calls[0]?.[0]).toMatchObject({
+      task: expect.stringContaining("[continuation:chain-hop:2]"),
+    });
+  });
+
+  it("keeps silent-wake propagation sticky across chain hops", async () => {
+    await runContinuationAnnounce({
+      childSessionKey: "agent:main:subagent:worker-silent-wake",
+      childTaskPrefix: "[continuation:chain-hop:1]",
+      reply: "step complete\n[[CONTINUE_DELEGATE: do step 2]]",
+      maxChainLength: 3,
+      wakeOnReturn: true,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mocked.spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    expect(mocked.spawnSubagentDirectMock.mock.calls[0]?.[0]).toMatchObject({
+      task: expect.stringContaining("[continuation:chain-hop:2]"),
+      silentAnnounce: true,
+      wakeOnReturn: true,
+    });
+  });
+
+  it("rejects the next hop when the current shard already sits at maxChainLength", async () => {
+    await runContinuationAnnounce({
+      childSessionKey: "agent:main:subagent:worker-2",
+      childTaskPrefix: "[continuation:chain-hop:2]",
+      reply: "step complete\n[[CONTINUE_DELEGATE: do step 3]]",
+      maxChainLength: 2,
+    });
+
+    expect(mocked.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects chain-hop fan-out when parent chain tokens already exceed costCapTokens", async () => {
+    writeSessionStore({
+      "agent:main:main": {
+        sessionId: "parent-session",
+        continuationChainTokens: 11,
+      },
+    });
+
+    await runContinuationAnnounce({
+      childSessionKey: "agent:main:subagent:worker-cost-cap",
+      childTaskPrefix: "[continuation:chain-hop:1]",
+      reply: "step complete\n[[CONTINUE_DELEGATE: do costed step]]",
+      maxChainLength: 3,
+      costCapTokens: 10,
+    });
+
+    expect(mocked.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("reroutes to the live grandparent before applying chain cost guards", async () => {
+    writeSessionStore({
+      "agent:main:main": {
+        sessionId: "grandparent-session",
+        continuationChainTokens: 11,
+      },
+      "agent:main:subagent:parent": null,
+    });
+    mocked.isSubagentSessionRunActiveMock.mockReturnValue(false);
+    mocked.resolveRequesterForChildSessionMock.mockReturnValue({
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "discord", to: "channel:999" },
+    });
+
+    await runContinuationAnnounce({
+      childSessionKey: "agent:main:subagent:worker-grandchild",
+      childTaskPrefix: "[continuation:chain-hop:1]",
+      reply: "step complete\n[[CONTINUE_DELEGATE: do rerouted step]]",
+      maxChainLength: 3,
+      costCapTokens: 10,
+      requesterSessionKey: "agent:main:subagent:parent",
+    });
+
+    expect(mocked.resolveRequesterForChildSessionMock).toHaveBeenCalledWith(
+      "agent:main:subagent:parent",
+    );
+    expect(mocked.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("reads generationGuardTolerance when the delayed chain-hop timer fires", async () => {
+    await runContinuationAnnounce({
+      childSessionKey: "agent:main:subagent:worker-live-tolerance",
+      childTaskPrefix: "[continuation:chain-hop:1]",
+      reply: "step complete\n[[CONTINUE_DELEGATE: do step 2 +1s]]",
+      maxChainLength: 3,
+      maxDelayMs: 10,
+    });
+
+    mocked.generationState.set("agent:main:main", 4);
+    // Update config with tolerance BEFORE the clamped timer fires — the
+    // setTimeout callback calls resolveContinuationRuntimeConfig() which reads
+    // the live config.
+    setRuntimeConfigSnapshot(makeBaseConfig({ maxChainLength: 3, generationGuardTolerance: 3 }));
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(mocked.registerContinuationTimerHandleMock).toHaveBeenCalledWith(
+      "agent:main:main",
+      expect.any(Object),
+    );
+    expect(mocked.retainContinuationTimerRefMock).toHaveBeenCalledWith("agent:main:main");
+    expect(mocked.unregisterContinuationTimerHandleMock).toHaveBeenCalledWith(
+      "agent:main:main",
+      expect.any(Object),
+    );
+    expect(mocked.spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -185,7 +185,7 @@ function loadSessionStoreFixture(): Record<string, SessionEntry> {
   }) as unknown as Record<string, SessionEntry>;
 }
 
-vi.mock("./subagent-registry.js", () => subagentRegistryMock);
+vi.mock("./subagent-announce.registry.runtime.js", () => subagentRegistryMock);
 vi.mock("./subagent-registry-runtime.js", () => subagentRegistryMock);
 
 describe("subagent announce formatting", () => {
@@ -338,6 +338,10 @@ describe("subagent announce formatting", () => {
   });
 
   it("sends instructional message to main agent with status and findings", async () => {
+    setConfigOverride({
+      ...configOverride,
+      agents: { defaults: { continuation: { enabled: true } } },
+    });
     sessionStore = {
       "agent:main:subagent:test": {
         sessionId: "child-session-123",
@@ -365,6 +369,7 @@ describe("subagent announce formatting", () => {
         message?: string;
         sessionKey?: string;
         internalEvents?: Array<{ type?: string; taskLabel?: string }>;
+        continuationTrigger?: string;
       };
     };
     const msg = call?.params?.message as string;
@@ -383,6 +388,24 @@ describe("subagent announce formatting", () => {
     expect(msg).toContain("Keep this internal context private");
     expect(call?.params?.internalEvents?.[0]?.type).toBe("task_completion");
     expect(call?.params?.internalEvents?.[0]?.taskLabel).toBe("do thing");
+    expect(call?.params?.continuationTrigger).toBe("delegate-return");
+  });
+
+  it("omits continuationTrigger when continuation is disabled", async () => {
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-no-continuation-trigger",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      ...defaultOutcomeAnnounce,
+    });
+
+    const call = agentSpy.mock.calls[0]?.[0] as {
+      params?: {
+        continuationTrigger?: string;
+      };
+    };
+    expect(call?.params?.continuationTrigger).toBeUndefined();
   });
 
   it("includes success status when outcome is ok", async () => {
@@ -1703,6 +1726,10 @@ describe("subagent announce formatting", () => {
   });
 
   it("prefers direct delivery first for completion-mode and then queues on direct failure", async () => {
+    setConfigOverride({
+      ...configOverride,
+      agents: { defaults: { continuation: { enabled: true } } },
+    });
     embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
     embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
     sessionStore = {
@@ -1741,6 +1768,10 @@ describe("subagent announce formatting", () => {
   });
 
   it("falls back to internal requester-session injection when completion route is missing", async () => {
+    setConfigOverride({
+      ...configOverride,
+      agents: { defaults: { continuation: { enabled: true } } },
+    });
     embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(false);
     embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
     sessionStore = {
@@ -1774,6 +1805,7 @@ describe("subagent announce formatting", () => {
       params: {
         sessionKey: "agent:main:main",
         deliver: false,
+        continuationTrigger: "delegate-return",
       },
     });
   });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,4 +1,16 @@
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { consumePendingDelegates } from "../auto-reply/continuation-delegate-store.js";
+import { resolveContinuationRuntimeConfig } from "../auto-reply/reply/continuation-runtime.js";
+import {
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  stripContinuationSignal,
+} from "../auto-reply/tokens.js";
+import {
+  resolveAgentIdFromSessionKey,
+  resolveStorePath,
+  updateSessionStore,
+} from "../config/sessions.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { defaultRuntime } from "../runtime.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -56,11 +68,29 @@ let subagentAnnounceDeps: SubagentAnnounceDeps = defaultSubagentAnnounceDeps;
 let subagentRegistryRuntimePromise: Promise<
   typeof import("./subagent-announce.registry.runtime.js")
 > | null = null;
+let continuationStateRuntimePromise: Promise<
+  typeof import("../auto-reply/reply/continuation-state.runtime.js")
+> | null = null;
+let subagentSpawnRuntimePromise: Promise<
+  Pick<typeof import("./subagent-spawn.js"), "spawnSubagentDirect">
+> | null = null;
 
 function loadSubagentRegistryRuntime() {
   subagentRegistryRuntimePromise ??= import("./subagent-announce.registry.runtime.js");
   return subagentRegistryRuntimePromise;
 }
+
+function loadContinuationStateRuntime() {
+  continuationStateRuntimePromise ??= import("../auto-reply/reply/continuation-state.runtime.js");
+  return continuationStateRuntimePromise;
+}
+
+function loadSubagentSpawnRuntime() {
+  subagentSpawnRuntimePromise ??= import("./subagent-spawn.js");
+  return subagentSpawnRuntimePromise;
+}
+
+const continuationGuardLog = createSubsystemLogger("continuation/guard");
 
 export { buildSubagentSystemPrompt } from "./subagent-system-prompt.js";
 export { captureSubagentCompletionReply } from "./subagent-announce-output.js";
@@ -72,6 +102,8 @@ function buildAnnounceReplyInstruction(params: {
   requesterIsSubagent: boolean;
   announceType: SubagentAnnounceType;
   expectsCompletionMessage?: boolean;
+  silentEnrichment?: boolean;
+  silentWakeEnrichment?: boolean;
 }): string {
   if (params.requesterIsSubagent) {
     return `Convert this completion into a concise internal orchestration update for your parent agent in your own words. Keep this internal context private (don't mention system/log/stats/session details or announce type). If this result is duplicate or no update is needed, reply ONLY: ${SILENT_REPLY_TOKEN}.`;
@@ -217,16 +249,48 @@ export async function runSubagentAnnounceFlow(params: {
   wakeOnDescendantSettle?: boolean;
   signal?: AbortSignal;
   bestEffortDeliver?: boolean;
+  /** When true, deliver completion as a silent system event instead of a
+   *  visible channel message. Used for ambient enrichment (DELEGATE | silent). */
+  silentAnnounce?: boolean;
+  /** When true (with silentAnnounce), trigger a generation cycle on the parent
+   *  session after enrichment delivery. Enables autonomous cognition loops
+   *  (DELEGATE | silent-wake). */
+  wakeOnReturn?: boolean;
 }): Promise<boolean> {
   let didAnnounce = false;
   const expectsCompletionMessage = params.expectsCompletionMessage === true;
   const announceType = params.announceType ?? "subagent task";
   let shouldDeleteChildSession = params.cleanup === "delete";
   try {
+    const sessionEntryCache = new Map<string, ReturnType<typeof loadSessionEntryByKey>>();
+    const requesterEntryCache = new Map<string, ReturnType<typeof loadRequesterSessionEntry>>();
+    const readSessionEntryByKey = (sessionKey: string, options?: { refresh?: boolean }) => {
+      if (options?.refresh || !sessionEntryCache.has(sessionKey)) {
+        sessionEntryCache.set(sessionKey, loadSessionEntryByKey(sessionKey));
+      }
+      return sessionEntryCache.get(sessionKey);
+    };
+    const readRequesterSessionEntry = (
+      requesterSessionKey: string,
+      options?: { refresh?: boolean },
+    ) => {
+      if (options?.refresh || !requesterEntryCache.has(requesterSessionKey)) {
+        requesterEntryCache.set(
+          requesterSessionKey,
+          loadRequesterSessionEntry(requesterSessionKey),
+        );
+      }
+      return requesterEntryCache.get(requesterSessionKey)!;
+    };
+    const invalidateSessionEntry = (sessionKey: string) => {
+      sessionEntryCache.delete(sessionKey);
+      requesterEntryCache.delete(sessionKey);
+    };
+
     let targetRequesterSessionKey = params.requesterSessionKey;
     let targetRequesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
     const childSessionId = (() => {
-      const entry = loadSessionEntryByKey(params.childSessionKey);
+      const entry = readSessionEntryByKey(params.childSessionKey);
       return typeof entry?.sessionId === "string" && entry.sessionId.trim()
         ? entry.sessionId.trim()
         : undefined;
@@ -269,13 +333,38 @@ export async function runSubagentAnnounceFlow(params: {
       | undefined;
     try {
       subagentRegistryRuntime = await subagentAnnounceDeps.loadSubagentRegistryRuntime();
-      if (
-        requesterDepth >= 1 &&
-        subagentRegistryRuntime.shouldIgnorePostCompletionAnnounceForSession(
-          targetRequesterSessionKey,
-        )
-      ) {
-        return true;
+      const runtime = subagentRegistryRuntime;
+      const refreshRequesterTarget = () => {
+        if (!requesterIsInternalSession()) {
+          return { ok: true } as const;
+        }
+        if (runtime.isSubagentSessionRunActive(targetRequesterSessionKey)) {
+          return { ok: true } as const;
+        }
+        if (runtime.shouldIgnorePostCompletionAnnounceForSession(targetRequesterSessionKey)) {
+          return { ok: false, ignored: true } as const;
+        }
+        const parentSessionEntry = readSessionEntryByKey(targetRequesterSessionKey);
+        if (hasUsableSessionEntry(parentSessionEntry)) {
+          return { ok: true } as const;
+        }
+        const fallback = runtime.resolveRequesterForChildSession(targetRequesterSessionKey);
+        if (!fallback?.requesterSessionKey) {
+          return { ok: false, missing: true } as const;
+        }
+        targetRequesterSessionKey = fallback.requesterSessionKey;
+        targetRequesterOrigin =
+          normalizeDeliveryContext(fallback.requesterOrigin) ?? targetRequesterOrigin;
+        requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
+        return { ok: true } as const;
+      };
+      const requesterTarget = refreshRequesterTarget();
+      if (!requesterTarget.ok) {
+        if (requesterTarget.ignored) {
+          return true;
+        }
+        shouldDeleteChildSession = false;
+        return false;
       }
 
       const pendingChildDescendantRuns = Math.max(
@@ -339,8 +428,16 @@ export async function runSubagentAnnounceFlow(params: {
       }
     }
 
-    if (!childCompletionFindings) {
-      const fallbackReply = normalizeOptionalString(params.fallbackReply);
+    // Track whether the announce delivery should be skipped (silent/skip reply
+    // with no fallback). Declared here so chain-hop accounting below still runs.
+    let skipAnnounceDelivery = false;
+
+    if (childCompletionFindings?.trim()) {
+      // Descendant completions were synthesized successfully; announce that
+      // result upward unless we converted it into a wake continuation above.
+      reply = childCompletionFindings;
+    } else {
+      const fallbackReply = params.fallbackReply?.trim() ? params.fallbackReply.trim() : undefined;
       const fallbackIsSilent =
         Boolean(fallbackReply) &&
         (isAnnounceSkip(fallbackReply) || isSilentReplyText(fallbackReply, SILENT_REPLY_TOKEN));
@@ -387,7 +484,12 @@ export async function runSubagentAnnounceFlow(params: {
         if (fallbackReply && !fallbackIsSilent) {
           reply = fallbackReply;
         } else {
-          return true;
+          // Do NOT early-return here — fall through to chain-hop accounting
+          // below so that token accumulation, chain guards, and tool-delegate
+          // consumption still run for silent/skip replies. Without this,
+          // subagents that reply with NO_REPLY bypass cost-cap enforcement
+          // and chain-hop accounting entirely (Swim 8, 8-T6 finding).
+          skipAnnounceDelivery = true;
         }
       }
     }
@@ -408,41 +510,410 @@ export async function runSubagentAnnounceFlow(params: {
 
     const taskLabel = params.label || params.task || "task";
     const announceSessionId = childSessionId || "unknown";
-    const findings = childCompletionFindings || reply || "(no output)";
+    let findings = reply || "(no output)";
+    if (
+      childCompletionFindings?.trim() &&
+      findings !== "(no output)" &&
+      findings !== childCompletionFindings
+    ) {
+      findings = `${findings}\n\n[Descendant completions]\n${childCompletionFindings}`;
+    }
 
-    let requesterIsSubagent = requesterIsInternalSession();
-    if (requesterIsSubagent) {
-      const {
-        isSubagentSessionRunActive,
-        resolveRequesterForChildSession,
-        shouldIgnorePostCompletionAnnounceForSession,
-      } = subagentRegistryRuntime ?? (await loadSubagentRegistryRuntime());
-      if (!isSubagentSessionRunActive(targetRequesterSessionKey)) {
-        if (shouldIgnorePostCompletionAnnounceForSession(targetRequesterSessionKey)) {
-          return true;
+    // --- Sub-agent continuation chain: accumulate child token cost + parse [[CONTINUE_DELEGATE:]] ---
+    const cfg = loadConfig();
+    const continuationEnabled = cfg?.agents?.defaults?.continuation?.enabled === true;
+
+    // Accumulate the completing shard's token cost unconditionally on delegate-return,
+    // even if the child doesn't emit another [[CONTINUE_DELEGATE:]]. Without this,
+    // children that finish normally leak their tokens from the chain budget.
+    const childTask = params.task ?? "";
+    const isContinuationChainDelegate = /\[continuation:chain-hop:\d+\]/.test(childTask);
+    let accumulatedChildTokens = 0;
+    if (continuationEnabled && isContinuationChainDelegate) {
+      let childEntry = readSessionEntryByKey(params.childSessionKey);
+      const hasTokenData =
+        typeof childEntry?.inputTokens === "number" ||
+        typeof childEntry?.outputTokens === "number";
+      if (!hasTokenData) {
+        // Best-effort single retry — avoid blocking the announce hot path
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        childEntry = readSessionEntryByKey(params.childSessionKey, { refresh: true });
+        const hasTokenDataRetry =
+          typeof childEntry?.inputTokens === "number" ||
+          typeof childEntry?.outputTokens === "number";
+        if (!hasTokenDataRetry) {
+          defaultRuntime.log(
+            `[subagent-chain-hop] Token data unavailable for ${params.childSessionKey} after retry, proceeding with zero token accumulation`,
+          );
         }
-        const parentSessionEntry = loadSessionEntryByKey(targetRequesterSessionKey);
-        const parentSessionAlive = hasUsableSessionEntry(parentSessionEntry);
-
-        if (!parentSessionAlive) {
-          const fallback = resolveRequesterForChildSession(targetRequesterSessionKey);
-          if (!fallback?.requesterSessionKey) {
-            shouldDeleteChildSession = false;
-            return false;
-          }
-          targetRequesterSessionKey = fallback.requesterSessionKey;
-          targetRequesterOrigin =
-            normalizeDeliveryContext(fallback.requesterOrigin) ?? targetRequesterOrigin;
-          requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
-          requesterIsSubagent = requesterIsInternalSession();
+      }
+      accumulatedChildTokens =
+        (typeof childEntry?.inputTokens === "number" ? childEntry.inputTokens : 0) +
+        (typeof childEntry?.outputTokens === "number" ? childEntry.outputTokens : 0);
+      if (accumulatedChildTokens > 0) {
+        const parentAgentId = resolveAgentIdFromSessionKey(targetRequesterSessionKey);
+        const parentStorePath = resolveStorePath(cfg?.session?.store, {
+          agentId: parentAgentId,
+        });
+        try {
+          await updateSessionStore(parentStorePath, (store) => {
+            const parentEntry = store[targetRequesterSessionKey];
+            if (parentEntry) {
+              const prev =
+                typeof parentEntry.continuationChainTokens === "number"
+                  ? parentEntry.continuationChainTokens
+                  : 0;
+              parentEntry.continuationChainTokens = prev + accumulatedChildTokens;
+            }
+          });
+          defaultRuntime.log(
+            `[subagent-chain-hop] Accumulated ${accumulatedChildTokens} tokens from ${params.childSessionKey} to parent chain cost`,
+          );
+          invalidateSessionEntry(targetRequesterSessionKey);
+        } catch (err) {
+          defaultRuntime.log(
+            `[subagent-chain-hop] Failed to persist token accumulation for ${targetRequesterSessionKey}: ${String(err)}`,
+          );
         }
       }
     }
+
+    // --- Consume tool-dispatched delegates from the completing subagent ---
+    const toolDelegates =
+      continuationEnabled && isContinuationChainDelegate
+        ? consumePendingDelegates(params.childSessionKey)
+        : [];
+    if (toolDelegates.length > 0) {
+      defaultRuntime.log(
+        `[subagent-chain-hop] Consuming ${toolDelegates.length} tool delegate(s) from subagent ${params.childSessionKey}`,
+      );
+    }
+
+    // Safety: drain orphaned delegates from non-chain-hop subagents that had tool access.
+    if (!isContinuationChainDelegate && continuationEnabled) {
+      const orphaned = consumePendingDelegates(params.childSessionKey);
+      if (orphaned.length > 0) {
+        defaultRuntime.log(
+          `[subagent-chain-hop] WARNING: ${orphaned.length} tool delegate(s) orphaned from non-chain-hop subagent ${params.childSessionKey} — drainsContinuationDelegateQueue was set but task has no chain-hop prefix`,
+        );
+      }
+    }
+
+    // Track whether a bracket delegate was consumed from findings — must
+    // capture BEFORE stripping mutates findings (P0-1 from review).
+    let bracketDelegateConsumed = false;
+
+    if (continuationEnabled && (findings !== "(no output)" || toolDelegates.length > 0)) {
+      const continuationResult = stripContinuationSignal(findings);
+      if (continuationResult.signal?.kind === "work") {
+        defaultRuntime.log(
+          `[subagent-chain-hop] CONTINUE_WORK not supported in sub-agent chain (from ${params.childSessionKey}), ignoring`,
+        );
+      } else if (continuationResult.signal?.kind === "delegate") {
+        bracketDelegateConsumed = true;
+        findings = continuationResult.text || "(no output)";
+        const chainTask = continuationResult.signal.task;
+        const chainDelayMs = continuationResult.signal.delayMs;
+        const parentWasSilent = params.silentAnnounce === true;
+        const chainSilent =
+          continuationResult.signal.silent ||
+          continuationResult.signal.silentWake ||
+          parentWasSilent;
+        const chainWake =
+          continuationResult.signal.silentWake || (parentWasSilent && params.wakeOnReturn === true);
+
+        const { maxChainLength, costCapTokens, minDelayMs, maxDelayMs } =
+          resolveContinuationRuntimeConfig(cfg);
+
+        const hopMatch = childTask.match(/\[continuation:chain-hop:(\d+)\]/);
+        const childChainHop = hopMatch ? parseInt(hopMatch[1], 10) : 0;
+        const nextChainHop = childChainHop + 1;
+
+        let chainGuardResult:
+          | { allowed: false; reason: "chain-length"; chainCount: number; maxChainLength: number }
+          | { allowed: false; reason: "cost-cap"; chainTokens: number; costCapTokens: number }
+          | { allowed: true; nextChainHop: number };
+
+        if (childChainHop >= maxChainLength) {
+          chainGuardResult = {
+            allowed: false,
+            reason: "chain-length",
+            chainCount: nextChainHop,
+            maxChainLength,
+          };
+        } else {
+          const parentEntry = readSessionEntryByKey(targetRequesterSessionKey);
+          const storedChainTokens = parentEntry?.continuationChainTokens ?? 0;
+          const parentChainTokens =
+            storedChainTokens >= accumulatedChildTokens
+              ? storedChainTokens
+              : storedChainTokens + accumulatedChildTokens;
+          if (costCapTokens > 0 && parentChainTokens > costCapTokens) {
+            chainGuardResult = {
+              allowed: false,
+              reason: "cost-cap",
+              chainTokens: parentChainTokens,
+              costCapTokens,
+            };
+          } else {
+            chainGuardResult = { allowed: true, nextChainHop };
+          }
+        }
+
+        if (!chainGuardResult.allowed) {
+          if (chainGuardResult.reason === "chain-length") {
+            defaultRuntime.log(
+              `[subagent-chain-hop] Chain length ${chainGuardResult.chainCount} > ${chainGuardResult.maxChainLength}, rejecting hop from ${params.childSessionKey}`,
+            );
+          } else {
+            defaultRuntime.log(
+              `[subagent-chain-hop] Cost cap exceeded (${chainGuardResult.chainTokens} > ${chainGuardResult.costCapTokens}), rejecting hop from ${params.childSessionKey}`,
+            );
+          }
+        } else {
+          const nextChainHop = chainGuardResult.nextChainHop;
+          const continuationStateRuntime = await loadContinuationStateRuntime();
+
+          continuationStateRuntime.setDelegatePending(targetRequesterSessionKey);
+
+          const doChainSpawn = async (timerTriggered = false) => {
+            try {
+              const childDepth = getSubagentDepthFromSessionStore(params.childSessionKey);
+              const { spawnSubagentDirect } = await loadSubagentSpawnRuntime();
+              const spawnResult = await spawnSubagentDirect(
+                {
+                  task: `[continuation:chain-hop:${nextChainHop}] Delegated from sub-agent (depth ${childDepth}): ${chainTask}`,
+                  ...(chainSilent ? { silentAnnounce: true } : {}),
+                  ...(chainWake ? { silentAnnounce: true, wakeOnReturn: true } : {}),
+                  drainsContinuationDelegateQueue: true,
+                },
+                {
+                  agentSessionKey: targetRequesterSessionKey,
+                  agentChannel: targetRequesterOrigin?.channel ?? undefined,
+                  agentAccountId: targetRequesterOrigin?.accountId ?? undefined,
+                  agentTo: targetRequesterOrigin?.to ?? undefined,
+                  agentThreadId: targetRequesterOrigin?.threadId ?? undefined,
+                },
+              );
+              if (spawnResult.status === "accepted") {
+                defaultRuntime.log(
+                  timerTriggered
+                    ? `[subagent-chain-hop] Timer fired and spawned chain delegate (${nextChainHop}/${maxChainLength}) from ${params.childSessionKey}: ${chainTask.slice(0, 80)}`
+                    : `[subagent-chain-hop] Spawned chain delegate (${nextChainHop}/${maxChainLength}) from ${params.childSessionKey}: ${chainTask.slice(0, 80)}`,
+                );
+              } else {
+                defaultRuntime.log(
+                  `[subagent-chain-hop] Spawn rejected (${spawnResult.status}) from ${params.childSessionKey}: ${chainTask.slice(0, 80)}`,
+                );
+              }
+            } catch (err) {
+              defaultRuntime.log(
+                `[subagent-chain-hop] Spawn failed from ${params.childSessionKey}: ${String(err)}`,
+              );
+            }
+          };
+
+          if (chainDelayMs && chainDelayMs > 0) {
+            const clampedDelay = Math.max(minDelayMs, Math.min(maxDelayMs, chainDelayMs));
+            const hopGeneration =
+              continuationStateRuntime.bumpContinuationGeneration(targetRequesterSessionKey);
+            continuationGuardLog.debug(
+              `[continuation-guard] Chain-hop timer set: generation=${hopGeneration} delayMs=${clampedDelay} session=${targetRequesterSessionKey}`,
+            );
+            continuationStateRuntime.retainContinuationTimerRef(targetRequesterSessionKey);
+            const timerHandle = setTimeout(() => {
+              try {
+                const { generationGuardTolerance } = resolveContinuationRuntimeConfig();
+                const currentGen =
+                  continuationStateRuntime.currentContinuationGeneration(targetRequesterSessionKey);
+                const drift = currentGen - hopGeneration;
+                continuationGuardLog.debug(
+                  `[continuation-guard] Chain-hop timer check: stored=${hopGeneration} current=${currentGen} drift=${drift} tolerance=${generationGuardTolerance} session=${targetRequesterSessionKey}`,
+                );
+                if (drift > generationGuardTolerance) {
+                  defaultRuntime.log(
+                    `[subagent-chain-hop] Timer cancelled (generation drift=${drift} > tolerance=${generationGuardTolerance}) for ${targetRequesterSessionKey}`,
+                  );
+                  return;
+                }
+                doChainSpawn(true).catch((err) => {
+                  defaultRuntime.log(
+                    `[subagent-chain-hop] Unhandled bracket delegate spawn error from ${params.childSessionKey}: ${String(err)}`,
+                  );
+                });
+              } finally {
+                continuationStateRuntime.unregisterContinuationTimerHandle(
+                  targetRequesterSessionKey,
+                  timerHandle,
+                );
+              }
+            }, clampedDelay);
+            continuationStateRuntime.registerContinuationTimerHandle(
+              targetRequesterSessionKey,
+              timerHandle,
+            );
+            timerHandle.unref();
+          } else {
+            // Fire-and-forget — don't block the announce flow
+            doChainSpawn().catch((err) => {
+              defaultRuntime.log(
+                `[subagent-chain-hop] Unhandled bracket delegate spawn error from ${params.childSessionKey}: ${String(err)}`,
+              );
+            });
+          }
+        }
+      }
+
+      // --- Tool-dispatched delegates from subagent (parallel to bracket delegates above) ---
+      if (toolDelegates.length > 0 && isContinuationChainDelegate) {
+        const {
+          maxChainLength: toolMaxChainLength,
+          costCapTokens: toolCostCapTokens,
+          minDelayMs: toolMinDelayMs,
+          maxDelayMs: toolMaxDelayMs,
+        } = resolveContinuationRuntimeConfig(cfg);
+        const hopMatch = childTask.match(/\[continuation:chain-hop:(\d+)\]/);
+        const childChainHop = hopMatch ? parseInt(hopMatch[1], 10) : 0;
+        // Use the flag captured before findings was mutated (not re-parsing stripped text).
+        const bracketConsumedHop = bracketDelegateConsumed ? 1 : 0;
+        let toolHopBase = childChainHop + bracketConsumedHop;
+
+        const parentWasSilent = params.silentAnnounce === true;
+
+        let toolDelegateIdx = 0;
+        for (const toolDelegate of toolDelegates) {
+          const nextToolHop = toolHopBase + 1;
+
+          if (nextToolHop > toolMaxChainLength) {
+            const remaining = toolDelegates.length - toolDelegateIdx;
+            defaultRuntime.log(
+              `[subagent-chain-hop] Tool delegate chain length ${nextToolHop} > ${toolMaxChainLength}, rejecting from ${params.childSessionKey}. ${remaining} delegate(s) dropped.`,
+            );
+            break;
+          }
+
+          const parentEntryForTool = readSessionEntryByKey(targetRequesterSessionKey);
+          const storedToolChainTokens = parentEntryForTool?.continuationChainTokens ?? 0;
+          const parentChainTokensForTool =
+            storedToolChainTokens >= accumulatedChildTokens
+              ? storedToolChainTokens
+              : storedToolChainTokens + accumulatedChildTokens;
+          if (toolCostCapTokens > 0 && parentChainTokensForTool > toolCostCapTokens) {
+            const remaining = toolDelegates.length - toolDelegateIdx;
+            defaultRuntime.log(
+              `[subagent-chain-hop] Tool delegate cost cap exceeded (${parentChainTokensForTool} > ${toolCostCapTokens}), rejecting from ${params.childSessionKey}. ${remaining} delegate(s) dropped.`,
+            );
+            break;
+          }
+
+          const toolSilent = toolDelegate.silent || toolDelegate.silentWake || parentWasSilent;
+          const toolWake =
+            toolDelegate.silentWake || (parentWasSilent && params.wakeOnReturn === true);
+          const toolDelayMs = toolDelegate.delayMs;
+          const continuationStateRuntime = await loadContinuationStateRuntime();
+
+          continuationStateRuntime.setDelegatePending(targetRequesterSessionKey);
+
+          const childDepth = getSubagentDepthFromSessionStore(params.childSessionKey);
+          const doToolChainSpawn = async (timerTriggered = false) => {
+            try {
+              const { spawnSubagentDirect } = await loadSubagentSpawnRuntime();
+              const spawnResult = await spawnSubagentDirect(
+                {
+                  task: `[continuation:chain-hop:${nextToolHop}] Tool-delegated from sub-agent (depth ${childDepth}): ${toolDelegate.task}`,
+                  ...(toolSilent ? { silentAnnounce: true } : {}),
+                  ...(toolWake ? { silentAnnounce: true, wakeOnReturn: true } : {}),
+                  drainsContinuationDelegateQueue: true,
+                },
+                {
+                  agentSessionKey: targetRequesterSessionKey,
+                  agentChannel: targetRequesterOrigin?.channel ?? undefined,
+                  agentAccountId: targetRequesterOrigin?.accountId ?? undefined,
+                  agentTo: targetRequesterOrigin?.to ?? undefined,
+                  agentThreadId: targetRequesterOrigin?.threadId ?? undefined,
+                },
+              );
+              if (spawnResult.status === "accepted") {
+                defaultRuntime.log(
+                  `[subagent-chain-hop] ${timerTriggered ? "Timer: " : ""}Tool delegate (${nextToolHop}/${toolMaxChainLength}) from ${params.childSessionKey}: ${toolDelegate.task.slice(0, 80)}`,
+                );
+              } else {
+                defaultRuntime.log(
+                  `[subagent-chain-hop] Tool delegate spawn rejected (${spawnResult.status}) from ${params.childSessionKey}`,
+                );
+              }
+            } catch (err) {
+              defaultRuntime.log(
+                `[subagent-chain-hop] Tool delegate spawn failed from ${params.childSessionKey}: ${String(err)}`,
+              );
+            }
+          };
+
+          if (toolDelayMs && toolDelayMs > 0) {
+            const clampedDelay = Math.max(toolMinDelayMs, Math.min(toolMaxDelayMs, toolDelayMs));
+            const hopGeneration =
+              continuationStateRuntime.bumpContinuationGeneration(targetRequesterSessionKey);
+            continuationGuardLog.debug(
+              `[continuation-guard] Tool delegate timer set: generation=${hopGeneration} delayMs=${clampedDelay} session=${targetRequesterSessionKey}`,
+            );
+            continuationStateRuntime.retainContinuationTimerRef(targetRequesterSessionKey);
+            const timerHandle = setTimeout(() => {
+              try {
+                const { generationGuardTolerance } = resolveContinuationRuntimeConfig();
+                const currentGen =
+                  continuationStateRuntime.currentContinuationGeneration(targetRequesterSessionKey);
+                const drift = currentGen - hopGeneration;
+                if (drift > generationGuardTolerance) {
+                  defaultRuntime.log(
+                    `[subagent-chain-hop] Tool delegate timer cancelled (generation drift=${drift} > tolerance=${generationGuardTolerance}) for ${targetRequesterSessionKey}`,
+                  );
+                  return;
+                }
+                doToolChainSpawn(true).catch((err) => {
+                  defaultRuntime.log(
+                    `[subagent-chain-hop] Unhandled tool delegate spawn error from ${params.childSessionKey}: ${String(err)}`,
+                  );
+                });
+              } finally {
+                continuationStateRuntime.unregisterContinuationTimerHandle(
+                  targetRequesterSessionKey,
+                  timerHandle,
+                );
+              }
+            }, clampedDelay);
+            continuationStateRuntime.registerContinuationTimerHandle(
+              targetRequesterSessionKey,
+              timerHandle,
+            );
+            timerHandle.unref();
+          } else {
+            doToolChainSpawn().catch((err) => {
+              defaultRuntime.log(
+                `[subagent-chain-hop] Unhandled tool delegate spawn error from ${params.childSessionKey}: ${String(err)}`,
+              );
+            });
+          }
+
+          toolHopBase = nextToolHop;
+          toolDelegateIdx += 1;
+        }
+      }
+    }
+
+    // If the reply was silent/skip and we fell through for chain-hop accounting,
+    // return now before delivery logic.
+    if (skipAnnounceDelivery) {
+      return true;
+    }
+
+    const requesterIsSubagent = requesterIsInternalSession();
 
     const replyInstruction = buildAnnounceReplyInstruction({
       requesterIsSubagent,
       announceType,
       expectsCompletionMessage,
+      silentEnrichment: params.silentAnnounce === true,
+      silentWakeEnrichment: params.silentAnnounce === true && params.wakeOnReturn === true,
     });
     const statsLine = await buildCompactAnnounceStatsLine({
       sessionKey: params.childSessionKey,
@@ -470,7 +941,7 @@ export async function runSubagentAnnounceFlow(params: {
     // follow-up injection (deliver=false) so the orchestrator receives it.
     let directOrigin = targetRequesterOrigin;
     if (!requesterIsSubagent) {
-      const { entry } = loadRequesterSessionEntry(targetRequesterSessionKey);
+      const { entry } = readRequesterSessionEntry(targetRequesterSessionKey);
       directOrigin = resolveAnnounceOrigin(entry, targetRequesterOrigin);
     }
     const completionDirectOrigin =
@@ -485,6 +956,9 @@ export async function runSubagentAnnounceFlow(params: {
           })
         : targetRequesterOrigin;
     const directIdempotencyKey = buildAnnounceIdempotencyKey(announceId);
+    // Structured completion wakes are enabled fleet-wide through the same
+    // continuation flag, even for ordinary subagent returns.
+    const delegateReturnTrigger = continuationEnabled ? "delegate-return" : undefined;
     const delivery = await deliverSubagentAnnouncement({
       requesterSessionKey: targetRequesterSessionKey,
       announceId,
@@ -508,6 +982,7 @@ export async function runSubagentAnnounceFlow(params: {
       bestEffortDeliver: params.bestEffortDeliver,
       directIdempotencyKey,
       signal: params.signal,
+      continuationTriggerOverride: delegateReturnTrigger,
     });
     didAnnounce = delivery.delivered;
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -525,6 +525,8 @@ export function createSubagentRegistryLifecycleController(params: {
         spawnMode: entry.spawnMode,
         expectsCompletionMessage: entry.expectsCompletionMessage,
         wakeOnDescendantSettle: entry.wakeOnDescendantSettle === true,
+        silentAnnounce: entry.silentAnnounce,
+        wakeOnReturn: entry.wakeOnReturn,
       })
       .then((didAnnounce) => {
         finalizeAnnounceCleanup(didAnnounce);

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -275,6 +275,8 @@ export function createSubagentRunManager(params: {
     attachmentsDir?: string;
     attachmentsRootDir?: string;
     retainAttachmentsOnKeep?: boolean;
+    silentAnnounce?: boolean;
+    wakeOnReturn?: boolean;
   }) => {
     const runId = registerParams.runId.trim();
     const childSessionKey = registerParams.childSessionKey.trim();
@@ -322,6 +324,8 @@ export function createSubagentRunManager(params: {
       attachmentsDir: registerParams.attachmentsDir,
       attachmentsRootDir: registerParams.attachmentsRootDir,
       retainAttachmentsOnKeep: registerParams.retainAttachmentsOnKeep,
+      silentAnnounce: registerParams.silentAnnounce,
+      wakeOnReturn: registerParams.wakeOnReturn,
     });
     try {
       createRunningTaskRun({

--- a/src/agents/subagent-registry-spawn-runtime.ts
+++ b/src/agents/subagent-registry-spawn-runtime.ts
@@ -1,0 +1,63 @@
+type RegisterSubagentRunParams = {
+  runId: string;
+  childSessionKey: string;
+  controllerSessionKey?: string;
+  requesterSessionKey: string;
+  requesterOrigin?: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+    groupId?: string | null;
+    groupChannel?: string | null;
+    groupSpace?: string | null;
+  };
+  requesterDisplayKey: string;
+  task: string;
+  cleanup: "delete" | "keep";
+  label?: string;
+  model?: string;
+  workspaceDir?: string;
+  runTimeoutSeconds?: number;
+  expectsCompletionMessage?: boolean;
+  spawnMode?: "run" | "session";
+  silentAnnounce?: boolean;
+  wakeOnReturn?: boolean;
+  attachmentsDir?: string;
+  attachmentsRootDir?: string;
+  retainAttachmentsOnKeep?: boolean;
+};
+
+type CountActiveRunsForSessionFn = (requesterSessionKey: string) => number;
+type RegisterSubagentRunFn = (params: RegisterSubagentRunParams) => void;
+
+let countActiveRunsForSessionImpl: CountActiveRunsForSessionFn | null = null;
+let registerSubagentRunImpl: RegisterSubagentRunFn | null = null;
+
+export function configureSubagentRegistrySpawnRuntime(params: {
+  countActiveRunsForSession: CountActiveRunsForSessionFn;
+  registerSubagentRun: RegisterSubagentRunFn;
+}) {
+  countActiveRunsForSessionImpl = params.countActiveRunsForSession;
+  registerSubagentRunImpl = params.registerSubagentRun;
+}
+
+export function countActiveRunsForSession(requesterSessionKey: string): number {
+  if (!countActiveRunsForSessionImpl) {
+    console.warn(
+      "[subagent-registry-spawn-runtime] countActiveRunsForSession called before configureSubagentRegistrySpawnRuntime()",
+    );
+    return 0;
+  }
+  return countActiveRunsForSessionImpl(requesterSessionKey);
+}
+
+export function registerSubagentRun(params: RegisterSubagentRunParams): void {
+  if (!registerSubagentRunImpl) {
+    console.warn(
+      "[subagent-registry-spawn-runtime] registerSubagentRun called before configureSubagentRegistrySpawnRuntime()",
+    );
+    return;
+  }
+  registerSubagentRunImpl(params);
+}

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -231,6 +231,110 @@ describe("subagent registry persistence", () => {
     expect(persisted?.startedAt).toBeLessThanOrEqual(endedAt);
   });
 
+  it("persists silent announce metadata and replays it after restart", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+
+    const { callGateway } = await import("../gateway/call.js");
+    let releaseInitialWait:
+      | ((value: { status: "ok"; startedAt: number; endedAt: number }) => void)
+      | undefined;
+    vi.mocked(callGateway)
+      .mockImplementationOnce(
+        async () =>
+          await new Promise((resolve) => {
+            releaseInitialWait = resolve as typeof releaseInitialWait;
+          }),
+      )
+      .mockResolvedValueOnce({
+        status: "ok",
+        startedAt: 111,
+        endedAt: 222,
+      });
+
+    registerSubagentRun({
+      runId: "run-silent",
+      childSessionKey: "agent:main:subagent:silent-test",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "quiet enrichment",
+      cleanup: "keep",
+      silentAnnounce: true,
+      wakeOnReturn: true,
+    });
+    await writeChildSessionEntry({
+      sessionKey: "agent:main:subagent:silent-test",
+      sessionId: "sess-silent",
+    });
+
+    const registryPath = path.join(tempStateDir, "subagents", "runs.json");
+    const run = await readPersistedRun<{
+      silentAnnounce?: boolean;
+      wakeOnReturn?: boolean;
+    }>(registryPath, "run-silent");
+    expect(run).toMatchObject({
+      silentAnnounce: true,
+      wakeOnReturn: true,
+    });
+
+    resetSubagentRegistryForTests({ persist: false });
+    initSubagentRegistry();
+    releaseInitialWait?.({
+      status: "ok",
+      startedAt: 111,
+      endedAt: 222,
+    });
+
+    await vi.waitFor(() => {
+      expect(announceSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          childRunId: "run-silent",
+          silentAnnounce: true,
+          wakeOnReturn: true,
+        }),
+      );
+    });
+  });
+
+  it("persists completed subagent timing into the child session entry", async () => {
+    tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+
+    const { callGateway } = await import("../gateway/call.js");
+    const now = Date.now();
+    const startedAt = now;
+    const endedAt = now + 500;
+    vi.mocked(callGateway).mockResolvedValueOnce({
+      status: "ok",
+      startedAt,
+      endedAt,
+    });
+
+    const storePath = await writeChildSessionEntry({
+      sessionKey: "agent:main:subagent:timing",
+      sessionId: "sess-timing",
+      updatedAt: startedAt - 1,
+    });
+    registerSubagentRun({
+      runId: "run-session-timing",
+      childSessionKey: "agent:main:subagent:timing",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "persist timing",
+      cleanup: "keep",
+    });
+
+    await flushQueuedRegistryWork();
+
+    const store = await readSubagentSessionStore(storePath);
+    const persisted = store["agent:main:subagent:timing"];
+    expect(persisted?.endedAt).toBe(endedAt);
+    expect(persisted?.runtimeMs).toBe(500);
+    expect(persisted?.status).toBe("done");
+    expect(persisted?.startedAt).toBeGreaterThanOrEqual(startedAt);
+    expect(persisted?.startedAt).toBeLessThanOrEqual(endedAt);
+  });
+
   it("skips cleanup when cleanupHandled was persisted", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
     process.env.OPENCLAW_STATE_DIR = tempStateDir;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -46,6 +46,7 @@ import {
   shouldIgnorePostCompletionAnnounceForSessionFromRuns,
 } from "./subagent-registry-queries.js";
 import { createSubagentRunManager } from "./subagent-registry-run-manager.js";
+import { configureSubagentRegistrySpawnRuntime } from "./subagent-registry-spawn-runtime.js";
 import {
   getSubagentRunsSnapshotForRead,
   persistSubagentRunsToDisk,
@@ -695,6 +696,11 @@ const subagentRunManager = createSubagentRunManager({
 configureSubagentRegistrySteerRuntime({
   replaceSubagentRunAfterSteer: (params) => subagentRunManager.replaceSubagentRunAfterSteer(params),
 });
+configureSubagentRegistrySpawnRuntime({
+  countActiveRunsForSession: (requesterSessionKey) =>
+    countActiveRunsForSession(requesterSessionKey),
+  registerSubagentRun: (params) => registerSubagentRun(params),
+});
 
 export function markSubagentRunForSteerRestart(runId: string) {
   return subagentRunManager.markSubagentRunForSteerRestart(runId);
@@ -729,6 +735,8 @@ export function registerSubagentRun(params: {
   runTimeoutSeconds?: number;
   expectsCompletionMessage?: boolean;
   spawnMode?: "run" | "session";
+  silentAnnounce?: boolean;
+  wakeOnReturn?: boolean;
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -41,4 +41,7 @@ export type SubagentRunRecord = {
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;
+  silentAnnounce?: boolean;
+  /** When true (with silentAnnounce), trigger a generation cycle after enrichment delivery. */
+  wakeOnReturn?: boolean;
 };

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -190,11 +190,10 @@ export async function loadSubagentSpawnModuleForTest(params: {
     getSubagentDepthFromSessionStore: () => 0,
   }));
 
-  vi.doMock("./subagent-registry.js", () => ({
+  vi.doMock("./subagent-registry-spawn-runtime.js", () => ({
     countActiveRunsForSession: () => 0,
     registerSubagentRun:
       params.registerSubagentRunMock ?? vi.fn((_record: Record<string, unknown>) => undefined),
-    resetSubagentRegistryForTests,
   }));
 
   const subagentSpawnModule = await import("./subagent-spawn.js");

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -20,7 +20,10 @@ import {
 } from "./subagent-attachments.js";
 import { resolveSubagentCapabilities } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
-import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
+import {
+  countActiveRunsForSession,
+  registerSubagentRun,
+} from "./subagent-registry-spawn-runtime.js";
 import { resolveSubagentSpawnAcceptedNote } from "./subagent-spawn-accepted-note.js";
 export {
   SUBAGENT_SPAWN_ACCEPTED_NOTE,
@@ -100,6 +103,16 @@ export type SpawnSubagentParams = {
     mimeType?: string;
   }>;
   attachMountPath?: string;
+  /** When true, sub-agent completion is delivered as a silent system event
+   *  instead of a visible channel message. Used for ambient enrichment shards. */
+  silentAnnounce?: boolean;
+  /** When true (with silentAnnounce), the parent session is woken after the
+   *  enrichment is enqueued. Enables autonomous cognition loops where the agent
+   *  acts on shard returns without external nudge. */
+  wakeOnReturn?: boolean;
+  /** When true, the spawned sub-agent's run drains the continuation delegate queue,
+   *  enabling the continue_delegate tool for chain-hop delegates. */
+  drainsContinuationDelegateQueue?: boolean;
 };
 
 export type SpawnSubagentContext = {
@@ -165,7 +178,7 @@ function readGatewayRunId(response: Awaited<ReturnType<typeof callGateway>>): st
   if (!response || typeof response !== "object") {
     return undefined;
   }
-  const { runId } = response as { runId?: unknown };
+  const { runId } = response as Record<string, unknown>;
   return typeof runId === "string" && runId ? runId : undefined;
 }
 
@@ -609,6 +622,16 @@ export async function spawnSubagentDirect(
     acpEnabled: cfg.acp?.enabled !== false && !childRuntime.sandboxed,
     childDepth,
     maxSpawnDepth,
+    // Hint tool availability so the subagent prompt teaches tool-primary vs bracket-only.
+    // The tool will actually appear when drains === true AND the child is not a leaf
+    // (DENY_LEAF blocks it at max depth). Also respect explicit deny config so the
+    // prompt doesn't teach a tool the policy will strip from the actual toolset.
+    toolNames:
+      params.drainsContinuationDelegateQueue === true &&
+      childDepth < maxSpawnDepth &&
+      !cfg.tools?.subagents?.tools?.deny?.includes("continue_delegate")
+        ? ["continue_delegate"]
+        : undefined,
   });
 
   let retainOnSessionKeep = false;
@@ -720,6 +743,9 @@ export async function spawnSubagentDirect(
         thinking: thinkingOverride,
         timeout: runTimeoutSeconds,
         label: label || undefined,
+        ...(params.drainsContinuationDelegateQueue
+          ? { drainsContinuationDelegateQueue: true }
+          : {}),
         ...(bootstrapContextMode
           ? {
               bootstrapContextMode,
@@ -815,6 +841,8 @@ export async function spawnSubagentDirect(
       attachmentsDir: attachmentAbsDir,
       attachmentsRootDir: attachmentRootDir,
       retainAttachmentsOnKeep: retainOnSessionKeep,
+      ...(params.silentAnnounce ? { silentAnnounce: true } : {}),
+      ...(params.wakeOnReturn ? { wakeOnReturn: true } : {}),
     });
   } catch (err) {
     if (attachmentAbsDir) {

--- a/src/agents/subagent-system-prompt.ts
+++ b/src/agents/subagent-system-prompt.ts
@@ -13,6 +13,10 @@ export function buildSubagentSystemPrompt(params: {
   childDepth?: number;
   /** Config value: max allowed spawn depth. */
   maxSpawnDepth?: number;
+  /** Tool names available to the child — used to teach tool-primary vs bracket-only continuation. */
+  toolNames?: string[];
+  /** Whether continuation chaining is enabled. Defaults to config value. */
+  continuationEnabled?: boolean;
 }) {
   const taskText =
     typeof params.task === "string" && params.task.trim()
@@ -92,6 +96,42 @@ export function buildSubagentSystemPrompt(params: {
       "You are a leaf worker and CANNOT spawn further sub-agents. Focus on your assigned task.",
       "",
     );
+  }
+
+  if (canSpawn && params.continuationEnabled) {
+    const toolPrimaryContinuation = params.toolNames?.includes("continue_delegate") === true;
+    lines.push("## Continuation Chaining");
+    if (toolPrimaryContinuation) {
+      lines.push(
+        "Use the `continue_delegate` tool to keep a delegate branch moving without making the parent relay every hop.",
+        "The tool supports structured parameters (`task`, `delaySeconds`, `mode`) and multi-delegate fan-out.",
+        "",
+        "Fallback bracket syntax (if the tool call fails or is unavailable):",
+        "  [[CONTINUE_DELEGATE: task description]]",
+        "  [[CONTINUE_DELEGATE: task +30s]]          — delayed spawn",
+        "  [[CONTINUE_DELEGATE: task | silent]]       — silent return (no channel output)",
+        "  [[CONTINUE_DELEGATE: task | silent-wake]]  — silent return + triggers parent turn",
+        "",
+        "Prefer the tool. Use brackets only as fallback.",
+        "The gateway handles chain tracking and depth limits.",
+        "",
+      );
+    } else {
+      lines.push(
+        "To dispatch a follow-up sub-agent from your output, end your ENTIRE response with:",
+        "  [[CONTINUE_DELEGATE: task description]]",
+        "",
+        "Optional modifiers:",
+        "  [[CONTINUE_DELEGATE: task +30s]]          — delayed spawn",
+        "  [[CONTINUE_DELEGATE: task | silent]]       — silent return (no channel output)",
+        "  [[CONTINUE_DELEGATE: task | silent-wake]]  — silent return + triggers parent turn",
+        "",
+        "Use `| silent` when the result should only enrich the parent's future context.",
+        "Use `| silent-wake` when the result should enrich the parent and wake it to act.",
+        "The gateway handles chain tracking and depth limits.",
+        "",
+      );
+    }
   }
 
   lines.push(

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -917,4 +917,63 @@ describe("buildSubagentSystemPrompt", () => {
       }
     }
   });
+
+  it("teaches tool-primary continuation when continue_delegate is in toolNames", () => {
+    const prompt = buildSubagentSystemPrompt({
+      childSessionKey: "agent:main:subagent:abc",
+      task: "chain task",
+      childDepth: 1,
+      maxSpawnDepth: 3,
+      toolNames: ["continue_delegate"],
+      continuationEnabled: true,
+    });
+
+    expect(prompt).toContain("## Continuation Chaining");
+    expect(prompt).toContain("Use the `continue_delegate` tool");
+    expect(prompt).toContain("Prefer the tool. Use brackets only as fallback.");
+    expect(prompt).toContain("[[CONTINUE_DELEGATE:");
+  });
+
+  it("teaches bracket-only continuation when continue_delegate is NOT in toolNames", () => {
+    const prompt = buildSubagentSystemPrompt({
+      childSessionKey: "agent:main:subagent:abc",
+      task: "chain task",
+      childDepth: 1,
+      maxSpawnDepth: 3,
+      toolNames: [],
+      continuationEnabled: true,
+    });
+
+    expect(prompt).toContain("## Continuation Chaining");
+    expect(prompt).toContain("end your ENTIRE response with:");
+    expect(prompt).toContain("[[CONTINUE_DELEGATE:");
+    expect(prompt).not.toContain("Use the `continue_delegate` tool");
+    expect(prompt).not.toContain("Prefer the tool");
+  });
+
+  it("teaches bracket-only continuation when toolNames is undefined", () => {
+    const prompt = buildSubagentSystemPrompt({
+      childSessionKey: "agent:main:subagent:abc",
+      task: "chain task",
+      childDepth: 1,
+      maxSpawnDepth: 3,
+      continuationEnabled: true,
+    });
+
+    expect(prompt).toContain("## Continuation Chaining");
+    expect(prompt).not.toContain("Use the `continue_delegate` tool");
+  });
+
+  it("omits continuation chaining for leaf agents even with toolNames", () => {
+    const prompt = buildSubagentSystemPrompt({
+      childSessionKey: "agent:main:subagent:abc:subagent:def",
+      task: "leaf task",
+      childDepth: 2,
+      maxSpawnDepth: 2,
+      toolNames: ["continue_delegate"],
+    });
+
+    expect(prompt).not.toContain("## Continuation Chaining");
+    expect(prompt).not.toContain("continue_delegate");
+  });
 });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -425,6 +425,8 @@ export function buildAgentSystemPrompt(params: {
   };
   includeMemorySection?: boolean;
   memoryCitationsMode?: MemoryCitationsMode;
+  /** Whether the continuation feature is enabled for this agent. */
+  continuationEnabled?: boolean;
   promptContribution?: ProviderSystemPromptContribution;
 }) {
   const acpEnabled = params.acpEnabled !== false;
@@ -657,6 +659,11 @@ export function buildAgentSystemPrompt(params: {
     "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
     `For long waits, avoid rapid poll loops: use ${execToolName} with enough yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
     "If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.",
+    ...(availableTools.has("continue_delegate")
+      ? [
+          "For background, delayed, silent, or compaction-aware delegate work, prefer `continue_delegate` over shell sleeps, ad-hoc `openclaw ...` CLI calls, or manual relay patterns.",
+        ]
+      : []),
     ...(acpHarnessSpawnAllowed
       ? [
           'For requests like "do this in codex/claude code/cursor/gemini" or similar ACP harnesses, treat it as ACP harness intent and call `sessions_spawn` with `runtime: "acp"`.',
@@ -723,7 +730,6 @@ export function buildAgentSystemPrompt(params: {
           "After restart, OpenClaw pings the last active session automatically.",
         ].join("\n")
       : "",
-    hasGateway && !isMinimal ? "" : "",
     "",
     // Skip model aliases for subagent/none modes
     params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal
@@ -916,6 +922,143 @@ export function buildAgentSystemPrompt(params: {
   }
 
   lines.push(...buildHeartbeatSection({ isMinimal, heartbeatPrompt }));
+
+  // Continuation tokens — only when the feature is enabled and not in subagent mode
+  if (!isMinimal && params.continuationEnabled) {
+    lines.push(
+      "## Continuation & Delegation",
+      "### Self-elected turns",
+      ...(availableTools.has("continue_work")
+        ? [
+            "Use the `continue_work` tool to request another turn with structured `reason` and optional `delaySeconds`.",
+            "Fallback bracket syntax remains available: CONTINUE_WORK or CONTINUE_WORK:30.",
+          ]
+        : []),
+      "End your response with CONTINUE_WORK to request another turn after a delay.",
+      "End with CONTINUE_WORK:30 to specify delay in seconds.",
+      "Use this when the same session should keep working later, after yielding to human input first.",
+      "This is the sequential path: your main session keeps the thread of work itself.",
+      "Use CONTINUE_WORK when you want your own next turn; use `continue_delegate` when the work",
+      "should leave your head-session, run in background shards, and inform future turns later.",
+      "",
+      "### Delegated continuation",
+      ...(availableTools.has("continue_delegate")
+        ? [
+            "Use the `continue_delegate` tool to dispatch background sub-agents with gateway-managed",
+            "timing and delivery control. This is the primary mechanism for delegation.",
+            "",
+            "Tool parameters:",
+            "  task (required) — the delegated sub-agent's task; include scope, context, and desired return shape",
+            "  delaySeconds — seconds to wait before spawning (0 or omitted = immediate; clamped to configured min/max)",
+            '  mode — "normal" (default, announces to channel), "silent" (internal context only),',
+            '         "silent-wake" (silent + triggers your next turn), "post-compaction" (fires at compaction)',
+            "",
+            "Call the tool multiple times in one turn for parallel fan-out while the main session stays free.",
+            "",
+            "Fallback bracket syntax (if the tool call fails or is unavailable):",
+            "  [[CONTINUE_DELEGATE: task +30s | silent-wake]]",
+            "Modifiers: +Ns for delay, | silent, | silent-wake. End your response with the bracket.",
+          ]
+        : [
+            "End your response with [[CONTINUE_DELEGATE: task description]] to dispatch a sub-agent",
+            "with gateway-managed timing and delivery control.",
+            "",
+            "Syntax:",
+            "  [[CONTINUE_DELEGATE: task +30s]]               — delayed spawn, normal return",
+            "  [[CONTINUE_DELEGATE: task | silent]]            — result as internal context only (no channel output)",
+            "  [[CONTINUE_DELEGATE: task | silent-wake]]       — silent result + triggers your next turn",
+            "  [[CONTINUE_DELEGATE: task +30s | silent-wake]]  — delayed spawn, silent return, triggers next turn",
+            "",
+            "The task text is free-form. Include working context alongside the instruction.",
+          ]),
+      "",
+      "Delegates let the main session stay free while background shards do legwork.",
+      "Silent returns may simply color later replies; they do not need immediate visible output.",
+      "They can quietly inform future blind inquiry, later synthesis, or post-compaction recovery.",
+      "Use `silent` for ambient enrichment or future recall. Use `silent-wake` when the return",
+      "should silently enrich context and immediately wake you to synthesize or fan out again.",
+      "",
+      "### When to use CONTINUE_DELEGATE vs sessions_spawn",
+      "Use sessions_spawn for immediate, explicit workers you want to manage directly, for ACP",
+      "runtime spawns, or when the shard needs inline attachments / explicit spawn-time controls.",
+      "Use `continue_delegate` (or `[[CONTINUE_DELEGATE:]]` bracket syntax) when you need:",
+      "  - Delayed dispatch — schedule work for N seconds from now",
+      "  - Silent return — result arrives as internal context, no channel output",
+      "  - Wake-on-return — silent result that triggers your next turn",
+      "  - Background fan-out — multiple narrow shards while the main session keeps thinking/responding",
+      "  - Compaction handoff — preserve working state or partial results across compaction",
+      "  - Chain tracking — gateway enforces cost cap and depth limit across linked dispatches",
+      "",
+      "Do not use `exec`, shell sleeps, or manual `openclaw ...` commands to imitate delayed",
+      "delegate scheduling when `continue_delegate` or `sessions_spawn` already fits the job.",
+      "",
+      "### Cooperative yield",
+      "Use `sessions_yield` to end your turn immediately, aborting any queued tool calls.",
+      "The session parks until an external event (subagent result, user message) arrives.",
+      "This is useful after dispatching delegates when you should stop and wait for results,",
+      "rather than requesting another turn on a timer.",
+      "",
+      "### Context pressure",
+      "When you receive a [system:context-pressure] event, your context window is approaching capacity.",
+      ...(availableTools.has("continue_delegate")
+        ? [
+            'Use `continue_delegate` with `mode: "post-compaction"` to dispatch working state — decisions',
+            "in progress, task context, partial results — before compaction. The post-compaction shard fires",
+            "when compaction happens and returns to re-inject context the summary cannot preserve.",
+            "Fallback if the tool call fails: [[CONTINUE_DELEGATE: ... | silent-wake]] (note: post-compaction mode requires the tool).",
+          ]
+        : [
+            "Use [[CONTINUE_DELEGATE: ... | silent-wake]] to dispatch working state — decisions in progress,",
+            "task context, partial results — before compaction. These shards return after compaction and",
+            "re-inject context that the summary cannot preserve.",
+          ]),
+      "",
+      "Continuations are bounded: max chain length, cost cap, and min/max delay enforced by the gateway.",
+      "",
+    );
+  }
+
+  // Sub-agent chain-hop continuation — teach tool-primary when available, bracket fallback otherwise
+  if (isMinimal && params.continuationEnabled) {
+    lines.push("## Chain Delegation");
+    if (availableTools.has("continue_delegate")) {
+      lines.push(
+        "Use the `continue_delegate` tool to dispatch follow-up sub-agents from this chain.",
+        "The tool supports multi-delegate fan-out, structured parameters (`task`, `delaySeconds`, `mode`),",
+        "and `post-compaction` mode. The parent/main session stays free while your branch keeps working.",
+        "",
+        "Fallback bracket syntax (if the tool call fails or is unavailable):",
+        "  [[CONTINUE_DELEGATE: task description]]",
+        "  [[CONTINUE_DELEGATE: task +30s]]          — delayed spawn",
+        "  [[CONTINUE_DELEGATE: task | silent]]       — silent return (no channel output)",
+        "  [[CONTINUE_DELEGATE: task | silent-wake]]  — silent return + triggers parent turn",
+        "",
+        "Prefer the tool. Use brackets only as fallback.",
+        "The gateway handles chain tracking and depth limits.",
+        "",
+      );
+    } else {
+      lines.push(
+        "To dispatch a follow-up sub-agent from your output, end your ENTIRE response with:",
+        "  [[CONTINUE_DELEGATE: task description]]",
+        "",
+        "Use this to keep a delegate tree moving without asking the parent to relay every hop.",
+        "The parent/main session stays free while your branch keeps working.",
+        "",
+        "Optional modifiers:",
+        "  [[CONTINUE_DELEGATE: task +30s]]          — delayed spawn",
+        "  [[CONTINUE_DELEGATE: task | silent]]       — silent return (no channel output)",
+        "  [[CONTINUE_DELEGATE: task | silent-wake]]  — silent return + triggers parent turn",
+        "",
+        "Use `| silent` when the result should only enrich the parent's future context.",
+        "Use `| silent-wake` when the result should enrich the parent and wake it to act.",
+        "",
+        "Emit exactly ONE bracket per response. Do not nest brackets inside brackets.",
+        "The gateway handles chain tracking and depth limits.",
+        "",
+      );
+    }
+  }
 
   lines.push(
     "## Runtime",

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -691,6 +691,21 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "TTS",
       detailKeys: ["text", "channel"],
     },
+    continue_delegate: {
+      emoji: "🔄",
+      title: "Continue Delegate",
+      detailKeys: ["task", "mode", "fireAfterMs"],
+    },
+    continue_work: {
+      emoji: "⏩",
+      title: "Continue Work",
+      detailKeys: ["reason"],
+    },
+    request_compaction: {
+      emoji: "📦",
+      title: "Request Compaction",
+      detailKeys: ["reason"],
+    },
   },
 };
 

--- a/src/agents/tools/continuation-tools-registration.test.ts
+++ b/src/agents/tools/continuation-tools-registration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOpenClawTools } from "../openclaw-tools.js";
+import "../test-helpers/fast-core-tools.js";
+import { createPerSenderSessionConfig } from "../test-helpers/session-config.js";
+
+describe("continuation tool registration", () => {
+  const config = {
+    session: createPerSenderSessionConfig(),
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: true,
+        },
+      },
+    },
+  } as const;
+
+  it("exposes continue_delegate on normal turns when continuation is enabled", () => {
+    const tools = createOpenClawTools({
+      config,
+      agentSessionKey: "main",
+    });
+
+    expect(tools.some((tool) => tool.name === "continue_delegate")).toBe(true);
+  });
+
+  it("hides continue_delegate when continuation is disabled", () => {
+    const tools = createOpenClawTools({
+      config: {
+        ...config,
+        agents: { defaults: { continuation: { enabled: false } } },
+      },
+      agentSessionKey: "main",
+    });
+
+    expect(tools.some((tool) => tool.name === "continue_delegate")).toBe(false);
+  });
+
+  it("exposes continue_work when continuation is enabled and the runner wires it", () => {
+    const tools = createOpenClawTools({
+      config,
+      agentSessionKey: "main",
+      continueWorkOpts: {
+        requestContinuation: vi.fn(),
+      },
+    });
+
+    expect(tools.some((tool) => tool.name === "continue_work")).toBe(true);
+  });
+});

--- a/src/agents/tools/continue-delegate-tool.test.ts
+++ b/src/agents/tools/continue-delegate-tool.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  consumePendingDelegates,
+  consumeStagedPostCompactionDelegates,
+} from "../../auto-reply/continuation-delegate-store.js";
+import {
+  setRuntimeConfigSnapshot,
+  clearRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../../config/config.js";
+import { createContinueDelegateTool } from "./continue-delegate-tool.js";
+
+describe("continue_delegate tool", () => {
+  beforeEach(() => {
+    consumePendingDelegates("test-session");
+    consumeStagedPostCompactionDelegates("test-session");
+    clearRuntimeConfigSnapshot();
+  });
+
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
+  });
+
+  async function executeTool(
+    tool: ReturnType<typeof createContinueDelegateTool>,
+    index: number,
+    args: Record<string, unknown>,
+  ) {
+    return (await tool.execute(`call-${index}`, args))?.details as Record<string, unknown>;
+  }
+
+  it("reads maxDelegatesPerTurn at execute time instead of tool construction time", async () => {
+    const initialConfig: OpenClawConfig = {
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 5 } } },
+    };
+    setRuntimeConfigSnapshot(initialConfig);
+    const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    const updatedConfig: OpenClawConfig = {
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 10 } } },
+    };
+    setRuntimeConfigSnapshot(updatedConfig);
+
+    for (let index = 0; index < 10; index += 1) {
+      const result = await executeTool(tool, index, { task: `delegate ${index + 1}` });
+      expect(result).toMatchObject({ status: "scheduled" });
+    }
+
+    const overflow = await executeTool(tool, 10, { task: "delegate 11" });
+    expect(overflow).toMatchObject({
+      status: "error",
+      limit: 10,
+    });
+  });
+
+  it("re-reads maxDelegatesPerTurn on each call", async () => {
+    const initialConfig: OpenClawConfig = {
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 10 } } },
+    };
+    setRuntimeConfigSnapshot(initialConfig);
+    const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    for (let index = 0; index < 5; index += 1) {
+      const result = await executeTool(tool, index, { task: `delegate ${index + 1}` });
+      expect(result).toMatchObject({ status: "scheduled" });
+    }
+
+    const updatedConfig: OpenClawConfig = {
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 5 } } },
+    };
+    setRuntimeConfigSnapshot(updatedConfig);
+
+    const overflow = await executeTool(tool, 5, { task: "delegate 6" });
+    expect(overflow).toMatchObject({
+      status: "error",
+      limit: 5,
+    });
+  });
+
+  it("uses the runtime default of 5 when maxDelegatesPerTurn is unset", async () => {
+    // No config snapshot set — loadConfig falls back to empty config,
+    // continuation-runtime resolves the default (5).
+    const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    for (let index = 0; index < 5; index += 1) {
+      const result = await executeTool(tool, index, { task: `delegate ${index + 1}` });
+      expect(result).toMatchObject({ status: "scheduled" });
+    }
+
+    const overflow = await executeTool(tool, 5, { task: "delegate 6" });
+    expect(overflow).toMatchObject({
+      status: "error",
+      limit: 5,
+    });
+  });
+
+  it("stages post-compaction delegates as silent-wake delegates", async () => {
+    const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    const result = await executeTool(tool, 0, {
+      task: "carry compacted working state forward",
+      mode: "post-compaction",
+    });
+
+    expect(result).toMatchObject({
+      status: "queued-for-compaction",
+      mode: "post-compaction",
+    });
+    expect(consumeStagedPostCompactionDelegates("test-session")).toEqual([
+      expect.objectContaining({
+        task: "carry compacted working state forward",
+        silent: true,
+        silentWake: true,
+      }),
+    ]);
+  });
+});

--- a/src/agents/tools/continue-delegate-tool.ts
+++ b/src/agents/tools/continue-delegate-tool.ts
@@ -1,0 +1,164 @@
+import { Type } from "@sinclair/typebox";
+import {
+  stagePostCompactionDelegate,
+  enqueuePendingDelegate,
+  pendingDelegateCount,
+  stagedPostCompactionDelegateCount,
+} from "../../auto-reply/continuation-delegate-store.js";
+import { resolveMaxDelegatesPerTurn } from "../../auto-reply/reply/continuation-runtime.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { optionalStringEnum } from "../schema/typebox.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readNumberParam, readStringParam, ToolInputError } from "./common.js";
+
+const log = createSubsystemLogger("continuation/delegate-tool");
+
+const DELEGATE_MODES = ["normal", "silent", "silent-wake", "post-compaction"] as const;
+
+const ContinueDelegateToolSchema = Type.Object({
+  task: Type.String({
+    description:
+      "The delegated sub-agent's task. Treat this like a letter to your future self: include scope, chunk/range, desired return shape, and what the parent should do with the result.",
+    maxLength: 4096,
+  }),
+  delaySeconds: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      description:
+        "Seconds to wait before spawning the delegate. 0 or omitted = immediate. " +
+        "Clamped to continuation.minDelayMs / maxDelayMs from config.",
+    }),
+  ),
+  mode: optionalStringEnum(DELEGATE_MODES, {
+    description:
+      'Return mode. "normal" = announces to channel (default). ' +
+      '"silent" = result injected as internal context only, no channel echo; use for ambient enrichment and future recall. ' +
+      '"silent-wake" = silent + triggers a new generation cycle so the agent can act on the enrichment immediately. ' +
+      '"post-compaction" = silent-wake delegate that fires when compaction happens, not on a timer. ' +
+      "Use for context evacuation: the shard starts at the moment of compaction and returns to the post-compaction session.",
+  }),
+});
+
+/**
+ * Creates the `continue_delegate` tool.
+ *
+ * This tool dispatches a sub-agent as a continuation delegate — tracked by the
+ * gateway's continuation chain (cost caps, depth limits, chain counters).
+ *
+ * Architecture (Path A — side-channel):
+ *   1. Tool writes to the module-level pending-delegate store during execution.
+ *   2. After the agent's response finalizes, `agent-runner.ts` reads from the
+ *      store and feeds delegates into the same scheduler that bracket-parsed
+ *      `[[CONTINUE_DELEGATE:]]` signals use.
+ *   3. Both paths (tool + brackets) converge at the same dispatch point —
+ *      same cost cap, same chain depth, same delay clamping.
+ *
+ * The tool can be called multiple times per turn (multi-delegate fan-out).
+ * Each call enqueues independently. No single-per-response regex limitation.
+ *
+ * NOTE: Delayed fan-out (multiple delegates with delaySeconds > 0) is subject
+ * to the generation guard — each scheduled timer checks that the session's
+ * generation counter hasn't advanced. In busy channels, intervening messages
+ * may cancel earlier timers. Use delaySeconds: 0 for reliable parallel fan-out,
+ * or set generationGuardTolerance >= N-1 for N delayed delegates.
+ */
+export function createContinueDelegateTool(opts: { agentSessionKey?: string }): AnyAgentTool {
+  return {
+    label: "Continuation",
+    name: "continue_delegate",
+    description:
+      "Schedule a continuation delegate — a background sub-agent that can run now, later, " +
+      "or at compaction, then return visibly or silently to this session. Use for ambient " +
+      "enrichment, chunked/aspected fan-out, or preserving working state across compaction. " +
+      'Use "silent-wake" when the result should quietly enrich context and wake you to act. ' +
+      "Can be called multiple times per turn for parallel fan-out while the main session stays free. " +
+      "Prefer this over exec or raw sessions_spawn when the goal is gateway-managed delayed/silent/wake-on-return delegate work. " +
+      "Note: delayed delegates share the same generation guard as delayed CONTINUE_WORK — use delay 0 for reliable parallel dispatch in noisy channels, or raise generationGuardTolerance.",
+    parameters: ContinueDelegateToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const sessionKey = opts.agentSessionKey;
+
+      if (!sessionKey) {
+        throw new ToolInputError(
+          "continue_delegate requires an active session. Not available in sessionless contexts.",
+        );
+      }
+
+      const task = readStringParam(params, "task", { required: true });
+      if (!task.trim()) {
+        throw new ToolInputError("task must be a non-empty string describing the delegated work.");
+      }
+
+      const delaySeconds = readNumberParam(params, "delaySeconds");
+      const delayMs = delaySeconds !== undefined ? Math.max(0, delaySeconds) * 1000 : undefined;
+
+      const modeRaw = typeof params.mode === "string" ? params.mode.trim().toLowerCase() : "";
+      if (modeRaw && !DELEGATE_MODES.includes(modeRaw as (typeof DELEGATE_MODES)[number])) {
+        throw new ToolInputError(
+          `Unknown mode "${modeRaw}". Valid modes: ${DELEGATE_MODES.join(", ")}`,
+        );
+      }
+      const isPostCompaction = modeRaw === "post-compaction";
+      const silent = modeRaw === "silent" || modeRaw === "silent-wake" || isPostCompaction;
+      const silentWake = modeRaw === "silent-wake" || isPostCompaction;
+
+      // Check per-turn delegate limit
+      const maxPerTurn = resolveMaxDelegatesPerTurn();
+      const currentCount =
+        pendingDelegateCount(sessionKey) + stagedPostCompactionDelegateCount(sessionKey);
+      if (currentCount >= maxPerTurn) {
+        return jsonResult({
+          status: "error",
+          reason: `maxDelegatesPerTurn exceeded (${maxPerTurn}). Cannot dispatch more delegates this turn.`,
+          dispatched: currentCount,
+          limit: maxPerTurn,
+        });
+      }
+
+      if (isPostCompaction) {
+        // Stage for the current turn. agent-runner commits successful turns to
+        // SessionEntry so failed runs do not leak stale compaction delegates.
+        stagePostCompactionDelegate(sessionKey, {
+          task,
+          createdAt: Date.now(),
+          silent: true,
+          silentWake: true,
+        });
+
+        return jsonResult({
+          status: "queued-for-compaction",
+          mode: "post-compaction",
+          note:
+            "Delegate will fire when compaction occurs, not on a timer. " +
+            "The shard starts at the moment of compaction and returns to the post-compaction session. " +
+            "Chain tracking applies at dispatch time.",
+        });
+      }
+
+      // Enqueue for post-run processing by agent-runner.ts
+      log.debug(
+        `[continue_delegate:enqueue] session=${sessionKey} silent=${silent} silentWake=${silentWake} delayMs=${delayMs} task=${task.slice(0, 80)}`,
+      );
+      enqueuePendingDelegate(sessionKey, {
+        task,
+        delayMs,
+        silent,
+        silentWake,
+      });
+
+      const dispatchIndex = currentCount + 1;
+
+      return jsonResult({
+        status: "scheduled",
+        mode: modeRaw || "normal",
+        delaySeconds: delaySeconds ?? 0,
+        delegateIndex: dispatchIndex,
+        delegatesThisTurn: dispatchIndex,
+        note:
+          "Delegate will be dispatched after your response completes. " +
+          "Chain tracking (cost cap, depth limit) applies.",
+      });
+    },
+  };
+}

--- a/src/agents/tools/continue-work-tool.test.ts
+++ b/src/agents/tools/continue-work-tool.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { createContinueWorkTool, type ContinueWorkRequest } from "./continue-work-tool.js";
+
+describe("continue_work tool", () => {
+  function makeTool(
+    overrides?: Partial<{
+      agentSessionKey: string | undefined;
+      requestContinuation: (request: ContinueWorkRequest) => void;
+    }>,
+  ) {
+    return createContinueWorkTool({
+      agentSessionKey: "test-session",
+      requestContinuation: vi.fn(),
+      ...overrides,
+    });
+  }
+
+  it("schedules another turn with the default delay and forwards the reason", async () => {
+    const requestContinuation = vi.fn();
+    const tool = makeTool({ requestContinuation });
+
+    const result = (
+      await tool.execute("call-1", {
+        reason: "Need one more turn to finish the summary.",
+      })
+    )?.details as Record<string, unknown>;
+
+    expect(requestContinuation).toHaveBeenCalledWith({
+      reason: "Need one more turn to finish the summary.",
+      delaySeconds: 0,
+    });
+    expect(result).toEqual({
+      status: "scheduled",
+      delaySeconds: 0,
+    });
+  });
+
+  it("honors an explicit delaySeconds value", async () => {
+    const requestContinuation = vi.fn();
+    const tool = makeTool({ requestContinuation });
+
+    const result = (
+      await tool.execute("call-2", {
+        reason: "Wait for the background write to settle.",
+        delaySeconds: 15,
+      })
+    )?.details as Record<string, unknown>;
+
+    expect(requestContinuation).toHaveBeenCalledWith({
+      reason: "Wait for the background write to settle.",
+      delaySeconds: 15,
+    });
+    expect(result).toEqual({
+      status: "scheduled",
+      delaySeconds: 15,
+    });
+  });
+
+  it("requires a reason", async () => {
+    const tool = makeTool();
+    await expect(tool.execute("call-3", {})).rejects.toThrow(/reason required/i);
+  });
+
+  it("requires an active session", async () => {
+    const tool = makeTool({ agentSessionKey: undefined });
+    await expect(tool.execute("call-4", { reason: "Need another turn" })).rejects.toThrow(
+      /requires an active session/i,
+    );
+  });
+});

--- a/src/agents/tools/continue-work-tool.ts
+++ b/src/agents/tools/continue-work-tool.ts
@@ -1,0 +1,73 @@
+import { Type } from "@sinclair/typebox";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readNumberParam, readStringParam, ToolInputError } from "./common.js";
+
+const log = createSubsystemLogger("continuation/continue-work");
+
+const ContinueWorkToolSchema = Type.Object({
+  reason: Type.String({
+    description:
+      "Why another turn is needed before you yield. Logged for diagnostics and continuation context.",
+    maxLength: 1024,
+  }),
+  delaySeconds: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      description:
+        "Seconds to wait before the next turn fires. 0 or omitted = immediate. " +
+        "Clamped to continuation.minDelayMs / maxDelayMs from config.",
+    }),
+  ),
+});
+
+export type ContinueWorkRequest = {
+  reason: string;
+  delaySeconds: number;
+};
+
+export type ContinueWorkToolOpts = {
+  agentSessionKey?: string;
+  requestContinuation: (request: ContinueWorkRequest) => void;
+};
+
+export function createContinueWorkTool(opts: ContinueWorkToolOpts): AnyAgentTool {
+  return {
+    label: "Continuation",
+    name: "continue_work",
+    description:
+      "Request another turn for this session. Use when you have more work to do but want to yield the current turn first. " +
+      "Equivalent to CONTINUE_WORK bracket syntax but as a structured tool call.",
+    parameters: ContinueWorkToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const sessionKey = opts.agentSessionKey;
+
+      if (!sessionKey) {
+        throw new ToolInputError(
+          "continue_work requires an active session. Not available in sessionless contexts.",
+        );
+      }
+
+      const reason = readStringParam(params, "reason", { required: true }).slice(0, 1024);
+      const parsedDelaySeconds = readNumberParam(params, "delaySeconds", { strict: true });
+      if (parsedDelaySeconds !== undefined && parsedDelaySeconds < 0) {
+        throw new ToolInputError("delaySeconds must be a non-negative number.");
+      }
+      const delaySeconds = parsedDelaySeconds ?? 0;
+
+      log.debug(
+        `[continue_work:request] session=${sessionKey} delaySeconds=${delaySeconds} reason=${reason.slice(0, 80)}`,
+      );
+      opts.requestContinuation({
+        reason,
+        delaySeconds,
+      });
+
+      return jsonResult({
+        status: "scheduled",
+        delaySeconds,
+      });
+    },
+  };
+}

--- a/src/agents/tools/request-compaction-tool.test.ts
+++ b/src/agents/tools/request-compaction-tool.test.ts
@@ -1,0 +1,403 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createRequestCompactionTool,
+  _resetGuardState,
+  _resetVolitionalCounts,
+  _setPending,
+  _guards,
+  getVolitionalCompactionCount,
+  incrementVolitionalCompactionCount,
+  type RequestCompactionToolOpts,
+} from "./request-compaction-tool.js";
+
+describe("request_compaction tool", () => {
+  const SESSION_KEY = "test-session";
+  const SESSION_ID = "session-uuid-1234";
+
+  let contextUsage: number;
+  let sessionGeneration: number;
+  let mockTriggerCompaction: ReturnType<
+    typeof vi.fn<RequestCompactionToolOpts["triggerCompaction"]>
+  >;
+
+  function makeOpts(overrides?: Partial<RequestCompactionToolOpts>): RequestCompactionToolOpts {
+    return {
+      agentSessionKey: SESSION_KEY,
+      sessionId: SESSION_ID,
+      getContextUsage: () => contextUsage,
+      getSessionGeneration: () => sessionGeneration,
+      turnGeneration: 1,
+      triggerCompaction: mockTriggerCompaction,
+      ...overrides,
+    };
+  }
+
+  function makeTool(overrides?: Partial<RequestCompactionToolOpts>) {
+    return createRequestCompactionTool(makeOpts(overrides));
+  }
+
+  async function executeTool(
+    tool: ReturnType<typeof createRequestCompactionTool>,
+    args: Record<string, unknown> = { reason: "test compaction request" },
+  ) {
+    return (await tool.execute("call-1", args))?.details as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    contextUsage = 0.85; // above threshold by default
+    sessionGeneration = 1; // matches turnGeneration by default
+    _resetGuardState();
+    _resetVolitionalCounts();
+    mockTriggerCompaction = vi.fn().mockResolvedValue({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "Session compacted successfully with key decisions preserved.",
+        firstKeptEntryId: "entry-42",
+        tokensBefore: 850_000,
+        tokensAfter: 120_000,
+      },
+    });
+  });
+
+  afterEach(() => {
+    _resetGuardState();
+    _resetVolitionalCounts();
+  });
+
+  // -------------------------------------------------------------------------
+  // Precondition errors
+  // -------------------------------------------------------------------------
+
+  it("throws when no session key is provided", async () => {
+    const tool = makeTool({ agentSessionKey: undefined });
+    await expect(tool.execute("call-1", {})).rejects.toThrow(/requires an active session/);
+  });
+
+  it("throws when no session id is provided", async () => {
+    const tool = makeTool({ sessionId: undefined });
+    await expect(tool.execute("call-1", {})).rejects.toThrow(/requires a sessionId/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Guard: context threshold
+  // -------------------------------------------------------------------------
+
+  it("rejects when context usage is below threshold", async () => {
+    contextUsage = 0.5;
+    const tool = makeTool();
+    const result = await executeTool(tool);
+
+    expect(result).toMatchObject({
+      status: "rejected",
+      guard: "context_threshold",
+      contextUsage: 50,
+      threshold: _guards.MIN_CONTEXT_THRESHOLD * 100,
+    });
+    expect(mockTriggerCompaction).not.toHaveBeenCalled();
+  });
+
+  it("accepts when context usage is exactly at threshold", async () => {
+    contextUsage = _guards.MIN_CONTEXT_THRESHOLD;
+    const tool = makeTool();
+    const result = await executeTool(tool);
+
+    expect(result).toMatchObject({ status: "compaction_requested" });
+    expect(mockTriggerCompaction).toHaveBeenCalledOnce();
+  });
+
+  // -------------------------------------------------------------------------
+  // Guard: rate limit
+  // -------------------------------------------------------------------------
+
+  it("rejects a second request within the rate limit window", async () => {
+    const tool = makeTool();
+
+    // First call succeeds
+    const first = await executeTool(tool);
+    expect(first).toMatchObject({ status: "compaction_requested" });
+
+    // Second call within 5 minutes is rate-limited
+    const second = await executeTool(tool);
+    expect(second).toMatchObject({
+      status: "rejected",
+      guard: "rate_limit",
+    });
+    expect(second.retryAfterSeconds).toBeGreaterThan(0);
+    expect(mockTriggerCompaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a request after the rate limit window expires", async () => {
+    const tool = makeTool();
+
+    let fakeNow = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => fakeNow);
+
+    // First call
+    const first = await executeTool(tool);
+    expect(first).toMatchObject({ status: "compaction_requested" });
+
+    // Advance past rate limit
+    fakeNow += _guards.RATE_LIMIT_MS + 1;
+
+    const second = await executeTool(tool);
+    expect(second).toMatchObject({ status: "compaction_requested" });
+    expect(mockTriggerCompaction).toHaveBeenCalledTimes(2);
+
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Guard: generation drift
+  // -------------------------------------------------------------------------
+
+  it("rejects when session generation has advanced", async () => {
+    sessionGeneration = 2; // drift from turnGeneration=1
+    const tool = makeTool();
+    const result = await executeTool(tool);
+
+    expect(result).toMatchObject({
+      status: "rejected",
+      guard: "generation_drift",
+      turnGeneration: 1,
+      currentGeneration: 2,
+    });
+    expect(mockTriggerCompaction).not.toHaveBeenCalled();
+  });
+
+  it("accepts when generation matches", async () => {
+    sessionGeneration = 1;
+    const tool = makeTool({ turnGeneration: 1 });
+    const result = await executeTool(tool);
+
+    expect(result).toMatchObject({ status: "compaction_requested" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Async fire-and-forget
+  // -------------------------------------------------------------------------
+
+  it("returns compaction_requested immediately without awaiting compaction", async () => {
+    // triggerCompaction returns a promise that never resolves — tool should
+    // still return immediately because it does not await.
+    let resolveCompaction!: () => void;
+    mockTriggerCompaction.mockReturnValue(
+      new Promise<{ ok: boolean; compacted: boolean }>((resolve) => {
+        resolveCompaction = () => resolve({ ok: true, compacted: true });
+      }),
+    );
+
+    const tool = makeTool();
+    const result = await executeTool(tool);
+
+    // Tool returned before compaction completed
+    expect(result).toMatchObject({ status: "compaction_requested" });
+    expect(mockTriggerCompaction).toHaveBeenCalledOnce();
+
+    // Clean up the dangling promise
+    resolveCompaction();
+  });
+
+  it("logs errors from background compaction without crashing the tool", async () => {
+    mockTriggerCompaction.mockRejectedValue(new Error("Lane contention timeout"));
+
+    const tool = makeTool();
+    const result = await executeTool(tool);
+
+    // Tool still returns success — the error is handled in the background
+    expect(result).toMatchObject({ status: "compaction_requested" });
+
+    // Let the rejection propagate through the microtask queue
+    await vi.waitFor(() => {
+      expect(mockTriggerCompaction).toHaveBeenCalledOnce();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reason parameter
+  // -------------------------------------------------------------------------
+
+  it("passes through the reason parameter in the result", async () => {
+    const tool = makeTool();
+    const result = await executeTool(tool, { reason: "thermal evacuation complete" });
+
+    expect(result).toMatchObject({
+      status: "compaction_requested",
+      reason: "thermal evacuation complete",
+    });
+  });
+
+  it("truncates long reasons to 1024 characters", async () => {
+    const tool = makeTool();
+    const longReason = "x".repeat(2000);
+    const result = await executeTool(tool, { reason: longReason });
+
+    expect((result.reason as string).length).toBe(1024);
+  });
+
+  // -------------------------------------------------------------------------
+  // Collision edge cases (Trigger dedup)
+  // -------------------------------------------------------------------------
+
+  it("two request_compaction calls in same turn — second is rate-limited", async () => {
+    const tool = makeTool();
+
+    const first = await executeTool(tool);
+    expect(first).toMatchObject({ status: "compaction_requested" });
+
+    // Second call in same turn
+    const second = await executeTool(tool);
+    expect(second).toMatchObject({
+      status: "rejected",
+      guard: "rate_limit",
+    });
+    expect(mockTriggerCompaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("request_compaction below 70% is rejected", async () => {
+    contextUsage = 0.69;
+    const tool = makeTool();
+    const result = await executeTool(tool);
+
+    expect(result).toMatchObject({
+      status: "rejected",
+      guard: "context_threshold",
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Guard isolation per session
+  // -------------------------------------------------------------------------
+
+  it("rate limits are per-session, not global", async () => {
+    const toolA = makeTool({ agentSessionKey: "session-a" });
+    const toolB = makeTool({ agentSessionKey: "session-b" });
+
+    // Session A compacts
+    const resultA = await executeTool(toolA);
+    expect(resultA).toMatchObject({ status: "compaction_requested" });
+
+    // Session B can still compact
+    const resultB = await executeTool(toolB);
+    expect(resultB).toMatchObject({ status: "compaction_requested" });
+
+    // Session A is rate-limited
+    const resultA2 = await executeTool(toolA);
+    expect(resultA2).toMatchObject({ status: "rejected", guard: "rate_limit" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Guard ordering
+  // -------------------------------------------------------------------------
+
+  it("checks context threshold before rate limit", async () => {
+    const tool = makeTool();
+
+    // First: succeed to set rate limit state
+    await executeTool(tool);
+
+    // Now drop context below threshold
+    contextUsage = 0.3;
+
+    // Should get threshold rejection, not rate limit rejection
+    const result = await executeTool(tool);
+    expect(result).toMatchObject({
+      status: "rejected",
+      guard: "context_threshold",
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // _resetGuardState
+  // -------------------------------------------------------------------------
+
+  it("_resetGuardState clears per-session state", async () => {
+    const tool = makeTool();
+
+    await executeTool(tool);
+    _resetGuardState(SESSION_KEY);
+
+    // After reset, should be able to request compaction again
+    const result = await executeTool(tool);
+    expect(result).toMatchObject({ status: "compaction_requested" });
+    expect(mockTriggerCompaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("_resetGuardState with no arg clears all sessions", async () => {
+    const toolA = makeTool({ agentSessionKey: "session-a" });
+    const toolB = makeTool({ agentSessionKey: "session-b" });
+
+    await executeTool(toolA);
+    await executeTool(toolB);
+
+    _resetGuardState();
+
+    const resultA = await executeTool(toolA);
+    const resultB = await executeTool(toolB);
+    expect(resultA).toMatchObject({ status: "compaction_requested" });
+    expect(resultB).toMatchObject({ status: "compaction_requested" });
+  });
+
+  it("expires volitional compaction counts after the diagnostic TTL", () => {
+    let fakeNow = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => fakeNow);
+
+    incrementVolitionalCompactionCount(SESSION_KEY);
+    expect(getVolitionalCompactionCount(SESSION_KEY)).toBe(1);
+
+    fakeNow += _guards.VOLITIONAL_COMPACTION_COUNT_TTL_MS + 1;
+    expect(getVolitionalCompactionCount(SESSION_KEY)).toBe(0);
+
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Guard: dedup (compaction already pending)
+  // -------------------------------------------------------------------------
+
+  it("returns already_pending when compaction is in-flight", async () => {
+    _setPending(SESSION_KEY);
+
+    const tool = makeTool();
+    const result = await executeTool(tool);
+
+    expect(result).toMatchObject({ status: "already_pending" });
+    expect(mockTriggerCompaction).not.toHaveBeenCalled();
+  });
+
+  it("dedup is cleared after triggerCompaction resolves", async () => {
+    let resolveCompaction!: () => void;
+    mockTriggerCompaction.mockReturnValue(
+      new Promise<{ ok: boolean; compacted: boolean }>((resolve) => {
+        resolveCompaction = () => resolve({ ok: true, compacted: true });
+      }),
+    );
+
+    const tool = makeTool();
+    const first = await executeTool(tool);
+    expect(first).toMatchObject({ status: "compaction_requested" });
+
+    // Resolve the background compaction and flush microtasks
+    resolveCompaction();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // After resolution, pending is cleared — a new call (with fresh guard state) works
+    _resetGuardState(SESSION_KEY);
+    const second = await executeTool(tool);
+    expect(second).toMatchObject({ status: "compaction_requested" });
+  });
+
+  // -------------------------------------------------------------------------
+  // Required reason parameter
+  // -------------------------------------------------------------------------
+
+  it("throws ToolInputError when reason is missing", async () => {
+    const tool = makeTool();
+    await expect(tool.execute("call-1", {})).rejects.toThrow(/reason required/);
+  });
+
+  it("throws ToolInputError when reason is empty string", async () => {
+    const tool = makeTool();
+    await expect(tool.execute("call-1", { reason: "  " })).rejects.toThrow(/reason required/);
+  });
+});

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -1,0 +1,301 @@
+import { Type } from "@sinclair/typebox";
+import { createExpiringMapCache } from "../../config/cache-utils.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam, ToolInputError } from "./common.js";
+
+const log = createSubsystemLogger("continuation/request-compaction");
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+/** Minimum context usage (0-1) before the tool will accept a compaction request. */
+const MIN_CONTEXT_THRESHOLD = 0.7;
+
+/** Minimum milliseconds between compaction requests per session. */
+const RATE_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Volitional compaction counts are status-only diagnostics, not durable state. */
+const VOLITIONAL_COMPACTION_COUNT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Per-session state for guards.
+ *
+ * Module-level map — same volatility contract as continuation-delegate-store.
+ * Does not survive gateway restarts. This is intentional: the guards are
+ * rate-limiters, not durable state. A restart resets the cooldown, which is
+ * fine — the session itself is fresh.
+ */
+const sessionGuardState = createExpiringMapCache<
+  string,
+  {
+    lastRequestMs: number;
+    lastGeneration: number;
+  }
+>({
+  ttlMs: RATE_LIMIT_MS,
+});
+
+/**
+ * Tracks sessions that have a compaction request in-flight.
+ * Used to dedup — if the agent calls request_compaction twice before the
+ * first one completes, the second call returns "already pending".
+ */
+const pendingCompactionSessions = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const RequestCompactionToolSchema = Type.Object({
+  reason: Type.String({
+    description:
+      "Why the agent is requesting compaction now. Logged for diagnostics. " +
+      "Example: 'context pressure at 92%, working state evacuated to memory files and 2 post-compaction delegates staged.'",
+    maxLength: 1024,
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export type RequestCompactionToolOpts = {
+  /** Current session key (e.g. "telegram:12345"). */
+  agentSessionKey?: string;
+  /** Session id (the Pi session UUID). */
+  sessionId?: string;
+  /**
+   * Returns the current context usage as a fraction (0-1).
+   * Injected so the tool does not reach into session internals.
+   */
+  getContextUsage: () => number;
+  /**
+   * Returns the current session generation counter.
+   * Used for the generation guard — if generation has advanced since the
+   * agent's turn started, another message arrived and compaction should
+   * be deferred to avoid compacting mid-conversation.
+   */
+  getSessionGeneration: () => number;
+  /**
+   * The generation counter at the start of the current agent turn.
+   * Compared against `getSessionGeneration()` to detect drift.
+   */
+  turnGeneration: number;
+  /**
+   * Async function that triggers compaction. Injected so the tool does not
+   * import the heavy compaction module directly. The caller provides a
+   * closure over `compactEmbeddedPiSession` with all required session params.
+   */
+  triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+};
+
+// ---------------------------------------------------------------------------
+// Tool factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the `request_compaction` tool.
+ *
+ * This tool allows the agent to **request** compaction after it has prepared —
+ * evacuated working state to memory files, staged post-compaction delegates,
+ * or otherwise accepted the context loss.
+ *
+ * The tool is ASYNC: it enqueues compaction and returns immediately. The
+ * compaction runs between turns via the lane queue, not during the tool call.
+ *
+ * Guards (all checked before compaction is enqueued):
+ *   - **Context threshold:** context usage must be >= 70%.
+ *   - **Rate limit:** at most one compaction per 5 minutes per session.
+ *   - **Generation guard:** if the session generation has advanced since the
+ *     agent's turn started, another message arrived.
+ */
+export function createRequestCompactionTool(opts: RequestCompactionToolOpts): AnyAgentTool {
+  return {
+    label: "Compaction",
+    name: "request_compaction",
+    description:
+      "Request compaction of the current session to reclaim context window space. " +
+      "Call this AFTER you have evacuated working state (memory files, post-compaction delegates, RESUMPTION.md). " +
+      "Guards: context must be >= 70% full, rate-limited to once per 5 minutes, and no new messages " +
+      "may have arrived since your turn started. Compaction is async — it runs after your turn completes. " +
+      "Prefer this over waiting for automatic compaction when you have context-pressure awareness and want " +
+      "to control the timing of state evacuation.",
+    parameters: RequestCompactionToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const sessionKey = opts.agentSessionKey;
+
+      if (!sessionKey) {
+        throw new ToolInputError(
+          "request_compaction requires an active session. Not available in sessionless contexts.",
+        );
+      }
+
+      if (!opts.sessionId) {
+        throw new ToolInputError(
+          "request_compaction requires a sessionId. Session may not be fully initialized.",
+        );
+      }
+
+      const reason = readStringParam(params, "reason", { required: true }).slice(0, 1024);
+
+      // ----- Guard 0: Dedup — compaction already pending -----
+      if (pendingCompactionSessions.has(sessionKey)) {
+        log.debug(`[request_compaction:already-pending] session=${sessionKey}`);
+        return jsonResult({
+          status: "already_pending",
+          reason: "A compaction request is already in-flight for this session.",
+        });
+      }
+
+      // ----- Guard 1: Context threshold -----
+      const contextUsage = opts.getContextUsage();
+      if (contextUsage < MIN_CONTEXT_THRESHOLD) {
+        log.debug(
+          `[request_compaction:below-threshold] session=${sessionKey} usage=${(contextUsage * 100).toFixed(1)}%`,
+        );
+        return jsonResult({
+          status: "rejected",
+          guard: "context_threshold",
+          contextUsage: Math.round(contextUsage * 100),
+          threshold: Math.round(MIN_CONTEXT_THRESHOLD * 100),
+          reason: `Context usage (${Math.round(contextUsage * 100)}%) is below the minimum threshold (${Math.round(MIN_CONTEXT_THRESHOLD * 100)}%). Compaction is not needed yet.`,
+        });
+      }
+
+      // ----- Guard 2: Rate limit -----
+      const now = Date.now();
+      const guard = sessionGuardState.get(sessionKey);
+      if (guard && now - guard.lastRequestMs < RATE_LIMIT_MS) {
+        const remainingMs = RATE_LIMIT_MS - (now - guard.lastRequestMs);
+        const remainingSec = Math.ceil(remainingMs / 1000);
+        log.debug(
+          `[request_compaction:rate-limited] session=${sessionKey} remainingSec=${remainingSec}`,
+        );
+        return jsonResult({
+          status: "rejected",
+          guard: "rate_limit",
+          retryAfterSeconds: remainingSec,
+          reason: `Rate limited. Next compaction request allowed in ${remainingSec}s.`,
+        });
+      }
+
+      // ----- Guard 3: Generation guard -----
+      const currentGeneration = opts.getSessionGeneration();
+      if (currentGeneration !== opts.turnGeneration) {
+        log.debug(
+          `[request_compaction:generation-drift] session=${sessionKey} turn=${opts.turnGeneration} current=${currentGeneration}`,
+        );
+        return jsonResult({
+          status: "rejected",
+          guard: "generation_drift",
+          turnGeneration: opts.turnGeneration,
+          currentGeneration,
+          reason:
+            "Session generation has advanced since your turn started — a new message arrived. " +
+            "Compacting now would lose that context. Re-evaluate on your next turn.",
+        });
+      }
+
+      // ----- All guards passed — enqueue compaction -----
+      log.info(
+        `[request_compaction:enqueuing] session=${sessionKey} usage=${(contextUsage * 100).toFixed(1)}% reason=${reason}`,
+      );
+
+      // Update rate-limit state BEFORE firing so a second call in the same
+      // turn (or a crash during compaction) still respects the cooldown.
+      sessionGuardState.set(sessionKey, {
+        lastRequestMs: now,
+        lastGeneration: currentGeneration,
+      });
+
+      // Fire-and-forget: compaction runs via the lane queue after the current
+      // agent turn releases the session lane. We do NOT await — the tool
+      // returns immediately so the agent can finish its response.
+      pendingCompactionSessions.add(sessionKey);
+      void opts
+        .triggerCompaction()
+        .then(
+          (result) => {
+            if (result.ok && result.compacted) {
+              incrementVolitionalCompactionCount(sessionKey);
+            }
+          },
+          (err: unknown) => {
+            log.error(
+              `[request_compaction:background-error] session=${sessionKey} error=${err instanceof Error ? err.message : String(err)}`,
+            );
+          },
+        )
+        .finally(() => {
+          pendingCompactionSessions.delete(sessionKey);
+        });
+
+      return jsonResult({
+        status: "compaction_requested",
+        contextUsage: Math.round(contextUsage * 100),
+        reason,
+        note:
+          "Compaction has been enqueued and will run after your turn completes. " +
+          "Post-compaction context (AGENTS.md, SOUL.md) will be injected on the next turn. " +
+          "Any staged post-compaction delegates will be dispatched.",
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Volitional compaction counter (module-level, survives compaction)
+// ---------------------------------------------------------------------------
+
+const volitionalCompactionCounts = createExpiringMapCache<string, number>({
+  ttlMs: VOLITIONAL_COMPACTION_COUNT_TTL_MS,
+});
+
+/** Increment the volitional compaction counter for a session. */
+export function incrementVolitionalCompactionCount(sessionKey: string): void {
+  volitionalCompactionCounts.set(sessionKey, (volitionalCompactionCounts.get(sessionKey) ?? 0) + 1);
+}
+
+/** Get the volitional compaction count for a session. */
+export function getVolitionalCompactionCount(sessionKey: string): number {
+  return volitionalCompactionCounts.get(sessionKey) ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Reset per-session guard state. Exported for tests only. */
+export function _resetGuardState(sessionKey?: string): void {
+  if (sessionKey) {
+    sessionGuardState.delete(sessionKey);
+    pendingCompactionSessions.delete(sessionKey);
+  } else {
+    sessionGuardState.clear();
+    pendingCompactionSessions.clear();
+  }
+}
+
+/** Mark a session as having a pending compaction. Exported for tests only. */
+export function _setPending(sessionKey: string): void {
+  pendingCompactionSessions.add(sessionKey);
+}
+
+/** Reset volitional compaction counters. Exported for tests only. */
+export function _resetVolitionalCounts(sessionKey?: string): void {
+  if (sessionKey) {
+    volitionalCompactionCounts.delete(sessionKey);
+  } else {
+    volitionalCompactionCounts.clear();
+  }
+}
+
+/** Expose constants for test assertions. */
+export const _guards = {
+  MIN_CONTEXT_THRESHOLD,
+  RATE_LIMIT_MS,
+  VOLITIONAL_COMPACTION_COUNT_TTL_MS,
+} as const;

--- a/src/auto-reply/continuation-delegate-store-taskflow.test.ts
+++ b/src/auto-reply/continuation-delegate-store-taskflow.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getTaskFlowById,
+  listTaskFlowsForOwnerKey,
+  resetTaskFlowRegistryForTests,
+} from "../tasks/task-flow-registry.js";
+import type { finishFlow as finishFlowType } from "../tasks/task-flow-registry.js";
+
+const hoisted = vi.hoisted(() => ({
+  finishFlowSpy: vi.fn(),
+  realFinishFlow: null as null | typeof finishFlowType,
+}));
+const { finishFlowSpy } = hoisted;
+vi.mock("../tasks/task-flow-registry.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../tasks/task-flow-registry.js")>();
+  hoisted.realFinishFlow = mod.finishFlow;
+  hoisted.finishFlowSpy.mockImplementation((params: Parameters<typeof mod.finishFlow>[0]) =>
+    mod.finishFlow(params),
+  );
+  return {
+    ...mod,
+    finishFlow: (params: Parameters<typeof mod.finishFlow>[0]) => hoisted.finishFlowSpy(params),
+  };
+});
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import {
+  taskFlowCancelPendingDelegates,
+  taskFlowConsumePendingDelegates,
+  taskFlowEnqueuePendingDelegate,
+  taskFlowPendingDelegateCount,
+} from "./continuation-delegate-store-taskflow.js";
+import {
+  cancelPendingDelegates,
+  consumePendingDelegates,
+  enqueuePendingDelegate,
+  isTaskFlowDelegatesEnabled,
+  pendingDelegateCount,
+  setTaskFlowDelegatesEnabled,
+} from "./continuation-delegate-store.js";
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+
+async function withFlowRegistryTempDir<T>(run: () => Promise<T>): Promise<T> {
+  return await withTempDir({ prefix: "openclaw-delegate-taskflow-" }, async (root) => {
+    process.env.OPENCLAW_STATE_DIR = root;
+    resetTaskFlowRegistryForTests();
+    try {
+      return await run();
+    } finally {
+      resetTaskFlowRegistryForTests();
+    }
+  });
+}
+
+describe("continuation-delegate-store-taskflow", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    finishFlowSpy.mockRestore();
+    // Re-bind default delegation to real implementation after restore.
+    if (hoisted.realFinishFlow) {
+      finishFlowSpy.mockImplementation((params: Parameters<typeof finishFlowType>[0]) =>
+        hoisted.realFinishFlow!(params),
+      );
+    }
+    setTaskFlowDelegatesEnabled(false);
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+    resetTaskFlowRegistryForTests();
+  });
+
+  it("returns empty array when no delegates pending", async () => {
+    await withFlowRegistryTempDir(async () => {
+      expect(taskFlowConsumePendingDelegates("test-session")).toEqual([]);
+    });
+  });
+
+  it("enqueues and consumes a single delegate", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", {
+        task: "summarize the RFC",
+        delayMs: 30000,
+        silent: false,
+        silentWake: false,
+      });
+
+      const delegates = taskFlowConsumePendingDelegates("test-session");
+      expect(delegates).toHaveLength(1);
+      expect(delegates[0].task).toBe("summarize the RFC");
+      expect(delegates[0].delayMs).toBe(30000);
+    });
+  });
+
+  it("consume removes delegates from store", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "task 1" });
+
+      const first = taskFlowConsumePendingDelegates("test-session");
+      expect(first).toHaveLength(1);
+
+      const second = taskFlowConsumePendingDelegates("test-session");
+      expect(second).toEqual([]);
+    });
+  });
+
+  it("supports multiple delegates per session (multi-arrow fan-out)", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "arrow 1", delayMs: 10000 });
+      taskFlowEnqueuePendingDelegate("test-session", {
+        task: "arrow 2",
+        delayMs: 20000,
+        silent: true,
+      });
+      taskFlowEnqueuePendingDelegate("test-session", {
+        task: "arrow 3",
+        delayMs: 30000,
+        silentWake: true,
+      });
+
+      const delegates = taskFlowConsumePendingDelegates("test-session");
+      expect(delegates).toHaveLength(3);
+      expect(delegates[0].task).toBe("arrow 1");
+      expect(delegates[1].task).toBe("arrow 2");
+      expect(delegates[1].silent).toBe(true);
+      expect(delegates[2].task).toBe("arrow 3");
+      expect(delegates[2].silentWake).toBe(true);
+    });
+  });
+
+  it("isolates delegates by session key", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "session A task" });
+      taskFlowEnqueuePendingDelegate("other-session", { task: "session B task" });
+
+      const a = taskFlowConsumePendingDelegates("test-session");
+      const b = taskFlowConsumePendingDelegates("other-session");
+
+      expect(a).toHaveLength(1);
+      expect(a[0].task).toBe("session A task");
+      expect(b).toHaveLength(1);
+      expect(b[0].task).toBe("session B task");
+    });
+  });
+
+  it("pendingDelegateCount reflects current queue depth", async () => {
+    await withFlowRegistryTempDir(async () => {
+      expect(taskFlowPendingDelegateCount("test-session")).toBe(0);
+
+      taskFlowEnqueuePendingDelegate("test-session", { task: "task 1" });
+      expect(taskFlowPendingDelegateCount("test-session")).toBe(1);
+
+      taskFlowEnqueuePendingDelegate("test-session", { task: "task 2" });
+      expect(taskFlowPendingDelegateCount("test-session")).toBe(2);
+
+      taskFlowConsumePendingDelegates("test-session");
+      expect(taskFlowPendingDelegateCount("test-session")).toBe(0);
+    });
+  });
+
+  it("handles delegates with no optional fields", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "minimal task" });
+
+      const delegates = taskFlowConsumePendingDelegates("test-session");
+      expect(delegates).toHaveLength(1);
+      expect(delegates[0]).toEqual({ task: "minimal task" });
+    });
+  });
+
+  it("handles zero delay (immediate dispatch)", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "immediate", delayMs: 0 });
+
+      const delegates = taskFlowConsumePendingDelegates("test-session");
+      expect(delegates[0].delayMs).toBe(0);
+    });
+  });
+
+  it("cancel removes all pending delegates for a session", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "task 1" });
+      taskFlowEnqueuePendingDelegate("test-session", { task: "task 2" });
+      expect(taskFlowPendingDelegateCount("test-session")).toBe(2);
+
+      taskFlowCancelPendingDelegates("test-session");
+
+      expect(taskFlowPendingDelegateCount("test-session")).toBe(0);
+      expect(taskFlowConsumePendingDelegates("test-session")).toEqual([]);
+    });
+  });
+
+  it("cancel does not affect other sessions", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "session A" });
+      taskFlowEnqueuePendingDelegate("other-session", { task: "session B" });
+
+      taskFlowCancelPendingDelegates("test-session");
+
+      expect(taskFlowPendingDelegateCount("test-session")).toBe(0);
+      expect(taskFlowPendingDelegateCount("other-session")).toBe(1);
+    });
+  });
+
+  it("cancel is idempotent on empty session", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowCancelPendingDelegates("test-session");
+      expect(taskFlowPendingDelegateCount("test-session")).toBe(0);
+    });
+  });
+
+  it("delegates persist across simulated restart (registry reset + reload)", async () => {
+    await withTempDir({ prefix: "openclaw-delegate-persist-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      taskFlowEnqueuePendingDelegate("test-session", {
+        task: "survive restart",
+        delayMs: 5000,
+        silent: true,
+      });
+
+      // Simulate a restart: reset in-memory state but keep SQLite on disk.
+      resetTaskFlowRegistryForTests({ persist: false });
+
+      // After restart, delegates should be recoverable.
+      const delegates = taskFlowConsumePendingDelegates("test-session");
+      expect(delegates).toHaveLength(1);
+      expect(delegates[0].task).toBe("survive restart");
+      expect(delegates[0].delayMs).toBe(5000);
+      expect(delegates[0].silent).toBe(true);
+
+      resetTaskFlowRegistryForTests();
+    });
+  });
+
+  it("consume transitions flow records to succeeded (not deleted)", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "lifecycle task" });
+
+      // Capture flow ID before consume.
+      const pendingFlows = listTaskFlowsForOwnerKey("test-session");
+      expect(pendingFlows).toHaveLength(1);
+      const flowId = pendingFlows[0].flowId;
+
+      taskFlowConsumePendingDelegates("test-session");
+
+      // Record still exists with "succeeded" status.
+      const flow = getTaskFlowById(flowId);
+      expect(flow).toBeDefined();
+      expect(flow!.status).toBe("succeeded");
+      expect(flow!.endedAt).toBeGreaterThan(0);
+    });
+  });
+
+  it("cancel transitions flow records to cancelled with cancel intent (not deleted)", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "cancel me" });
+
+      const pendingFlows = listTaskFlowsForOwnerKey("test-session");
+      const flowId = pendingFlows[0].flowId;
+
+      taskFlowCancelPendingDelegates("test-session");
+
+      // Record persists with cancelled status and cancel timestamp.
+      const flow = getTaskFlowById(flowId);
+      expect(flow).toBeDefined();
+      expect(flow!.status).toBe("cancelled");
+      expect(flow!.cancelRequestedAt).toBeGreaterThan(0);
+      expect(flow!.endedAt).toBeGreaterThan(0);
+    });
+  });
+
+  it("returns all delegates even when finishFlow throws for some flows", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "task 1" });
+      taskFlowEnqueuePendingDelegate("test-session", { task: "task 2" });
+      taskFlowEnqueuePendingDelegate("test-session", { task: "task 3" });
+
+      // Make finishFlow throw on the second call (flow #2 of 3).
+      let callCount = 0;
+      finishFlowSpy.mockImplementation((...args: unknown[]) => {
+        callCount++;
+        if (callCount === 2) {
+          throw new Error("simulated SQLite failure");
+        }
+        return (hoisted.realFinishFlow as Function)(...args);
+      });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        // Should NOT throw — delegates are collected before cleanup.
+        const delegates = taskFlowConsumePendingDelegates("test-session");
+
+        expect(delegates).toHaveLength(3);
+        expect(delegates[0].task).toBe("task 1");
+        expect(delegates[1].task).toBe("task 2");
+        expect(delegates[2].task).toBe("task 3");
+
+        // The failed finishFlow should have been logged as a warning.
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain("simulated SQLite failure");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  it("completed/cancelled records are excluded from pending listings", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", { task: "will complete" });
+      taskFlowEnqueuePendingDelegate("test-session", { task: "will cancel" });
+      taskFlowEnqueuePendingDelegate("test-session", { task: "stays queued" });
+
+      // Consume first delegate (→ succeeded).
+      const consumed = taskFlowConsumePendingDelegates("test-session");
+      expect(consumed).toHaveLength(3);
+
+      // Re-enqueue one to have a pending record.
+      taskFlowEnqueuePendingDelegate("test-session", { task: "new pending" });
+
+      // Only the new pending delegate is visible.
+      expect(taskFlowPendingDelegateCount("test-session")).toBe(1);
+      const delegates = taskFlowConsumePendingDelegates("test-session");
+      expect(delegates).toHaveLength(1);
+      expect(delegates[0].task).toBe("new pending");
+
+      // All records still exist in the registry (succeeded + new succeeded).
+      const allFlows = listTaskFlowsForOwnerKey("test-session");
+      expect(allFlows.length).toBe(4);
+    });
+  });
+});
+
+describe("config-gated delegate store routing", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    setTaskFlowDelegatesEnabled(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setTaskFlowDelegatesEnabled(false);
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+    resetTaskFlowRegistryForTests();
+  });
+
+  it("defaults to volatile store when taskFlowDelegates is disabled", () => {
+    expect(isTaskFlowDelegatesEnabled()).toBe(false);
+
+    enqueuePendingDelegate("test-session", { task: "volatile task" });
+    expect(pendingDelegateCount("test-session")).toBe(1);
+
+    const delegates = consumePendingDelegates("test-session");
+    expect(delegates).toHaveLength(1);
+    expect(delegates[0].task).toBe("volatile task");
+  });
+
+  it("routes through TaskFlow store when enabled", async () => {
+    await withFlowRegistryTempDir(async () => {
+      setTaskFlowDelegatesEnabled(true);
+
+      enqueuePendingDelegate("test-session", { task: "taskflow task", delayMs: 1000 });
+      expect(pendingDelegateCount("test-session")).toBe(1);
+
+      const delegates = consumePendingDelegates("test-session");
+      expect(delegates).toHaveLength(1);
+      expect(delegates[0].task).toBe("taskflow task");
+      expect(delegates[0].delayMs).toBe(1000);
+    });
+  });
+
+  it("cancelPendingDelegates works for volatile store", () => {
+    enqueuePendingDelegate("test-session", { task: "will be cancelled" });
+    expect(pendingDelegateCount("test-session")).toBe(1);
+
+    cancelPendingDelegates("test-session");
+    expect(pendingDelegateCount("test-session")).toBe(0);
+  });
+
+  it("cancelPendingDelegates routes to TaskFlow when enabled", async () => {
+    await withFlowRegistryTempDir(async () => {
+      setTaskFlowDelegatesEnabled(true);
+
+      enqueuePendingDelegate("test-session", { task: "will be cancelled" });
+      expect(pendingDelegateCount("test-session")).toBe(1);
+
+      cancelPendingDelegates("test-session");
+      expect(pendingDelegateCount("test-session")).toBe(0);
+    });
+  });
+
+  it("volatile and TaskFlow stores are independent (migration scenario)", async () => {
+    // Stage a volatile delegate with TaskFlow disabled.
+    enqueuePendingDelegate("test-session", { task: "volatile delegate" });
+    expect(pendingDelegateCount("test-session")).toBe(1);
+
+    await withFlowRegistryTempDir(async () => {
+      // Enable TaskFlow — volatile delegate is invisible to TaskFlow.
+      setTaskFlowDelegatesEnabled(true);
+      expect(pendingDelegateCount("test-session")).toBe(0);
+
+      // Enqueue a TaskFlow delegate.
+      enqueuePendingDelegate("test-session", { task: "taskflow delegate" });
+      expect(pendingDelegateCount("test-session")).toBe(1);
+
+      // Disable TaskFlow — volatile delegate reappears.
+      setTaskFlowDelegatesEnabled(false);
+      expect(pendingDelegateCount("test-session")).toBe(1);
+
+      const volatile = consumePendingDelegates("test-session");
+      expect(volatile).toHaveLength(1);
+      expect(volatile[0].task).toBe("volatile delegate");
+
+      // Re-enable — TaskFlow delegate is still there.
+      setTaskFlowDelegatesEnabled(true);
+      const taskflow = consumePendingDelegates("test-session");
+      expect(taskflow).toHaveLength(1);
+      expect(taskflow[0].task).toBe("taskflow delegate");
+    });
+  });
+});

--- a/src/auto-reply/continuation-delegate-store-taskflow.ts
+++ b/src/auto-reply/continuation-delegate-store-taskflow.ts
@@ -1,0 +1,144 @@
+/**
+ * Task Flow-backed implementation of the pending continuation delegate store.
+ *
+ * Each pending delegate is modeled as a managed TaskFlow record with
+ * `controllerId = "core/continuation-delegate"` and status `"queued"`.
+ * Delegate fields are stored in `stateJson`; `goal` mirrors the task string.
+ *
+ * This gives delegates SQLite-backed persistence (survive gateway restarts),
+ * cancel/retry semantics, and lifecycle tracking through the Task Flow registry.
+ *
+ * Gated behind `agents.defaults.continuation.taskFlowDelegates` (opt-in).
+ * The volatile Map store remains the default fallback.
+ */
+
+import type { TaskFlowRecord, JsonValue } from "../tasks/task-flow-registry.types.js";
+import {
+  createManagedTaskFlow,
+  finishFlow,
+  listTaskFlowsForOwnerKey,
+  requestFlowCancel,
+  updateFlowRecordByIdExpectedRevision,
+} from "../tasks/task-flow-runtime-internal.js";
+import type { PendingContinuationDelegate } from "./continuation-delegate.types.js";
+
+const CONTROLLER_ID = "core/continuation-delegate";
+
+function delegateToStateJson(delegate: PendingContinuationDelegate): JsonValue {
+  const state: Record<string, JsonValue> = { task: delegate.task };
+  if (delegate.delayMs != null) {
+    state.delayMs = delegate.delayMs;
+  }
+  if (delegate.silent != null) {
+    state.silent = delegate.silent;
+  }
+  if (delegate.silentWake != null) {
+    state.silentWake = delegate.silentWake;
+  }
+  return state;
+}
+
+function flowToDelegate(flow: TaskFlowRecord): PendingContinuationDelegate {
+  const state = (flow.stateJson ?? {}) as Record<string, unknown>;
+  const delegate: PendingContinuationDelegate = {
+    task: typeof state.task === "string" ? state.task : flow.goal,
+  };
+  if (typeof state.delayMs === "number") {
+    delegate.delayMs = state.delayMs;
+  }
+  if (typeof state.silent === "boolean") {
+    delegate.silent = state.silent;
+  }
+  if (typeof state.silentWake === "boolean") {
+    delegate.silentWake = state.silentWake;
+  }
+  return delegate;
+}
+
+function listPendingFlows(sessionKey: string): TaskFlowRecord[] {
+  return listTaskFlowsForOwnerKey(sessionKey)
+    .filter((f) => f.controllerId === CONTROLLER_ID && f.status === "queued")
+    .toSorted((a, b) => a.createdAt - b.createdAt);
+}
+
+/**
+ * Enqueue a pending delegate as a TaskFlow record.
+ */
+export function taskFlowEnqueuePendingDelegate(
+  sessionKey: string,
+  delegate: PendingContinuationDelegate,
+): void {
+  createManagedTaskFlow({
+    ownerKey: sessionKey,
+    controllerId: CONTROLLER_ID,
+    goal: delegate.task,
+    stateJson: delegateToStateJson(delegate),
+    status: "queued",
+  });
+}
+
+/**
+ * Consume (drain) all pending delegates for a session.
+ * Returns delegates in FIFO order and transitions backing flow records
+ * from "queued" → "succeeded" (proper lifecycle, not delete).
+ *
+ * Collect-then-cleanup: delegates are converted first so callers always
+ * receive them even if finishFlow() fails for some records.
+ */
+export function taskFlowConsumePendingDelegates(sessionKey: string): PendingContinuationDelegate[] {
+  const flows = listPendingFlows(sessionKey);
+
+  // Collect phase — convert all flows to delegates before any mutation.
+  const delegates = flows.map((flow) => flowToDelegate(flow));
+
+  // Cleanup phase — mark each flow as finished individually so one failure
+  // does not prevent the rest from being finalized.
+  for (const flow of flows) {
+    try {
+      finishFlow({
+        flowId: flow.flowId,
+        expectedRevision: flow.revision,
+      });
+    } catch (err) {
+      console.warn(
+        `[continuation-delegate] finishFlow failed for flowId=${flow.flowId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return delegates;
+}
+
+/**
+ * Count of pending delegates for a session without consuming them.
+ */
+export function taskFlowPendingDelegateCount(sessionKey: string): number {
+  return listPendingFlows(sessionKey).length;
+}
+
+/**
+ * Cancel all pending TaskFlow delegates for a session.
+ * Called when an external message arrives or a session is reset.
+ * Records persist with cancelled status for audit trail.
+ */
+export function taskFlowCancelPendingDelegates(sessionKey: string): void {
+  const flows = listPendingFlows(sessionKey);
+  for (const flow of flows) {
+    // Mark cancel intent (sticky timestamp).
+    const cancelResult = requestFlowCancel({
+      flowId: flow.flowId,
+      expectedRevision: flow.revision,
+    });
+    // Transition to terminal "cancelled" status.
+    if (cancelResult.applied) {
+      updateFlowRecordByIdExpectedRevision({
+        flowId: flow.flowId,
+        expectedRevision: cancelResult.flow.revision,
+        patch: {
+          status: "cancelled",
+          endedAt: Date.now(),
+        },
+      });
+    }
+  }
+}

--- a/src/auto-reply/continuation-delegate-store.test.ts
+++ b/src/auto-reply/continuation-delegate-store.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  addDelayedContinuationReservation,
+  clearDelayedContinuationReservations,
+  consumeStagedPostCompactionDelegates,
+  delayedContinuationReservationCount,
+  enqueuePendingDelegate,
+  highestDelayedContinuationReservationHop,
+  listDelayedContinuationReservations,
+  removeDelayedContinuationReservation,
+  consumePendingDelegates,
+  pendingDelegateCount,
+  stagePostCompactionDelegate,
+  stagedPostCompactionDelegateCount,
+  takeDelayedContinuationReservation,
+} from "./continuation-delegate-store.js";
+
+describe("continuation-delegate-store", () => {
+  // Clear state between tests by consuming any leftover delegates
+  beforeEach(() => {
+    consumePendingDelegates("test-session");
+    consumePendingDelegates("other-session");
+    consumeStagedPostCompactionDelegates("test-session");
+    consumeStagedPostCompactionDelegates("other-session");
+    clearDelayedContinuationReservations("test-session");
+    clearDelayedContinuationReservations("other-session");
+  });
+
+  it("returns empty array when no delegates pending", () => {
+    expect(consumePendingDelegates("test-session")).toEqual([]);
+  });
+
+  it("enqueues and consumes a single delegate", () => {
+    enqueuePendingDelegate("test-session", {
+      task: "summarize the RFC",
+      delayMs: 30000,
+      silent: false,
+      silentWake: false,
+    });
+
+    const delegates = consumePendingDelegates("test-session");
+    expect(delegates).toHaveLength(1);
+    expect(delegates[0].task).toBe("summarize the RFC");
+    expect(delegates[0].delayMs).toBe(30000);
+  });
+
+  it("consumes removes delegates from store", () => {
+    enqueuePendingDelegate("test-session", { task: "task 1" });
+
+    const first = consumePendingDelegates("test-session");
+    expect(first).toHaveLength(1);
+
+    const second = consumePendingDelegates("test-session");
+    expect(second).toEqual([]);
+  });
+
+  it("supports multiple delegates per session (multi-arrow fan-out)", () => {
+    enqueuePendingDelegate("test-session", { task: "arrow 1", delayMs: 10000 });
+    enqueuePendingDelegate("test-session", { task: "arrow 2", delayMs: 20000, silent: true });
+    enqueuePendingDelegate("test-session", {
+      task: "arrow 3",
+      delayMs: 30000,
+      silentWake: true,
+    });
+
+    const delegates = consumePendingDelegates("test-session");
+    expect(delegates).toHaveLength(3);
+    expect(delegates[0].task).toBe("arrow 1");
+    expect(delegates[1].task).toBe("arrow 2");
+    expect(delegates[1].silent).toBe(true);
+    expect(delegates[2].task).toBe("arrow 3");
+    expect(delegates[2].silentWake).toBe(true);
+  });
+
+  it("isolates delegates by session key", () => {
+    enqueuePendingDelegate("test-session", { task: "session A task" });
+    enqueuePendingDelegate("other-session", { task: "session B task" });
+
+    const a = consumePendingDelegates("test-session");
+    const b = consumePendingDelegates("other-session");
+
+    expect(a).toHaveLength(1);
+    expect(a[0].task).toBe("session A task");
+    expect(b).toHaveLength(1);
+    expect(b[0].task).toBe("session B task");
+  });
+
+  it("pendingDelegateCount reflects current queue depth", () => {
+    expect(pendingDelegateCount("test-session")).toBe(0);
+
+    enqueuePendingDelegate("test-session", { task: "task 1" });
+    expect(pendingDelegateCount("test-session")).toBe(1);
+
+    enqueuePendingDelegate("test-session", { task: "task 2" });
+    expect(pendingDelegateCount("test-session")).toBe(2);
+
+    consumePendingDelegates("test-session");
+    expect(pendingDelegateCount("test-session")).toBe(0);
+  });
+
+  it("handles delegates with no optional fields", () => {
+    enqueuePendingDelegate("test-session", { task: "minimal task" });
+
+    const delegates = consumePendingDelegates("test-session");
+    expect(delegates).toHaveLength(1);
+    expect(delegates[0]).toEqual({ task: "minimal task" });
+  });
+
+  it("handles zero delay (immediate dispatch)", () => {
+    enqueuePendingDelegate("test-session", { task: "immediate", delayMs: 0 });
+
+    const delegates = consumePendingDelegates("test-session");
+    expect(delegates[0].delayMs).toBe(0);
+  });
+});
+
+describe("delayed continuation reservations", () => {
+  beforeEach(() => {
+    clearDelayedContinuationReservations("test-session");
+    clearDelayedContinuationReservations("other-session");
+  });
+
+  it("adds and lists reservations for a session", () => {
+    addDelayedContinuationReservation("test-session", {
+      id: "reservation-1",
+      source: "tool",
+      task: "inspect shard health",
+      createdAt: 1,
+      fireAt: 2,
+      generation: 3,
+      plannedHop: 4,
+      silentWake: true,
+    });
+
+    expect(listDelayedContinuationReservations("test-session")).toEqual([
+      {
+        id: "reservation-1",
+        source: "tool",
+        task: "inspect shard health",
+        createdAt: 1,
+        fireAt: 2,
+        generation: 3,
+        plannedHop: 4,
+        silentWake: true,
+      },
+    ]);
+    expect(delayedContinuationReservationCount("test-session")).toBe(1);
+  });
+
+  it("isolates reservations by session key", () => {
+    addDelayedContinuationReservation("test-session", {
+      id: "reservation-a",
+      source: "bracket",
+      task: "session A task",
+      createdAt: 1,
+      fireAt: 2,
+      generation: 3,
+      plannedHop: 1,
+    });
+    addDelayedContinuationReservation("other-session", {
+      id: "reservation-b",
+      source: "tool",
+      task: "session B task",
+      createdAt: 1,
+      fireAt: 2,
+      generation: 3,
+      plannedHop: 1,
+    });
+
+    expect(delayedContinuationReservationCount("test-session")).toBe(1);
+    expect(delayedContinuationReservationCount("other-session")).toBe(1);
+    expect(listDelayedContinuationReservations("test-session")[0]?.task).toBe("session A task");
+    expect(listDelayedContinuationReservations("other-session")[0]?.task).toBe("session B task");
+  });
+
+  it("takes one reservation by id and leaves the others intact", () => {
+    addDelayedContinuationReservation("test-session", {
+      id: "reservation-1",
+      source: "tool",
+      task: "first",
+      createdAt: 1,
+      fireAt: 2,
+      generation: 3,
+      plannedHop: 1,
+    });
+    addDelayedContinuationReservation("test-session", {
+      id: "reservation-2",
+      source: "tool",
+      task: "second",
+      createdAt: 2,
+      fireAt: 3,
+      generation: 4,
+      plannedHop: 2,
+    });
+
+    expect(takeDelayedContinuationReservation("test-session", "reservation-1")).toMatchObject({
+      id: "reservation-1",
+      task: "first",
+    });
+    expect(listDelayedContinuationReservations("test-session")).toEqual([
+      expect.objectContaining({ id: "reservation-2", task: "second" }),
+    ]);
+    expect(delayedContinuationReservationCount("test-session")).toBe(1);
+    expect(highestDelayedContinuationReservationHop("test-session")).toBe(2);
+  });
+
+  it("remove is idempotent for unknown reservation ids", () => {
+    addDelayedContinuationReservation("test-session", {
+      id: "reservation-1",
+      source: "tool",
+      task: "first",
+      createdAt: 1,
+      fireAt: 2,
+      generation: 3,
+      plannedHop: 1,
+    });
+
+    expect(removeDelayedContinuationReservation("test-session", "missing")).toBe(false);
+    expect(removeDelayedContinuationReservation("test-session", "reservation-1")).toBe(true);
+    expect(removeDelayedContinuationReservation("test-session", "reservation-1")).toBe(false);
+    expect(delayedContinuationReservationCount("test-session")).toBe(0);
+  });
+
+  it("clear removes all reservations for a session", () => {
+    addDelayedContinuationReservation("test-session", {
+      id: "reservation-1",
+      source: "bracket",
+      task: "first",
+      createdAt: 1,
+      fireAt: 2,
+      generation: 3,
+      plannedHop: 1,
+    });
+    addDelayedContinuationReservation("test-session", {
+      id: "reservation-2",
+      source: "tool",
+      task: "second",
+      createdAt: 2,
+      fireAt: 3,
+      generation: 4,
+      plannedHop: 2,
+    });
+
+    clearDelayedContinuationReservations("test-session");
+
+    expect(listDelayedContinuationReservations("test-session")).toEqual([]);
+    expect(delayedContinuationReservationCount("test-session")).toBe(0);
+  });
+
+  it("tracks the highest planned hop across outstanding reservations", () => {
+    addDelayedContinuationReservation("test-session", {
+      id: "reservation-1",
+      source: "bracket",
+      task: "first",
+      createdAt: 1,
+      fireAt: 2,
+      generation: 3,
+      plannedHop: 2,
+    });
+    addDelayedContinuationReservation("test-session", {
+      id: "reservation-2",
+      source: "tool",
+      task: "second",
+      createdAt: 2,
+      fireAt: 3,
+      generation: 4,
+      plannedHop: 5,
+    });
+
+    expect(highestDelayedContinuationReservationHop("test-session")).toBe(5);
+
+    removeDelayedContinuationReservation("test-session", "reservation-2");
+    expect(highestDelayedContinuationReservationHop("test-session")).toBe(2);
+
+    clearDelayedContinuationReservations("test-session");
+    expect(highestDelayedContinuationReservationHop("test-session")).toBe(0);
+  });
+});
+
+describe("post-compaction delegate staging", () => {
+  beforeEach(() => {
+    consumeStagedPostCompactionDelegates("test-session");
+    consumeStagedPostCompactionDelegates("other-session");
+  });
+
+  it("returns empty array when no staged delegates are pending", () => {
+    expect(consumeStagedPostCompactionDelegates("test-session")).toEqual([]);
+  });
+
+  it("stages and consumes a post-compaction delegate", () => {
+    stagePostCompactionDelegate("test-session", {
+      task: "carry working state past compaction",
+      createdAt: 123,
+    });
+
+    const delegates = consumeStagedPostCompactionDelegates("test-session");
+    expect(delegates).toHaveLength(1);
+    expect(delegates[0].task).toBe("carry working state past compaction");
+    expect(delegates[0].createdAt).toBe(123);
+  });
+
+  it("consuming removes staged delegates from store", () => {
+    stagePostCompactionDelegate("test-session", { task: "task 1", createdAt: 1 });
+
+    const first = consumeStagedPostCompactionDelegates("test-session");
+    expect(first).toHaveLength(1);
+
+    const second = consumeStagedPostCompactionDelegates("test-session");
+    expect(second).toEqual([]);
+  });
+
+  it("supports multiple staged delegates per session", () => {
+    stagePostCompactionDelegate("test-session", { task: "shard 1", createdAt: 1 });
+    stagePostCompactionDelegate("test-session", { task: "shard 2", createdAt: 2 });
+    stagePostCompactionDelegate("test-session", { task: "shard 3", createdAt: 3 });
+
+    const delegates = consumeStagedPostCompactionDelegates("test-session");
+    expect(delegates).toHaveLength(3);
+    expect(delegates.map((d) => d.task)).toEqual(["shard 1", "shard 2", "shard 3"]);
+  });
+
+  it("isolates staged delegates by session key", () => {
+    stagePostCompactionDelegate("test-session", { task: "session A", createdAt: 1 });
+    stagePostCompactionDelegate("other-session", { task: "session B", createdAt: 1 });
+
+    expect(consumeStagedPostCompactionDelegates("test-session")).toHaveLength(1);
+    expect(consumeStagedPostCompactionDelegates("other-session")).toHaveLength(1);
+  });
+
+  it("staged delegates are separate from immediate delegates", () => {
+    enqueuePendingDelegate("test-session", { task: "immediate task" });
+    stagePostCompactionDelegate("test-session", { task: "compaction task", createdAt: 1 });
+
+    expect(pendingDelegateCount("test-session")).toBe(1);
+    expect(stagedPostCompactionDelegateCount("test-session")).toBe(1);
+
+    const immediate = consumePendingDelegates("test-session");
+    expect(immediate).toHaveLength(1);
+    expect(immediate[0].task).toBe("immediate task");
+
+    const compaction = consumeStagedPostCompactionDelegates("test-session");
+    expect(compaction).toHaveLength(1);
+    expect(compaction[0].task).toBe("compaction task");
+  });
+
+  it("stagedPostCompactionDelegateCount reflects current queue depth", () => {
+    expect(stagedPostCompactionDelegateCount("test-session")).toBe(0);
+
+    stagePostCompactionDelegate("test-session", { task: "task 1", createdAt: 1 });
+    expect(stagedPostCompactionDelegateCount("test-session")).toBe(1);
+
+    stagePostCompactionDelegate("test-session", { task: "task 2", createdAt: 2 });
+    expect(stagedPostCompactionDelegateCount("test-session")).toBe(2);
+
+    consumeStagedPostCompactionDelegates("test-session");
+    expect(stagedPostCompactionDelegateCount("test-session")).toBe(0);
+  });
+});

--- a/src/auto-reply/continuation-delegate-store.ts
+++ b/src/auto-reply/continuation-delegate-store.ts
@@ -1,0 +1,209 @@
+import type { SessionPostCompactionDelegate } from "../config/sessions.js";
+import {
+  taskFlowCancelPendingDelegates,
+  taskFlowConsumePendingDelegates,
+  taskFlowEnqueuePendingDelegate,
+  taskFlowPendingDelegateCount,
+} from "./continuation-delegate-store-taskflow.js";
+import type {
+  DelayedContinuationReservation,
+  PendingContinuationDelegate,
+} from "./continuation-delegate.types.js";
+
+/**
+ * Module-level store for `continue_delegate` tool calls.
+ *
+ * The tool writes pending delegates here during execution. After the agent's
+ * response finalizes, `agent-runner.ts` reads and consumes them, feeding them
+ * into the same continuation scheduler that bracket-parsed signals use.
+ *
+ * This is the "tool writes → runner reads" pattern. Precedent:
+ * `sessions_spawn` writes to the sub-agent registry during its tool call,
+ * and the runner reads completion events later. Same topology.
+ *
+ * The store is keyed by session key. Multiple delegates per turn are supported
+ * (the tool can be called N times in one turn). The runner consumes all pending
+ * delegates after the run completes.
+ *
+ * When `taskFlowDelegates` is enabled, pending delegates are backed by the
+ * Task Flow registry (SQLite persistence). Otherwise, the volatile in-memory
+ * Map is used (default).
+ */
+
+// ---------------------------------------------------------------------------
+// Task Flow delegate gate
+// ---------------------------------------------------------------------------
+
+let taskFlowDelegatesEnabled = false;
+
+/**
+ * Enable or disable the Task Flow-backed delegate store.
+ * Called by agent-runner at startup based on
+ * `agents.defaults.continuation.taskFlowDelegates`.
+ */
+export function setTaskFlowDelegatesEnabled(enabled: boolean): void {
+  taskFlowDelegatesEnabled = enabled;
+}
+
+export function isTaskFlowDelegatesEnabled(): boolean {
+  return taskFlowDelegatesEnabled;
+}
+
+// ---------------------------------------------------------------------------
+// Pending delegates — volatile Map (default) or Task Flow (opt-in)
+// ---------------------------------------------------------------------------
+
+const pendingDelegates = new Map<string, PendingContinuationDelegate[]>();
+const delayedReservations = new Map<string, DelayedContinuationReservation[]>();
+
+/**
+ * Called by the `continue_delegate` tool during execution.
+ * Appends a delegate to the pending list for the session.
+ */
+export function enqueuePendingDelegate(
+  sessionKey: string,
+  delegate: PendingContinuationDelegate,
+): void {
+  if (taskFlowDelegatesEnabled) {
+    taskFlowEnqueuePendingDelegate(sessionKey, delegate);
+    return;
+  }
+  const existing = pendingDelegates.get(sessionKey) ?? [];
+  existing.push(delegate);
+  pendingDelegates.set(sessionKey, existing);
+}
+
+/**
+ * Called by `agent-runner.ts` after the run completes.
+ * Returns and removes all pending delegates for the session.
+ * Returns an empty array if none are pending.
+ */
+export function consumePendingDelegates(sessionKey: string): PendingContinuationDelegate[] {
+  if (taskFlowDelegatesEnabled) {
+    return taskFlowConsumePendingDelegates(sessionKey);
+  }
+  const delegates = pendingDelegates.get(sessionKey) ?? [];
+  pendingDelegates.delete(sessionKey);
+  return delegates;
+}
+
+/**
+ * Returns the count of pending delegates for a session without consuming them.
+ * Used by the tool to report chain position in its return value.
+ */
+export function pendingDelegateCount(sessionKey: string): number {
+  if (taskFlowDelegatesEnabled) {
+    return taskFlowPendingDelegateCount(sessionKey);
+  }
+  return pendingDelegates.get(sessionKey)?.length ?? 0;
+}
+
+/**
+ * Cancel and remove all pending delegates for a session.
+ * For the volatile store this is a no-op (delegates are turn-local).
+ * For the Task Flow store this cancels and deletes the flow records.
+ */
+export function cancelPendingDelegates(sessionKey: string): void {
+  if (taskFlowDelegatesEnabled) {
+    taskFlowCancelPendingDelegates(sessionKey);
+    return;
+  }
+  // Volatile store: delegates are turn-local, no explicit cancel needed.
+  // Drain them to prevent leakage.
+  pendingDelegates.delete(sessionKey);
+}
+
+export function addDelayedContinuationReservation(
+  sessionKey: string,
+  reservation: DelayedContinuationReservation,
+): void {
+  const existing = delayedReservations.get(sessionKey) ?? [];
+  existing.push(reservation);
+  delayedReservations.set(sessionKey, existing);
+}
+
+export function listDelayedContinuationReservations(
+  sessionKey: string,
+): DelayedContinuationReservation[] {
+  return [...(delayedReservations.get(sessionKey) ?? [])];
+}
+
+export function delayedContinuationReservationCount(sessionKey: string): number {
+  return delayedReservations.get(sessionKey)?.length ?? 0;
+}
+
+export function highestDelayedContinuationReservationHop(sessionKey: string): number {
+  const reservations = delayedReservations.get(sessionKey);
+  if (!reservations || reservations.length === 0) {
+    return 0;
+  }
+  let highestHop = 0;
+  for (const reservation of reservations) {
+    if (reservation.plannedHop > highestHop) {
+      highestHop = reservation.plannedHop;
+    }
+  }
+  return highestHop;
+}
+
+export function takeDelayedContinuationReservation(
+  sessionKey: string,
+  reservationId: string,
+): DelayedContinuationReservation | undefined {
+  const existing = delayedReservations.get(sessionKey);
+  if (!existing || existing.length === 0) {
+    return undefined;
+  }
+  const idx = existing.findIndex((reservation) => reservation.id === reservationId);
+  if (idx < 0) {
+    return undefined;
+  }
+  const [removed] = existing.splice(idx, 1);
+  if (existing.length === 0) {
+    delayedReservations.delete(sessionKey);
+  }
+  return removed;
+}
+
+export function removeDelayedContinuationReservation(
+  sessionKey: string,
+  reservationId: string,
+): boolean {
+  return takeDelayedContinuationReservation(sessionKey, reservationId) !== undefined;
+}
+
+export function clearDelayedContinuationReservations(sessionKey: string): void {
+  delayedReservations.delete(sessionKey);
+}
+
+// ---------------------------------------------------------------------------
+// Post-compaction delegate staging
+//
+// `post-compaction` delegates stay turn-local until the run succeeds. If the
+// same run compacts, agent-runner dispatches them immediately. Otherwise the
+// successful run persists them onto SessionEntry for a later compaction cycle.
+// Failed turns simply drop this staged state in finally.
+// ---------------------------------------------------------------------------
+
+const stagedPostCompactionDelegates = new Map<string, SessionPostCompactionDelegate[]>();
+
+export function stagePostCompactionDelegate(
+  sessionKey: string,
+  delegate: SessionPostCompactionDelegate,
+): void {
+  const existing = stagedPostCompactionDelegates.get(sessionKey) ?? [];
+  existing.push(delegate);
+  stagedPostCompactionDelegates.set(sessionKey, existing);
+}
+
+export function consumeStagedPostCompactionDelegates(
+  sessionKey: string,
+): SessionPostCompactionDelegate[] {
+  const delegates = stagedPostCompactionDelegates.get(sessionKey) ?? [];
+  stagedPostCompactionDelegates.delete(sessionKey);
+  return delegates;
+}
+
+export function stagedPostCompactionDelegateCount(sessionKey: string): number {
+  return stagedPostCompactionDelegates.get(sessionKey)?.length ?? 0;
+}

--- a/src/auto-reply/continuation-delegate.types.ts
+++ b/src/auto-reply/continuation-delegate.types.ts
@@ -1,0 +1,18 @@
+export interface PendingContinuationDelegate {
+  task: string;
+  delayMs?: number;
+  silent?: boolean;
+  silentWake?: boolean;
+}
+
+export interface DelayedContinuationReservation {
+  id: string;
+  source: "bracket" | "tool";
+  task: string;
+  createdAt: number;
+  fireAt: number;
+  generation: number;
+  plannedHop: number;
+  silent?: boolean;
+  silentWake?: boolean;
+}

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -3,6 +3,8 @@ import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { ReplyPayload } from "./reply-payload.js";
 import type { TypingController } from "./reply/typing.js";
 
+export type ContinuationTrigger = "work-wake" | "delegate-return";
+
 export type BlockReplyContext = {
   abortSignal?: AbortSignal;
   timeoutMs?: number;
@@ -45,6 +47,13 @@ export type GetReplyOptions = {
   onTypingCleanup?: () => void;
   onTypingController?: (typing: TypingController) => void;
   isHeartbeat?: boolean;
+  /**
+   * Structured trigger identifying why this turn exists.
+   * Used for wake classification instead of inferring from system-event queue text.
+   * - "work-wake": CONTINUE_WORK timer fired
+   * - "delegate-return": a delegate sub-agent completed and returned results
+   */
+  continuationTrigger?: ContinuationTrigger;
   /** Policy-level typing control for run classes (user/system/internal/heartbeat). */
   typingPolicy?: TypingPolicy;
   /** Force-disable typing indicators for this run (system/internal/cross-channel routes). */

--- a/src/auto-reply/reply.test-harness.ts
+++ b/src/auto-reply/reply.test-harness.ts
@@ -65,6 +65,7 @@ vi.mock("../agents/pi-embedded.runtime.js", () => ({
 }));
 
 vi.mock("./reply/agent-runner.runtime.js", () => ({
+  clearDelegatePending: vi.fn(),
   runReplyAgent: async (params: {
     commandBody: string;
     followupRun: {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -25,8 +25,9 @@ import {
   isTransientHttpError,
 } from "../../agents/pi-embedded-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
+import { compactEmbeddedPiSession } from "../../agents/pi-embedded-runner/compact.queued.js";
 import { isLikelyExecutionAckPrompt } from "../../agents/pi-embedded-runner/run/incomplete-turn.js";
-import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import type { ContinueWorkRequest } from "../../agents/tools/continue-work-tool.js";
 import {
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
@@ -59,6 +60,7 @@ import {
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
   startsWithSilentToken,
+  stripContinuationSignal,
   stripLeadingSilentToken,
 } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -74,6 +76,29 @@ import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.runtime.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import type { TypingSignaler } from "./typing-mode.js";
+
+type EmbeddedPiAgentRunResult = Awaited<
+  ReturnType<typeof import("../../agents/pi-embedded.runtime.js").runEmbeddedPiAgent>
+>;
+
+async function runEmbeddedPiAgentDefault(
+  ...args: Parameters<typeof import("../../agents/pi-embedded.runtime.js").runEmbeddedPiAgent>
+): Promise<EmbeddedPiAgentRunResult> {
+  const { runEmbeddedPiAgent } = await import("../../agents/pi-embedded.runtime.js");
+  return await runEmbeddedPiAgent(...args);
+}
+
+/** Type guard for wrapped continuation run results. */
+function isContinuationWrappedRunResult(
+  result: unknown,
+): result is { result: EmbeddedPiAgentRunResult; continueWorkRequest?: ContinueWorkRequest } {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    "result" in result &&
+    "continueWorkRequest" in result
+  );
+}
 
 // Maximum number of LiveSessionModelSwitchError retries before surfacing a
 // user-visible error. Prevents infinite ping-pong when the persisted session
@@ -98,13 +123,14 @@ export type AgentRunLoopResult =
   | {
       kind: "success";
       runId: string;
-      runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
+      runResult: EmbeddedPiAgentRunResult;
       fallbackProvider?: string;
       fallbackModel?: string;
       fallbackAttempts: RuntimeFallbackAttempt[];
       didLogHeartbeatStrip: boolean;
       autoCompactionCount: number;
       /** Payload keys sent directly (not via pipeline) during tool flush. */
+      continueWorkRequest?: import("../../agents/tools/continue-work-tool.js").ContinueWorkRequest;
       directlySentBlockKeys?: Set<string>;
     }
   | { kind: "final"; payload: ReplyPayload };
@@ -573,6 +599,7 @@ export async function runAgentTurnWithFallback(params: {
   resetSessionAfterRoleOrderingConflict: (reason: string) => Promise<boolean>;
   isHeartbeat: boolean;
   sessionKey?: string;
+  getCurrentContinuationGeneration?: (sessionKey: string) => number;
   getActiveSessionEntry: () => SessionEntry | undefined;
   activeSessionStore?: Record<string, SessionEntry>;
   storePath?: string;
@@ -619,10 +646,11 @@ export async function runAgentTurnWithFallback(params: {
       isControlUiVisible: shouldSurfaceToControlUi,
     });
   }
-  let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
+  let runResult: EmbeddedPiAgentRunResult;
   let fallbackProvider = params.followupRun.run.provider;
   let fallbackModel = params.followupRun.run.model;
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
+  let continueWorkRequest: ContinueWorkRequest | undefined;
   let didResetAfterCompactionFailure = false;
   let didRetryTransientHttpError = false;
   let liveModelSwitchRetries = 0;
@@ -754,6 +782,21 @@ export async function runAgentTurnWithFallback(params: {
         if (text && startsWithSilentToken(text, SILENT_REPLY_TOKEN)) {
           text = stripLeadingSilentToken(text, SILENT_REPLY_TOKEN);
         }
+        // Strip continuation markers (CONTINUE_WORK, [[CONTINUE_DELEGATE:…]])
+        // from streamed blocks so they never reach the channel. The regex anchors
+        // to the end of the text, so mid-sentence mentions are safe. Final-payload
+        // stripping in runReplyAgent still runs for the assembled payloads.
+        // Only strip when continuation is enabled — otherwise the tokens are
+        // regular text the model happened to generate. (#104)
+        if (
+          text &&
+          params.followupRun.run.config?.agents?.defaults?.continuation?.enabled === true
+        ) {
+          const cont = stripContinuationSignal(text);
+          if (cont.signal) {
+            text = cont.text;
+          }
+        }
         if (!text) {
           // Allow media-only payloads (e.g. tool result screenshots) through.
           if (reply.hasMedia) {
@@ -799,7 +842,10 @@ export async function runAgentTurnWithFallback(params: {
           })
         : undefined;
       const onToolResult = params.opts?.onToolResult;
-      const fallbackResult = await runWithModelFallback({
+      const fallbackResult = await runWithModelFallback<
+        | EmbeddedPiAgentRunResult
+        | { result: EmbeddedPiAgentRunResult; continueWorkRequest?: ContinueWorkRequest }
+      >({
         ...resolveModelFallbackOptions(params.followupRun.run),
         runId,
         run: async (provider, model, runOptions) => {
@@ -957,8 +1003,9 @@ export async function runAgentTurnWithFallback(params: {
           );
           return (async () => {
             let attemptCompactionCount = 0;
+            let attemptContinueWorkRequest: ContinueWorkRequest | undefined;
             try {
-              const result = await runEmbeddedPiAgent({
+              const result = await runEmbeddedPiAgentDefault({
                 ...embeddedContext,
                 allowGatewaySubagentBinding: true,
                 trigger: params.isHeartbeat ? "heartbeat" : "user",
@@ -971,6 +1018,61 @@ export async function runAgentTurnWithFallback(params: {
                 ...runBaseParams,
                 prompt: params.commandBody,
                 extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                drainsContinuationDelegateQueue:
+                  params.followupRun.run.drainsContinuationDelegateQueue,
+                continueWorkOpts:
+                  params.followupRun.run.config?.agents?.defaults?.continuation?.enabled === true
+                    ? {
+                        requestContinuation: (request) => {
+                          attemptContinueWorkRequest = request;
+                        },
+                      }
+                    : undefined,
+                requestCompactionOpts:
+                  params.followupRun.run.config?.agents?.defaults?.continuation?.enabled === true
+                    ? {
+                        getContextUsage: () => {
+                          const entry = params.sessionKey
+                            ? params.activeSessionStore?.[params.sessionKey]
+                            : undefined;
+                          if (!entry?.totalTokens || entry.totalTokensFresh === false) {
+                            return 0;
+                          }
+                          const contextWindow = entry.contextTokens ?? 200_000;
+                          return entry.totalTokens / contextWindow;
+                        },
+                        getSessionGeneration: () => {
+                          return params.sessionKey
+                            ? (params.getCurrentContinuationGeneration?.(params.sessionKey) ?? 0)
+                            : 0;
+                        },
+                        turnGeneration: params.sessionKey
+                          ? (params.getCurrentContinuationGeneration?.(params.sessionKey) ?? 0)
+                          : 0,
+                        triggerCompaction: async () => {
+                          try {
+                            const result = await compactEmbeddedPiSession({
+                              sessionId:
+                                params.followupRun.run.sessionId ??
+                                params.getActiveSessionEntry()?.sessionId ??
+                                "",
+                              sessionKey: params.sessionKey ?? "",
+                              sessionFile: params.followupRun.run.sessionFile,
+                              workspaceDir: params.followupRun.run.workspaceDir,
+                              config: params.followupRun.run.config,
+                              trigger: "volitional",
+                            });
+                            return {
+                              ok: result?.ok ?? false,
+                              compacted: result?.compacted ?? false,
+                              reason: result?.reason,
+                            };
+                          } catch (err) {
+                            return { ok: false, compacted: false, reason: String(err) };
+                          }
+                        },
+                      }
+                    : undefined,
                 toolResultFormat: (() => {
                   const channel = resolveMessageChannel(
                     params.sessionCtx.Surface,
@@ -1218,7 +1320,10 @@ export async function runAgentTurnWithFallback(params: {
                 result.meta?.agentMeta?.compactionCount ?? 0,
               );
               attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
-              return result;
+              return {
+                result,
+                continueWorkRequest: attemptContinueWorkRequest,
+              };
             } catch (err) {
               if (rollbackFallbackCandidateSelection) {
                 try {
@@ -1236,7 +1341,16 @@ export async function runAgentTurnWithFallback(params: {
           })();
         },
       });
-      runResult = fallbackResult.result;
+      const fallbackRunResult = fallbackResult.result as
+        | EmbeddedPiAgentRunResult
+        | { result: EmbeddedPiAgentRunResult; continueWorkRequest?: ContinueWorkRequest };
+      if (isContinuationWrappedRunResult(fallbackRunResult)) {
+        runResult = fallbackRunResult.result;
+        continueWorkRequest = fallbackRunResult.continueWorkRequest;
+      } else {
+        runResult = fallbackRunResult;
+        continueWorkRequest = undefined;
+      }
       fallbackProvider = fallbackResult.provider;
       fallbackModel = fallbackResult.model;
       fallbackAttempts = Array.isArray(fallbackResult.attempts)
@@ -1568,5 +1682,6 @@ export async function runAgentTurnWithFallback(params: {
     didLogHeartbeatStrip,
     autoCompactionCount,
     directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
+    continueWorkRequest,
   };
 }

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -75,6 +75,9 @@ export async function resetReplyRunSession(params: {
     fallbackNoticeSelectedModel: undefined,
     fallbackNoticeActiveModel: undefined,
     fallbackNoticeReason: undefined,
+    continuationChainCount: undefined,
+    continuationChainStartedAt: undefined,
+    continuationChainTokens: undefined,
   };
   const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
   const nextSessionFile = resolveSessionTranscriptPath(

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -147,6 +147,8 @@ export function resolveModelFallbackOptions(run: FollowupRun["run"]) {
   };
 }
 
+/** Flatten a FollowupRun into the base parameter object for runEmbeddedPiAgent.
+ * Derives enforceFinalTag and spreads authProfile; all other fields pass through from the run. */
 export function buildEmbeddedRunBaseParams(params: {
   run: FollowupRun["run"];
   provider: string;

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -14,6 +14,7 @@ import {
   clearMemoryPluginState,
   registerMemoryFlushPlanResolver,
 } from "../../plugins/memory-state.js";
+import { delayedContinuationReservationCount } from "../continuation-delegate-store.js";
 import type { TemplateContext } from "../templating.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import { __testing as replyRunRegistryTesting } from "./reply-run-registry.js";
@@ -42,6 +43,8 @@ const refreshQueuedFollowupSessionMock = vi.fn();
 const compactState = vi.hoisted(() => ({
   compactEmbeddedPiSessionMock: vi.fn(),
 }));
+const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
+const spawnSubagentDirectMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -77,6 +80,12 @@ vi.mock("../../agents/cli-runner.js", () => ({
   runCliAgent: (...args: unknown[]) => runCliAgentMock(...args),
 }));
 
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  SUBAGENT_SPAWN_MODES: ["run", "session"],
+  SUBAGENT_SPAWN_SANDBOX_MODES: ["inherit", "require"],
+  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+}));
+
 vi.mock("../../runtime.js", () => {
   return {
     defaultRuntime: {
@@ -86,6 +95,10 @@ vi.mock("../../runtime.js", () => {
     },
   };
 });
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
+}));
 
 vi.mock("./queue.js", () => {
   return {
@@ -129,7 +142,11 @@ vi.mock("../../agents/subagent-registry.js", () => ({
   markSubagentRunTerminated: () => 0,
 }));
 
-import { runReplyAgent } from "./agent-runner.js";
+import {
+  cancelContinuationTimer,
+  currentContinuationGeneration,
+  runReplyAgent,
+} from "./agent-runner.js";
 
 type RunWithModelFallbackParams = {
   provider: string;
@@ -157,6 +174,12 @@ beforeEach(() => {
   loadCronStoreMock.mockClear();
   // Default: no cron jobs in store.
   loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+  requestHeartbeatNowMock.mockReset();
+  spawnSubagentDirectMock.mockReset().mockResolvedValue({
+    status: "accepted",
+    childSessionKey: "agent:main:subagent:spawned",
+    runId: "run-spawned",
+  });
 
   // Default: no provider switch; execute the chosen provider+model.
   runWithModelFallbackMock.mockImplementation(
@@ -173,6 +196,283 @@ afterEach(() => {
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
+});
+
+describe("runReplyAgent continuation volatile state", () => {
+  function createContinuationRun(params?: {
+    sessionKey?: string;
+    config?: Record<string, unknown>;
+    sessionEntry?: SessionEntry;
+  }) {
+    const sessionKey = params?.sessionKey ?? "continuation-main";
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "discord",
+      OriginatingTo: "channel:1",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const sessionEntry =
+      params?.sessionEntry ??
+      ({
+        sessionId: "session",
+        updatedAt: Date.now(),
+      } satisfies SessionEntry);
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey,
+        messageProvider: "discord",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config:
+          params?.config ??
+          ({
+            agents: {
+              defaults: {
+                continuation: {
+                  enabled: true,
+                  minDelayMs: 0,
+                  maxDelayMs: 1_000,
+                  defaultDelayMs: 1_000,
+                  generationGuardTolerance: 0,
+                  maxChainLength: 4,
+                },
+              },
+            },
+          } satisfies Record<string, unknown>),
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    return {
+      sessionKey,
+      sessionEntry,
+      typing,
+      sessionCtx,
+      resolvedQueue,
+      followupRun,
+    };
+  }
+
+  it("does not create continuation generation state for ordinary inbound turns", async () => {
+    const run = createContinuationRun();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Normal reply" }],
+      meta: {},
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun: run.followupRun,
+      queueKey: run.sessionKey,
+      resolvedQueue: run.resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing: run.typing,
+      sessionCtx: run.sessionCtx,
+      sessionEntry: run.sessionEntry,
+      sessionStore: { [run.sessionKey]: run.sessionEntry },
+      sessionKey: run.sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toMatchObject({ text: "Normal reply" });
+    expect(currentContinuationGeneration(run.sessionKey)).toBe(0);
+  });
+
+  it("drops continuation generation state after a delayed work timer fires", async () => {
+    vi.useFakeTimers();
+
+    const run = createContinuationRun({ sessionKey: "continuation-work-timer" });
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Normal reply\nCONTINUE_WORK:1" }],
+      meta: {
+        agentMeta: {
+          usage: {
+            input: 2,
+            output: 3,
+          },
+        },
+      },
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun: run.followupRun,
+      queueKey: run.sessionKey,
+      resolvedQueue: run.resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing: run.typing,
+      sessionCtx: run.sessionCtx,
+      sessionEntry: run.sessionEntry,
+      sessionStore: { [run.sessionKey]: run.sessionEntry },
+      sessionKey: run.sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toMatchObject({ text: "Normal reply" });
+    expect(currentContinuationGeneration(run.sessionKey)).toBeGreaterThan(0);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      sessionKey: run.sessionKey,
+      reason: "continuation",
+    });
+    expect(currentContinuationGeneration(run.sessionKey)).toBe(0);
+  });
+
+  it("clears delayed work timers when a plain inbound turn arrives", async () => {
+    vi.useFakeTimers();
+
+    const run = createContinuationRun({ sessionKey: "continuation-work-cancel" });
+    const sessionStore = { [run.sessionKey]: run.sessionEntry };
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Normal reply\nCONTINUE_WORK:1" }],
+      meta: {},
+    });
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun: run.followupRun,
+      queueKey: run.sessionKey,
+      resolvedQueue: run.resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing: run.typing,
+      sessionCtx: run.sessionCtx,
+      sessionEntry: run.sessionEntry,
+      sessionStore,
+      sessionKey: run.sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(currentContinuationGeneration(run.sessionKey)).toBeGreaterThan(0);
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Interrupting message" }],
+      meta: {},
+    });
+
+    await runReplyAgent({
+      commandBody: "user interrupted",
+      followupRun: run.followupRun,
+      queueKey: run.sessionKey,
+      resolvedQueue: run.resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing: run.typing,
+      sessionCtx: run.sessionCtx,
+      sessionEntry: run.sessionEntry,
+      sessionStore,
+      sessionKey: run.sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    expect(currentContinuationGeneration(run.sessionKey)).toBe(0);
+  });
+
+  it("clears delayed delegate reservations and timers on explicit cancellation", async () => {
+    vi.useFakeTimers();
+
+    const run = createContinuationRun({ sessionKey: "continuation-delegate-cancel" });
+    const sessionStore = { [run.sessionKey]: run.sessionEntry };
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Normal reply\n[[CONTINUE_DELEGATE: inspect logs +1s]]" }],
+      meta: {},
+    });
+
+    await runReplyAgent({
+      commandBody: "hello",
+      followupRun: run.followupRun,
+      queueKey: run.sessionKey,
+      resolvedQueue: run.resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing: run.typing,
+      sessionCtx: run.sessionCtx,
+      sessionEntry: run.sessionEntry,
+      sessionStore,
+      sessionKey: run.sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(delayedContinuationReservationCount(run.sessionKey)).toBe(1);
+    expect(currentContinuationGeneration(run.sessionKey)).toBeGreaterThan(0);
+
+    cancelContinuationTimer(run.sessionKey, {
+      sessionEntry: run.sessionEntry,
+      sessionStore,
+    });
+
+    expect(delayedContinuationReservationCount(run.sessionKey)).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(currentContinuationGeneration(run.sessionKey)).toBe(0);
+  });
 });
 
 describe("runReplyAgent auto-compaction token update", () => {

--- a/src/auto-reply/reply/agent-runner.runtime.ts
+++ b/src/auto-reply/reply/agent-runner.runtime.ts
@@ -1,1 +1,9 @@
-export { runReplyAgent } from "./agent-runner.js";
+export { clearDelegatePending, runReplyAgent } from "./agent-runner.js";
+export {
+  bumpContinuationGeneration,
+  currentContinuationGeneration,
+  registerContinuationTimerHandle,
+  retainContinuationTimerRef,
+  setDelegatePending,
+  unregisterContinuationTimerHandle,
+} from "./continuation-state.js";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,24 +1,35 @@
 import fs from "node:fs/promises";
-import { hasConfiguredModelFallbacks } from "../../agents/agent-scope.js";
+import {
+  hasConfiguredModelFallbacks,
+  resolveAgentWorkspaceDir,
+} from "../../agents/agent-scope.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded-runner/runs.js";
+import { spawnSubagentDirect } from "../../agents/subagent-spawn.js";
 import { hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
 import {
   loadSessionStore,
   resolveSessionPluginStatusLines,
   resolveSessionPluginTraceLines,
+  resolveSessionStoreEntry,
   type SessionEntry,
+  type SessionPostCompactionDelegate,
+  updateSessionStore,
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.fs.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
+import { generateSecureUuid } from "../../infra/secure-random.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
+import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   estimateUsageCost,
@@ -26,13 +37,27 @@ import {
   resolveModelCostConfig,
 } from "../../utils/usage-format.js";
 import {
+  addDelayedContinuationReservation,
+  cancelPendingDelegates,
+  clearDelayedContinuationReservations,
+  consumeStagedPostCompactionDelegates,
+  delayedContinuationReservationCount,
+  highestDelayedContinuationReservationHop,
+  takeDelayedContinuationReservation,
+  setTaskFlowDelegatesEnabled,
+  stagePostCompactionDelegate,
+  consumePendingDelegates,
+  pendingDelegateCount,
+  stagedPostCompactionDelegateCount,
+} from "../continuation-delegate-store.js";
+import {
   buildFallbackClearedNotice,
   buildFallbackNotice,
   resolveFallbackTransition,
 } from "../fallback-state.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
-import { SILENT_REPLY_TOKEN } from "../tokens.js";
+import { SILENT_REPLY_TOKEN, stripContinuationSignal, type ContinuationSignal } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
 import {
@@ -54,6 +79,22 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-l
 import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
+import { checkContextPressure } from "./context-pressure.js";
+import { resolveContinuationRuntimeConfig } from "./continuation-runtime.js";
+import {
+  bumpContinuationGeneration,
+  clearDelegatePending,
+  clearDelegatePendingIfNoDelayedReservations,
+  clearTrackedContinuationTimers,
+  currentContinuationGeneration,
+  hasDelegatePending,
+  hasLiveContinuationTimerRefs,
+  maybeDropContinuationGeneration,
+  registerContinuationTimerHandle,
+  retainContinuationTimerRef,
+  setDelegatePending,
+  unregisterContinuationTimerHandle,
+} from "./continuation-state.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
@@ -75,8 +116,18 @@ import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-t
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
+export {
+  bumpContinuationGeneration,
+  clearDelegatePending,
+  currentContinuationGeneration,
+  registerContinuationTimerHandle,
+  retainContinuationTimerRef,
+  setDelegatePending,
+  unregisterContinuationTimerHandle,
+} from "./continuation-state.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
+const continuationGuardLog = createSubsystemLogger("continuation/guard");
 
 function buildInlinePluginStatusPayload(params: {
   entry: SessionEntry | undefined;
@@ -854,6 +905,262 @@ function refreshSessionEntryFromStore(params: {
   }
 }
 
+function syncPendingPostCompactionDelegates(params: {
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey: string;
+  delegates: SessionPostCompactionDelegate[] | undefined;
+}) {
+  if (params.sessionEntry) {
+    params.sessionEntry.pendingPostCompactionDelegates = params.delegates;
+  }
+  if (params.sessionStore?.[params.sessionKey]) {
+    params.sessionStore[params.sessionKey] = {
+      ...params.sessionStore[params.sessionKey],
+      pendingPostCompactionDelegates: params.delegates,
+    };
+  }
+}
+
+function normalizePostCompactionDelegate(
+  delegate: SessionPostCompactionDelegate,
+): SessionPostCompactionDelegate {
+  // Legacy delegates persisted before silent/wake fields existed. Post-compaction
+  // mode is defined as silent-wake, so missing flags must preserve that contract.
+  const legacySilentWake = delegate.silent == null && delegate.silentWake == null;
+  const silentWake = legacySilentWake ? true : delegate.silentWake === true;
+  const silent = legacySilentWake ? true : delegate.silent === true || silentWake;
+
+  return {
+    task: delegate.task,
+    createdAt: delegate.createdAt,
+    ...(delegate.silent != null || legacySilentWake ? { silent } : {}),
+    ...(delegate.silentWake != null || legacySilentWake ? { silentWake } : {}),
+  };
+}
+
+async function persistPendingPostCompactionDelegates(params: {
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey: string;
+  storePath?: string;
+  delegates: SessionPostCompactionDelegate[];
+}): Promise<SessionPostCompactionDelegate[]> {
+  if (params.delegates.length === 0) {
+    return (params.sessionEntry?.pendingPostCompactionDelegates ?? []).map(
+      normalizePostCompactionDelegate,
+    );
+  }
+
+  const normalizedDelegates = params.delegates.map(normalizePostCompactionDelegate);
+  const localExisting = (params.sessionEntry?.pendingPostCompactionDelegates ?? []).map(
+    normalizePostCompactionDelegate,
+  );
+  const combinedLocal = [...localExisting, ...normalizedDelegates];
+
+  if (!params.storePath) {
+    syncPendingPostCompactionDelegates({
+      sessionEntry: params.sessionEntry,
+      sessionStore: params.sessionStore,
+      sessionKey: params.sessionKey,
+      delegates: combinedLocal,
+    });
+    return combinedLocal;
+  }
+
+  const persisted = await updateSessionStore(params.storePath, (store) => {
+    const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
+    const current =
+      resolved.existing ??
+      params.sessionStore?.[params.sessionKey] ??
+      params.sessionEntry ??
+      undefined;
+    const combined = [
+      ...(current?.pendingPostCompactionDelegates ?? []).map(normalizePostCompactionDelegate),
+      ...normalizedDelegates,
+    ];
+    if (current) {
+      store[resolved.normalizedKey] = {
+        ...current,
+        pendingPostCompactionDelegates: combined,
+      };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
+    }
+    return combined;
+  });
+
+  syncPendingPostCompactionDelegates({
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore,
+    sessionKey: params.sessionKey,
+    delegates: persisted.length > 0 ? persisted : combinedLocal,
+  });
+  return persisted.length > 0 ? persisted : combinedLocal;
+}
+
+async function takePendingPostCompactionDelegates(params: {
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey: string;
+  storePath?: string;
+}): Promise<SessionPostCompactionDelegate[]> {
+  const localDelegates = (params.sessionEntry?.pendingPostCompactionDelegates ?? []).map(
+    normalizePostCompactionDelegate,
+  );
+
+  if (!params.storePath) {
+    syncPendingPostCompactionDelegates({
+      sessionEntry: params.sessionEntry,
+      sessionStore: params.sessionStore,
+      sessionKey: params.sessionKey,
+      delegates: undefined,
+    });
+    return localDelegates;
+  }
+
+  const persisted = await updateSessionStore(params.storePath, (store) => {
+    const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
+    const current =
+      resolved.existing ??
+      params.sessionStore?.[params.sessionKey] ??
+      params.sessionEntry ??
+      undefined;
+    const delegates = (current?.pendingPostCompactionDelegates ?? []).map(
+      normalizePostCompactionDelegate,
+    );
+    if (current && delegates.length > 0) {
+      store[resolved.normalizedKey] = {
+        ...current,
+        pendingPostCompactionDelegates: undefined,
+      };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
+    }
+    return delegates;
+  });
+
+  syncPendingPostCompactionDelegates({
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore,
+    sessionKey: params.sessionKey,
+    delegates: undefined,
+  });
+  return persisted.length > 0 ? persisted : localDelegates;
+}
+
+function buildPostCompactionLifecycleEvent(params: {
+  compactionCount?: number;
+  releasedDelegates: number;
+  droppedDelegates: number;
+}): string {
+  const parts = [
+    `[system:post-compaction] Session compacted at ${new Date().toISOString()}.`,
+    typeof params.compactionCount === "number"
+      ? `Compaction count: ${params.compactionCount}.`
+      : undefined,
+    `Released ${params.releasedDelegates} post-compaction delegate(s) into the fresh session.`,
+    params.droppedDelegates > 0
+      ? `${params.droppedDelegates} delegate(s) were not released into the fresh session.`
+      : undefined,
+  ].filter(Boolean);
+  return parts.join(" ");
+}
+
+// clearContinuationGeneration intentionally removed: clearing the map entry
+// resets the counter to 0, creating a generation-reuse window where a new
+// chain's value can collide with a stale in-flight timer. All paths now use
+// bumpContinuationGeneration instead.
+
+/**
+ * Cancel any pending continuation timer for the given session AND reset
+ * chain metadata. Call this from early-return paths (inline actions, slash
+ * commands, directive replies) that bypass runReplyAgent but still represent
+ * real user input that should preempt a running continuation chain.
+ *
+ * We only bump (not clear) generations to avoid reuse: if we cleared the map
+ * entry, a subsequent chain could reuse a generation value that matches a
+ * stale in-flight timer callback.
+ */
+export function cancelContinuationTimer(
+  sessionKey: string,
+  sessionCtx?: {
+    sessionEntry?: SessionEntry;
+    sessionStore?: Record<string, SessionEntry>;
+    storePath?: string;
+  },
+): void {
+  // Only bump when a generation exists — avoids unbounded map growth
+  // from sessions that never use continuation.
+  if (currentContinuationGeneration(sessionKey) > 0) {
+    bumpContinuationGeneration(sessionKey);
+  }
+
+  clearTrackedContinuationTimers(sessionKey);
+  clearDelayedContinuationReservations(sessionKey);
+
+  // Reset chain metadata so stale counters don't block future chains.
+  // Check both chain count and chain tokens — chain count may be on child shards
+  // (via task prefix), but tokens accumulate on the parent session.
+  const hasChainState =
+    (sessionCtx?.sessionEntry?.continuationChainCount ?? 0) > 0 ||
+    (sessionCtx?.sessionEntry?.continuationChainTokens ?? 0) > 0;
+  if (sessionCtx?.sessionEntry && hasChainState) {
+    sessionCtx.sessionEntry.continuationChainCount = 0;
+    sessionCtx.sessionEntry.continuationChainStartedAt = undefined;
+    sessionCtx.sessionEntry.continuationChainTokens = undefined;
+  }
+  if (sessionCtx?.sessionStore) {
+    const storeResolved = resolveSessionStoreEntry({ store: sessionCtx.sessionStore, sessionKey });
+    const storeEntry = storeResolved.existing;
+    const storeHasChainState =
+      (storeEntry?.continuationChainCount ?? 0) > 0 ||
+      (storeEntry?.continuationChainTokens ?? 0) > 0;
+    if (storeEntry && storeHasChainState) {
+      sessionCtx.sessionStore[storeResolved.normalizedKey] = {
+        ...storeEntry,
+        continuationChainCount: 0,
+        continuationChainStartedAt: undefined,
+        continuationChainTokens: undefined,
+      };
+      for (const legacyKey of storeResolved.legacyKeys) {
+        delete sessionCtx.sessionStore[legacyKey];
+      }
+    }
+  }
+  if (sessionCtx?.storePath) {
+    void updateSessionStore(sessionCtx.storePath, (store) => {
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      const entryHasChainState =
+        (resolved.existing?.continuationChainCount ?? 0) > 0 ||
+        (resolved.existing?.continuationChainTokens ?? 0) > 0;
+      if (resolved.existing && entryHasChainState) {
+        store[resolved.normalizedKey] = {
+          ...resolved.existing,
+          continuationChainCount: 0,
+          continuationChainStartedAt: undefined,
+          continuationChainTokens: undefined,
+        };
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
+      }
+    }).catch(() => {
+      // Best-effort — chain state will be reset on next runReplyAgent entry.
+    });
+  }
+
+  // Cancel any Task Flow-backed pending delegates that may have survived a
+  // restart. For the volatile store this drains the Map as a safety net.
+  cancelPendingDelegates(sessionKey);
+
+  // Clear delegate-pending flag — no delegate should be considered in-flight
+  // after explicit cancellation.
+  clearDelegatePending(sessionKey);
+}
+
 export async function runReplyAgent(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -885,6 +1192,8 @@ export async function runReplyAgent(params: {
   sessionCtx: TemplateContext;
   shouldInjectGroupIntro: boolean;
   typingMode: TypingMode;
+  /** True when this turn was triggered by a continuation timer (detected before system events are drained). */
+  isContinuationWake?: boolean;
   resetTriggered?: boolean;
   replyOperation?: ReplyOperation;
 }): Promise<ReplyPayload | ReplyPayload[] | undefined> {
@@ -914,6 +1223,7 @@ export async function runReplyAgent(params: {
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    isContinuationWake,
     resetTriggered,
     replyOperation: providedReplyOperation,
   } = params;
@@ -923,6 +1233,102 @@ export async function runReplyAgent(params: {
   let activeIsNewSession = isNewSession;
 
   const isHeartbeat = opts?.isHeartbeat === true;
+  const cfg = followupRun.run.config;
+  const continuationFeatureEnabled = cfg?.agents?.defaults?.continuation?.enabled === true;
+  const taskFlowDelegatesConfigured =
+    cfg?.agents?.defaults?.continuation?.taskFlowDelegates === true;
+
+  // Route delegate store operations to the Task Flow-backed implementation
+  // before any inbound-message cancellation logic runs.
+  setTaskFlowDelegatesEnabled(continuationFeatureEnabled && taskFlowDelegatesConfigured);
+
+  // Detect whether this turn is a continuation wake or an external message.
+  // The isContinuationWake flag is set by the caller (get-reply-run) by peeking
+  // system events BEFORE they are drained by buildQueuedSystemPrompt. This avoids
+  // the race where draining empties the queue before we can check it here.
+  const isContinuationEvent = isContinuationWake === true;
+
+  if (!isContinuationEvent && !isHeartbeat && sessionKey) {
+    // External (non-heartbeat) message — reset chain tracking and cancel timers.
+    // Regular heartbeats (including periodic polls) must NOT preempt pending
+    // continuation timers; only real user/external messages should.
+    const hadActiveChain = (activeSessionEntry?.continuationChainCount ?? 0) > 0;
+    const hadStaleTokens =
+      !hadActiveChain &&
+      typeof activeSessionEntry?.continuationChainTokens === "number" &&
+      activeSessionEntry.continuationChainTokens > 0;
+    const hadDelayedReservations = delayedContinuationReservationCount(sessionKey) > 0;
+    const hadLiveTimerRefs = hasLiveContinuationTimerRefs(sessionKey);
+    const hadPendingDelegateQueue = pendingDelegateCount(sessionKey) > 0;
+    const hadDelegatePendingFlag = hasDelegatePending(sessionKey);
+    if (activeSessionEntry && (hadActiveChain || hadStaleTokens)) {
+      activeSessionEntry.continuationChainCount = 0;
+      activeSessionEntry.continuationChainStartedAt = undefined;
+      activeSessionEntry.continuationChainTokens = undefined;
+    }
+    // Every inbound user message on a continuation-enabled session must advance
+    // the generation so in-flight guards observe the new turn, even when the
+    // session had not armed a timer or created state yet.
+    // Skip when clearDelegatePending will bump below to avoid double-incrementing.
+    const willClearDelegates =
+      continuationFeatureEnabled &&
+      (hadDelayedReservations || hadPendingDelegateQueue || hadDelegatePendingFlag);
+    const shouldBumpGeneration =
+      continuationFeatureEnabled && !willClearDelegates && hadLiveTimerRefs;
+    if (shouldBumpGeneration) {
+      bumpContinuationGeneration(sessionKey);
+    }
+    if (hadLiveTimerRefs) {
+      clearTrackedContinuationTimers(sessionKey);
+    }
+    if (hadDelayedReservations) {
+      clearDelayedContinuationReservations(sessionKey);
+    }
+    // Task Flow-backed delegates can survive restarts even after volatile
+    // delayed reservations are gone, so external input must cancel them on
+    // the first post-restart turn. The volatile store remains turn-local.
+    if (willClearDelegates) {
+      cancelPendingDelegates(sessionKey);
+      clearDelegatePending(sessionKey);
+    }
+    if ((hadActiveChain || hadStaleTokens) && activeSessionStore && activeSessionEntry) {
+      const resolved = resolveSessionStoreEntry({ store: activeSessionStore, sessionKey });
+      activeSessionStore[resolved.normalizedKey] = {
+        ...activeSessionEntry,
+        continuationChainCount: 0,
+        continuationChainStartedAt: undefined,
+        continuationChainTokens: undefined,
+      };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete activeSessionStore[legacyKey];
+      }
+    }
+    // Persist reset to disk only when a chain was actually active — avoids
+    // unnecessary lock + disk write on every normal message.
+    if ((hadActiveChain || hadStaleTokens) && storePath) {
+      try {
+        await updateSessionStore(storePath, (store) => {
+          const resolved = resolveSessionStoreEntry({ store, sessionKey });
+          if (resolved.existing) {
+            store[resolved.normalizedKey] = {
+              ...resolved.existing,
+              continuationChainCount: 0,
+              continuationChainStartedAt: undefined,
+              continuationChainTokens: undefined,
+            };
+            for (const legacyKey of resolved.legacyKeys) {
+              delete store[legacyKey];
+            }
+          }
+        });
+      } catch (err) {
+        defaultRuntime.log(
+          `Failed to persist continuation chain reset for ${sessionKey}: ${String(err)}`,
+        );
+      }
+    }
+  }
+
   const typingSignals = createTypingSignaler({
     typing,
     mode: typingMode,
@@ -950,11 +1356,15 @@ export async function runReplyAgent(params: {
     activeSessionEntry.updatedAt = updatedAt;
     activeSessionStore[sessionKey] = activeSessionEntry;
     if (storePath) {
-      await updateSessionStoreEntry({
-        storePath,
-        sessionKey,
-        update: async () => ({ updatedAt }),
-      });
+      try {
+        await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => ({ updatedAt }),
+        });
+      } catch (err) {
+        defaultRuntime.log(`Failed to persist session touch for ${sessionKey}: ${String(err)}`);
+      }
     }
   };
 
@@ -1014,28 +1424,28 @@ export async function runReplyAgent(params: {
   }
 
   followupRun.run.config = await resolveQueuedReplyExecutionConfig(followupRun.run.config);
+  const resolvedRunCfg = followupRun.run.config;
 
   const replyToChannel = resolveOriginMessageProvider({
     originatingChannel: sessionCtx.OriginatingChannel,
     provider: sessionCtx.Surface ?? sessionCtx.Provider,
   }) as OriginatingChannelType | undefined;
   const replyToMode = resolveReplyToMode(
-    followupRun.run.config,
+    resolvedRunCfg,
     replyToChannel,
     sessionCtx.AccountId,
     sessionCtx.ChatType,
   );
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
-  const cfg = followupRun.run.config;
   const normalizeReplyMediaPaths = createReplyMediaPathNormalizer({
-    cfg,
+    cfg: resolvedRunCfg,
     sessionKey,
     workspaceDir: followupRun.run.workspaceDir,
   });
   const blockReplyCoalescing =
     blockStreamingEnabled && opts?.onBlockReply
       ? resolveEffectiveBlockStreamingConfig({
-          cfg,
+          cfg: resolvedRunCfg,
           provider: sessionCtx.Provider,
           accountId: sessionCtx.AccountId,
           chunking: blockReplyChunking,
@@ -1075,11 +1485,64 @@ export async function runReplyAgent(params: {
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied = false;
 
+  const postCompactionDelegatesToPreserve: SessionPostCompactionDelegate[] = [];
+
+  const persistContinuationChainState = async (params: {
+    count: number;
+    startedAt: number;
+    tokens: number;
+  }): Promise<void> => {
+    if (!sessionKey) {
+      return;
+    }
+    if (activeSessionEntry) {
+      activeSessionEntry.continuationChainCount = params.count;
+      activeSessionEntry.continuationChainStartedAt = params.startedAt;
+      activeSessionEntry.continuationChainTokens = params.tokens;
+    }
+    if (activeSessionStore) {
+      const resolved = resolveSessionStoreEntry({ store: activeSessionStore, sessionKey });
+      const existingEntry = resolved.existing ?? activeSessionEntry;
+      if (existingEntry) {
+        activeSessionStore[resolved.normalizedKey] = {
+          ...existingEntry,
+          continuationChainCount: params.count,
+          continuationChainStartedAt: params.startedAt,
+          continuationChainTokens: params.tokens,
+        };
+        for (const legacyKey of resolved.legacyKeys) {
+          delete activeSessionStore[legacyKey];
+        }
+      }
+    }
+    if (storePath) {
+      try {
+        await updateSessionStore(storePath, (store) => {
+          const resolved = resolveSessionStoreEntry({ store, sessionKey });
+          if (resolved.existing) {
+            store[resolved.normalizedKey] = {
+              ...resolved.existing,
+              continuationChainCount: params.count,
+              continuationChainStartedAt: params.startedAt,
+              continuationChainTokens: params.tokens,
+            };
+            for (const legacyKey of resolved.legacyKeys) {
+              delete store[legacyKey];
+            }
+          }
+        });
+      } catch (err) {
+        defaultRuntime.log(
+          `Failed to persist continuation chain state for ${sessionKey}: ${String(err)}`,
+        );
+      }
+    }
+  };
   try {
     await typingSignals.signalRunStart();
 
     activeSessionEntry = await runPreflightCompactionIfNeeded({
-      cfg,
+      cfg: resolvedRunCfg,
       followupRun,
       promptForEstimate: followupRun.prompt,
       defaultModel,
@@ -1095,7 +1558,7 @@ export async function runReplyAgent(params: {
       (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
 
     activeSessionEntry = await runMemoryFlushIfNeeded({
-      cfg,
+      cfg: resolvedRunCfg,
       followupRun,
       promptForEstimate: followupRun.prompt,
       sessionCtx,
@@ -1170,6 +1633,56 @@ export async function runReplyAgent(params: {
       });
 
     replyOperation.setPhase("running");
+
+    // Trigger D: check context pressure before the agent turn and inject
+    // a [system:context-pressure] event when a threshold band is crossed.
+    if (activeSessionEntry && sessionKey) {
+      const { contextPressureThreshold } = resolveContinuationRuntimeConfig(cfg);
+      const contextWindowTokens =
+        resolveContextTokensForModel({
+          cfg,
+          provider: followupRun.run.provider,
+          model: defaultModel,
+          contextTokensOverride: agentCfgContextTokens,
+          fallbackContextTokens: activeSessionEntry.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+          allowAsyncLoad: false,
+        }) ?? DEFAULT_CONTEXT_TOKENS;
+      const pressureResult = checkContextPressure({
+        sessionEntry: activeSessionEntry,
+        sessionKey,
+        contextPressureThreshold,
+        contextWindowTokens,
+      });
+      if (pressureResult.fired && storePath) {
+        try {
+          await updateSessionStore(storePath, (store) => {
+            const resolved = resolveSessionStoreEntry({ store, sessionKey });
+            if (resolved.existing) {
+              store[resolved.normalizedKey] = {
+                ...resolved.existing,
+                lastContextPressureBand: pressureResult.band,
+              };
+              for (const legacyKey of resolved.legacyKeys) {
+                delete store[legacyKey];
+              }
+            }
+          });
+        } catch (err) {
+          defaultRuntime.log(
+            `context-pressure band persistence failed (non-fatal): ${String(err)}`,
+          );
+        }
+      }
+    }
+
+    // Sync the Task Flow delegate gate BEFORE the agent turn starts.
+    // Tools (continue_delegate) call enqueuePendingDelegate() during the turn,
+    // so the routing flag must be set before any tool execution.
+    const taskFlowDelegatesEarly =
+      cfg.agents?.defaults?.continuation?.enabled === true &&
+      cfg.agents?.defaults?.continuation?.taskFlowDelegates === true;
+    setTaskFlowDelegatesEnabled(taskFlowDelegatesEarly);
+
     const runStartedAt = Date.now();
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,
@@ -1190,6 +1703,7 @@ export async function runReplyAgent(params: {
       resetSessionAfterRoleOrderingConflict,
       isHeartbeat,
       sessionKey,
+      getCurrentContinuationGeneration: currentContinuationGeneration,
       getActiveSessionEntry: () => activeSessionEntry,
       activeSessionStore,
       storePath,
@@ -1210,6 +1724,7 @@ export async function runReplyAgent(params: {
       fallbackModel,
       fallbackAttempts,
       directlySentBlockKeys,
+      continueWorkRequest,
     } = runOutcome;
     let { didLogHeartbeatStrip, autoCompactionCount } = runOutcome;
 
@@ -1225,18 +1740,101 @@ export async function runReplyAgent(params: {
       activeSessionEntry.updatedAt = updatedAt;
       activeSessionStore[sessionKey] = activeSessionEntry;
       if (storePath) {
-        await updateSessionStoreEntry({
-          storePath,
-          sessionKey,
-          update: async () => ({
-            groupActivationNeedsSystemIntro: false,
-            updatedAt,
-          }),
-        });
+        try {
+          await updateSessionStoreEntry({
+            storePath,
+            sessionKey,
+            update: async () => ({
+              groupActivationNeedsSystemIntro: false,
+              updatedAt,
+            }),
+          });
+        } catch (err) {
+          defaultRuntime.log(
+            `Failed to persist group activation intro state for ${sessionKey}: ${String(err)}`,
+          );
+        }
       }
     }
 
     const payloadArray = runResult.payloads ?? [];
+
+    // Detect and strip continuation signal only when the feature is enabled.
+    // This prevents output mutation on disabled deployments where a model might
+    // mention CONTINUE_WORK or [[CONTINUE_DELEGATE:]] in explanatory text.
+    // Sync the Task Flow delegate gate from config so the store routes
+    // enqueue/consume/count through the TaskFlow-backed implementation.
+    setTaskFlowDelegatesEnabled(
+      continuationFeatureEnabled && cfg.agents?.defaults?.continuation?.taskFlowDelegates === true,
+    );
+    let continuationSignal: ContinuationSignal | null = null;
+    if (continuationFeatureEnabled && payloadArray.length > 0) {
+      // Find the last payload with text content — tool-call payloads may follow
+      // the text payload, pushing the bracket token out of the final position.
+      // This is critical for subagent chain-hops where the bracket is the ONLY
+      // continuation path (continue_delegate tool is denied for subagents).
+      let lastTextPayload: (typeof payloadArray)[number] | undefined;
+      for (let i = payloadArray.length - 1; i >= 0; i--) {
+        if (payloadArray[i].text) {
+          lastTextPayload = payloadArray[i];
+          break;
+        }
+      }
+      // [continuation:trace] Log what the backward scan sees for bracket diagnosis (#102 F4)
+      const payloadSummary = payloadArray
+        .map(
+          (p: ReplyPayload, i: number) =>
+            `[${i}]text=${!!p.text}${p.text ? `:"${p.text.slice(-60).replace(/\n/g, "\\n")}"` : ""}`,
+        )
+        .join(" ");
+      continuationGuardLog.info(
+        `[continuation:trace] payload-scan: count=${payloadArray.length} lastTextIdx=${lastTextPayload ? payloadArray.indexOf(lastTextPayload) : -1} ${payloadSummary} session=${sessionKey}`,
+      );
+      if (lastTextPayload?.text) {
+        const continuationResult = stripContinuationSignal(lastTextPayload.text);
+        if (continuationResult.signal) {
+          continuationSignal = continuationResult.signal;
+          lastTextPayload.text = continuationResult.text;
+          continuationGuardLog.info(
+            `[continuation:trace] bracket-parse: kind=${continuationResult.signal.kind} ` +
+              `task=${continuationResult.signal.kind === "delegate" ? continuationResult.signal.task.slice(0, 80) : ""} delayMs=${continuationResult.signal.delayMs} ` +
+              `silent=${continuationResult.signal.kind === "delegate" ? continuationResult.signal.silent : undefined} ` +
+              `silentWake=${continuationResult.signal.kind === "delegate" ? continuationResult.signal.silentWake : undefined} ` +
+              `payloads=${payloadArray.length} textPayloadIdx=${payloadArray.indexOf(lastTextPayload)} session=${sessionKey}`,
+          );
+        }
+      }
+    } else if (!continuationFeatureEnabled) {
+      continuationGuardLog.info(
+        `[continuation:trace] bracket-parse skipped: feature disabled session=${sessionKey}`,
+      );
+    } else if (payloadArray.length === 0) {
+      continuationGuardLog.info(
+        `[continuation:trace] bracket-parse skipped: empty payloadArray session=${sessionKey}`,
+      );
+    }
+    // Reserve generation at parse time so external messages arriving during
+    // the ~660-line gap before the scheduling block are visible as drift.
+    const earlyDelegateGeneration =
+      continuationSignal?.kind === "delegate" && sessionKey
+        ? bumpContinuationGeneration(sessionKey)
+        : null;
+    const effectiveContinuationSignal: ContinuationSignal | null =
+      continuationSignal ??
+      (continuationFeatureEnabled && continueWorkRequest
+        ? {
+            kind: "work",
+            delayMs: continueWorkRequest.delaySeconds * 1000,
+          }
+        : null);
+    continuationGuardLog.info(
+      `[continuation:trace] effective-signal: origin=${continuationSignal ? "bracket" : effectiveContinuationSignal ? "tool-call" : "none"} ` +
+        `kind=${effectiveContinuationSignal?.kind ?? "none"} session=${sessionKey}`,
+    );
+    const continuationWorkReason =
+      !continuationSignal && effectiveContinuationSignal?.kind === "work"
+        ? continueWorkRequest?.reason
+        : undefined;
 
     if (blockReplyPipeline) {
       await blockReplyPipeline.flush({ force: true });
@@ -1276,15 +1874,21 @@ export async function runReplyAgent(params: {
         activeSessionStore[sessionKey] = fallbackStateEntry;
       }
       if (sessionKey && storePath) {
-        await updateSessionStoreEntry({
-          storePath,
-          sessionKey,
-          update: async () => ({
-            fallbackNoticeSelectedModel: fallbackTransition.nextState.selectedModel,
-            fallbackNoticeActiveModel: fallbackTransition.nextState.activeModel,
-            fallbackNoticeReason: fallbackTransition.nextState.reason,
-          }),
-        });
+        try {
+          await updateSessionStoreEntry({
+            storePath,
+            sessionKey,
+            update: async () => ({
+              fallbackNoticeSelectedModel: fallbackTransition.nextState.selectedModel,
+              fallbackNoticeActiveModel: fallbackTransition.nextState.activeModel,
+              fallbackNoticeReason: fallbackTransition.nextState.reason,
+            }),
+          });
+        } catch (err) {
+          defaultRuntime.log(
+            `Failed to persist fallback notice state for ${sessionKey}: ${String(err)}`,
+          );
+        }
       }
     }
     const cliSessionId = isCliProvider(providerUsed, cfg)
@@ -1319,10 +1923,16 @@ export async function runReplyAgent(params: {
       usageIsContextSnapshot: isCliProvider(providerUsed, cfg),
     });
 
+    const hasQueuedDelegateWork =
+      continuationFeatureEnabled &&
+      !!sessionKey &&
+      (pendingDelegateCount(sessionKey) > 0 || stagedPostCompactionDelegateCount(sessionKey) > 0);
+
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
-    // keep the typing indicator stuck.
-    if (payloadArray.length === 0) {
+    // keep the typing indicator stuck. A tool-only continuation turn may have no visible
+    // text while still needing delegate consumption/persistence below.
+    if (payloadArray.length === 0 && !hasQueuedDelegateWork && !effectiveContinuationSignal) {
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 
@@ -1353,8 +1963,17 @@ export async function runReplyAgent(params: {
     const { replyPayloads } = payloadResult;
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
+    // Track whether the agent reply was purely a continuation signal (stripped to empty).
+    // Used later to suppress verbose/usage augmentation that would break silent continuation.
+    const wasSilentContinuation = replyPayloads.length === 0 && !!effectiveContinuationSignal;
+
     if (replyPayloads.length === 0) {
-      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+      // If the agent replied with only a continuation signal (e.g. bare CONTINUE_WORK),
+      // the signal was stripped and all payloads became empty. We still need to process
+      // the continuation below. Tool-only delegate turns also pass through here.
+      if (!effectiveContinuationSignal && !hasQueuedDelegateWork) {
+        return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+      }
     }
 
     const successfulCronAdds = runResult.successfulCronAdds ?? 0;
@@ -1543,7 +2162,49 @@ export async function runReplyAgent(params: {
 
       // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {
-        const workspaceDir = process.cwd();
+        const stagedCompactionDelegates = consumeStagedPostCompactionDelegates(sessionKey);
+        let persistedCompactionDelegates: SessionPostCompactionDelegate[] = [];
+        try {
+          persistedCompactionDelegates = await takePendingPostCompactionDelegates({
+            sessionEntry: activeSessionEntry,
+            sessionStore: activeSessionStore,
+            sessionKey,
+            storePath,
+          });
+        } catch (err) {
+          defaultRuntime.log(
+            `Failed to load post-compaction delegates for ${sessionKey}: ${String(err)}`,
+          );
+        }
+        const allCompactionDelegates = [
+          ...persistedCompactionDelegates,
+          ...stagedCompactionDelegates,
+        ].map(normalizePostCompactionDelegate);
+        const {
+          maxChainLength: maxCompactionChainLength,
+          maxDelegatesPerTurn: maxCompactionDelegates,
+          costCapTokens: compactionCostCapTokens,
+        } = resolveContinuationRuntimeConfig(cfg);
+        // Account for bracket delegate spawned this turn so combined count
+        // cannot exceed maxDelegatesPerTurn.
+        const bracketDelegateOffset = continuationSignal?.kind === "delegate" ? 1 : 0;
+        const compactionBudget = Math.max(0, maxCompactionDelegates - bracketDelegateOffset);
+        const releasedCompactionDelegates = allCompactionDelegates.slice(0, compactionBudget);
+        let droppedCompactionDelegates = Math.max(
+          0,
+          allCompactionDelegates.length - releasedCompactionDelegates.length,
+        );
+        const originalCompactionChainCount = activeSessionEntry?.continuationChainCount ?? 0;
+        let currentCompactionChainCount = originalCompactionChainCount;
+        const compactionChainStartedAt =
+          activeSessionEntry?.continuationChainStartedAt ?? Date.now();
+        const compactionChainTokens = activeSessionEntry?.continuationChainTokens ?? 0;
+        let dispatchedCompactionDelegates = 0;
+
+        const workspaceDir =
+          typeof followupRun.run.workspaceDir === "string" && followupRun.run.workspaceDir.trim()
+            ? followupRun.run.workspaceDir
+            : resolveAgentWorkspaceDir(cfg, followupRun.run.agentId);
         readPostCompactionContext(workspaceDir, cfg)
           .then((contextContent) => {
             if (contextContent) {
@@ -1553,6 +2214,148 @@ export async function runReplyAgent(params: {
           .catch(() => {
             // Silent failure — post-compaction context is best-effort
           });
+
+        // Dispatch compaction-triggered delegates (| post-compaction mode).
+        for (const delegate of releasedCompactionDelegates) {
+          if (currentCompactionChainCount >= maxCompactionChainLength) {
+            droppedCompactionDelegates += 1;
+            defaultRuntime.log(
+              `Post-compaction delegate rejected: chain length ${currentCompactionChainCount} >= ${maxCompactionChainLength} for session ${sessionKey}`,
+            );
+            enqueueSystemEvent(
+              `[continuation] Post-compaction delegate rejected: chain length ${maxCompactionChainLength} reached. Task: ${delegate.task}`,
+              { sessionKey },
+            );
+            continue;
+          }
+
+          if (compactionCostCapTokens > 0 && compactionChainTokens > compactionCostCapTokens) {
+            droppedCompactionDelegates += 1;
+            defaultRuntime.log(
+              `Post-compaction delegate rejected: cost cap exceeded (${compactionChainTokens} > ${compactionCostCapTokens}) for session ${sessionKey}`,
+            );
+            enqueueSystemEvent(
+              `[continuation] Post-compaction delegate rejected: cost cap exceeded (${compactionChainTokens} > ${compactionCostCapTokens}). Task: ${delegate.task}`,
+              { sessionKey },
+            );
+            continue;
+          }
+
+          const nextCompactionChainCount = currentCompactionChainCount + 1;
+          defaultRuntime.log(
+            `Post-compaction delegate dispatch for session ${sessionKey}: ${delegate.task}`,
+          );
+          try {
+            const delegateWakeOnReturn = delegate.silentWake ?? true;
+            const delegateSilentAnnounce = delegate.silent ?? delegateWakeOnReturn;
+            const spawnResult = await spawnSubagentDirect(
+              {
+                task:
+                  `[continuation:post-compaction] ` +
+                  `[continuation:chain-hop:${nextCompactionChainCount}] ` +
+                  `Compaction just completed. Carry this working state to the post-compaction session: ${delegate.task}`,
+                ...(delegateSilentAnnounce ? { silentAnnounce: true } : {}),
+                ...(delegateWakeOnReturn ? { silentAnnounce: true, wakeOnReturn: true } : {}),
+                drainsContinuationDelegateQueue: true,
+              },
+              {
+                agentSessionKey: sessionKey,
+                agentChannel: followupRun.originatingChannel ?? undefined,
+                agentAccountId: followupRun.originatingAccountId ?? undefined,
+                agentTo: followupRun.originatingTo ?? undefined,
+                agentThreadId: followupRun.originatingThreadId ?? undefined,
+              },
+            );
+            if (spawnResult.status === "accepted") {
+              currentCompactionChainCount = nextCompactionChainCount;
+              dispatchedCompactionDelegates += 1;
+              enqueueSystemEvent(
+                `[continuation:compaction-delegate-spawned] Post-compaction shard dispatched: ${delegate.task}`,
+                { sessionKey },
+              );
+            } else {
+              droppedCompactionDelegates += 1;
+              postCompactionDelegatesToPreserve.push(delegate);
+              defaultRuntime.log(
+                `Post-compaction delegate rejected (${spawnResult.status}) for session ${sessionKey} (re-staged)`,
+              );
+            }
+          } catch (err) {
+            droppedCompactionDelegates += 1;
+            postCompactionDelegatesToPreserve.push(delegate);
+            defaultRuntime.log(
+              `Post-compaction delegate failed for session ${sessionKey} (re-staged): ${String(err)}`,
+            );
+          }
+        }
+
+        if (postCompactionDelegatesToPreserve.length > 0) {
+          try {
+            await persistPendingPostCompactionDelegates({
+              sessionEntry: activeSessionEntry,
+              sessionStore: activeSessionStore,
+              sessionKey,
+              storePath,
+              delegates: postCompactionDelegatesToPreserve,
+            });
+            postCompactionDelegatesToPreserve.length = 0;
+          } catch (err) {
+            defaultRuntime.log(
+              `Failed to persist re-staged post-compaction delegates for ${sessionKey} (${postCompactionDelegatesToPreserve.length}): ${String(err)}`,
+            );
+          }
+        }
+
+        enqueueSystemEvent(
+          buildPostCompactionLifecycleEvent({
+            compactionCount: count,
+            releasedDelegates: dispatchedCompactionDelegates,
+            droppedDelegates: droppedCompactionDelegates,
+          }),
+          { sessionKey },
+        );
+
+        if (currentCompactionChainCount > originalCompactionChainCount) {
+          if (activeSessionEntry) {
+            activeSessionEntry.continuationChainCount = currentCompactionChainCount;
+            activeSessionEntry.continuationChainStartedAt = compactionChainStartedAt;
+            activeSessionEntry.continuationChainTokens = compactionChainTokens;
+          }
+          if (activeSessionStore) {
+            const resolved = resolveSessionStoreEntry({ store: activeSessionStore, sessionKey });
+            activeSessionStore[resolved.normalizedKey] = {
+              ...(resolved.existing ?? activeSessionEntry!),
+              continuationChainCount: currentCompactionChainCount,
+              continuationChainStartedAt: compactionChainStartedAt,
+              continuationChainTokens: compactionChainTokens,
+            };
+            for (const legacyKey of resolved.legacyKeys) {
+              delete activeSessionStore[legacyKey];
+            }
+          }
+          if (storePath) {
+            try {
+              await updateSessionStore(storePath, (store) => {
+                const resolved = resolveSessionStoreEntry({ store, sessionKey });
+                if (resolved.existing) {
+                  store[resolved.normalizedKey] = {
+                    ...resolved.existing,
+                    continuationChainCount: currentCompactionChainCount,
+                    continuationChainStartedAt: compactionChainStartedAt,
+                    continuationChainTokens: compactionChainTokens,
+                  };
+                  for (const legacyKey of resolved.legacyKeys) {
+                    delete store[legacyKey];
+                  }
+                }
+              });
+            } catch (err) {
+              defaultRuntime.log(
+                `Failed to persist post-compaction delegate chain state for ${sessionKey}: ${String(err)}`,
+              );
+            }
+          }
+        }
       }
 
       if (verboseEnabled) {
@@ -1560,143 +2363,652 @@ export async function runReplyAgent(params: {
         verboseNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
       }
     }
-    const prefixPayloads = [...verboseNotices];
-    const rawUserText =
-      runResult.meta?.finalPromptText ??
-      sessionCtx.CommandBody ??
-      sessionCtx.RawBody ??
-      sessionCtx.BodyForAgent ??
-      sessionCtx.Body;
-    const rawAssistantText =
-      runResult.meta?.finalAssistantRawText ?? runResult.meta?.finalAssistantVisibleText;
-    const traceAuthorized = followupRun.run.traceAuthorized === true;
-    const executionTrace = mergeExecutionTrace({
-      fallbackAttempts,
-      executionTrace: runResult.meta?.executionTrace as TraceExecutionView | undefined,
-      provider: providerUsed,
-      model: modelUsed,
-      runner: isCliProvider(providerUsed, cfg) ? "cli" : "embedded",
-    });
-    const requestShaping = {
-      authMode:
-        runResult.meta?.requestShaping?.authMode ??
-        (cfg?.models?.providers && providerUsed in cfg.models.providers
-          ? (resolveModelAuthMode(providerUsed, cfg) ?? undefined)
-          : undefined),
-      thinking:
-        runResult.meta?.requestShaping?.thinking ??
-        normalizeOptionalString(followupRun.run.thinkLevel),
-      reasoning:
-        runResult.meta?.requestShaping?.reasoning ??
-        normalizeOptionalString(followupRun.run.reasoningLevel),
-      verbose:
-        runResult.meta?.requestShaping?.verbose ?? normalizeOptionalString(resolvedVerboseLevel),
-      trace:
-        runResult.meta?.requestShaping?.trace ??
-        normalizeOptionalString(activeSessionEntry?.traceLevel),
-      fallbackEligible:
-        runResult.meta?.requestShaping?.fallbackEligible ??
-        hasConfiguredModelFallbacks({
-          cfg,
-          agentId: followupRun.run.agentId,
-          sessionKey: followupRun.run.sessionKey,
-        }),
-      blockStreaming:
-        runResult.meta?.requestShaping?.blockStreaming ??
-        normalizeOptionalString(resolvedBlockStreamingBreak),
-    };
-    const promptSegments =
-      (runResult.meta?.promptSegments as TracePromptSegmentView[] | undefined) ??
-      derivePromptSegments(rawUserText);
-    const toolSummary = runResult.meta?.toolSummary as TraceToolSummaryView | undefined;
-    const completion =
-      (runResult.meta?.completion as TraceCompletionView | undefined) ??
-      (runResult.meta?.stopReason
-        ? {
-            stopReason: runResult.meta.stopReason,
-            finishReason: runResult.meta.stopReason,
-            ...(runResult.meta.stopReason.toLowerCase().includes("refusal")
-              ? { refusal: true }
-              : {}),
-          }
-        : undefined);
-    const contextManagement = {
-      ...(typeof activeSessionEntry?.compactionCount === "number"
-        ? { sessionCompactions: activeSessionEntry.compactionCount }
-        : {}),
-      ...(typeof runResult.meta?.contextManagement?.lastTurnCompactions === "number"
-        ? { lastTurnCompactions: runResult.meta.contextManagement.lastTurnCompactions }
-        : typeof runResult.meta?.agentMeta?.compactionCount === "number"
-          ? { lastTurnCompactions: runResult.meta.agentMeta.compactionCount }
-          : {}),
-      ...(runResult.meta?.contextManagement &&
-      typeof runResult.meta.contextManagement.preflightCompactionApplied === "boolean"
-        ? {
-            preflightCompactionApplied: runResult.meta.contextManagement.preflightCompactionApplied,
-          }
-        : preflightCompactionApplied
-          ? { preflightCompactionApplied }
-          : {}),
-      ...(runResult.meta?.contextManagement &&
-      typeof runResult.meta.contextManagement.postCompactionContextInjected === "boolean"
-        ? {
-            postCompactionContextInjected:
-              runResult.meta.contextManagement.postCompactionContextInjected,
-          }
-        : {}),
-    } satisfies TraceContextManagementView;
-    const sessionUsage =
-      traceAuthorized && activeSessionEntry?.traceLevel === "raw"
-        ? await accumulateSessionUsageFromTranscript({
-            sessionId: runResult.meta?.agentMeta?.sessionId ?? followupRun.run.sessionId,
-            storePath,
-            sessionFile: followupRun.run.sessionFile,
-          })
-        : undefined;
-    const traceEnabledForSender =
-      traceAuthorized &&
-      (activeSessionEntry?.traceLevel === "on" || activeSessionEntry?.traceLevel === "raw");
-    const shouldAppendTracePayload = verboseEnabled || traceEnabledForSender;
-    let trailingPluginStatusPayload: ReplyPayload | undefined;
-    if (shouldAppendTracePayload) {
-      const pluginStatusPayload = buildInlinePluginStatusPayload({
-        entry: activeSessionEntry,
-        includeTraceLines: traceEnabledForSender,
+    // Skip verbose/usage augmentation for silent continuations — a bare
+    // CONTINUE_WORK should produce no user-visible output.
+    if (!wasSilentContinuation) {
+      const prefixPayloads = [...verboseNotices];
+      const rawUserText =
+        runResult.meta?.finalPromptText ??
+        sessionCtx.CommandBody ??
+        sessionCtx.RawBody ??
+        sessionCtx.BodyForAgent ??
+        sessionCtx.Body;
+      const rawAssistantText =
+        runResult.meta?.finalAssistantRawText ?? runResult.meta?.finalAssistantVisibleText;
+      const traceAuthorized = followupRun.run.traceAuthorized === true;
+      const executionTrace = mergeExecutionTrace({
+        fallbackAttempts,
+        executionTrace: runResult.meta?.executionTrace as TraceExecutionView | undefined,
+        provider: providerUsed,
+        model: modelUsed,
+        runner: isCliProvider(providerUsed, cfg) ? "cli" : "embedded",
       });
-      const rawTracePayload =
+      const requestShaping = {
+        authMode:
+          runResult.meta?.requestShaping?.authMode ??
+          (cfg?.models?.providers && providerUsed in cfg.models.providers
+            ? (resolveModelAuthMode(providerUsed, cfg) ?? undefined)
+            : undefined),
+        thinking:
+          runResult.meta?.requestShaping?.thinking ??
+          normalizeOptionalString(followupRun.run.thinkLevel),
+        reasoning:
+          runResult.meta?.requestShaping?.reasoning ??
+          normalizeOptionalString(followupRun.run.reasoningLevel),
+        verbose:
+          runResult.meta?.requestShaping?.verbose ?? normalizeOptionalString(resolvedVerboseLevel),
+        trace:
+          runResult.meta?.requestShaping?.trace ??
+          normalizeOptionalString(activeSessionEntry?.traceLevel),
+        fallbackEligible:
+          runResult.meta?.requestShaping?.fallbackEligible ??
+          hasConfiguredModelFallbacks({
+            cfg,
+            agentId: followupRun.run.agentId,
+            sessionKey: followupRun.run.sessionKey,
+          }),
+        blockStreaming:
+          runResult.meta?.requestShaping?.blockStreaming ??
+          normalizeOptionalString(resolvedBlockStreamingBreak),
+      };
+      const promptSegments =
+        (runResult.meta?.promptSegments as TracePromptSegmentView[] | undefined) ??
+        derivePromptSegments(rawUserText);
+      const toolSummary = runResult.meta?.toolSummary as TraceToolSummaryView | undefined;
+      const completion =
+        (runResult.meta?.completion as TraceCompletionView | undefined) ??
+        (runResult.meta?.stopReason
+          ? {
+              stopReason: runResult.meta.stopReason,
+              finishReason: runResult.meta.stopReason,
+              ...(runResult.meta.stopReason.toLowerCase().includes("refusal")
+                ? { refusal: true }
+                : {}),
+            }
+          : undefined);
+      const contextManagement = {
+        ...(typeof activeSessionEntry?.compactionCount === "number"
+          ? { sessionCompactions: activeSessionEntry.compactionCount }
+          : {}),
+        ...(typeof runResult.meta?.contextManagement?.lastTurnCompactions === "number"
+          ? { lastTurnCompactions: runResult.meta.contextManagement.lastTurnCompactions }
+          : typeof runResult.meta?.agentMeta?.compactionCount === "number"
+            ? { lastTurnCompactions: runResult.meta.agentMeta.compactionCount }
+            : {}),
+        ...(runResult.meta?.contextManagement &&
+        typeof runResult.meta.contextManagement.preflightCompactionApplied === "boolean"
+          ? {
+              preflightCompactionApplied: runResult.meta.contextManagement.preflightCompactionApplied,
+            }
+          : preflightCompactionApplied
+            ? { preflightCompactionApplied }
+            : {}),
+        ...(runResult.meta?.contextManagement &&
+        typeof runResult.meta.contextManagement.postCompactionContextInjected === "boolean"
+          ? {
+              postCompactionContextInjected:
+                runResult.meta.contextManagement.postCompactionContextInjected,
+            }
+          : {}),
+      } satisfies TraceContextManagementView;
+      const sessionUsage =
         traceAuthorized && activeSessionEntry?.traceLevel === "raw"
-          ? buildInlineRawTracePayload({
-              entry: activeSessionEntry,
-              rawUserText,
-              rawAssistantText,
-              sessionUsage,
-              usage: runResult.meta?.agentMeta?.usage,
-              lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
-              provider: providerUsed,
-              model: modelUsed,
-              contextLimit: contextTokensUsed,
-              promptTokens,
-              executionTrace,
-              requestShaping,
-              promptSegments,
-              toolSummary,
-              completion,
-              contextManagement,
+          ? await accumulateSessionUsageFromTranscript({
+              sessionId: runResult.meta?.agentMeta?.sessionId ?? followupRun.run.sessionId,
+              storePath,
+              sessionFile: followupRun.run.sessionFile,
             })
           : undefined;
-      trailingPluginStatusPayload =
-        pluginStatusPayload && rawTracePayload
-          ? { text: `${pluginStatusPayload.text}\n\n${rawTracePayload.text}` }
-          : (pluginStatusPayload ?? rawTracePayload);
+      const traceEnabledForSender =
+        traceAuthorized &&
+        (activeSessionEntry?.traceLevel === "on" || activeSessionEntry?.traceLevel === "raw");
+      const shouldAppendTracePayload = verboseEnabled || traceEnabledForSender;
+      let trailingPluginStatusPayload: ReplyPayload | undefined;
+      if (shouldAppendTracePayload) {
+        const pluginStatusPayload = buildInlinePluginStatusPayload({
+          entry: activeSessionEntry,
+          includeTraceLines: traceEnabledForSender,
+        });
+        const rawTracePayload =
+          traceAuthorized && activeSessionEntry?.traceLevel === "raw"
+            ? buildInlineRawTracePayload({
+                entry: activeSessionEntry,
+                rawUserText,
+                rawAssistantText,
+                sessionUsage,
+                usage: runResult.meta?.agentMeta?.usage,
+                lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
+                provider: providerUsed,
+                model: modelUsed,
+                contextLimit: contextTokensUsed,
+                promptTokens,
+                executionTrace,
+                requestShaping,
+                promptSegments,
+                toolSummary,
+                completion,
+                contextManagement,
+              })
+            : undefined;
+        trailingPluginStatusPayload =
+          pluginStatusPayload && rawTracePayload
+            ? { text: `${pluginStatusPayload.text}\n\n${rawTracePayload.text}` }
+            : (pluginStatusPayload ?? rawTracePayload);
+      }
+      if (prefixPayloads.length > 0) {
+        finalPayloads = [...prefixPayloads, ...finalPayloads];
+      }
+      if (trailingPluginStatusPayload) {
+        finalPayloads = [...finalPayloads, trailingPluginStatusPayload];
+      }
+      if (responseUsageLine) {
+        finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
+      }
     }
-    if (prefixPayloads.length > 0) {
-      finalPayloads = [...prefixPayloads, ...finalPayloads];
+
+    // Handle continuation signal (CONTINUE_WORK / CONTINUE_DELEGATE).
+    // `effectiveContinuationSignal` is either the parsed bracket signal or the
+    // structured continue_work tool request captured during the run.
+    let bracketTokensAccumulated = false;
+    if (effectiveContinuationSignal && sessionKey) {
+      const { maxChainLength, defaultDelayMs, minDelayMs, maxDelayMs, costCapTokens } =
+        resolveContinuationRuntimeConfig(cfg);
+
+      {
+        // continuation scheduling block
+        const currentChainCount = activeSessionEntry?.continuationChainCount ?? 0;
+        const allocatedChainHop = Math.max(
+          currentChainCount,
+          highestDelayedContinuationReservationHop(sessionKey),
+        );
+
+        if (allocatedChainHop >= maxChainLength) {
+          defaultRuntime.log(
+            `Continuation chain capped at ${maxChainLength} for session ${sessionKey}`,
+          );
+          // Bump (not clear) to invalidate stale timers without reuse risk.
+          // Clearing would reset to 0, letting a new chain's generation collide
+          // with a stale in-flight timer's captured value.
+          bumpContinuationGeneration(sessionKey);
+          maybeDropContinuationGeneration(sessionKey);
+        } else {
+          // Accumulate token usage for cost cap (input + output only, excludes
+          // cache reads/writes which inflate with inherited system prompt context).
+          const usage = runResult.meta?.agentMeta?.usage;
+          const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
+          const previousChainTokens = activeSessionEntry?.continuationChainTokens ?? 0;
+          const accumulatedChainTokens = previousChainTokens + turnTokens;
+          if (costCapTokens > 0 && accumulatedChainTokens > costCapTokens) {
+            defaultRuntime.log(
+              `Continuation cost cap exceeded (${accumulatedChainTokens} > ${costCapTokens}) for session ${sessionKey}`,
+            );
+            bumpContinuationGeneration(sessionKey);
+            maybeDropContinuationGeneration(sessionKey);
+          } else {
+            bracketTokensAccumulated = true;
+            const nextChainCount = allocatedChainHop + 1;
+            const chainStartedAt = activeSessionEntry?.continuationChainStartedAt ?? Date.now();
+            if (effectiveContinuationSignal.kind === "delegate") {
+              const delegateTask = effectiveContinuationSignal.task;
+              const delegateDelayMs = effectiveContinuationSignal.delayMs;
+              continuationGuardLog.info(
+                `[continuation:trace] delegate-schedule: generation=${currentContinuationGeneration(sessionKey)} ` +
+                  `hop=${nextChainCount}/${maxChainLength} delayMs=${delegateDelayMs} ` +
+                  `origin=${continuationSignal ? "bracket" : "tool-call"} session=${sessionKey}`,
+              );
+
+              const doSpawn = async (
+                plannedHop: number,
+                task: string,
+                options?: {
+                  timerTriggered?: boolean;
+                  silent?: boolean;
+                  silentWake?: boolean;
+                  startedAt?: number;
+                },
+              ) => {
+                continuationGuardLog.info(
+                  `[continuation:trace] doSpawn: hop=${plannedHop}/${maxChainLength} ` +
+                    `timerTriggered=${options?.timerTriggered ?? false} silent=${options?.silent ?? false} ` +
+                    `silentWake=${options?.silentWake ?? false} session=${sessionKey}`,
+                );
+                try {
+                  const spawnResult = await spawnSubagentDirect(
+                    {
+                      // The spawned child carries its current chain position in-band.
+                      // Announce-side chain hops parse this prefix as the canonical hop source.
+                      task: `[continuation:chain-hop:${plannedHop}] Delegated task (turn ${plannedHop}/${maxChainLength}): ${task}`,
+                      ...(options?.silent ? { silentAnnounce: true } : {}),
+                      ...(options?.silentWake ? { silentAnnounce: true, wakeOnReturn: true } : {}),
+                      drainsContinuationDelegateQueue: true,
+                    },
+                    {
+                      agentSessionKey: sessionKey,
+                      agentChannel: followupRun.originatingChannel ?? undefined,
+                      agentAccountId: followupRun.originatingAccountId ?? undefined,
+                      agentTo: followupRun.originatingTo ?? undefined,
+                      agentThreadId: followupRun.originatingThreadId ?? undefined,
+                    },
+                  );
+                  if (spawnResult.status === "accepted") {
+                    if (options?.timerTriggered) {
+                      defaultRuntime.log(
+                        `DELEGATE timer fired and spawned turn ${plannedHop}/${maxChainLength} for session ${sessionKey}: ${task}`,
+                      );
+                    }
+                    await persistContinuationChainState({
+                      count: Math.max(activeSessionEntry?.continuationChainCount ?? 0, plannedHop),
+                      startedAt: options?.startedAt ?? chainStartedAt,
+                      tokens: Math.max(
+                        accumulatedChainTokens,
+                        activeSessionEntry?.continuationChainTokens ?? 0,
+                      ),
+                    });
+                    enqueueSystemEvent(
+                      `[continuation:delegate-spawned] Spawned turn ${plannedHop}/${maxChainLength}: ${task}`,
+                      { sessionKey },
+                    );
+                    return true;
+                  } else {
+                    defaultRuntime.log(
+                      `DELEGATE spawn rejected (${spawnResult.status}) for session ${sessionKey}`,
+                    );
+                    enqueueSystemEvent(
+                      `[continuation] DELEGATE spawn ${spawnResult.status}: delegation was not accepted. Use sessions_spawn manually. Original task: ${task}`,
+                      { sessionKey },
+                    );
+                    clearDelegatePendingIfNoDelayedReservations(sessionKey);
+                    return false;
+                  }
+                } catch (err) {
+                  clearDelegatePendingIfNoDelayedReservations(sessionKey);
+                  defaultRuntime.log(
+                    `DELEGATE spawn failed for session ${sessionKey}: ${String(err)}`,
+                  );
+                  enqueueSystemEvent(
+                    `[continuation] DELEGATE spawn failed: ${String(err)}. Original task: ${task}`,
+                    { sessionKey },
+                  );
+                  return false;
+                }
+              };
+
+              // Mark delegate-pending via dedicated flag (not system event queue)
+              // so it survives buildQueuedSystemPrompt draining on intervening turns.
+              if (sessionKey) {
+                setDelegatePending(sessionKey);
+              }
+
+              if (delegateDelayMs && delegateDelayMs > 0) {
+                // Timed dispatch: spawn after delay. Timer does not survive
+                // gateway restart — acceptable for v1 (see #176 for durable timers).
+                const clampedDelay = Math.max(minDelayMs, Math.min(maxDelayMs, delegateDelayMs));
+                // Generation guard: use the generation reserved at parse time so
+                // external messages that arrived during the gap are visible as drift.
+                const delegateGeneration =
+                  earlyDelegateGeneration ?? bumpContinuationGeneration(sessionKey);
+                const reservationId = generateSecureUuid();
+                addDelayedContinuationReservation(sessionKey, {
+                  id: reservationId,
+                  source: "bracket",
+                  task: delegateTask,
+                  createdAt: chainStartedAt,
+                  fireAt: Date.now() + clampedDelay,
+                  generation: delegateGeneration,
+                  plannedHop: nextChainCount,
+                  silent: effectiveContinuationSignal.silent,
+                  silentWake: effectiveContinuationSignal.silentWake,
+                });
+                await persistContinuationChainState({
+                  count: currentChainCount,
+                  startedAt: chainStartedAt,
+                  tokens: accumulatedChainTokens,
+                });
+                continuationGuardLog.debug(
+                  `[continuation-guard] DELEGATE timer set: generation=${delegateGeneration} delayMs=${clampedDelay} session=${sessionKey}`,
+                );
+                retainContinuationTimerRef(sessionKey);
+                const timerHandle = setTimeout(() => {
+                  try {
+                    const reservation = takeDelayedContinuationReservation(
+                      sessionKey,
+                      reservationId,
+                    );
+                    if (!reservation) {
+                      continuationGuardLog.info(
+                        `[continuation-guard] DELEGATE timer fired but reservation already cleared for session ${sessionKey}`,
+                      );
+                      return;
+                    }
+                    const { generationGuardTolerance } = resolveContinuationRuntimeConfig();
+                    const currentGen = currentContinuationGeneration(sessionKey);
+                    const drift = currentGen - reservation.generation;
+                    continuationGuardLog.info(
+                      `[continuation-guard] DELEGATE timer check: stored=${reservation.generation} current=${currentGen} drift=${drift} tolerance=${generationGuardTolerance} session=${sessionKey}`,
+                    );
+                    if (drift > generationGuardTolerance) {
+                      clearDelegatePendingIfNoDelayedReservations(sessionKey);
+                      defaultRuntime.log(
+                        `DELEGATE timer cancelled (generation drift ${drift} > tolerance ${generationGuardTolerance}) for session ${sessionKey}`,
+                      );
+                      return;
+                    }
+                    void doSpawn(reservation.plannedHop, reservation.task, {
+                      timerTriggered: true,
+                      silent: reservation.silent,
+                      silentWake: reservation.silentWake,
+                      startedAt: reservation.createdAt,
+                    });
+                  } finally {
+                    unregisterContinuationTimerHandle(sessionKey, timerHandle);
+                  }
+                }, clampedDelay);
+                registerContinuationTimerHandle(sessionKey, timerHandle);
+                timerHandle.unref();
+              } else {
+                await doSpawn(nextChainCount, delegateTask, {
+                  silent: effectiveContinuationSignal.silent,
+                  silentWake: effectiveContinuationSignal.silentWake,
+                  startedAt: chainStartedAt,
+                });
+              }
+            } else {
+              await persistContinuationChainState({
+                count: nextChainCount,
+                startedAt: chainStartedAt,
+                tokens: accumulatedChainTokens,
+              });
+              // WORK: schedule a continuation turn after delay
+              const requestedDelay = effectiveContinuationSignal.delayMs ?? defaultDelayMs;
+              const clampedDelay = Math.max(minDelayMs, Math.min(maxDelayMs, requestedDelay));
+
+              // Schedule continuation with the same live-read guard used for
+              // delegate timers. In busy channels, generation drift reflects
+              // generic session interruption, not just direct human preemption.
+              const generation = bumpContinuationGeneration(sessionKey);
+              continuationGuardLog.debug(
+                `[continuation-guard] WORK timer set: generation=${generation} delayMs=${clampedDelay} session=${sessionKey}`,
+              );
+              retainContinuationTimerRef(sessionKey);
+              const timerHandle = setTimeout(() => {
+                try {
+                  const { generationGuardTolerance } = resolveContinuationRuntimeConfig();
+                  const currentGen = currentContinuationGeneration(sessionKey);
+                  const drift = currentGen - generation;
+                  continuationGuardLog.info(
+                    `[continuation-guard] WORK timer check: stored=${generation} current=${currentGen} drift=${drift} tolerance=${generationGuardTolerance} session=${sessionKey}`,
+                  );
+                  if (drift > generationGuardTolerance) {
+                    defaultRuntime.log(
+                      `WORK timer cancelled (generation drift ${drift} > tolerance ${generationGuardTolerance}) for session ${sessionKey}`,
+                    );
+                    return;
+                  }
+                  defaultRuntime.log(`WORK timer fired for session ${sessionKey}`);
+                  enqueueSystemEvent(
+                    `[continuation:wake] Turn ${nextChainCount}/${maxChainLength}. ` +
+                      `Chain started at ${new Date(chainStartedAt).toISOString()}. ` +
+                      `Accumulated tokens: ${accumulatedChainTokens}. ` +
+                      `The agent elected to continue working.` +
+                      (continuationWorkReason ? ` Reason: ${continuationWorkReason}` : ""),
+                    { sessionKey },
+                  );
+                  requestHeartbeatNow({ sessionKey, reason: "continuation" });
+                } finally {
+                  unregisterContinuationTimerHandle(sessionKey, timerHandle);
+                }
+              }, clampedDelay);
+              registerContinuationTimerHandle(sessionKey, timerHandle);
+              timerHandle.unref();
+            }
+          }
+        }
+      }
+    } else if (effectiveContinuationSignal && !sessionKey) {
+      continuationGuardLog.info(
+        `[continuation:trace] scheduling skipped: no sessionKey for signal kind=${effectiveContinuationSignal.kind}`,
+      );
     }
-    if (trailingPluginStatusPayload) {
-      finalPayloads = [...finalPayloads, trailingPluginStatusPayload];
+    // Handle tool-dispatched continuation delegates (continue_delegate tool).
+    // These are enqueued by the tool during execution and consumed here,
+    // going through the same chain tracking as bracket-parsed signals.
+    // Multiple delegates per turn are supported (multi-arrow fan-out).
+    if (continuationFeatureEnabled && sessionKey) {
+      const toolDelegates = consumePendingDelegates(sessionKey);
+      if (toolDelegates.length > 0) {
+        defaultRuntime.log(
+          `[continue_delegate] Consuming ${toolDelegates.length} tool delegate(s) for session ${sessionKey}`,
+        );
+      }
+      if (toolDelegates.length > 0) {
+        const { maxChainLength, minDelayMs, maxDelayMs, costCapTokens, maxDelegatesPerTurn } =
+          resolveContinuationRuntimeConfig(cfg);
+        // If a bracket-signal delegate was already spawned this turn, count it
+        // against the per-turn cap so mixed-signal turns cannot exceed the limit.
+        const bracketDelegateCount = effectiveContinuationSignal?.kind === "delegate" ? 1 : 0;
+        const remainingBudget = Math.max(0, maxDelegatesPerTurn - bracketDelegateCount);
+        const delegatesWithinLimit = toolDelegates.slice(0, remainingBudget);
+        const delegatesOverLimit = toolDelegates.slice(remainingBudget);
+        for (const droppedDelegate of delegatesOverLimit) {
+          enqueueSystemEvent(
+            `[continuation] Tool delegate rejected: maxDelegatesPerTurn exceeded (${maxDelegatesPerTurn}). Task: ${droppedDelegate.task}`,
+            { sessionKey },
+          );
+        }
+
+        let currentChainCount = activeSessionEntry?.continuationChainCount ?? 0;
+        // Accumulate current turn's token usage into chain cost.
+        // Skip if the bracket-signal path already accumulated this turn's tokens
+        // (both paths read from the same activeSessionEntry.continuationChainTokens).
+        const bracketAlreadyAccumulated = bracketTokensAccumulated;
+        const toolDelegateUsage = runResult.meta?.agentMeta?.usage;
+        // Count only input + output tokens for cost cap (excludes cache reads/writes
+        // which inflate the count with inherited system prompt context).
+        const toolDelegateTurnTokens = bracketAlreadyAccumulated
+          ? 0
+          : (toolDelegateUsage?.input ?? 0) + (toolDelegateUsage?.output ?? 0);
+        let accumulatedChainTokens =
+          (activeSessionEntry?.continuationChainTokens ?? 0) + toolDelegateTurnTokens;
+        const chainStartedAt = activeSessionEntry?.continuationChainStartedAt ?? Date.now();
+
+        for (const delegate of delegatesWithinLimit) {
+          const allocatedChainHop = Math.max(
+            currentChainCount,
+            highestDelayedContinuationReservationHop(sessionKey),
+          );
+          if (allocatedChainHop >= maxChainLength) {
+            defaultRuntime.log(
+              `Continuation chain capped at ${maxChainLength} for tool delegate in session ${sessionKey}`,
+            );
+            enqueueSystemEvent(
+              `[continuation] Tool delegate rejected: chain length ${maxChainLength} reached. Task: ${delegate.task}`,
+              { sessionKey },
+            );
+            break;
+          }
+
+          if (costCapTokens > 0 && accumulatedChainTokens > costCapTokens) {
+            defaultRuntime.log(
+              `Continuation cost cap exceeded for tool delegate in session ${sessionKey}`,
+            );
+            enqueueSystemEvent(
+              `[continuation] Tool delegate rejected: cost cap exceeded (${accumulatedChainTokens} > ${costCapTokens}). Task: ${delegate.task}`,
+              { sessionKey },
+            );
+            break;
+          }
+
+          const nextChainCount = allocatedChainHop + 1;
+
+          const doToolSpawn = async (
+            plannedHop: number,
+            task: string,
+            options?: {
+              timerTriggered?: boolean;
+              silent?: boolean;
+              silentWake?: boolean;
+              startedAt?: number;
+            },
+          ) => {
+            try {
+              const spawnResult = await spawnSubagentDirect(
+                {
+                  task: `[continuation:chain-hop:${plannedHop}] Delegated task (turn ${plannedHop}/${maxChainLength}): ${task}`,
+                  ...(options?.silent ? { silentAnnounce: true } : {}),
+                  ...(options?.silentWake ? { silentAnnounce: true, wakeOnReturn: true } : {}),
+                  drainsContinuationDelegateQueue: true,
+                },
+                {
+                  agentSessionKey: sessionKey,
+                  agentChannel: followupRun.originatingChannel ?? undefined,
+                  agentAccountId: followupRun.originatingAccountId ?? undefined,
+                  agentTo: followupRun.originatingTo ?? undefined,
+                  agentThreadId: followupRun.originatingThreadId ?? undefined,
+                },
+              );
+              if (spawnResult.status === "accepted") {
+                if (options?.timerTriggered) {
+                  defaultRuntime.log(
+                    `Tool DELEGATE timer fired and spawned turn ${plannedHop}/${maxChainLength} for session ${sessionKey}: ${task}`,
+                  );
+                }
+                currentChainCount = Math.max(currentChainCount, plannedHop);
+                await persistContinuationChainState({
+                  count: currentChainCount,
+                  startedAt: options?.startedAt ?? chainStartedAt,
+                  tokens: Math.max(
+                    accumulatedChainTokens,
+                    activeSessionEntry?.continuationChainTokens ?? 0,
+                  ),
+                });
+                enqueueSystemEvent(
+                  `[continuation:delegate-spawned] Tool delegate turn ${plannedHop}/${maxChainLength}: ${task}`,
+                  { sessionKey },
+                );
+                return true;
+              } else {
+                defaultRuntime.log(
+                  `Tool DELEGATE spawn rejected (${spawnResult.status}) for session ${sessionKey}`,
+                );
+                enqueueSystemEvent(
+                  `[continuation] Tool DELEGATE spawn ${spawnResult.status}: ${task}`,
+                  { sessionKey },
+                );
+                clearDelegatePendingIfNoDelayedReservations(sessionKey);
+                return false;
+              }
+            } catch (err) {
+              clearDelegatePendingIfNoDelayedReservations(sessionKey);
+              defaultRuntime.log(
+                `Tool DELEGATE spawn failed for session ${sessionKey}: ${String(err)}`,
+              );
+              enqueueSystemEvent(
+                `[continuation] Tool DELEGATE spawn failed: ${String(err)}. Task: ${task}`,
+                { sessionKey },
+              );
+              return false;
+            }
+          };
+
+          // Mark delegate-pending via dedicated flag (not system event queue)
+          // so it survives buildQueuedSystemPrompt draining on intervening turns.
+          if (sessionKey) {
+            setDelegatePending(sessionKey);
+          }
+
+          if (delegate.delayMs && delegate.delayMs > 0) {
+            const clampedDelay = Math.max(minDelayMs, Math.min(maxDelayMs, delegate.delayMs));
+            // Generation guard: same as bracket-path delegate timers
+            const toolDelegateGeneration = bumpContinuationGeneration(sessionKey);
+            const reservationId = generateSecureUuid();
+            addDelayedContinuationReservation(sessionKey, {
+              id: reservationId,
+              source: "tool",
+              task: delegate.task,
+              createdAt: chainStartedAt,
+              fireAt: Date.now() + clampedDelay,
+              generation: toolDelegateGeneration,
+              plannedHop: nextChainCount,
+              silent: delegate.silent,
+              silentWake: delegate.silentWake,
+            });
+            await persistContinuationChainState({
+              count: currentChainCount,
+              startedAt: chainStartedAt,
+              tokens: accumulatedChainTokens,
+            });
+            continuationGuardLog.debug(
+              `[continuation-guard] Tool DELEGATE timer set: generation=${toolDelegateGeneration} delayMs=${clampedDelay} session=${sessionKey}`,
+            );
+            retainContinuationTimerRef(sessionKey);
+            const timerHandle = setTimeout(() => {
+              try {
+                const reservation = takeDelayedContinuationReservation(sessionKey, reservationId);
+                if (!reservation) {
+                  continuationGuardLog.info(
+                    `[continuation-guard] Tool DELEGATE timer fired but reservation already cleared for session ${sessionKey}`,
+                  );
+                  return;
+                }
+                const { generationGuardTolerance } = resolveContinuationRuntimeConfig();
+                const currentGen = currentContinuationGeneration(sessionKey);
+                const drift = currentGen - reservation.generation;
+                continuationGuardLog.info(
+                  `[continuation-guard] Tool DELEGATE timer check: stored=${reservation.generation} current=${currentGen} drift=${drift} tolerance=${generationGuardTolerance} session=${sessionKey}`,
+                );
+                if (drift > generationGuardTolerance) {
+                  clearDelegatePendingIfNoDelayedReservations(sessionKey);
+                  defaultRuntime.log(
+                    `Tool DELEGATE timer cancelled (generation drift ${drift} > tolerance ${generationGuardTolerance}) for session ${sessionKey}`,
+                  );
+                  return;
+                }
+                void doToolSpawn(reservation.plannedHop, reservation.task, {
+                  timerTriggered: true,
+                  silent: reservation.silent,
+                  silentWake: reservation.silentWake,
+                  startedAt: reservation.createdAt,
+                });
+              } finally {
+                unregisterContinuationTimerHandle(sessionKey, timerHandle);
+              }
+            }, clampedDelay);
+            registerContinuationTimerHandle(sessionKey, timerHandle);
+            timerHandle.unref();
+          } else {
+            await doToolSpawn(nextChainCount, delegate.task, {
+              silent: delegate.silent,
+              silentWake: delegate.silentWake,
+              startedAt: chainStartedAt,
+            });
+          }
+        }
+      }
     }
-    if (responseUsageLine) {
-      finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
+
+    if (!autoCompactionCount && continuationFeatureEnabled && sessionKey) {
+      const stagedCompactionDelegates = consumeStagedPostCompactionDelegates(sessionKey);
+      if (stagedCompactionDelegates.length > 0) {
+        try {
+          await persistPendingPostCompactionDelegates({
+            sessionEntry: activeSessionEntry,
+            sessionStore: activeSessionStore,
+            sessionKey,
+            storePath,
+            delegates: stagedCompactionDelegates,
+          });
+        } catch (err) {
+          postCompactionDelegatesToPreserve.push(...stagedCompactionDelegates);
+          defaultRuntime.log(
+            `Failed to persist post-compaction delegates for ${sessionKey} (re-staged ${stagedCompactionDelegates.length}): ${String(err)}`,
+          );
+        }
+      }
+    }
+
+    // Silent continuations should produce no user-visible output.
+    if (wasSilentContinuation) {
+      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 
     return finalizeWithFollowup(
@@ -1743,6 +3055,15 @@ export async function runReplyAgent(params: {
     replyOperation.complete();
     blockReplyPipeline?.stop();
     typing.markRunComplete();
+    // Drain any stale delegates from a failed turn — they must not leak
+    // into the next successful turn for the same session.
+    if (sessionKey) {
+      consumePendingDelegates(sessionKey);
+      consumeStagedPostCompactionDelegates(sessionKey);
+      for (const delegate of postCompactionDelegatesToPreserve) {
+        stagePostCompactionDelegate(sessionKey, delegate);
+      }
+    }
     // Safety net: the dispatcher's onIdle callback normally fires
     // markDispatchIdle(), but if the dispatcher exits early, errors,
     // or the reply path doesn't go through it cleanly, the second

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -7,6 +7,10 @@ import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
 } from "../../agents/subagent-registry.js";
+import {
+  _resetVolitionalCounts,
+  incrementVolitionalCompactionCount,
+} from "../../agents/tools/request-compaction-tool.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   completeTaskRunByRunId,
@@ -16,6 +20,12 @@ import {
 } from "../../tasks/task-executor.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { configureTaskRegistryRuntime } from "../../tasks/task-registry.store.js";
+import {
+  consumePendingDelegates,
+  consumeStagedPostCompactionDelegates,
+  enqueuePendingDelegate,
+  stagePostCompactionDelegate,
+} from "../continuation-delegate-store.js";
 import { buildStatusReply, buildStatusText } from "./commands-status.js";
 import { buildCommandTestParams } from "./commands.test-harness.js";
 
@@ -481,5 +491,125 @@ describe("buildStatusReply subagent summary", () => {
 
       expect(normalizeTestText(text)).toContain("Context: 1.0k/32k");
     });
+  });
+});
+
+describe("buildStatusText continuation line", () => {
+  const continuationSessionKey = "agent:main:cont-test";
+
+  afterEach(() => {
+    consumePendingDelegates(continuationSessionKey);
+    consumeStagedPostCompactionDelegates(continuationSessionKey);
+    _resetVolitionalCounts(continuationSessionKey);
+  });
+
+  const cfgWithContinuation = {
+    ...baseCfg,
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: true,
+          maxChainLength: 100,
+        },
+      },
+    },
+  } as OpenClawConfig;
+
+  it("shows continuation line when continuation is enabled", async () => {
+    incrementVolitionalCompactionCount(continuationSessionKey);
+
+    const text = await buildStatusText({
+      cfg: cfgWithContinuation,
+      sessionEntry: {
+        sessionId: "cont-test",
+        updatedAt: 0,
+        totalTokens: 0,
+        continuationChainCount: 3,
+        compactionCount: 1,
+      },
+      sessionKey: continuationSessionKey,
+      parentSessionKey: continuationSessionKey,
+      sessionScope: "per-sender",
+      statusChannel: "whatsapp",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      contextTokens: 0,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+    });
+
+    expect(text).toContain("🔄 Continuation: chain 3/100");
+    expect(text).toContain("volitional: 1");
+  });
+
+  it("does not show continuation line when continuation is disabled", async () => {
+    const text = await buildStatusText({
+      cfg: baseCfg,
+      sessionEntry: {
+        sessionId: "cont-test",
+        updatedAt: 0,
+        totalTokens: 0,
+      },
+      sessionKey: continuationSessionKey,
+      parentSessionKey: continuationSessionKey,
+      sessionScope: "per-sender",
+      statusChannel: "whatsapp",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      contextTokens: 0,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+    });
+
+    expect(text).not.toContain("Continuation:");
+  });
+
+  it("renders delegate and post-compaction counts correctly", async () => {
+    incrementVolitionalCompactionCount(continuationSessionKey);
+    incrementVolitionalCompactionCount(continuationSessionKey);
+    enqueuePendingDelegate(continuationSessionKey, { task: "task-a" });
+    enqueuePendingDelegate(continuationSessionKey, { task: "task-b" });
+    stagePostCompactionDelegate(continuationSessionKey, {
+      task: "compaction-task",
+      createdAt: Date.now(),
+      silent: false,
+    });
+
+    const text = await buildStatusText({
+      cfg: cfgWithContinuation,
+      sessionEntry: {
+        sessionId: "cont-test",
+        updatedAt: 0,
+        totalTokens: 0,
+        continuationChainCount: 5,
+        compactionCount: 2,
+      },
+      sessionKey: continuationSessionKey,
+      parentSessionKey: continuationSessionKey,
+      sessionScope: "per-sender",
+      statusChannel: "whatsapp",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      contextTokens: 0,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+    });
+
+    expect(text).toContain("chain 5/100");
+    expect(text).toContain("2 delegates pending");
+    expect(text).toContain("1 post-compaction staged");
+    expect(text).toContain("volitional: 2");
   });
 });

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -156,6 +156,7 @@ export async function resolveCommandsSystemPromptBundle(
     runtimeInfo,
     sandboxInfo,
     memoryCitationsMode: params.cfg?.memory?.citations,
+    continuationEnabled: params.cfg?.agents?.defaults?.continuation?.enabled === true,
   });
 
   return { systemPrompt, tools, skillsPrompt, bootstrapFiles, injectedFiles, sandboxRuntime };

--- a/src/auto-reply/reply/context-pressure.integration.test.ts
+++ b/src/auto-reply/reply/context-pressure.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Phase 2 integration test: verifies context-pressure event appears in the
+ * system event queue BEFORE buildQueuedSystemPrompt would drain it.
+ *
+ * This exercises the real enqueueSystemEvent → peekSystemEventEntries path
+ * to confirm the P1 fix (event ordering) works end-to-end.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { peekSystemEventEntries, drainSystemEventEntries } from "../../infra/system-events.js";
+import { checkContextPressure } from "./context-pressure.js";
+
+const TEST_SESSION_KEY = "phase2-integration-test";
+
+/** Helper: partial SessionEntry for testing */
+function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    totalTokens: 8000,
+    lastContextPressureBand: undefined,
+    ...overrides,
+  } as SessionEntry;
+}
+
+describe("Phase 2 integration: context-pressure → event queue → drain ordering", () => {
+  beforeEach(() => {
+    // Drain any leftover events from prior tests
+    drainSystemEventEntries(TEST_SESSION_KEY);
+  });
+
+  it("event is available in queue BEFORE drain (P1 fix verification)", () => {
+    const entry = makeEntry({ totalTokens: 8500 });
+
+    // 1. checkContextPressure enqueues the event
+    const { fired, band } = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: TEST_SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: 10000,
+    });
+
+    expect(fired).toBe(true);
+    expect(band).toBe(80);
+
+    // 2. Peek — event should be visible (this is what buildQueuedSystemPrompt reads)
+    const peeked = peekSystemEventEntries(TEST_SESSION_KEY);
+    expect(peeked).toBeDefined();
+    expect(peeked.length).toBeGreaterThanOrEqual(1);
+    const pressureEvent = peeked.find((e) => e.text?.includes("[system:context-pressure]"));
+    expect(pressureEvent).toBeDefined();
+    expect(pressureEvent!.text).toContain("85%");
+    expect(pressureEvent!.text).toContain("context window consumed");
+
+    // 3. Drain — event should be consumed (simulating buildQueuedSystemPrompt)
+    const drained = drainSystemEventEntries(TEST_SESSION_KEY);
+    expect(drained).toBeDefined();
+    const drainedPressure = drained.find((e) => e.text?.includes("[system:context-pressure]"));
+    expect(drainedPressure).toBeDefined();
+
+    // 4. After drain, queue should be empty
+    const afterDrain = peekSystemEventEntries(TEST_SESSION_KEY);
+    expect(!afterDrain || afterDrain.length === 0).toBe(true);
+  });
+
+  it("band escalation: 80 → 90 → 95 each produce separate events", () => {
+    const entry = makeEntry({ totalTokens: 8000 });
+
+    // Band 80 (80%)
+    checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: TEST_SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: 10000,
+    });
+    let events = drainSystemEventEntries(TEST_SESSION_KEY);
+    expect(events.some((e) => e.text?.includes("[system:context-pressure]"))).toBe(true);
+
+    // Band 90 (simulate tokens growing)
+    entry.totalTokens = 9200;
+    checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: TEST_SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: 10000,
+    });
+    events = drainSystemEventEntries(TEST_SESSION_KEY);
+    expect(events.some((e) => e.text?.includes("[system:context-pressure]"))).toBe(true);
+
+    // Band 95
+    entry.totalTokens = 9700;
+    checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: TEST_SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: 10000,
+    });
+    events = drainSystemEventEntries(TEST_SESSION_KEY);
+    const imminent = events.find((e) => e.text?.toLowerCase().includes("imminent"));
+    expect(imminent).toBeDefined();
+  });
+
+  it("dedup: same band does not produce duplicate events", () => {
+    const entry = makeEntry({ totalTokens: 8500 });
+
+    // First fire at band 80
+    const r1 = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: TEST_SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: 10000,
+    });
+    expect(r1.fired).toBe(true);
+    drainSystemEventEntries(TEST_SESSION_KEY);
+
+    // Second call at same band — should NOT fire
+    const r2 = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: TEST_SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: 10000,
+    });
+    expect(r2.fired).toBe(false);
+
+    // Queue should be empty
+    const events = peekSystemEventEntries(TEST_SESSION_KEY);
+    expect(!events || events.length === 0).toBe(true);
+  });
+
+  it("threshold 0.1 fires immediately (Phase 2 live-fire config)", () => {
+    const entry = makeEntry({ totalTokens: 1500 });
+
+    const { fired, band } = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: TEST_SESSION_KEY,
+      contextPressureThreshold: 0.1,
+      contextWindowTokens: 10000,
+    });
+
+    expect(fired).toBe(true);
+    expect(band).toBe(10);
+
+    const events = drainSystemEventEntries(TEST_SESSION_KEY);
+    const pressureEvent = events.find((e) => e.text?.includes("[system:context-pressure]"));
+    expect(pressureEvent).toBeDefined();
+    expect(pressureEvent!.text).toContain("15%");
+  });
+
+  it("disabled config produces no events", () => {
+    const entry = makeEntry({ totalTokens: 9500 });
+
+    const { fired } = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: TEST_SESSION_KEY,
+      contextPressureThreshold: undefined,
+      contextWindowTokens: 10000,
+    });
+
+    expect(fired).toBe(false);
+    const events = peekSystemEventEntries(TEST_SESSION_KEY);
+    expect(!events || events.length === 0).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/context-pressure.test.ts
+++ b/src/auto-reply/reply/context-pressure.test.ts
@@ -1,0 +1,566 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
+/**
+ * Context-pressure awareness tests (#165).
+ *
+ * Tests the `checkContextPressure` injection logic that fires
+ * [system:context-pressure] events when session token usage crosses
+ * configurable thresholds. Dedup via `lastContextPressureBand` on
+ * the session entry prevents repeated events within the same band.
+ *
+ * The function under test is imported from context-pressure.ts (created by #164).
+ * Signature:
+ *   checkContextPressure(params: {
+ *     sessionEntry: SessionEntry;
+ *     sessionKey: string;
+ *     contextPressureThreshold: number;
+ *     contextWindowTokens: number;
+ *   }): { fired: boolean; band: number }
+ */
+// The module will be created by #164. Import will resolve once Cael pushes.
+// Until then, tests will fail at import — that's intentional (test-first).
+import { checkContextPressure } from "./context-pressure.js";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+/** Partial mock — SessionEntry has ~40 optional fields; we only set what the function reads. */
+function makeSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    totalTokens: 0,
+    totalTokensFresh: true,
+    lastContextPressureBand: undefined,
+    ...overrides,
+  } as SessionEntry;
+}
+
+const SESSION_KEY = "test:context-pressure";
+const CONTEXT_WINDOW = 100_000; // 100k token context window
+
+/* ------------------------------------------------------------------ */
+/*  Setup / teardown                                                  */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+  resetSystemEventsForTest();
+});
+
+afterEach(() => {
+  resetSystemEventsForTest();
+});
+
+/* ------------------------------------------------------------------ */
+/*  No event when threshold not configured                            */
+/* ------------------------------------------------------------------ */
+
+describe("checkContextPressure", () => {
+  it("does not fire when contextPressureThreshold is undefined", () => {
+    const entry = makeSessionEntry({ totalTokens: 90_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: undefined as unknown as number,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+    const events = peekSystemEvents(SESSION_KEY);
+    expect(events).toHaveLength(0);
+  });
+
+  it("does not fire when contextPressureThreshold is 0 if called directly", () => {
+    const entry = makeSessionEntry({ totalTokens: 90_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+    expect(peekSystemEvents(SESSION_KEY)).toHaveLength(0);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  No event below threshold                                        */
+  /* ---------------------------------------------------------------- */
+
+  it("does not fire at 75% when threshold is 0.8", () => {
+    const entry = makeSessionEntry({ totalTokens: 75_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  it("does not fire at exactly threshold boundary minus 1 token", () => {
+    const entry = makeSessionEntry({ totalTokens: 79_999, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Event fires at threshold                                        */
+  /* ---------------------------------------------------------------- */
+
+  it("fires at 80% when threshold is 0.8", () => {
+    const entry = makeSessionEntry({ totalTokens: 80_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(80);
+    expect(entry.lastContextPressureBand).toBe(80);
+  });
+
+  it("fires at 85% when threshold is 0.8 (still in first band)", () => {
+    const entry = makeSessionEntry({ totalTokens: 85_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(80);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Band escalation                                                 */
+  /* ---------------------------------------------------------------- */
+
+  it("fires at 90% with band 90", () => {
+    const entry = makeSessionEntry({ totalTokens: 90_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(90);
+    expect(entry.lastContextPressureBand).toBe(90);
+  });
+
+  it("fires at 95% with band 95 and imminent language", () => {
+    const entry = makeSessionEntry({ totalTokens: 95_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(95);
+    expect(entry.lastContextPressureBand).toBe(95);
+    // Verify the event text contains imminent language
+    const events = peekSystemEvents(SESSION_KEY);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0]).toMatch(/imminent/i);
+  });
+
+  it("fires at 99% with band 95", () => {
+    const entry = makeSessionEntry({ totalTokens: 99_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(95);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Dedup — no duplicate within same band                           */
+  /* ---------------------------------------------------------------- */
+
+  it("does not fire again within the same band", () => {
+    const entry = makeSessionEntry({
+      totalTokens: 82_000,
+      totalTokensFresh: true,
+      lastContextPressureBand: 80,
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(80);
+  });
+
+  it("does not fire at 88% when band 80 already emitted", () => {
+    const entry = makeSessionEntry({
+      totalTokens: 88_000,
+      totalTokensFresh: true,
+      lastContextPressureBand: 80,
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(80);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Dedup — fires when crossing into next band                      */
+  /* ---------------------------------------------------------------- */
+
+  it("fires when crossing from band 80 to band 90", () => {
+    const entry = makeSessionEntry({
+      totalTokens: 91_000,
+      totalTokensFresh: true,
+      lastContextPressureBand: 80,
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(90);
+    expect(entry.lastContextPressureBand).toBe(90);
+  });
+
+  it("fires when crossing from band 90 to band 95", () => {
+    const entry = makeSessionEntry({
+      totalTokens: 96_000,
+      totalTokensFresh: true,
+      lastContextPressureBand: 90,
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(95);
+    expect(entry.lastContextPressureBand).toBe(95);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Stale data guard                                                */
+  /* ---------------------------------------------------------------- */
+
+  it("does not fire when totalTokensFresh is false", () => {
+    const entry = makeSessionEntry({
+      totalTokens: 90_000,
+      totalTokensFresh: false,
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  it("does not fire when totalTokens is undefined", () => {
+    const entry = makeSessionEntry({
+      totalTokens: undefined,
+      totalTokensFresh: true,
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  it("does not fire when totalTokens is 0", () => {
+    const entry = makeSessionEntry({
+      totalTokens: 0,
+      totalTokensFresh: true,
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Context window edge cases                                       */
+  /* ---------------------------------------------------------------- */
+
+  it("does not fire when contextWindowTokens is 0", () => {
+    const entry = makeSessionEntry({ totalTokens: 90_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: 0,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Event text content                                              */
+  /* ---------------------------------------------------------------- */
+
+  it("includes correct percentage in event text", () => {
+    const entry = makeSessionEntry({ totalTokens: 85_000, totalTokensFresh: true });
+    checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    const events = peekSystemEvents(SESSION_KEY);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0]).toMatch(/85%/);
+  });
+
+  it("includes token counts in event text", () => {
+    const entry = makeSessionEntry({ totalTokens: 85_000, totalTokensFresh: true });
+    checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    const events = peekSystemEvents(SESSION_KEY);
+    expect(events.length).toBeGreaterThan(0);
+    // 85k / 100k
+    expect(events[0]).toMatch(/85k/);
+    expect(events[0]).toMatch(/100k/);
+  });
+
+  it("uses evacuation language at sub-95% bands", () => {
+    const entry = makeSessionEntry({ totalTokens: 85_000, totalTokensFresh: true });
+    checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    const events = peekSystemEvents(SESSION_KEY);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0]).toMatch(/evacuat/i);
+    expect(events[0]).not.toMatch(/imminent/i);
+  });
+
+  it("uses imminent language at 95%+ band", () => {
+    const entry = makeSessionEntry({ totalTokens: 97_000, totalTokensFresh: true });
+    checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    const events = peekSystemEvents(SESSION_KEY);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0]).toMatch(/imminent/i);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Custom threshold values                                         */
+  /* ---------------------------------------------------------------- */
+
+  it("respects custom threshold of 0.5", () => {
+    const entry = makeSessionEntry({ totalTokens: 50_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.5,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(50);
+  });
+
+  it("does not fire below custom threshold of 0.5", () => {
+    const entry = makeSessionEntry({ totalTokens: 49_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.5,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  it("respects thresholds above 90% without collapsing to the 90 band", () => {
+    const entry = makeSessionEntry({ totalTokens: 94_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.94,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(94);
+  });
+
+  it("does not backslide from a custom 94% band to 90% on later turns", () => {
+    const entry = makeSessionEntry({
+      totalTokens: 91_000,
+      totalTokensFresh: true,
+      lastContextPressureBand: 94,
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.94,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Session reset (band clears)                                     */
+  /* ---------------------------------------------------------------- */
+
+  it("fires again after band is cleared (session reset)", () => {
+    const entry = makeSessionEntry({
+      totalTokens: 85_000,
+      totalTokensFresh: true,
+      lastContextPressureBand: undefined, // cleared by session reset
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(80);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Edge cases from review (ratio > 1.0, negative tokens)           */
+  /* ---------------------------------------------------------------- */
+
+  it("handles ratio > 1.0 (tokens exceed window) as band 95", () => {
+    const entry = makeSessionEntry({ totalTokens: 120_000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(95);
+  });
+
+  it("does not fire for negative totalTokens", () => {
+    const entry = makeSessionEntry({ totalTokens: -1000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  it("does not fire for NaN totalTokens", () => {
+    const entry = makeSessionEntry({ totalTokens: NaN, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  it("custom threshold above 0.9 is not shadowed by fixed 90 band", () => {
+    // At 92% usage with threshold 0.92, should fire at custom band 92, not fixed band 90
+    const entry = makeSessionEntry({ totalTokens: 92000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.92,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(92);
+  });
+
+  it("custom threshold 0.94 at 91% does not fire (below threshold)", () => {
+    const entry = makeSessionEntry({ totalTokens: 91000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.94,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(false);
+    expect(result.band).toBe(0);
+  });
+
+  it("fixed 95 band still fires above custom threshold in (0.9, 0.95)", () => {
+    const entry = makeSessionEntry({ totalTokens: 96000, totalTokensFresh: true });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.92,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(95);
+  });
+
+  it("band resets allow re-fire after compaction", () => {
+    const entry = makeSessionEntry({
+      totalTokens: 92000,
+      totalTokensFresh: true,
+      lastContextPressureBand: 0,
+    });
+    const result = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.band).toBe(90);
+    // After compaction resets the band to 0 and tokens drop:
+    entry.lastContextPressureBand = 0;
+    entry.totalTokens = 82000;
+    const result2 = checkContextPressure({
+      sessionEntry: entry,
+      sessionKey: SESSION_KEY,
+      contextPressureThreshold: 0.8,
+      contextWindowTokens: CONTEXT_WINDOW,
+    });
+    expect(result2.fired).toBe(true);
+    expect(result2.band).toBe(80);
+  });
+});

--- a/src/auto-reply/reply/context-pressure.ts
+++ b/src/auto-reply/reply/context-pressure.ts
@@ -1,0 +1,91 @@
+import type { SessionEntry } from "../../config/sessions.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("continuation/context-pressure");
+
+export interface CheckContextPressureParams {
+  sessionEntry: SessionEntry;
+  sessionKey: string;
+  contextPressureThreshold: number | undefined;
+  contextWindowTokens: number;
+}
+
+export interface CheckContextPressureResult {
+  fired: boolean;
+  band: number;
+}
+
+/**
+ * Check whether the session's token usage has crossed a context-pressure
+ * threshold band and, if so, enqueue a `[system:context-pressure]` event.
+ *
+ * Bands are fixed at 90 and 95; the first band uses the configured threshold
+ * rounded to percentage (e.g. 0.8 → 80, 0.5 → 50). Dedup is via
+ * `lastContextPressureBand` on the session entry — each band fires once.
+ *
+ * Returns `{ fired, band }` so callers can persist the band to the session store.
+ */
+export function checkContextPressure(
+  params: CheckContextPressureParams,
+): CheckContextPressureResult {
+  const { sessionEntry, sessionKey, contextPressureThreshold, contextWindowTokens } = params;
+
+  // Guard: feature disabled or no usable data.
+  // Zod rejects 0 because "fire on empty session" is not a useful configuration.
+  // Negative totalTokens (data corruption) produces a negative ratio which falls below
+  // all band thresholds → band = 0 → no event. Safe by arithmetic, not by explicit guard.
+  if (
+    contextPressureThreshold == null ||
+    contextPressureThreshold <= 0 ||
+    contextWindowTokens <= 0 ||
+    sessionEntry.totalTokens == null ||
+    sessionEntry.totalTokens <= 0 ||
+    sessionEntry.totalTokensFresh === false
+  ) {
+    return { fired: false, band: 0 };
+  }
+
+  // Clamp ratio to [0, ∞) — negative should not occur after the guard above,
+  // but defensive. Ratios > 1.0 are valid (token overrun).
+  const ratio = Math.max(0, sessionEntry.totalTokens / contextWindowTokens);
+  const thresholdPct = Math.round(contextPressureThreshold * 100);
+  const bandThresholds = [
+    { threshold: contextPressureThreshold, band: thresholdPct },
+    ...(contextPressureThreshold < 0.9 ? [{ threshold: 0.9, band: 90 }] : []),
+    ...(Math.max(contextPressureThreshold, 0.9) < 0.95 ? [{ threshold: 0.95, band: 95 }] : []),
+  ];
+  let band = 0;
+  for (const candidate of bandThresholds) {
+    if (ratio >= candidate.threshold) {
+      band = candidate.band;
+    }
+  }
+
+  if (band === 0 || band === (sessionEntry.lastContextPressureBand ?? 0)) {
+    return { fired: false, band };
+  }
+
+  const pct = Math.round(ratio * 100);
+  const tokensK = Math.round(sessionEntry.totalTokens / 1000);
+  const windowK = Math.round(contextWindowTokens / 1000);
+
+  const urgency =
+    band >= 95
+      ? `🚨 COMPACTION IMMINENT — evacuate working state NOW. Use CONTINUE_DELEGATE to dispatch shards or write critical state to memory files immediately. This is your last chance before context resets.`
+      : band >= 90
+        ? `⚠️ CONTEXT WINDOW NEARLY FULL — strongly consider evacuating working state via CONTINUE_DELEGATE or memory files. Compaction will occur soon.`
+        : `⚠️ CONTEXT PRESSURE — acknowledge this event and begin planning evacuation. Save important state to memory files or prepare CONTINUE_DELEGATE shards.`;
+
+  log.debug(
+    `[context-pressure:fire] band=${band} ratio=${pct}% tokens=${tokensK}k/${windowK}k session=${sessionKey}`,
+  );
+
+  enqueueSystemEvent(
+    `[system:context-pressure] ${pct}% of context window consumed (${tokensK}k / ${windowK}k tokens). ${urgency}`,
+    { sessionKey },
+  );
+
+  sessionEntry.lastContextPressureBand = band;
+  return { fired: true, band };
+}

--- a/src/auto-reply/reply/continuation-runtime.test.ts
+++ b/src/auto-reply/reply/continuation-runtime.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setRuntimeConfigSnapshot, clearRuntimeConfigSnapshot } from "../../config/io.js";
+import {
+  resolveContinuationRuntimeConfig,
+  resolveMaxDelegatesPerTurn,
+} from "./continuation-runtime.js";
+
+describe("continuation runtime config", () => {
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("clamps invalid numeric values back to safe defaults", () => {
+    setRuntimeConfigSnapshot({
+      agents: {
+        defaults: {
+          continuation: {
+            enabled: true,
+            defaultDelayMs: -1,
+            minDelayMs: Number.NaN,
+            maxDelayMs: -10,
+            maxChainLength: 0,
+            costCapTokens: -50,
+            maxDelegatesPerTurn: 0,
+            generationGuardTolerance: -3,
+            contextPressureThreshold: 2,
+          },
+        },
+      },
+    } as Parameters<typeof setRuntimeConfigSnapshot>[0]);
+
+    expect(resolveContinuationRuntimeConfig()).toEqual({
+      enabled: true,
+      taskFlowDelegates: false,
+      defaultDelayMs: 15_000,
+      minDelayMs: 5_000,
+      maxDelayMs: 300_000,
+      maxChainLength: 10,
+      costCapTokens: 500_000,
+      maxDelegatesPerTurn: 5,
+      generationGuardTolerance: 0,
+      contextPressureThreshold: undefined,
+    });
+  });
+
+  it("truncates positive numeric fields while preserving valid fractional thresholds", () => {
+    setRuntimeConfigSnapshot({
+      agents: {
+        defaults: {
+          continuation: {
+            defaultDelayMs: 15_999.8,
+            minDelayMs: 5_001.2,
+            maxDelayMs: 300_999.7,
+            maxChainLength: 2.9,
+            costCapTokens: 1234.8,
+            maxDelegatesPerTurn: 7.6,
+            generationGuardTolerance: 4.9,
+            contextPressureThreshold: 0.8,
+          },
+        },
+      },
+    } as Parameters<typeof setRuntimeConfigSnapshot>[0]);
+
+    expect(resolveContinuationRuntimeConfig()).toMatchObject({
+      defaultDelayMs: 15_999,
+      minDelayMs: 5_001,
+      maxDelayMs: 300_999,
+      maxChainLength: 2,
+      costCapTokens: 1234,
+      maxDelegatesPerTurn: 7,
+      generationGuardTolerance: 4,
+      contextPressureThreshold: 0.8,
+    });
+  });
+
+  it("treats non-positive contextPressureThreshold values as unset", () => {
+    setRuntimeConfigSnapshot({
+      agents: {
+        defaults: {
+          continuation: {
+            contextPressureThreshold: 0,
+          },
+        },
+      },
+    } as Parameters<typeof setRuntimeConfigSnapshot>[0]);
+
+    expect(resolveContinuationRuntimeConfig()).toMatchObject({
+      contextPressureThreshold: undefined,
+    });
+  });
+
+  it("allows zero delay bounds for runtime-only/test overrides", () => {
+    setRuntimeConfigSnapshot({
+      agents: {
+        defaults: {
+          continuation: {
+            defaultDelayMs: 0,
+            minDelayMs: 0,
+            maxDelayMs: 0,
+          },
+        },
+      },
+    } as Parameters<typeof setRuntimeConfigSnapshot>[0]);
+
+    expect(resolveContinuationRuntimeConfig()).toMatchObject({
+      defaultDelayMs: 0,
+      minDelayMs: 0,
+      maxDelayMs: 0,
+    });
+  });
+
+  it("exposes resolveMaxDelegatesPerTurn as a live convenience accessor", () => {
+    setRuntimeConfigSnapshot({
+      agents: {
+        defaults: {
+          continuation: {
+            maxDelegatesPerTurn: 12,
+          },
+        },
+      },
+    } as Parameters<typeof setRuntimeConfigSnapshot>[0]);
+
+    expect(resolveMaxDelegatesPerTurn()).toBe(12);
+  });
+});

--- a/src/auto-reply/reply/continuation-runtime.ts
+++ b/src/auto-reply/reply/continuation-runtime.ts
@@ -1,0 +1,95 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
+
+export type ContinuationRuntimeConfig = {
+  enabled: boolean;
+  taskFlowDelegates: boolean;
+  defaultDelayMs: number;
+  minDelayMs: number;
+  maxDelayMs: number;
+  maxChainLength: number;
+  costCapTokens: number;
+  maxDelegatesPerTurn: number;
+  generationGuardTolerance: number;
+  contextPressureThreshold?: number;
+};
+
+const DEFAULT_CONTINUATION_DELAY_MS = 15_000;
+const DEFAULT_CONTINUATION_MIN_DELAY_MS = 5_000;
+const DEFAULT_CONTINUATION_MAX_DELAY_MS = 300_000;
+const DEFAULT_CONTINUATION_MAX_CHAIN_LENGTH = 10;
+const DEFAULT_CONTINUATION_COST_CAP_TOKENS = 500_000;
+const DEFAULT_CONTINUATION_MAX_DELEGATES_PER_TURN = 5;
+const DEFAULT_CONTINUATION_GENERATION_GUARD_TOLERANCE = 0;
+
+function clampPositiveInt(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.max(1, Math.trunc(value));
+}
+
+function clampNonNegativeDelayMs(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+  return Math.max(0, Math.trunc(value));
+}
+
+function clampNonNegativeInt(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+  return Math.max(0, Math.trunc(value));
+}
+
+function clampOptionalUnitInterval(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0 || value > 1) {
+    return undefined;
+  }
+  return value;
+}
+
+export function resolveContinuationRuntimeConfig(
+  cfg: OpenClawConfig = loadConfig(),
+): ContinuationRuntimeConfig {
+  const continuation = cfg.agents?.defaults?.continuation;
+
+  return {
+    enabled: continuation?.enabled === true,
+    taskFlowDelegates: continuation?.taskFlowDelegates === true,
+    defaultDelayMs: clampNonNegativeDelayMs(
+      continuation?.defaultDelayMs,
+      DEFAULT_CONTINUATION_DELAY_MS,
+    ),
+    minDelayMs: clampNonNegativeDelayMs(
+      continuation?.minDelayMs,
+      DEFAULT_CONTINUATION_MIN_DELAY_MS,
+    ),
+    maxDelayMs: clampNonNegativeDelayMs(
+      continuation?.maxDelayMs,
+      DEFAULT_CONTINUATION_MAX_DELAY_MS,
+    ),
+    maxChainLength: clampPositiveInt(
+      continuation?.maxChainLength,
+      DEFAULT_CONTINUATION_MAX_CHAIN_LENGTH,
+    ),
+    costCapTokens: clampNonNegativeInt(
+      continuation?.costCapTokens,
+      DEFAULT_CONTINUATION_COST_CAP_TOKENS,
+    ),
+    maxDelegatesPerTurn: clampPositiveInt(
+      continuation?.maxDelegatesPerTurn,
+      DEFAULT_CONTINUATION_MAX_DELEGATES_PER_TURN,
+    ),
+    generationGuardTolerance: clampNonNegativeInt(
+      continuation?.generationGuardTolerance,
+      DEFAULT_CONTINUATION_GENERATION_GUARD_TOLERANCE,
+    ),
+    contextPressureThreshold: clampOptionalUnitInterval(continuation?.contextPressureThreshold),
+  };
+}
+
+export function resolveMaxDelegatesPerTurn(cfg: OpenClawConfig = loadConfig()): number {
+  return resolveContinuationRuntimeConfig(cfg).maxDelegatesPerTurn;
+}

--- a/src/auto-reply/reply/continuation-state.runtime.ts
+++ b/src/auto-reply/reply/continuation-state.runtime.ts
@@ -1,0 +1,10 @@
+export {
+  bumpContinuationGeneration,
+  clearDelegatePending,
+  currentContinuationGeneration,
+  registerContinuationTimerHandle,
+  releaseContinuationTimerRef,
+  retainContinuationTimerRef,
+  setDelegatePending,
+  unregisterContinuationTimerHandle,
+} from "./continuation-state.js";

--- a/src/auto-reply/reply/continuation-state.ts
+++ b/src/auto-reply/reply/continuation-state.ts
@@ -1,0 +1,108 @@
+import { delayedContinuationReservationCount } from "../continuation-delegate-store.js";
+
+type ContinuationTimerHandle = ReturnType<typeof setTimeout>;
+
+const continuationGenerations = new Map<string, number>();
+const continuationTimerRefs = new Map<string, number>();
+const continuationTimerHandles = new Map<string, Set<ContinuationTimerHandle>>();
+const delegatePendingFlags = new Map<string, boolean>();
+
+export function setDelegatePending(sessionKey: string): void {
+  delegatePendingFlags.set(sessionKey, true);
+}
+
+export function hasDelegatePending(sessionKey: string): boolean {
+  return delegatePendingFlags.get(sessionKey) === true;
+}
+
+export function clearDelegatePending(sessionKey: string): void {
+  delegatePendingFlags.delete(sessionKey);
+  bumpContinuationGeneration(sessionKey);
+  maybeDropContinuationGeneration(sessionKey);
+}
+
+export function clearDelegatePendingIfNoDelayedReservations(sessionKey: string): void {
+  if (delayedContinuationReservationCount(sessionKey) === 0) {
+    clearDelegatePending(sessionKey);
+  }
+}
+
+export function currentContinuationGeneration(sessionKey: string): number {
+  return continuationGenerations.get(sessionKey) ?? 0;
+}
+
+export function bumpContinuationGeneration(sessionKey: string): number {
+  const next = currentContinuationGeneration(sessionKey) + 1;
+  continuationGenerations.set(sessionKey, next);
+  return next;
+}
+
+export function hasLiveContinuationTimerRefs(sessionKey: string): boolean {
+  return (continuationTimerRefs.get(sessionKey) ?? 0) > 0;
+}
+
+export function maybeDropContinuationGeneration(sessionKey: string): void {
+  if (hasLiveContinuationTimerRefs(sessionKey)) {
+    return;
+  }
+  if (delayedContinuationReservationCount(sessionKey) > 0) {
+    return;
+  }
+  continuationGenerations.delete(sessionKey);
+}
+
+export function retainContinuationTimerRef(sessionKey: string): void {
+  continuationTimerRefs.set(sessionKey, (continuationTimerRefs.get(sessionKey) ?? 0) + 1);
+}
+
+export function releaseContinuationTimerRef(sessionKey: string): void {
+  const current = continuationTimerRefs.get(sessionKey) ?? 0;
+  if (current <= 1) {
+    continuationTimerRefs.delete(sessionKey);
+  } else {
+    continuationTimerRefs.set(sessionKey, current - 1);
+  }
+  maybeDropContinuationGeneration(sessionKey);
+}
+
+export function registerContinuationTimerHandle(
+  sessionKey: string,
+  handle: ContinuationTimerHandle,
+): void {
+  const existing = continuationTimerHandles.get(sessionKey);
+  if (existing) {
+    existing.add(handle);
+    return;
+  }
+  continuationTimerHandles.set(sessionKey, new Set([handle]));
+}
+
+export function unregisterContinuationTimerHandle(
+  sessionKey: string,
+  handle: ContinuationTimerHandle,
+): boolean {
+  const existing = continuationTimerHandles.get(sessionKey);
+  if (!existing?.delete(handle)) {
+    return false;
+  }
+  if (existing.size === 0) {
+    continuationTimerHandles.delete(sessionKey);
+  }
+  releaseContinuationTimerRef(sessionKey);
+  return true;
+}
+
+export function clearTrackedContinuationTimers(sessionKey: string): void {
+  const existing = continuationTimerHandles.get(sessionKey);
+  if (!existing || existing.size === 0) {
+    return;
+  }
+  continuationTimerHandles.delete(sessionKey);
+  for (const handle of existing) {
+    clearTimeout(handle);
+    const releaseHandle = setTimeout(() => {
+      releaseContinuationTimerRef(sessionKey);
+    }, 0);
+    releaseHandle.unref();
+  }
+}

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -67,10 +67,16 @@ vi.mock("../command-detection.js", () => ({
 
 vi.mock("./agent-runner.runtime.js", () => ({
   runReplyAgent: vi.fn().mockResolvedValue({ text: "ok" }),
+  cancelContinuationTimer: vi.fn(),
+  clearDelegatePending: vi.fn(),
 }));
 
 vi.mock("./body.js", () => ({
   applySessionHints: vi.fn().mockImplementation(async ({ baseBody }) => baseBody),
+}));
+
+vi.mock("./context-pressure.js", () => ({
+  checkContextPressure: vi.fn().mockReturnValue({ fired: false, band: 0 }),
 }));
 
 vi.mock("./groups.js", () => ({
@@ -108,6 +114,7 @@ vi.mock("./typing-mode.js", () => ({
 }));
 
 let runPreparedReply: typeof import("./get-reply-run.js").runPreparedReply;
+let clearDelegatePending: typeof import("./agent-runner.runtime.js").clearDelegatePending;
 let runReplyAgent: typeof import("./agent-runner.runtime.js").runReplyAgent;
 let routeReply: typeof import("./route-reply.runtime.js").routeReply;
 let drainFormattedSystemEvents: typeof import("./session-system-events.js").drainFormattedSystemEvents;
@@ -208,7 +215,7 @@ function baseParams(
 describe("runPreparedReply media-only handling", () => {
   beforeAll(async () => {
     ({ runPreparedReply } = await import("./get-reply-run.js"));
-    ({ runReplyAgent } = await import("./agent-runner.runtime.js"));
+    ({ clearDelegatePending, runReplyAgent } = await import("./agent-runner.runtime.js"));
     ({ routeReply } = await import("./route-reply.runtime.js"));
     ({ drainFormattedSystemEvents } = await import("./session-system-events.js"));
     ({ resolveTypingMode } = await import("./typing-mode.js"));
@@ -699,6 +706,42 @@ describe("runPreparedReply media-only handling", () => {
       | { suppressTyping?: boolean }
       | undefined;
     expect(call?.suppressTyping).toBe(true);
+  });
+
+  it("marks delegate-return turns as continuation wakes and clears delegate-pending state", async () => {
+    await runPreparedReply(
+      baseParams({
+        opts: {
+          continuationTrigger: "delegate-return",
+        },
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call?.isContinuationWake).toBe(true);
+    expect(vi.mocked(clearDelegatePending)).toHaveBeenCalledWith("session-key");
+  });
+
+  it("marks work-wake turns as continuation wakes without clearing delegate-pending state", async () => {
+    await runPreparedReply(
+      baseParams({
+        opts: {
+          continuationTrigger: "work-wake",
+        },
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call?.isContinuationWake).toBe(true);
+    expect(vi.mocked(clearDelegatePending)).not.toHaveBeenCalled();
+  });
+
+  it("leaves ordinary turns unmarked as continuation wakes", async () => {
+    await runPreparedReply(baseParams());
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call?.isContinuationWake).toBe(false);
+    expect(vi.mocked(clearDelegatePending)).not.toHaveBeenCalled();
   });
 
   it("routes queued system events into user prompt text, not system prompt context", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -251,6 +251,9 @@ export async function runPreparedReply(
   const isGroupChat = sessionCtx.ChatType === "group";
   const wasMentioned = ctx.WasMentioned === true;
   const isHeartbeat = opts?.isHeartbeat === true;
+  const continuationTrigger = opts?.continuationTrigger;
+  const isDelegateWake = continuationTrigger === "delegate-return";
+  const isContinuationWake = continuationTrigger === "work-wake" || isDelegateWake;
   const { typingPolicy, suppressTyping } = resolveRunTypingPolicy({
     requestedPolicy: opts?.typingPolicy,
     suppressTyping: opts?.suppressTyping === true,
@@ -540,7 +543,6 @@ export async function runPreparedReply(
         storePath,
         isNewSession,
       });
-  const { runReplyAgent } = await loadAgentRunnerRuntime();
   const queueKey = sessionKey ?? sessionIdFinal;
   preparedSessionState = resolvePreparedSessionState();
   const resolveActiveQueueSessionId = () =>
@@ -690,6 +692,10 @@ export async function runPreparedReply(
     },
   };
 
+  const { clearDelegatePending, runReplyAgent } = await loadAgentRunnerRuntime();
+  if (isDelegateWake && sessionKey) {
+    clearDelegatePending(sessionKey);
+  }
   return runReplyAgent({
     commandBody: prefixedCommandBody,
     followupRun,
@@ -721,6 +727,7 @@ export async function runPreparedReply(
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    isContinuationWake,
     resetTriggered,
   });
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -10,6 +10,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { removeSystemEvents } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
@@ -18,6 +19,7 @@ import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import { normalizeVerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
+import { cancelContinuationTimer } from "./agent-runner.js";
 import { resolveDefaultModel } from "./directive-handling.defaults.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
@@ -446,6 +448,12 @@ export async function getReplyFromConfig(
     skillFilter: mergedSkillFilter,
   });
   if (directiveResult.kind === "reply") {
+    // Directive-handled replies bypass runReplyAgent — cancel pending timers,
+    // reset chain metadata, and drain stale wake events.
+    if (sessionKey && !opts?.isHeartbeat) {
+      cancelContinuationTimer(sessionKey, { sessionEntry, sessionStore, storePath });
+      removeSystemEvents(sessionKey, (e) => e.text?.startsWith("[continuation:wake]") ?? false);
+    }
     return directiveResult.reply;
   }
 
@@ -543,6 +551,13 @@ export async function getReplyFromConfig(
     skillFilter: mergedSkillFilter,
   });
   if (inlineActionResult.kind === "reply") {
+    // Inline actions (slash commands, status, etc.) bypass runReplyAgent but
+    // represent real user input — cancel timers, reset chain metadata, drain
+    // stale wake events.
+    if (sessionKey && !opts?.isHeartbeat) {
+      cancelContinuationTimer(sessionKey, { sessionEntry, sessionStore, storePath });
+      removeSystemEvents(sessionKey, (e) => e.text?.startsWith("[continuation:wake]") ?? false);
+    }
     await maybeEmitMissingResetHooks();
     return inlineActionResult.reply;
   }

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -84,6 +84,7 @@ export type FollowupRun = {
     enforceFinalTag?: boolean;
     skipProviderRuntimeHints?: boolean;
     silentExpected?: boolean;
+    drainsContinuationDelegateQueue?: boolean;
   };
 };
 

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -416,7 +416,12 @@ describe("resolveMemoryFlushContextWindowTokens", () => {
 
 describe("incrementCompactionCount", () => {
   it("increments compaction count", async () => {
-    const entry = { sessionId: "s1", updatedAt: Date.now(), compactionCount: 2 } as SessionEntry;
+    const entry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      compactionCount: 2,
+      lastContextPressureBand: 90,
+    } as SessionEntry;
     const { storePath, sessionKey, sessionStore } = await createCompactionSessionFixture(entry);
 
     const count = await incrementCompactionCount({
@@ -429,6 +434,7 @@ describe("incrementCompactionCount", () => {
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
     expect(stored[sessionKey].compactionCount).toBe(3);
+    expect(stored[sessionKey].lastContextPressureBand).toBeUndefined();
   });
 
   it("updates totalTokens when tokensAfter is provided", async () => {

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -7,7 +7,7 @@ import {
   type ModelAliasIndex,
 } from "../../agents/model-selection.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { updateSessionStore } from "../../config/sessions.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -79,7 +79,11 @@ function applySelectionToSession(params: {
   sessionStore[sessionKey] = sessionEntry;
   if (storePath) {
     updateSessionStore(storePath, (store) => {
-      store[sessionKey] = sessionEntry;
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      store[resolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     }).catch(() => {
       // Ignore persistence errors; session still proceeds.
     });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -14,7 +14,9 @@ import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   type SessionEntry,
+  resolveSessionStoreEntry,
   updateSessionStore,
+  updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveStableSessionEndTranscript } from "../../gateway/session-transcript-files.fs.js";
@@ -43,7 +45,11 @@ async function persistSessionEntryUpdate(params: {
     return;
   }
   await updateSessionStore(params.storePath, (store) => {
-    store[params.sessionKey!] = { ...store[params.sessionKey!], ...params.nextEntry };
+    const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey! });
+    store[resolved.normalizedKey] = { ...resolved.existing, ...params.nextEntry };
+    for (const legacyKey of resolved.legacyKeys) {
+      delete store[legacyKey];
+    }
   });
 }
 
@@ -243,6 +249,7 @@ export async function incrementCompactionCount(params: {
   // Build update payload with compaction count and optionally updated token counts
   const updates: Partial<SessionEntry> = {
     compactionCount: nextCount,
+    lastContextPressureBand: undefined,
     updatedAt: now,
   };
   if (newSessionId && newSessionId !== entry.sessionId) {
@@ -269,11 +276,10 @@ export async function incrementCompactionCount(params: {
     ...updates,
   };
   if (storePath) {
-    await updateSessionStore(storePath, (store) => {
-      store[sessionKey] = {
-        ...store[sessionKey],
-        ...updates,
-      };
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      update: async () => updates,
     });
   }
   if (newSessionId && newSessionId !== entry.sessionId && cfg) {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1610,6 +1610,8 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       thinkingLevel: "high",
       reasoningLevel: "low",
       label: "telegram-priority",
+      lastContextPressureBand: 95,
+      pendingPostCompactionDelegates: [{ task: "carry notes", createdAt: 1 }],
     } as const;
     const cases = [
       {
@@ -1653,7 +1655,14 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect(result.isNewSession, testCase.name).toBe(true);
       expect(result.resetTriggered, testCase.name).toBe(true);
       expect(result.sessionId, testCase.name).not.toBe(existingSessionId);
-      expect(result.sessionEntry, testCase.name).toMatchObject(overrides);
+      expect(result.sessionEntry, testCase.name).toMatchObject({
+        verboseLevel: "on",
+        thinkingLevel: "high",
+        reasoningLevel: "low",
+        label: "telegram-priority",
+      });
+      expect(result.sessionEntry.lastContextPressureBand, testCase.name).toBeUndefined();
+      expect(result.sessionEntry.pendingPostCompactionDelegates, testCase.name).toBeUndefined();
     }
   });
 

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -20,7 +20,11 @@ import {
 import { resolveAndPersistSessionFile } from "../../config/sessions/session-file.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
-import { loadSessionStore, updateSessionStore } from "../../config/sessions/store.js";
+import {
+  loadSessionStore,
+  resolveSessionStoreEntry,
+  updateSessionStore,
+} from "../../config/sessions/store.js";
 import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import {
   DEFAULT_RESET_TRIGGERS,
@@ -716,12 +720,22 @@ export async function initSessionState(params: {
     sessionEntry.contextTokens = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
-  sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
+  {
+    const resolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+    sessionStore[resolved.normalizedKey] = { ...resolved.existing, ...sessionEntry };
+    for (const legacyKey of resolved.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
+  }
   await updateSessionStore(
     storePath,
     (store) => {
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
       // Preserve per-session overrides while resetting compaction state on /new.
-      store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      store[resolved.normalizedKey] = { ...resolved.existing, ...sessionEntry };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
       if (retiredLegacyMainDelivery) {
         store[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
       }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -98,6 +98,7 @@ type StatusArgs = {
   mediaDecisions?: ReadonlyArray<MediaUnderstandingDecision>;
   subagentsLine?: string;
   taskLine?: string;
+  continuationLine?: string;
   includeTranscriptUsage?: boolean;
   now?: number;
 };
@@ -852,6 +853,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     `🧵 ${sessionLine}`,
     args.subagentsLine,
     args.taskLine,
+    args.continuationLine,
     `⚙️ ${optionsLine}`,
     pluginStatusLine ? `🧩 ${pluginStatusLine}` : null,
     voiceLine,

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,11 +1,411 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
+  CONTINUE_WORK_TOKEN,
+  HEARTBEAT_TOKEN,
+  SILENT_REPLY_TOKEN,
   isSilentReplyPrefixText,
   isSilentReplyText,
+  parseContinuationSignal,
   startsWithSilentToken,
+  stripContinuationSignal,
   stripLeadingSilentToken,
-  stripSilentToken,
 } from "./tokens.js";
+
+/* ------------------------------------------------------------------ */
+/*  parseContinuationSignal                                           */
+/* ------------------------------------------------------------------ */
+
+describe("parseContinuationSignal", () => {
+  it("returns null for undefined input", () => {
+    expect(parseContinuationSignal(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseContinuationSignal("")).toBeNull();
+  });
+
+  it("returns null for normal text without signals", () => {
+    expect(parseContinuationSignal("Hello, world!")).toBeNull();
+  });
+
+  it("returns null for text with signal-like words in the middle", () => {
+    expect(parseContinuationSignal("I said CONTINUE_WORK but then kept talking")).toBeNull();
+  });
+
+  // --- CONTINUE_WORK (bare) ---
+
+  it("parses bare CONTINUE_WORK at end of text", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK");
+    expect(result).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("parses CONTINUE_WORK with leading whitespace", () => {
+    const result = parseContinuationSignal("  CONTINUE_WORK  ");
+    expect(result).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("parses CONTINUE_WORK after response text", () => {
+    const result = parseContinuationSignal("I finished the first task.\nCONTINUE_WORK");
+    expect(result).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("parses CONTINUE_WORK with trailing whitespace", () => {
+    const result = parseContinuationSignal("Done for now. CONTINUE_WORK   ");
+    expect(result).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  // --- CONTINUE_WORK with delay ---
+
+  it("parses CONTINUE_WORK:30 with 30-second delay", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK:30");
+    expect(result).toEqual({ kind: "work", delayMs: 30_000 });
+  });
+
+  it("parses CONTINUE_WORK:0 with zero delay", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK:0");
+    expect(result).toEqual({ kind: "work", delayMs: 0 });
+  });
+
+  it("parses CONTINUE_WORK:120 after response text", () => {
+    const result = parseContinuationSignal("Processing complete. CONTINUE_WORK:120");
+    expect(result).toEqual({ kind: "work", delayMs: 120_000 });
+  });
+
+  it("parses CONTINUE_WORK:5 with trailing whitespace", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK:5  ");
+    expect(result).toEqual({ kind: "work", delayMs: 5_000 });
+  });
+
+  // --- [[CONTINUE_DELEGATE: task]] (bracket syntax) ---
+
+  it("parses [[CONTINUE_DELEGATE: task]] with simple task", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: run the tests]]");
+    expect(result).toEqual({ kind: "delegate", task: "run the tests" });
+  });
+
+  it("parses [[CONTINUE_DELEGATE: task]] after response text", () => {
+    const result = parseContinuationSignal(
+      "I'll hand this off.\n[[CONTINUE_DELEGATE: review PR #42 and leave comments]]",
+    );
+    expect(result).toEqual({
+      kind: "delegate",
+      task: "review PR #42 and leave comments",
+    });
+  });
+
+  it("parses [[CONTINUE_DELEGATE: multiline task]] naturally", () => {
+    const result = parseContinuationSignal(
+      "[[CONTINUE_DELEGATE: first do X\nthen do Y\nfinally Z]]",
+    );
+    expect(result).toEqual({
+      kind: "delegate",
+      task: "first do X\nthen do Y\nfinally Z",
+    });
+  });
+
+  it("trims whitespace from delegate task", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE:   check the logs   ]]");
+    expect(result).toEqual({ kind: "delegate", task: "check the logs" });
+  });
+
+  it("rejects empty delegate task (whitespace only)", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE:    ]]");
+    expect(result).toBeNull();
+  });
+
+  it("does not match bare CONTINUE_DELEGATE: without brackets", () => {
+    const result = parseContinuationSignal("CONTINUE_DELEGATE:run the tests");
+    expect(result).toBeNull();
+  });
+
+  it("does not match adversarial bare pattern with nested brackets (single-line)", () => {
+    const result = parseContinuationSignal('CONTINUE_DELEGATE:[[[["bc annoying"]]]]');
+    expect(result).toBeNull();
+  });
+
+  it("does not match adversarial bare pattern with nested brackets (multiline)", () => {
+    const result = parseContinuationSignal('CONTINUE_DELEGATE:[[[["bc\nannoying"]]]]');
+    expect(result).toBeNull();
+  });
+
+  it("does not match unclosed bracket", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: run the tests");
+    expect(result).toBeNull();
+  });
+
+  it("does not match mid-text bracket directive followed by more content", () => {
+    const result = parseContinuationSignal(
+      "Use [[CONTINUE_DELEGATE: example]] to delegate.\nMore text here.",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("matches only the LAST bracket directive when same token appears mid-text", () => {
+    const result = parseContinuationSignal(
+      "I used [[CONTINUE_DELEGATE: example]] earlier.\n[[CONTINUE_DELEGATE: real task]]",
+    );
+    expect(result).toEqual({ kind: "delegate", task: "real task" });
+  });
+
+  it("rejects ]] inside the task body", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: task with ]] inside]]");
+    expect(result).toBeNull();
+  });
+
+  it("matches bracket directive at end after text", () => {
+    const result = parseContinuationSignal(
+      "I've finished the analysis.\n[[CONTINUE_DELEGATE: review the results]]",
+    );
+    expect(result).toEqual({ kind: "delegate", task: "review the results" });
+  });
+
+  it("handles extra whitespace inside brackets", () => {
+    const result = parseContinuationSignal("[[  CONTINUE_DELEGATE:  do the thing  ]]");
+    expect(result).toEqual({ kind: "delegate", task: "do the thing" });
+  });
+
+  it("handles trailing whitespace after closing bracket", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: task]]   ");
+    expect(result).toEqual({ kind: "delegate", task: "task" });
+  });
+
+  // --- [[CONTINUE_DELEGATE: task +Ns]] (timed dispatch) ---
+
+  it("parses [[CONTINUE_DELEGATE: task +5s]] with 5-second delay", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: run tests +5s]]");
+    expect(result).toEqual({ kind: "delegate", task: "run tests", delayMs: 5000 });
+  });
+
+  it("parses [[CONTINUE_DELEGATE: task +30s]] with 30-second delay", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: review PR #42 +30s]]");
+    expect(result).toEqual({ kind: "delegate", task: "review PR #42", delayMs: 30000 });
+  });
+
+  it("parses [[CONTINUE_DELEGATE: multiline task +10s]] with delay", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: first do X\nthen do Y +10s]]");
+    expect(result).toEqual({ kind: "delegate", task: "first do X\nthen do Y", delayMs: 10000 });
+  });
+
+  it("parses [[CONTINUE_DELEGATE: task]] without delay as undefined delayMs", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: run tests]]");
+    expect(result).toEqual({ kind: "delegate", task: "run tests", delayMs: undefined });
+  });
+
+  it("does not treat +Ns mid-task as a delay", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: wait +5s then do thing]]");
+    expect(result).toEqual({
+      kind: "delegate",
+      task: "wait +5s then do thing",
+      delayMs: undefined,
+    });
+  });
+
+  it("handles +0s as zero delay", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: immediate +0s]]");
+    expect(result).toEqual({ kind: "delegate", task: "immediate", delayMs: 0 });
+  });
+
+  // --- [[CONTINUE_DELEGATE: task | silent]] (silent enrichment) ---
+
+  it("parses [[CONTINUE_DELEGATE: task | silent]] with silent flag", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: enrich context | silent]]");
+    expect(result).toEqual({ kind: "delegate", task: "enrich context", silent: true });
+  });
+
+  it("parses [[CONTINUE_DELEGATE: task +15s | silent]] with delay and silent", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: think about X +15s | silent]]");
+    expect(result).toEqual({
+      kind: "delegate",
+      task: "think about X",
+      delayMs: 15000,
+      silent: true,
+    });
+  });
+
+  it("parses | silent case-insensitively", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: task | SILENT]]");
+    expect(result).toEqual({ kind: "delegate", task: "task", silent: true });
+  });
+
+  it("does not set silent when | silent is not at end", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: check | silent | then report]]");
+    // "| silent" is not at the end — the whole thing is the task
+    expect(result?.kind === "delegate" && result.silent).toBeFalsy();
+  });
+
+  it("parses delegate without | silent as silent undefined", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: normal task]]");
+    expect(result).toEqual({ kind: "delegate", task: "normal task" });
+    expect(result?.kind === "delegate" ? result.silent : undefined).toBeUndefined();
+  });
+
+  // --- [[CONTINUE_DELEGATE: task | silent-wake]] (silent wake enrichment) ---
+
+  it("parses [[CONTINUE_DELEGATE: task | silent-wake]] with silentWake flag", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: enrich context | silent-wake]]");
+    expect(result).toEqual({ kind: "delegate", task: "enrich context", silentWake: true });
+  });
+
+  it("parses [[CONTINUE_DELEGATE: task +20s | silent-wake]] with delay and silentWake", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: chain hop 2 +20s | silent-wake]]");
+    expect(result).toEqual({
+      kind: "delegate",
+      task: "chain hop 2",
+      delayMs: 20000,
+      silentWake: true,
+    });
+  });
+
+  it("parses | silent-wake case-insensitively", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: task | SILENT-WAKE]]");
+    expect(result).toEqual({ kind: "delegate", task: "task", silentWake: true });
+  });
+
+  it("parses | silent wake (space instead of hyphen)", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: task | silent wake]]");
+    expect(result).toEqual({ kind: "delegate", task: "task", silentWake: true });
+  });
+
+  it("does not confuse | silent-wake with | silent", () => {
+    const silentWake = parseContinuationSignal("[[CONTINUE_DELEGATE: task | silent-wake]]");
+    const silent = parseContinuationSignal("[[CONTINUE_DELEGATE: task | silent]]");
+    expect(silentWake?.kind === "delegate" && silentWake.silentWake).toBe(true);
+    expect(silentWake?.kind === "delegate" ? silentWake.silent : undefined).toBeUndefined();
+    expect(silent?.kind === "delegate" && silent.silent).toBe(true);
+    expect(silent?.kind === "delegate" ? silent.silentWake : undefined).toBeUndefined();
+  });
+
+  it("parses delegate without suffix as neither silent nor silentWake", () => {
+    const result = parseContinuationSignal("[[CONTINUE_DELEGATE: plain task]]");
+    expect(result?.kind === "delegate" ? result.silent : undefined).toBeUndefined();
+    expect(result?.kind === "delegate" ? result.silentWake : undefined).toBeUndefined();
+  });
+
+  // --- Precedence ---
+
+  it("prefers [[CONTINUE_DELEGATE:]] over CONTINUE_WORK when both present", () => {
+    const result = parseContinuationSignal("CONTINUE_WORK\n[[CONTINUE_DELEGATE: do something]]");
+    expect(result).toEqual({ kind: "delegate", task: "do something" });
+  });
+
+  // --- Regression: bracket in non-last payload (2026-03-28) ---
+  // When tool calls interleave, the bracket token may be in a non-last payload.
+  // The parser itself is correct (end-anchored regex matches), but agent-runner.ts
+  // must scan backwards for the last TEXT-BEARING payload. This test documents
+  // that the parser works when given the correct text fragment.
+  // See: fix/2026.03.24-codex-review-findings commit 2b53fa4
+
+  it("parses bracket delegate from text that would be a non-last payload (regression)", () => {
+    // Simulates the text payload when tool calls follow:
+    // payload[0] = { text: "Here's my response.\n[[CONTINUE_DELEGATE: task +3s]]" }
+    // payload[1] = { toolCallId: "...", name: "exec", ... }  ← no .text
+    // payload[2] = { toolResultId: "...", ... }               ← no .text
+    // agent-runner must find payload[0], not payload[2]
+    const textPayload = "Here's my response.\n[[CONTINUE_DELEGATE: chain-hop task +3s]]";
+    const result = parseContinuationSignal(textPayload);
+    expect(result).toEqual({
+      kind: "delegate",
+      task: "chain-hop task",
+      delayMs: 3000,
+      silent: undefined,
+      silentWake: undefined,
+    });
+  });
+
+  it("parses bracket delegate after multi-line response with emoji (live regression)", () => {
+    // Exact pattern from Ronan's Test 5 at 01:08:16 UTC 2026-03-28
+    const text =
+      "✅ Test 2 passed.\nMoving to Test 5:\nBracket delegate dispatched. 🌊\n" +
+      "[[CONTINUE_DELEGATE: Report back with 'bracket delegate confirmed' +3s]]";
+    const result = parseContinuationSignal(text);
+    expect(result).toEqual({
+      kind: "delegate",
+      task: "Report back with 'bracket delegate confirmed'",
+      delayMs: 3000,
+      silent: undefined,
+      silentWake: undefined,
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  stripContinuationSignal                                           */
+/* ------------------------------------------------------------------ */
+
+describe("stripContinuationSignal", () => {
+  it("returns original text and null signal when no signal present", () => {
+    const result = stripContinuationSignal("Hello, world!");
+    expect(result).toEqual({ text: "Hello, world!", signal: null });
+  });
+
+  it("strips bare CONTINUE_WORK from end, returns empty text", () => {
+    const result = stripContinuationSignal("CONTINUE_WORK");
+    expect(result.text).toBe("");
+    expect(result.signal).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("strips CONTINUE_WORK from end of response, preserving visible text", () => {
+    const result = stripContinuationSignal("I finished the task.\nCONTINUE_WORK");
+    expect(result.text).toBe("I finished the task.");
+    expect(result.signal).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("strips CONTINUE_WORK:60 and preserves preceding text", () => {
+    const result = stripContinuationSignal("Processing batch 1/5. CONTINUE_WORK:60");
+    expect(result.text).toBe("Processing batch 1/5.");
+    expect(result.signal).toEqual({ kind: "work", delayMs: 60_000 });
+  });
+
+  it("strips [[CONTINUE_DELEGATE:]] and preserves preceding text", () => {
+    const result = stripContinuationSignal(
+      "I'll delegate this.\n[[CONTINUE_DELEGATE: run tests on PR #7]]",
+    );
+    expect(result.text).toBe("I'll delegate this.");
+    expect(result.signal).toEqual({
+      kind: "delegate",
+      task: "run tests on PR #7",
+    });
+  });
+
+  it("strips [[CONTINUE_DELEGATE:]] with multiline task", () => {
+    const result = stripContinuationSignal(
+      "Handing off.\n[[CONTINUE_DELEGATE: check CI\nreview the PR\nrun lint]]",
+    );
+    expect(result.text).toBe("Handing off.");
+    expect(result.signal).toEqual({
+      kind: "delegate",
+      task: "check CI\nreview the PR\nrun lint",
+    });
+  });
+
+  it("strips [[CONTINUE_DELEGATE:]] with timed delay suffix", () => {
+    const result = stripContinuationSignal(
+      "Scheduling review.\n[[CONTINUE_DELEGATE: review PR #42 +30s]]",
+    );
+    expect(result.text).toBe("Scheduling review.");
+    expect(result.signal).toEqual({
+      kind: "delegate",
+      task: "review PR #42",
+      delayMs: 30000,
+    });
+  });
+
+  it("strips CONTINUE_WORK with trailing whitespace after signal", () => {
+    const result = stripContinuationSignal("Done. CONTINUE_WORK   ");
+    expect(result.text).toBe("Done.");
+    expect(result.signal).toEqual({ kind: "work", delayMs: undefined });
+  });
+
+  it("handles only-whitespace text after stripping", () => {
+    const result = stripContinuationSignal("  CONTINUE_WORK");
+    expect(result.text).toBe("");
+    expect(result.signal).toEqual({ kind: "work", delayMs: undefined });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  isSilentReplyText                                                 */
+/* ------------------------------------------------------------------ */
 
 describe("isSilentReplyText", () => {
   it("returns true for exact token", () => {
@@ -24,65 +424,48 @@ describe("isSilentReplyText", () => {
 
   it("returns false for undefined/empty", () => {
     expect(isSilentReplyText(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
     expect(isSilentReplyText("")).toBe(false);
   });
 
-  it("returns false for substantive text ending with token (#19537)", () => {
-    const text = "Here is a helpful response.\n\nNO_REPLY";
-    expect(isSilentReplyText(text)).toBe(false);
+  it("returns true for exact NO_REPLY", () => {
+    expect(isSilentReplyText("NO_REPLY")).toBe(true);
   });
 
-  it("returns false for substantive text starting with token", () => {
-    const text = "NO_REPLY but here is more content";
-    expect(isSilentReplyText(text)).toBe(false);
+  it("returns true for NO_REPLY with leading whitespace", () => {
+    expect(isSilentReplyText("  NO_REPLY")).toBe(true);
   });
 
-  it("returns false for token embedded in text", () => {
-    expect(isSilentReplyText("Please NO_REPLY to this")).toBe(false);
+  it("returns false for substantive text ending with NO_REPLY (#19537)", () => {
+    // Substantive replies ending with NO_REPLY must NOT be silently dropped.
+    // Only exact-match (entire message is NO_REPLY) should be treated as silent.
+    expect(isSilentReplyText("Some text NO_REPLY")).toBe(false);
   });
 
-  it("works with custom token", () => {
-    expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
-    expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+  it("returns false for NO_REPLY embedded in a word", () => {
+    // The regex uses \b word boundary, so embedded shouldn't match at suffix
+    // But the prefix check just looks at start-of-string
+    expect(isSilentReplyText("NOTNO_REPLY")).toBe(false);
+  });
+
+  it("returns true for HEARTBEAT_OK when token is overridden", () => {
+    expect(isSilentReplyText("HEARTBEAT_OK", HEARTBEAT_TOKEN)).toBe(true);
+  });
+
+  it("returns true for NO_REPLY followed by newline", () => {
+    expect(isSilentReplyText("NO_REPLY\n")).toBe(true);
+  });
+
+  it("returns false for normal conversational text", () => {
+    expect(isSilentReplyText("Hello, how are you?")).toBe(false);
   });
 });
 
-describe("stripSilentToken", () => {
-  it("strips token from end of text", () => {
-    expect(stripSilentToken("Done.\n\nNO_REPLY")).toBe("Done.");
-  });
-
-  it("does not strip token from start of text", () => {
-    expect(stripSilentToken("NO_REPLY 👍")).toBe("NO_REPLY 👍");
-  });
-
-  it("strips token with emoji (#30916)", () => {
-    expect(stripSilentToken("😄 NO_REPLY")).toBe("😄");
-  });
-
-  it("does not strip embedded token suffix without whitespace delimiter", () => {
-    expect(stripSilentToken("interject.NO_REPLY")).toBe("interject.NO_REPLY");
-  });
-
-  it("strips only trailing occurrence", () => {
-    expect(stripSilentToken("NO_REPLY ok NO_REPLY")).toBe("NO_REPLY ok");
-  });
-
-  it("returns empty string when only token remains", () => {
-    expect(stripSilentToken("NO_REPLY")).toBe("");
-    expect(stripSilentToken("  NO_REPLY  ")).toBe("");
-  });
-
-  it("strips token preceded by bold markdown formatting", () => {
-    expect(stripSilentToken("**NO_REPLY")).toBe("");
-    expect(stripSilentToken("some text **NO_REPLY")).toBe("some text");
-    expect(stripSilentToken("reasoning**NO_REPLY")).toBe("reasoning");
-  });
-
-  it("works with custom token", () => {
-    expect(stripSilentToken("done HEARTBEAT_OK", "HEARTBEAT_OK")).toBe("done");
-  });
-});
+/* ------------------------------------------------------------------ */
+/*  isSilentReplyPrefixText                                           */
+/* ------------------------------------------------------------------ */
 
 describe("stripLeadingSilentToken", () => {
   it("strips glued leading token text", () => {
@@ -133,5 +516,17 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("NO_X")).toBe(false);
     expect(isSilentReplyPrefixText("NO_REPLY more")).toBe(false);
     expect(isSilentReplyPrefixText("NO-")).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Token constants                                                   */
+/* ------------------------------------------------------------------ */
+
+describe("token constants", () => {
+  it("exports expected token values", () => {
+    expect(HEARTBEAT_TOKEN).toBe("HEARTBEAT_OK");
+    expect(SILENT_REPLY_TOKEN).toBe("NO_REPLY");
+    expect(CONTINUE_WORK_TOKEN).toBe("CONTINUE_WORK");
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -2,6 +2,7 @@ import { escapeRegExp } from "../utils.js";
 
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
+export const CONTINUE_WORK_TOKEN = "CONTINUE_WORK";
 
 const silentExactRegexByToken = new Map<string, RegExp>();
 const silentTrailingRegexByToken = new Map<string, RegExp>();
@@ -24,7 +25,7 @@ function getSilentTrailingRegex(token: string): RegExp {
     return cached;
   }
   const escaped = escapeRegExp(token);
-  const regex = new RegExp(`(?:^|\\s+|\\*+)${escaped}\\s*$`);
+  const regex = new RegExp(`(?:^|\\s+|\\*+)${escaped}\\s*$`, "i");
   silentTrailingRegexByToken.set(token, regex);
   return regex;
 }
@@ -176,4 +177,118 @@ export function isSilentReplyPrefixText(
   // uppercase words (e.g. HEART/HE with HEARTBEAT_OK). Only allow bare "NO"
   // because NO_REPLY streaming can transiently emit that fragment.
   return tokenUpper === SILENT_REPLY_TOKEN && normalized === "NO";
+}
+
+// ============================================================================
+// Continuation signal parsing
+// ============================================================================
+
+export type ContinuationSignal =
+  | { kind: "work"; delayMs?: number }
+  | { kind: "delegate"; task: string; delayMs?: number; silent?: boolean; silentWake?: boolean };
+
+/**
+ * Checks if the agent response ends with a continuation signal.
+ * Returns the parsed signal or null if no continuation is requested.
+ *
+ * Formats:
+ *   CONTINUE_WORK              → continue with default delay
+ *   CONTINUE_WORK:30           → continue after 30 seconds
+ *   [[CONTINUE_DELEGATE: task]]      → spawn sub-agent with task immediately
+ *   [[CONTINUE_DELEGATE: task +30s]] → spawn sub-agent after 30-second delay
+ *
+ * The `+Ns` suffix on DELEGATE specifies a timer offset before the sub-agent
+ * spawns (delegate-as-scheduler pattern). Timers do not survive gateway restarts.
+ *
+ * DELEGATE uses bracket syntax ([[...]]) following the repo convention for tokens
+ * that carry body content (see reply_to, tts, line directives). Brackets naturally
+ * delimit the boundary, so multiline tasks work without ambiguity.
+ */
+export function parseContinuationSignal(text: string | undefined): ContinuationSignal | null {
+  if (!text) {
+    return null;
+  }
+
+  const trimmed = text.trim();
+
+  // Check for [[CONTINUE_DELEGATE: task]] at end of response.
+  // The bracket pair [[ ... ]] delimits the body, so multiline tasks are safe.
+  // The negative lookahead (?!\]\]) prevents ]] inside the body from prematurely
+  // closing the bracket, and ensures we match the LAST [[CONTINUE_DELEGATE:]] when
+  // the same token appears mid-text earlier in the response.
+  const delegateMatch = trimmed.match(
+    /\[\[\s*CONTINUE_DELEGATE:\s*((?:(?!\]\])[\s\S])+?)\s*\]\]\s*$/,
+  );
+  if (delegateMatch) {
+    let taskBody = delegateMatch[1].trim();
+    // Parse optional | silent-wake or | silent suffix
+    // Check silent-wake FIRST to avoid partial match on silent
+    let silent: boolean | undefined;
+    let silentWake: boolean | undefined;
+    const silentWakeSuffixMatch = taskBody.match(/\s*\|\s*silent[- ]wake\s*$/i);
+    if (silentWakeSuffixMatch) {
+      silentWake = true;
+      taskBody = taskBody.slice(0, -silentWakeSuffixMatch[0].length).trimEnd();
+    } else {
+      const silentSuffixMatch = taskBody.match(/\s*\|\s*silent\s*$/i);
+      if (silentSuffixMatch) {
+        silent = true;
+        taskBody = taskBody.slice(0, -silentSuffixMatch[0].length).trimEnd();
+      }
+    }
+    // Parse optional +Ns delay suffix (e.g. "+30s", "+5s")
+    let delayMs: number | undefined;
+    const delayMatch = taskBody.match(/\s+\+(\d+)s\s*$/);
+    if (delayMatch) {
+      delayMs = parseInt(delayMatch[1], 10) * 1000;
+      taskBody = taskBody.slice(0, -delayMatch[0].length).trimEnd();
+    }
+    if (taskBody) {
+      // Truncate overly long task strings to prevent context-dumping patterns.
+      // Same limit as the continue_delegate tool schema (4096 chars).
+      const maxTaskLength = 4096;
+      const truncatedTask =
+        taskBody.length > maxTaskLength ? taskBody.slice(0, maxTaskLength) : taskBody;
+      return { kind: "delegate", task: truncatedTask, delayMs, silent, silentWake };
+    }
+  }
+
+  // Check for CONTINUE_WORK or CONTINUE_WORK:<delay> at end of response
+  const workMatch = trimmed.match(/\bCONTINUE_WORK(?::(\d+))?\s*$/);
+  if (workMatch) {
+    const delaySec = workMatch[1] ? parseInt(workMatch[1], 10) : undefined;
+    return {
+      kind: "work",
+      delayMs: delaySec !== undefined ? delaySec * 1000 : undefined,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Strips the continuation signal from the response text, returning the
+ * displayable text and the parsed signal separately.
+ */
+export function stripContinuationSignal(text: string): {
+  text: string;
+  signal: ContinuationSignal | null;
+} {
+  const signal = parseContinuationSignal(text);
+  if (!signal) {
+    return { text, signal: null };
+  }
+
+  let stripped: string;
+  if (signal.kind === "delegate") {
+    // Strip the [[CONTINUE_DELEGATE: ...]] bracket directive.
+    // Mirrors the parser grammar exactly.
+    stripped = text.replace(/\[\[\s*CONTINUE_DELEGATE:\s*(?:(?!\]\])[\s\S])+?\s*\]\]\s*$/, "");
+  } else {
+    // Only strip CONTINUE_WORK when it's the signal type parsed
+    stripped = text.replace(/\bCONTINUE_WORK(?::\d+)?\s*$/, "");
+  }
+  stripped = stripped.trimEnd();
+
+  return { text: stripped, signal };
 }

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -1,5 +1,6 @@
 export type {
   BlockReplyContext,
+  ContinuationTrigger,
   GetReplyOptions,
   ModelSelectedContext,
   ReplyThreadingPolicy,

--- a/src/config/cache-utils.ts
+++ b/src/config/cache-utils.ts
@@ -64,7 +64,7 @@ export function createExpiringMapCache<TKey, TValue>(options: {
   clock?: () => number;
 }): ExpiringMapCache<TKey, TValue> {
   const cache = new Map<TKey, ExpiringMapCacheEntry<TValue>>();
-  const now = options.clock ?? Date.now;
+  const now = options.clock ?? (() => Date.now());
   let lastPruneAt = 0;
 
   function getTtlMs(): number {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5500,6 +5500,58 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 },
                 additionalProperties: false,
               },
+              continuation: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                  },
+                  taskFlowDelegates: {
+                    type: "boolean",
+                  },
+                  defaultDelayMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  minDelayMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  maxDelayMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  maxChainLength: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  costCapTokens: {
+                    type: "integer",
+                    minimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  maxDelegatesPerTurn: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  generationGuardTolerance: {
+                    type: "integer",
+                    minimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  contextPressureThreshold: {
+                    type: "number",
+                    exclusiveMinimum: 0,
+                    maximum: 1,
+                  },
+                },
+                additionalProperties: false,
+              },
             },
             additionalProperties: false,
             title: "Agent Defaults",

--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { getSerializedSessionStore } from "./sessions/store-cache.js";
 import {
   clearSessionStoreCacheForTest,
   loadSessionStore,
@@ -227,5 +228,21 @@ describe("Session Store Cache", () => {
     const loaded2 = loadSessionStore(storePath);
     expect(loaded2["session:2"]).toBeDefined();
     expect(loaded2["session:2"].displayName).toBe("Added");
+  });
+
+  it("expires serialized write-through cache on the same TTL as the object cache", async () => {
+    process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "10";
+    clearSessionStoreCacheForTest();
+
+    let fakeNow = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => fakeNow);
+
+    const testStore = createSingleSessionStore();
+    await saveSessionStore(storePath, testStore);
+    expect(getSerializedSessionStore(storePath)).toBeDefined();
+
+    fakeNow += 11;
+    expect(getSerializedSessionStore(storePath)).toBeUndefined();
+    vi.restoreAllMocks();
   });
 });

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -5,7 +5,6 @@ type SessionStoreCacheEntry = {
   store: Record<string, SessionEntry>;
   mtimeMs?: number;
   sizeBytes?: number;
-  serialized?: string;
 };
 
 const DEFAULT_SESSION_STORE_TTL_MS = 45_000; // 45 seconds (between 30-60s)
@@ -13,7 +12,9 @@ const DEFAULT_SESSION_STORE_TTL_MS = 45_000; // 45 seconds (between 30-60s)
 const SESSION_STORE_CACHE = createExpiringMapCache<string, SessionStoreCacheEntry>({
   ttlMs: getSessionStoreTtl,
 });
-const SESSION_STORE_SERIALIZED_CACHE = new Map<string, string>();
+const SESSION_STORE_SERIALIZED_CACHE = createExpiringMapCache<string, string>({
+  ttlMs: getSessionStoreTtl,
+});
 
 export function getSessionStoreTtl(): number {
   return resolveCacheTtlMs({
@@ -50,6 +51,7 @@ export function setSerializedSessionStore(storePath: string, serialized?: string
 
 export function dropSessionStoreObjectCache(storePath: string): void {
   SESSION_STORE_CACHE.delete(storePath);
+  SESSION_STORE_SERIALIZED_CACHE.delete(storePath);
 }
 
 export function readSessionStoreCache(params: {
@@ -73,15 +75,10 @@ export function writeSessionStoreCache(params: {
   store: Record<string, SessionEntry>;
   mtimeMs?: number;
   sizeBytes?: number;
-  serialized?: string;
 }): void {
   SESSION_STORE_CACHE.set(params.storePath, {
     store: structuredClone(params.store),
     mtimeMs: params.mtimeMs,
     sizeBytes: params.sizeBytes,
-    serialized: params.serialized,
   });
-  if (params.serialized !== undefined) {
-    SESSION_STORE_SERIALIZED_CACHE.set(params.storePath, params.serialized);
-  }
 }

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -125,7 +125,6 @@ export function loadSessionStore(
       store,
       mtimeMs,
       sizeBytes: fileStat?.sizeBytes,
-      serialized: serializedFromDisk,
     });
   }
 

--- a/src/config/sessions/store.runtime.ts
+++ b/src/config/sessions/store.runtime.ts
@@ -1,1 +1,1 @@
-export { updateSessionStore, updateSessionStoreEntry } from "./store.js";
+export { resolveSessionStoreEntry, updateSessionStore, updateSessionStoreEntry } from "./store.js";

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -211,7 +211,6 @@ function updateSessionStoreWriteCaches(params: {
     store: params.store,
     mtimeMs: fileStat?.mtimeMs,
     sizeBytes: fileStat?.sizeBytes,
-    serialized: params.serialized,
   });
 }
 

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -108,6 +108,16 @@ export type SessionPluginDebugEntry = {
   lines: string[];
 };
 
+export type SessionPostCompactionDelegate = {
+  task: string;
+  createdAt: number;
+  /**
+   * Post-compaction delegates are silent by contract. Persist the explicit
+   * flags so the intent survives session-store round trips.
+   */
+  silent?: boolean;
+  silentWake?: boolean;
+};
 export type SessionEntry = {
   /**
    * Last delivered heartbeat payload (used to suppress duplicate heartbeat notifications).
@@ -227,6 +237,11 @@ export type SessionEntry = {
   fallbackNoticeActiveModel?: string;
   fallbackNoticeReason?: string;
   contextTokens?: number;
+  /**
+   * Last context-pressure band that fired (e.g. 80, 90, 95). Used to deduplicate
+   * pressure events — only re-fires when the session crosses into a higher band.
+   */
+  lastContextPressureBand?: number;
   compactionCount?: number;
   compactionCheckpoints?: SessionCompactionCheckpoint[];
   memoryFlushAt?: number;
@@ -256,6 +271,14 @@ export type SessionEntry = {
    */
   pluginDebugEntries?: SessionPluginDebugEntry[];
   acp?: SessionAcpMeta;
+  /** Number of continuation turns completed in the current chain. Reset on external message. */
+  continuationChainCount?: number;
+  /** Timestamp (ms) when the current continuation chain started. */
+  continuationChainStartedAt?: number;
+  /** Accumulated token usage across the current continuation chain. Reset on external message. */
+  continuationChainTokens?: number;
+  /** Post-compaction delegates staged for execution after context compaction. */
+  pendingPostCompactionDelegates?: SessionPostCompactionDelegate[];
 };
 
 function isSessionPluginTraceLine(line: string): boolean {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -367,6 +367,34 @@ export type AgentDefaultsConfig = {
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;
+  /** Agent self-elected turn continuation (CONTINUE_WORK signal). */
+  continuation?: {
+    enabled?: boolean;
+    /** Use Task Flow-backed delegate store (SQLite persistence, cancel/retry). Default: false. */
+    taskFlowDelegates?: boolean;
+    defaultDelayMs?: number;
+    minDelayMs?: number;
+    maxDelayMs?: number;
+    maxChainLength?: number;
+    costCapTokens?: number;
+    /** Maximum number of continue_delegate tool calls per agent turn (default: 5). */
+    maxDelegatesPerTurn?: number;
+    /**
+     * Generation guard tolerance for timed delegates (default: 0).
+     * The generation guard cancels a pending delegate timer when the session's
+     * generation counter drifts more than this threshold. 0 = strict (any message
+     * cancels). Higher values let delegates survive in busy channels where
+     * incidental traffic would otherwise preempt every timer.
+     */
+    generationGuardTolerance?: number;
+    /**
+     * Context-pressure awareness threshold (exclusive (0.0, 1.0]). When the session's token
+     * usage exceeds this fraction of the context window, a [system:context-pressure]
+     * event is injected pre-run so the agent can elect evacuation. Disabled when
+     * unset. Recommended: 0.8 (80%).
+     */
+    contextPressureThreshold?: number;
+  };
 };
 
 export type AgentCompactionMode = "default" | "safeguard";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -239,6 +239,25 @@ export const AgentDefaultsSchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    continuation: z
+      .object({
+        enabled: z.boolean().optional(),
+        taskFlowDelegates: z.boolean().optional(),
+        defaultDelayMs: z.number().int().positive().optional(),
+        minDelayMs: z.number().int().positive().optional(),
+        maxDelayMs: z.number().int().positive().optional(),
+        maxChainLength: z.number().int().positive().optional(),
+        costCapTokens: z.number().int().nonnegative().optional(),
+        maxDelegatesPerTurn: z.number().int().positive().optional(),
+        generationGuardTolerance: z.number().int().nonnegative().optional(),
+        contextPressureThreshold: z
+          .number()
+          .gt(0, "contextPressureThreshold must be > 0 (0 would fire on empty sessions)")
+          .max(1)
+          .optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.continuation.test.ts
+++ b/src/config/zod-schema.continuation.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
+
+/**
+ * Continuation config Zod schema boundary tests.
+ *
+ * Validates that invalid config values are rejected at parse time,
+ * not silently swallowed or reset to defaults. Convention: fail loudly.
+ */
+
+function parseContinuation(continuation: unknown) {
+  return AgentDefaultsSchema.safeParse({ continuation });
+}
+
+describe("continuation config schema validation", () => {
+  /* ---------------------------------------------------------------- */
+  /*  contextPressureThreshold: z.number().gt(0).max(1).optional()    */
+  /* ---------------------------------------------------------------- */
+
+  it("accepts contextPressureThreshold = 0.8", () => {
+    const result = parseContinuation({ contextPressureThreshold: 0.8 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects contextPressureThreshold = 0", () => {
+    const result = parseContinuation({ contextPressureThreshold: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts contextPressureThreshold = 1.0 (upper bound)", () => {
+    const result = parseContinuation({ contextPressureThreshold: 1.0 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects contextPressureThreshold = -1 (below min)", () => {
+    const result = parseContinuation({ contextPressureThreshold: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects contextPressureThreshold = 2.0 (above max)", () => {
+    const result = parseContinuation({ contextPressureThreshold: 2.0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects contextPressureThreshold = 'bc annoying' (string)", () => {
+    const result = parseContinuation({ contextPressureThreshold: "bc annoying" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts contextPressureThreshold = undefined (optional)", () => {
+    const result = parseContinuation({});
+    expect(result.success).toBe(true);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  maxDelegatesPerTurn: z.number().int().positive().optional()      */
+  /* ---------------------------------------------------------------- */
+
+  it("accepts maxDelegatesPerTurn = 5", () => {
+    const result = parseContinuation({ maxDelegatesPerTurn: 5 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects maxDelegatesPerTurn = 0 (not positive)", () => {
+    const result = parseContinuation({ maxDelegatesPerTurn: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects maxDelegatesPerTurn = -1 (negative)", () => {
+    const result = parseContinuation({ maxDelegatesPerTurn: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects maxDelegatesPerTurn = 3.5 (not integer)", () => {
+    const result = parseContinuation({ maxDelegatesPerTurn: 3.5 });
+    expect(result.success).toBe(false);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  costCapTokens: z.number().int().nonnegative().optional()         */
+  /* ---------------------------------------------------------------- */
+
+  it("accepts costCapTokens = 0 (nonnegative includes zero)", () => {
+    const result = parseContinuation({ costCapTokens: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts costCapTokens = 500000", () => {
+    const result = parseContinuation({ costCapTokens: 500000 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects costCapTokens = -1 (negative)", () => {
+    const result = parseContinuation({ costCapTokens: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  defaultDelayMs / minDelayMs / maxDelayMs / maxChainLength       */
+  /* ---------------------------------------------------------------- */
+
+  it("rejects defaultDelayMs = 0 (not positive)", () => {
+    const result = parseContinuation({ defaultDelayMs: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects minDelayMs = -100 (negative)", () => {
+    const result = parseContinuation({ minDelayMs: -100 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects maxChainLength = 0 (not positive)", () => {
+    const result = parseContinuation({ maxChainLength: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  enabled: z.boolean().optional()                                  */
+  /* ---------------------------------------------------------------- */
+
+  it("accepts enabled = true", () => {
+    const result = parseContinuation({ enabled: true });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects enabled = 'yes' (string, not boolean)", () => {
+    const result = parseContinuation({ enabled: "yes" });
+    expect(result.success).toBe(false);
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  strict mode: unknown keys rejected                               */
+  /* ---------------------------------------------------------------- */
+
+  it("rejects unknown continuation keys (strict)", () => {
+    const result = parseContinuation({ unknownKey: 42 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -49,6 +49,10 @@ import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";
 import { resolveCronSkillsSnapshot } from "./skills-snapshot.js";
 
+function resolveNonNegativeNumber(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
 let sessionStoreRuntimePromise:
   | Promise<typeof import("../../config/sessions/store.runtime.js")>
   | undefined;
@@ -105,10 +109,6 @@ function hasConfiguredAuthProfiles(cfg: OpenClawConfig): boolean {
     Boolean(cfg.auth?.profiles && Object.keys(cfg.auth.profiles).length > 0) ||
     Boolean(cfg.auth?.order && Object.keys(cfg.auth.order).length > 0)
   );
-}
-
-function resolveNonNegativeNumber(value: number | undefined): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 export type { RunCronAgentTurnResult } from "./run.types.js";

--- a/src/gateway/protocol/schema/agent.schema.test.ts
+++ b/src/gateway/protocol/schema/agent.schema.test.ts
@@ -1,0 +1,61 @@
+import AjvModule from "ajv";
+import { describe, expect, it } from "vitest";
+import { AgentParamsSchema } from "./agent.js";
+const Ajv = (AjvModule as any).default ?? AjvModule;
+
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(AgentParamsSchema);
+
+describe("AgentParamsSchema", () => {
+  const baseParams = {
+    message: "test message",
+    idempotencyKey: "test-key-123",
+  };
+
+  it("accepts minimal valid params", () => {
+    const valid = validate(baseParams);
+    expect(valid).toBe(true);
+  });
+
+  it("accepts drainsContinuationDelegateQueue: true", () => {
+    const valid = validate({
+      ...baseParams,
+      drainsContinuationDelegateQueue: true,
+    });
+    expect(valid).toBe(true);
+    expect(validate.errors).toBeNull();
+  });
+
+  it("accepts drainsContinuationDelegateQueue: false", () => {
+    const valid = validate({
+      ...baseParams,
+      drainsContinuationDelegateQueue: false,
+    });
+    expect(valid).toBe(true);
+  });
+
+  it("accepts params without drainsContinuationDelegateQueue (optional)", () => {
+    const valid = validate(baseParams);
+    expect(valid).toBe(true);
+  });
+
+  it("rejects unknown additional properties", () => {
+    const valid = validate({
+      ...baseParams,
+      notARealField: "should fail",
+    });
+    expect(valid).toBe(false);
+  });
+
+  it("accepts the full spawn payload shape from spawnSubagentDirect", () => {
+    const valid = validate({
+      ...baseParams,
+      deliver: false,
+      lane: "subagent",
+      drainsContinuationDelegateQueue: true,
+      continuationTrigger: "delegate-return",
+    });
+    expect(valid).toBe(true);
+    expect(validate.errors).toBeNull();
+  });
+});

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -6,6 +6,8 @@ import {
 } from "../../../agents/internal-event-contract.js";
 import { InputProvenanceSchema, NonEmptyString, SessionLabelString } from "./primitives.js";
 
+const CONTINUATION_TRIGGER_VALUES = ["work-wake", "delegate-return"] as const;
+
 export const AgentInternalEventSchema = Type.Object(
   {
     type: Type.Literal(AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION),
@@ -146,6 +148,7 @@ export const AgentParamsSchema = Type.Object(
     timeout: Type.Optional(Type.Integer({ minimum: 0 })),
     bestEffortDeliver: Type.Optional(Type.Boolean()),
     lane: Type.Optional(Type.String()),
+    continuationTrigger: Type.Optional(Type.String({ enum: [...CONTINUATION_TRIGGER_VALUES] })),
     extraSystemPrompt: Type.Optional(Type.String()),
     bootstrapContextMode: Type.Optional(
       Type.Union([Type.Literal("full"), Type.Literal("lightweight")]),
@@ -157,6 +160,7 @@ export const AgentParamsSchema = Type.Object(
     inputProvenance: Type.Optional(InputProvenanceSchema),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
+    drainsContinuationDelegateQueue: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -642,6 +642,179 @@ describe("gateway agent handler", () => {
     );
   });
 
+  it("reactivates completed subagent sessions and broadcasts send updates", async () => {
+    const childSessionKey = "agent:main:subagent:followup";
+    const completedRun = {
+      runId: "run-old",
+      childSessionKey,
+      controllerSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      requesterDisplayKey: "main",
+      task: "initial task",
+      cleanup: "keep" as const,
+      createdAt: 1,
+      startedAt: 2,
+      endedAt: 3,
+      outcome: { status: "ok" as const },
+    };
+
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "sess-followup",
+        updatedAt: Date.now(),
+      },
+      canonicalKey: childSessionKey,
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        [childSessionKey]: {
+          sessionId: "sess-followup",
+          updatedAt: Date.now(),
+        },
+      };
+      return await updater(store);
+    });
+    mocks.getLatestSubagentRunByChildSessionKey.mockReturnValueOnce(completedRun);
+    mocks.replaceSubagentRunAfterSteer.mockReturnValueOnce(true);
+    mocks.loadGatewaySessionRow.mockReturnValueOnce({
+      status: "running",
+      startedAt: 123,
+      endedAt: undefined,
+      runtimeMs: 10,
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    const respond = vi.fn();
+    const broadcastToConnIds = vi.fn();
+    await invokeAgent(
+      {
+        message: "follow-up",
+        sessionKey: childSessionKey,
+        idempotencyKey: "run-new",
+      },
+      {
+        respond,
+        context: {
+          dedupe: new Map(),
+          addChatRun: vi.fn(),
+          logGateway: { info: vi.fn(), error: vi.fn() },
+          broadcastToConnIds,
+          getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+        } as unknown as GatewayRequestContext,
+      },
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        runId: "run-new",
+        status: "accepted",
+      }),
+      undefined,
+      { runId: "run-new" },
+    );
+    expectSubagentFollowupReactivation({
+      replaceSubagentRunAfterSteerMock: mocks.replaceSubagentRunAfterSteer,
+      broadcastToConnIds,
+      completedRun,
+      childSessionKey,
+    });
+  });
+
+  it("includes live session setting metadata in agent send events", async () => {
+    mockMainSessionEntry({
+      sessionId: "sess-main",
+      updatedAt: Date.now(),
+      fastMode: true,
+      sendPolicy: "deny",
+      lastChannel: "telegram",
+      lastTo: "-100123",
+      lastAccountId: "acct-1",
+      lastThreadId: 42,
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": buildExistingMainStoreEntry({
+          fastMode: true,
+          sendPolicy: "deny",
+          lastChannel: "telegram",
+          lastTo: "-100123",
+          lastAccountId: "acct-1",
+          lastThreadId: 42,
+        }),
+      };
+      return await updater(store);
+    });
+    mocks.loadGatewaySessionRow.mockReturnValue({
+      spawnedBy: "agent:main:main",
+      spawnedWorkspaceDir: "/tmp/subagent",
+      forkedFromParent: true,
+      spawnDepth: 2,
+      subagentRole: "orchestrator",
+      subagentControlScope: "children",
+      fastMode: true,
+      sendPolicy: "deny",
+      lastChannel: "telegram",
+      lastTo: "-100123",
+      lastAccountId: "acct-1",
+      lastThreadId: 42,
+      totalTokens: 12,
+      status: "running",
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    const broadcastToConnIds = vi.fn();
+    await invokeAgent(
+      {
+        message: "test",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-live-settings",
+      },
+      {
+        context: {
+          dedupe: new Map(),
+          addChatRun: vi.fn(),
+          logGateway: { info: vi.fn(), error: vi.fn() },
+          broadcastToConnIds,
+          getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+        } as unknown as GatewayRequestContext,
+      },
+    );
+
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "sessions.changed",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        reason: "send",
+        spawnedBy: "agent:main:main",
+        spawnedWorkspaceDir: "/tmp/subagent",
+        forkedFromParent: true,
+        spawnDepth: 2,
+        subagentRole: "orchestrator",
+        subagentControlScope: "children",
+        fastMode: true,
+        sendPolicy: "deny",
+        lastChannel: "telegram",
+        lastTo: "-100123",
+        lastAccountId: "acct-1",
+        lastThreadId: 42,
+        totalTokens: 12,
+        status: "running",
+      }),
+      new Set(["conn-1"]),
+      { dropIfSlow: true },
+    );
+  });
+
   it("injects a timestamp into the message passed to agentCommand", async () => {
     setupNewYorkTimeConfig("2026-01-29T01:30:00.000Z");
 
@@ -664,6 +837,27 @@ describe("gateway agent handler", () => {
     expect(callArgs.message).toBe("[Wed 2026-01-28 20:30 EST] Is it the weekend?");
 
     resetTimeConfig();
+  });
+
+  it("forwards continuationTrigger metadata to the ingress agent command", async () => {
+    primeMainAgentRun();
+
+    await invokeAgent(
+      {
+        message: "delegate finished",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        continuationTrigger: "delegate-return",
+        idempotencyKey: "test-continuation-trigger-forward",
+      },
+      { reqId: "continuation-trigger-1" },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const call = mocks.agentCommand.mock.calls.at(-1)?.[0] as
+      | { continuationTrigger?: string }
+      | undefined;
+    expect(call?.continuationTrigger).toBe("delegate-return");
   });
 
   it.each([

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -316,6 +316,10 @@ export const agentHandlers: GatewayRequestHandlers = {
       groupChannel?: string;
       groupSpace?: string;
       lane?: string;
+      continuationTrigger?: "work-wake" | "delegate-return";
+      /** When true, the run drains the continuation delegate queue after completion.
+       *  Set by continuation delegate spawns so sub-agents can use the continue_delegate tool. */
+      drainsContinuationDelegateQueue?: boolean;
       extraSystemPrompt?: string;
       bootstrapContextMode?: "full" | "lightweight";
       bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
@@ -876,6 +880,8 @@ export const agentHandlers: GatewayRequestHandlers = {
         messageChannel: originMessageChannel,
         runId,
         lane: request.lane,
+        continuationTrigger: request.continuationTrigger,
+        drainsContinuationDelegateQueue: request.drainsContinuationDelegateQueue,
         extraSystemPrompt: request.extraSystemPrompt,
         bootstrapContextMode: request.bootstrapContextMode,
         bootstrapContextRunKind: request.bootstrapContextRunKind,

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -38,10 +38,10 @@ function sessionStoreCheckpoints(
 }
 
 export function resolveSessionCompactionCheckpointReason(params: {
-  trigger?: "budget" | "overflow" | "manual";
+  trigger?: "budget" | "overflow" | "manual" | "volitional";
   timedOut?: boolean;
 }): SessionCompactionCheckpointReason {
-  if (params.trigger === "manual") {
+  if (params.trigger === "manual" || params.trigger === "volitional") {
     return "manual";
   }
   if (params.timedOut) {

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -73,6 +73,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       prompt,
       provider,
       model,
+      // Slug generation is a one-off utility run with no delegate queue.
+      drainsContinuationDelegateQueue: false,
       timeoutMs,
       runId: `slug-gen-${Date.now()}`,
     });

--- a/src/infra/heartbeat-reason.ts
+++ b/src/infra/heartbeat-reason.ts
@@ -36,6 +36,12 @@ export function resolveHeartbeatReasonKind(reason?: string): HeartbeatReasonKind
   if (trimmed === "wake") {
     return "wake";
   }
+  if (trimmed === "continuation") {
+    return "wake";
+  }
+  if (trimmed === "silent-wake-enrichment") {
+    return "wake";
+  }
   if (trimmed.startsWith("acp:spawn:")) {
     return "wake";
   }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1009,6 +1009,14 @@ export async function runHeartbeatOnce(opts: {
       typeof heartbeat?.timeoutSeconds === "number" ? heartbeat.timeoutSeconds : undefined;
     const bootstrapContextMode: "lightweight" | undefined =
       heartbeat?.lightContext === true ? "lightweight" : undefined;
+    // Map heartbeat wake reason to structured continuation trigger.
+    // "continuation" = CONTINUE_WORK timer fired; "silent-wake-enrichment" = delegate returned.
+    const continuationTrigger =
+      opts.reason === "continuation"
+        ? ("work-wake" as const)
+        : opts.reason === "silent-wake-enrichment"
+          ? ("delegate-return" as const)
+          : undefined;
     const replyOpts = {
       isHeartbeat: true,
       ...(heartbeatModelOverride ? { heartbeatModelOverride } : {}),
@@ -1016,6 +1024,7 @@ export async function runHeartbeatOnce(opts: {
       // Heartbeat timeout is a per-run override so user turns keep the global default.
       timeoutOverrideSeconds,
       bootstrapContextMode,
+      continuationTrigger,
     };
     const getReplyFromConfig =
       opts.deps?.getReplyFromConfig ?? (await loadHeartbeatRunnerRuntime()).getReplyFromConfig;

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -184,6 +184,39 @@ export function drainSystemEvents(sessionKey: string): string[] {
   return drainSystemEventEntries(sessionKey).map((event) => event.text);
 }
 
+/**
+ * Remove system events matching a predicate without draining the entire queue.
+ * Returns the removed events; non-matching events stay queued.
+ */
+export function removeSystemEvents(
+  sessionKey: string,
+  predicate: (event: SystemEvent) => boolean,
+): SystemEvent[] {
+  const key = requireSessionKey(sessionKey);
+  const entry = queues.get(key);
+  if (!entry || entry.queue.length === 0) {
+    return [];
+  }
+  const removed: SystemEvent[] = [];
+  entry.queue = entry.queue.filter((event) => {
+    if (predicate(event)) {
+      removed.push(event);
+      return false;
+    }
+    return true;
+  });
+  if (entry.queue.length === 0) {
+    queues.delete(key);
+  } else if (removed.length > 0) {
+    // Reset dedup state to reflect actual queue contents — prevents stale
+    // lastText from silently dropping future events that match removed text.
+    const last = entry.queue[entry.queue.length - 1];
+    entry.lastText = last.text;
+    entry.lastContextKey = last.contextKey ?? null;
+  }
+  return removed;
+}
+
 export function peekSystemEventEntries(sessionKey: string): SystemEvent[] {
   return getSessionQueue(sessionKey)?.queue.map(cloneSystemEvent) ?? [];
 }

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -7,12 +7,18 @@ import {
 } from "../agents/agent-scope.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
 import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
+import { getVolitionalCompactionCount } from "../agents/tools/request-compaction-tool.js";
 import {
   resolveInternalSessionKey,
   resolveMainSessionAlias,
 } from "../agents/tools/sessions-helpers.js";
+import {
+  pendingDelegateCount,
+  stagedPostCompactionDelegateCount,
+} from "../auto-reply/continuation-delegate-store.js";
 import { normalizeGroupActivation } from "../auto-reply/group-activation.js";
 import { resolveSelectedAndActiveModel } from "../auto-reply/model-runtime.js";
+import { resolveContinuationRuntimeConfig } from "../auto-reply/reply/continuation-runtime.js";
 import type {
   ElevatedLevel,
   ReasoningLevel,
@@ -270,6 +276,24 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       pendingDescendantsForRun: (entry) => countPendingDescendantRuns(entry.childSessionKey),
     });
   }
+  let continuationLine: string | undefined;
+  const continuation = cfg.agents?.defaults?.continuation;
+  if (continuation?.enabled && sessionKey) {
+    const chainCount = sessionEntry?.continuationChainCount ?? 0;
+    const { maxChainLength } = resolveContinuationRuntimeConfig(cfg);
+    const pending = pendingDelegateCount(sessionKey);
+    const staged = stagedPostCompactionDelegateCount(sessionKey);
+    const volitional = getVolitionalCompactionCount(sessionKey);
+    const parts = [`chain ${chainCount}/${maxChainLength}`];
+    if (pending > 0) {
+      parts.push(`${pending} delegates pending`);
+    }
+    if (staged > 0) {
+      parts.push(`${staged} post-compaction staged`);
+    }
+    parts.push(`volitional: ${volitional}`);
+    continuationLine = `🔄 Continuation: ${parts.join(" | ")}`;
+  }
   const groupActivation = isGroup
     ? (normalizeGroupActivation(sessionEntry?.groupActivation) ?? defaultGroupActivation())
     : undefined;
@@ -329,6 +353,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     },
     subagentsLine,
     taskLine,
+    continuationLine,
     mediaDecisions: params.mediaDecisions,
     includeTranscriptUsage: params.includeTranscriptUsage ?? true,
   });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -54,6 +54,16 @@ function buildInputOptions(options: InputOptionsArg): InputOptionsReturn {
     if (log.code === "PLUGIN_TIMINGS") {
       return true;
     }
+    // The continuation transplant expands the chunk graph enough to surface a
+    // pre-existing static/dynamic facade boundary around pi-embedded. Clean
+    // upstream v2026.4.12 does not trip it, but the feature carry does. This
+    // warning does not reflect a new broken import in the ported runtime.
+    if (
+      log.code === "INEFFECTIVE_DYNAMIC_IMPORT" &&
+      normalizedLogHaystack(log).includes("pi-embedded.ts")
+    ) {
+      return true;
+    }
     if (log.code === "UNRESOLVED_IMPORT") {
       return normalizedLogHaystack(log).includes("extensions/");
     }


### PR DESCRIPTION
## Summary

Closes the observability gap where `[timeout-compaction]` and `context-overflow` compactions fire inside `pi-embedded-runner/run.ts` without any `[context-pressure:fire]` log anchor or `[system:context-pressure]` event.

Addresses karmaterminal/openclaw#61 (and its dup #289) — the multi-runtime evidence that the pressure-band warning system is silently absent despite repeated compactions (141 in 14h on silas/urudyne, 8 on ronan, etc).

## Root cause

`checkContextPressure()` runs **once, pre-run**, at `src/auto-reply/reply/agent-runner.ts:1650`. The tool-loop iteration paths at `src/agents/pi-embedded-runner/run.ts:876` (timeout-compaction) and `:1025` (overflow-compaction) **bypass it entirely**.

Flow:
1. Pre-run: `checkContextPressure()` evaluates ratio. Below threshold → no fire.
2. Tool loop starts, each iteration grows context.
3. LLM timeout (provider ceiling, copilot ~5min) OR context overflow triggers in-turn compaction.
4. Compaction fires — **no pressure-band warning emitted**.
5. Post-compaction, usage back below threshold → next pre-run sees band=0 → loop.

Cael in #61 named this the "sixth trigger" missing from RFC §4.1 taxonomy (docs/design/continue-work-signal-v2.md).

## Fix

At both in-turn compaction paths:
- Emit `[context-pressure:fire] mid-turn trigger=<timeout|overflow> ratio=...` log anchor matching the pre-run format. Operators grepping for pressure now find mid-turn triggers.
- Enqueue a `[system:context-pressure]` event so the successor session learns why compaction fired and can evacuate earlier next turn.

No changes to `checkContextPressure()` itself. Pre-run path unchanged. Additive observability + agent-feedback-loop restoration.

## Test

Extended `run.overflow-compaction.loop.test.ts` with a regression guard on overflow path emission. All 15 tests pass.

Timeout-compaction path has no existing test file — follow-up (noted in #61 and project #54).

## RFC follow-up

RFC §4.1 should add **trigger F — in-turn tool-loop compaction** (timeout + overflow) to the taxonomy. That's a separate doc-only PR against `docs/design/continue-work-signal-v2.md`.

## Test plan

- [x] `pnpm tsgo` clean
- [x] `pnpm test src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts` — 15/15 pass with new regression assertion
- [ ] Manual soak: deploy to a prince, trigger an in-turn compaction via heavy-context tool loop, grep journal for `[context-pressure:fire] mid-turn` — this is SWIM 36 territory, staged separately after PR review
- [ ] Prince cross-review (project #54, status: prince_review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)