### PR TITLE
docs(tools-template): substrate-adoption convention for new tool descriptors (#336 lift)

### DIFF
--- a/docs/reference/templates/TOOLS.md
+++ b/docs/reference/templates/TOOLS.md
@@ -46,6 +46,48 @@ Skills are shared. Your setup is yours. Keeping them apart means you can update 
 
 Add whatever helps you do your job. This is your cheat sheet.
 
+## Substrate-adoption convention for new tool descriptors
+
+Adopted Sprint 56 against `karmaterminal-2026.4.24-base`. Use this when adding a new optional field to a tool descriptor whose runtime is split across two phases — an (a)-shape RPC-style address-recipient form that ships now, and a (b)-shape broadcast/publish form that ships later under the host substrate (e.g. karmaterminal/binary-canticle#11).
+
+### bc#11 conditional-voice block
+
+Quote this 8-line block verbatim on the new field. The `(a)`/`(b)` framing tells a future reader the field has an evolution path and which substrate carries the (b)-shape:
+
+```ts
+  targetSessionKey: Type.Optional(
+    Type.String({
+      description:
+        "Address a sibling session for cross-session enrichment. " +
+        "This is the (a)-shape (RPC-style address-recipient); v3 surfaces broadcast-mode " +
+        "via karmaterminal/binary-canticle#11. Same substrate; different verb-set.",
+    }),
+  ),
+```
+
+For richer descriptors, extend with the address format and the runtime-issue cite:
+
+- Concrete sessions: `prince:<role>:agent:<id>:<channel>`
+- Role-aliased delivery: `prince:<role>:role:<role-name>`
+- `DESCRIPTOR-ONLY` in this version; runtime lands in `#<runtime-issue>`; calling it now fails loudly.
+
+### Descriptor-only loud-failure
+
+When the field exists in the schema but the runtime hasn't landed, fail at `execute()` with `ToolInputError` (not plain `Error`) — matches the line-80 pattern at `src/agents/tools/continue-delegate-tool.ts:80`:
+
+> this field exists in the schema; runtime lands in `#N`; calling it now fails immediately and points at the runtime issue.
+
+### Doctrine
+
+- **Ride upstream substrate for free wins.** Drain ordering, idempotency, route resolution, W3C trace-context (`traceparent`), sha256 content-addressing — if the host already grants it, do not re-implement. Each substrate adopted is one less bespoke mechanism the cohort maintains through the next compaction (prince-power-velocity).
+- **Add verbs over the substrate-noun.** The queue is the noun; `address`, `publish`, `broadcast` are verbs that evolve over it. Never add a parallel mechanism that bypasses the substrate.
+- **Cite-pin the (a) to (b) path.** A future prince adding a descriptor should ask at design-time: is there a substrate already granting this capability, and does this descriptor have a (b)-shape arriving later? Pin the runtime issue and the bc#-tracking link so the convergence stays legible across compactions.
+
+### One-source-of-truth examples
+
+- gpt2 applied: `7df92a78b4` (Surface 1, `targetSessionKey?` descriptor) and `b948632594` (Surface 2, `QueuedSessionDeliveryPayloadMetadata` intersection — `traceparent?` and `attachments?`) on `frond-scribe/20260424/candidate-gpt2`.
+- claude2 textual-savegame: `87b1bffb14` on `frond-scribe/20260424/candidate-claude2` — longer-form rationale and address-format examples.
+
 ## Related
 
 - [Agent workspace](/concepts/agent-workspace)


### PR DESCRIPTION
Closes part of #336 (TOOLS.md addendum slice from copilot v2.5 assist lane).

## What

Adds a 42-line **"Substrate-adoption convention for new tool descriptors"** section to `docs/reference/templates/TOOLS.md`. Captures the bc#11 conditional-voice JSDoc template + (a)-shape longer-form rationale + descriptor-only loud-failure pattern + 3-bullet substrate-adoption doctrine as a workspace convention prince-authored tool descriptors should follow at design-time.

## Why (maintainer-pitch)

The 2026.4.24 changelog already includes `continuation` vocabulary. The cohort is shipping tool descriptors that ride the existing host substrate (session-delivery-queue, restart-sentinel, W3C trace-context, sha256 content-addressing) instead of building parallel mechanisms — and we want that pattern to be **legible at design-time** so future princes adopting the same substrate inherit the convention.

This addendum is **template-prose only** (no runtime, no code change, no test impact). It documents the convention captured by **two convergent independent walks** of the same surface:

- gpt2 (copilot v2.5 / gpt-5.5 / xhigh) applied: `7df92a78b4` + `b948632594` on `frond-scribe/20260424/candidate-gpt2`
- claude2 (claude opus 4.7) textual-savegame: `87b1bffb14` on `frond-scribe/20260424/candidate-claude2`

Different model families landed identical descriptor surface + identical bc#11 conditional-voice JSDoc — convergence-across-model-families is the substrate-validation evidence-shape this addendum names.

## Doctrine captured

- **Ride upstream substrate.** Drain ordering, idempotency, route resolution, W3C trace-context, sha256 content-addressing — if the host grants it, do not re-implement.
- **Verbs over the substrate-noun.** The queue is the noun; `address`, `publish`, `broadcast` are verbs that evolve over it.
- **Cite-pin the (a) to (b) path.** Pin the runtime issue and the bc# tracking link so the convergence stays legible across compactions.

## Loud-failure pattern

Standardizes `ToolInputError` (not plain `Error`) for descriptor-only-in-this-version fields, matching the existing line-80 pattern at `src/agents/tools/continue-delegate-tool.ts:80` — claude2's read, which gpt2 also-applied-but-with-plain-Error.

## Scope

- Single file: `docs/reference/templates/TOOLS.md`
- 42 lines added, 0 removed
- No code, no tests, no build impact
- Branch is the savegame (#326 discipline)

Refs: #336 #337 #325 #332 #334 karmaterminal/binary-canticle#11