### PR TITLE
fix(queue): stabilize B-shape idempotency on canonical2

### DIFF
--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -80,11 +80,18 @@ function getErrnoCode(err: unknown): string | null {
     : null;
 }
 
+// Strip trailing whitespace per line and at end-of-string before hashing the
+// idempotency key, so same-intent keys that differ only by trailing whitespace
+// produce the same sha256 taskHash and the replay-dedupe path stays robust.
+function canonicalizeIdempotencyKey(key: string): string {
+  return key.replace(/[ \t\r\f\v]+(?=\n|$)/g, "").replace(/\s+$/, "");
+}
+
 function buildEntryId(idempotencyKey?: string): string {
   if (!idempotencyKey) {
     return generateSecureUuid();
   }
-  return createHash("sha256").update(idempotencyKey).digest("hex");
+  return createHash("sha256").update(canonicalizeIdempotencyKey(idempotencyKey)).digest("hex");
 }
 
 async function unlinkBestEffort(filePath: string): Promise<void> {

--- a/src/infra/session-delivery-queue.storage.test.ts
+++ b/src/infra/session-delivery-queue.storage.test.ts
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
   ackSessionDelivery,
@@ -114,6 +114,127 @@ describe("session-delivery queue storage", () => {
       await loadPendingSessionDeliveries(tempDir);
 
       expect(fs.existsSync(tmpPath)).toBe(false);
+    });
+  });
+
+  it("keeps same-tuple unkeyed concurrent enqueues distinct in the same wall-clock millisecond", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const fixedNow = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+      try {
+        const firstId = await enqueueSessionDelivery(
+          {
+            kind: "systemEvent",
+            sessionKey: "agent:main:main",
+            text: "concurrent enqueue",
+          },
+          tempDir,
+        );
+        const secondId = await enqueueSessionDelivery(
+          {
+            kind: "systemEvent",
+            sessionKey: "agent:main:main",
+            text: "concurrent enqueue",
+          },
+          tempDir,
+        );
+
+        expect(secondId).not.toBe(firstId);
+        const entries = await loadPendingSessionDeliveries(tempDir);
+        expect(entries).toHaveLength(2);
+        expect(entries.every((entry) => entry.enqueuedAt === 1_700_000_000_000)).toBe(true);
+      } finally {
+        fixedNow.mockRestore();
+      }
+    });
+  });
+
+  it("does not collapse sub-second siblings that share a wall-clock second", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const nowSpy = vi.spyOn(Date, "now");
+      nowSpy.mockReturnValueOnce(1_700_000_000_010);
+      nowSpy.mockReturnValueOnce(1_700_000_000_730);
+      try {
+        const firstId = await enqueueSessionDelivery(
+          {
+            kind: "agentTurn",
+            sessionKey: "agent:main:main",
+            message: "sibling",
+            messageId: "msg-1",
+          },
+          tempDir,
+        );
+        const secondId = await enqueueSessionDelivery(
+          {
+            kind: "agentTurn",
+            sessionKey: "agent:main:main",
+            message: "sibling",
+            messageId: "msg-2",
+          },
+          tempDir,
+        );
+
+        expect(secondId).not.toBe(firstId);
+        const entries = await loadPendingSessionDeliveries(tempDir);
+        expect(entries).toHaveLength(2);
+        const [earlier, later] = entries.map((entry) => entry.enqueuedAt).toSorted((a, b) => a - b);
+        expect([earlier, later]).toEqual([1_700_000_000_010, 1_700_000_000_730]);
+        expect(Math.floor(earlier / 1000)).toBe(Math.floor(later / 1000));
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+  });
+
+  it("treats trailing-whitespace variants of an idempotency key as the same taskHash", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const baseKey = "restart-sentinel:agent:main:main:agentTurn:1700000000123";
+      const cleanId = await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "first",
+          messageId: baseKey,
+          idempotencyKey: baseKey,
+        },
+        tempDir,
+      );
+      const trailingSpaceId = await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "trailing space duplicate",
+          messageId: baseKey,
+          idempotencyKey: `${baseKey}   `,
+        },
+        tempDir,
+      );
+      const trailingNewlineId = await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "trailing newline duplicate",
+          messageId: baseKey,
+          idempotencyKey: `${baseKey}\n`,
+        },
+        tempDir,
+      );
+      const trailingMixedId = await enqueueSessionDelivery(
+        {
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "trailing mixed whitespace duplicate",
+          messageId: baseKey,
+          idempotencyKey: `${baseKey} \t\n`,
+        },
+        tempDir,
+      );
+
+      const expected = createHash("sha256").update(baseKey).digest("hex");
+      expect(cleanId).toBe(expected);
+      expect(trailingSpaceId).toBe(expected);
+      expect(trailingNewlineId).toBe(expected);
+      expect(trailingMixedId).toBe(expected);
+      expect(await loadPendingSessionDeliveries(tempDir)).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- preserve canonical2's concurrency-first queue identity surface for unkeyed enqueues
- canonicalize trailing whitespace before hashing `idempotencyKey` so explicit replay-dedupe stays stable
- add queue-storage tests proving same-second siblings stay distinct while whitespace-drifted keys collapse

## Tests
- `pnpm test src/infra/session-delivery-queue.storage.test.ts`
- `pnpm test src/infra/session-delivery-queue.recovery.test.ts src/gateway/server-restart-sentinel.test.ts`
- `pnpm check:changed`

## Notes
- full test lane still shows pre-existing unrelated failures on base (`auto-reply/agent-runner`, `amazon-bedrock cache points`, `gateway agent handler`, `plugin-sdk channel-entry-contract`); re-ran one with my patch stashed and reproduced on base
- follows the locked B-shape from #342: concurrency-distinguishability first, no coarse 1s bucket, explicit replay-dedupe via keyed path
