### PR TITLE
fix: clear pre-existing canonical2 base-noise blocking PR #345

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -936,8 +936,9 @@ export async function runAgentTurnWithFallback(params: {
         ...resolveModelFallbackOptions(params.followupRun.run),
         runId,
         classifyResult: async ({ result, provider, model }) => {
+          const effectiveResult = isContinuationWrappedRunResult(result) ? result.result : result;
           const classification = outcomePlan.classifyRunResult({
-            result,
+            result: effectiveResult,
             provider,
             model,
             hasDirectlySentBlockReply: directlySentBlockKeys.size > 0,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -83,6 +83,7 @@ vi.mock("../../agents/cli-runner.js", () => ({
 vi.mock("../../agents/subagent-spawn.js", () => ({
   SUBAGENT_SPAWN_MODES: ["run", "session"],
   SUBAGENT_SPAWN_SANDBOX_MODES: ["inherit", "require"],
+  SUBAGENT_SPAWN_CONTEXT_MODES: ["isolated", "fork"],
   spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
 }));
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -739,6 +739,7 @@ describe("gateway agent handler", () => {
         context: {
           dedupe: new Map(),
           addChatRun: vi.fn(),
+          chatAbortControllers: new Map(),
           logGateway: { info: vi.fn(), error: vi.fn() },
           broadcastToConnIds,
           getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
@@ -819,6 +820,7 @@ describe("gateway agent handler", () => {
         context: {
           dedupe: new Map(),
           addChatRun: vi.fn(),
+          chatAbortControllers: new Map(),
           logGateway: { info: vi.fn(), error: vi.fn() },
           broadcastToConnIds,
           getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -176,10 +176,14 @@ async function expectBuiltArtifactNodeRequireFastPath(
     fs.writeFileSync(sidecarPath, "module.exports = { sentinel: 7 };\n", "utf8");
 
     expect(
-      channelEntryContract.loadBundledEntryExportSync<number>(pathToFileURL(importerPath).href, {
-        specifier: "./fast-path-sidecar.js",
-        exportName: "sentinel",
-      }),
+      channelEntryContract.loadBundledEntryExportSync<number>(
+        pathToFileURL(importerPath).href,
+        {
+          specifier: "./fast-path-sidecar.js",
+          exportName: "sentinel",
+        },
+        { installRuntimeDeps: false },
+      ),
     ).toBe(7);
 
     const profileLine = errorSpy.mock.calls


### PR DESCRIPTION
🌫 base-noise fixes for canonical2, blocking PR #345 from clean merge.

## What this fixes

All four were pre-existing regressions on canonical2 `56cb6f712a`, reproducible with zero PR diff applied.

### 1. `agent-runner-execution.ts` — fallback classifier received continuation-wrapped result (production fix)
- **Root cause**: Continuation-core implementation wrapped run results as `{ result, continueWorkRequest }`. The unwrap was added at the `fallbackRunResult` callsite (line 1480) but missed at the `classifyResult` callback callsite (line 936-939). Classifier received the wrapper, looked for `meta` at top level, returned `null`, downstream `toMatchObject` threw, outer catch swallowed it as `kind: "final"` with a generic error.
- **Commit**: `a197cf405e` — apply the same `isContinuationWrappedRunResult` unwrap at the missed callsite. 1-line + 1-line change.
- **This is a real production bug**, not a stale test. Fallback classification was silently failing for any run that came through the continuation-wrapping path.

### 2. `agent.test.ts` — `chatAbortControllers.has()` TypeError
- **Root cause**: `registerChatAbortController` was added to the agent RPC handler reading `context.chatAbortControllers`. Two inline test contexts were missing the field.
- **Commit**: `f0aa7ec62f` — add `chatAbortControllers: new Map()` to the two stale test contexts. Test-only fix.

### 3. `agent-runner.misc.runreplyagent.test.ts` — missing `SUBAGENT_SPAWN_CONTEXT_MODES` mock export
- **Root cause**: `SUBAGENT_SPAWN_CONTEXT_MODES` was added to the production module; the `subagent-spawn.js` mock didn't track it. `sessions-spawn-tool.ts` (loaded transitively) crashed at module load when reading the constant for schema definition.
- **Commit**: `57c4e87346` — add the constant to the mock. Test-only fix.

### 4. `channel-entry-contract.test.ts` — nonzero jiti timing on supposed fast-path
- **Root cause**: `prepareBundledPluginRuntimeRoot` (added by `9c733956c0`) mirrors plugin files into a runtime root with `"type": "module"`. Node then refuses CJS `.js` files via `nodeRequire`, falls back to jiti, timing assertions fail.
- **Commit**: `360e69cabc` — pass `installRuntimeDeps: false` in the fast-path test (testing the nodeRequire mechanism, not the runtime-deps mirroring).

## Verification

```
src/auto-reply/reply/agent-runner-execution.test.ts     45/45 passed
src/gateway/server-methods/agent.test.ts                46/46 passed
src/plugin-sdk/channel-entry-contract.test.ts            8/8 passed
src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts  36/36 passed

Broader smoke (auto-reply 102 files / 1273 tests, gateway, plugin-sdk):
  all green
```

## Surface

```
src/auto-reply/reply/agent-runner-execution.ts               | 3 ++- (production)
src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts | 1 +
src/gateway/server-methods/agent.test.ts                     | 2 ++
src/plugin-sdk/channel-entry-contract.test.ts                | 12 ++++++++----
4 files, 13 insertions, 5 deletions
```

## Why this matters now

🩸 caught these on PR #345's CI surface; we byte-confirmed they reproduce on canonical2 base with zero PR diff. Per 🩸's call: path 2 (fix base first, then merge #345 clean) over path 1 (land #345 on red board on trust).

This PR clears the path. Once green and merged into canonical2, PR #345 should rebase cleanly and CI should go green for real.

cc @cael-dandelion-cult @figs-dandelion-cult
