### PR TITLE
feat(session-delivery-queue): failed TTL prune + queueDir soft-cap (#332)

### DIFF
--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -26,7 +26,7 @@ async function maybePruneFailedRecords(opts: {
   if (failedMaxAgeMs == null || !(failedMaxAgeMs > 0)) {
     return;
   }
-  if (now - lastGcAt <= FAILED_GC_AMORTIZATION_MS) {
+  if (now - lastGcAt < FAILED_GC_AMORTIZATION_MS) {
     return;
   }
   try {

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -5,8 +5,43 @@ import {
   loadPendingSessionDelivery,
   loadPendingSessionDeliveries,
   moveSessionDeliveryToFailed,
+  pruneFailedOlderThan,
   type QueuedSessionDelivery,
 } from "./session-delivery-queue-storage.js";
+
+const FAILED_GC_AMORTIZATION_MS = 60_000;
+let lastGcAt = 0;
+
+export function __resetFailedGcWatermarkForTests(): void {
+  lastGcAt = 0;
+}
+
+async function maybePruneFailedRecords(opts: {
+  failedMaxAgeMs?: number;
+  stateDir?: string;
+  log: SessionDeliveryRecoveryLogger;
+  now: number;
+}): Promise<void> {
+  const { failedMaxAgeMs, stateDir, log, now } = opts;
+  if (failedMaxAgeMs == null || !(failedMaxAgeMs > 0)) {
+    return;
+  }
+  if (now - lastGcAt <= FAILED_GC_AMORTIZATION_MS) {
+    return;
+  }
+  try {
+    const summary = await pruneFailedOlderThan(failedMaxAgeMs, now, stateDir);
+    if (summary.removed > 0) {
+      log.info(
+        `Session delivery failed/ prune: removed ${summary.removed} of ${summary.scanned} entries older than ${failedMaxAgeMs}ms`,
+      );
+    }
+  } catch (err) {
+    log.warn(`Session delivery failed/ prune error: ${formatErrorMessage(err)}`);
+  } finally {
+    lastGcAt = now;
+  }
+}
 
 export type SessionDeliveryRecoverySummary = {
   recovered: number;
@@ -126,6 +161,7 @@ export async function drainPendingSessionDeliveries(opts: {
   stateDir?: string;
   deliver: DeliverSessionDeliveryFn;
   selectEntry: (entry: QueuedSessionDelivery, now: number) => PendingSessionDeliveryDrainDecision;
+  failedMaxAgeMs?: number;
 }): Promise<void> {
   if (drainInProgress.get(opts.drainKey)) {
     opts.log.info(`${opts.logLabel}: already in progress for ${opts.drainKey}, skipping`);
@@ -134,6 +170,12 @@ export async function drainPendingSessionDeliveries(opts: {
 
   drainInProgress.set(opts.drainKey, true);
   try {
+    await maybePruneFailedRecords({
+      failedMaxAgeMs: opts.failedMaxAgeMs,
+      stateDir: opts.stateDir,
+      log: opts.log,
+      now: Date.now(),
+    });
     const matchingEntries = (await loadPendingSessionDeliveries(opts.stateDir))
       .filter((entry) => opts.selectEntry(entry, Date.now()).match)
       .toSorted((a, b) => a.enqueuedAt - b.enqueuedAt);
@@ -200,7 +242,14 @@ export async function recoverPendingSessionDeliveries(opts: {
   stateDir?: string;
   maxRecoveryMs?: number;
   maxEnqueuedAt?: number;
+  failedMaxAgeMs?: number;
 }): Promise<SessionDeliveryRecoverySummary> {
+  await maybePruneFailedRecords({
+    failedMaxAgeMs: opts.failedMaxAgeMs,
+    stateDir: opts.stateDir,
+    log: opts.log,
+    now: Date.now(),
+  });
   const pending = (await loadPendingSessionDeliveries(opts.stateDir)).filter(
     (entry) => opts.maxEnqueuedAt == null || entry.enqueuedAt <= opts.maxEnqueuedAt,
   );

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -9,6 +9,23 @@ const QUEUE_DIRNAME = "session-delivery-queue";
 const FAILED_DIRNAME = "failed";
 const TMP_SWEEP_MAX_AGE_MS = 5_000;
 
+export const DEFAULT_FAILED_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+export const DEFAULT_QUEUE_DIR_MAX_FILES = 10_000;
+
+export class SessionDeliveryQueueOverflowError extends Error {
+  readonly kind = "session-delivery-queue-overflow" as const;
+  readonly count: number;
+  readonly maxFiles: number;
+  constructor(count: number, maxFiles: number) {
+    super(
+      `session-delivery-queue overflow: ${count} queued files at top level, soft-cap is ${maxFiles}`,
+    );
+    this.name = "SessionDeliveryQueueOverflowError";
+    this.count = count;
+    this.maxFiles = maxFiles;
+  }
+}
+
 export type SessionDeliveryContext = {
   channel?: string;
   to?: string;
@@ -158,9 +175,29 @@ export async function ensureSessionDeliveryQueueDir(stateDir?: string): Promise<
   return queueDir;
 }
 
+export async function countQueuedFiles(queueDir: string): Promise<number> {
+  let entries: string[];
+  try {
+    entries = await fs.promises.readdir(queueDir);
+  } catch (err) {
+    if (getErrnoCode(err) === "ENOENT") {
+      return 0;
+    }
+    throw err;
+  }
+  let count = 0;
+  for (const entry of entries) {
+    if (entry.endsWith(".json") || entry.endsWith(".tmp") || entry.endsWith(".delivered")) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
 export async function enqueueSessionDelivery(
   params: QueuedSessionDeliveryPayload,
   stateDir?: string,
+  opts?: { maxQueuedFiles?: number },
 ): Promise<string> {
   const queueDir = await ensureSessionDeliveryQueueDir(stateDir);
   const id = buildEntryId(params.idempotencyKey);
@@ -176,6 +213,17 @@ export async function enqueueSessionDelivery(
       if (getErrnoCode(err) !== "ENOENT") {
         throw err;
       }
+    }
+  }
+
+  const maxQueuedFiles = opts?.maxQueuedFiles ?? DEFAULT_QUEUE_DIR_MAX_FILES;
+  if (Number.isFinite(maxQueuedFiles) && maxQueuedFiles > 0) {
+    const count = await countQueuedFiles(queueDir);
+    if (count >= maxQueuedFiles) {
+      console.warn(
+        `[session-delivery-queue] enqueue rejected: ${count} queued files at top level, soft-cap is ${maxQueuedFiles}`,
+      );
+      throw new SessionDeliveryQueueOverflowError(count, maxQueuedFiles);
     }
   }
 
@@ -282,4 +330,50 @@ export async function moveSessionDeliveryToFailed(id: string, stateDir?: string)
   const failedDir = resolveFailedDir(stateDir);
   await fs.promises.mkdir(failedDir, { recursive: true, mode: 0o700 });
   await fs.promises.rename(path.join(queueDir, `${id}.json`), path.join(failedDir, `${id}.json`));
+}
+
+export async function pruneFailedOlderThan(
+  maxAgeMs: number,
+  now: number,
+  stateDir?: string,
+): Promise<{ scanned: number; removed: number }> {
+  const failedDir = resolveFailedDir(stateDir);
+  let entries: string[];
+  try {
+    entries = await fs.promises.readdir(failedDir);
+  } catch (err) {
+    if (getErrnoCode(err) === "ENOENT") {
+      return { scanned: 0, removed: 0 };
+    }
+    throw err;
+  }
+
+  let scanned = 0;
+  let removed = 0;
+  for (const entry of entries) {
+    const filePath = path.join(failedDir, entry);
+    try {
+      const stat = await fs.promises.stat(filePath);
+      if (!stat.isFile()) {
+        continue;
+      }
+      scanned += 1;
+      if (now - stat.mtimeMs > maxAgeMs) {
+        try {
+          await fs.promises.unlink(filePath);
+          removed += 1;
+        } catch (unlinkErr) {
+          if (getErrnoCode(unlinkErr) !== "ENOENT") {
+            throw unlinkErr;
+          }
+        }
+      }
+    } catch (err) {
+      if (getErrnoCode(err) === "ENOENT") {
+        continue;
+      }
+      throw err;
+    }
+  }
+  return { scanned, removed };
 }

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -1,14 +1,26 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
+import { __resetFailedGcWatermarkForTests } from "./session-delivery-queue-recovery.js";
+import * as storage from "./session-delivery-queue-storage.js";
 import {
   enqueueSessionDelivery,
   failSessionDelivery,
   isSessionDeliveryEligibleForRetry,
   loadPendingSessionDeliveries,
   recoverPendingSessionDeliveries,
+  resolveSessionDeliveryQueueDir,
 } from "./session-delivery-queue.js";
 
 describe("session-delivery queue recovery", () => {
+  beforeEach(() => {
+    __resetFailedGcWatermarkForTests();
+  });
+  afterEach(() => {
+    __resetFailedGcWatermarkForTests();
+  });
+
   it("replays and acks pending entries on recovery", async () => {
     await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
       await enqueueSessionDelivery(
@@ -116,6 +128,71 @@ describe("session-delivery queue recovery", () => {
     });
 
     vi.useRealTimers();
+  });
+
+  it("amortizes failed/ prune across rapid recovery ticks via the lastGcAt watermark", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const failedDir = path.join(resolveSessionDeliveryQueueDir(tempDir), "failed");
+      fs.mkdirSync(failedDir, { recursive: true });
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const deliver = vi.fn(async () => undefined);
+
+      const pruneSpy = vi
+        .spyOn(storage, "pruneFailedOlderThan")
+        .mockResolvedValue({ scanned: 0, removed: 0 });
+      const nowSpy = vi.spyOn(Date, "now");
+      try {
+        nowSpy.mockReturnValue(1_700_000_000_000);
+        await recoverPendingSessionDeliveries({
+          deliver,
+          stateDir: tempDir,
+          log,
+          failedMaxAgeMs: 14 * 24 * 60 * 60 * 1000,
+        });
+        expect(pruneSpy).toHaveBeenCalledTimes(1);
+
+        // Same wall-clock — within the 60s amortization window — must NOT re-prune.
+        await recoverPendingSessionDeliveries({
+          deliver,
+          stateDir: tempDir,
+          log,
+          failedMaxAgeMs: 14 * 24 * 60 * 60 * 1000,
+        });
+        expect(pruneSpy).toHaveBeenCalledTimes(1);
+
+        // Advance past the amortization window — next tick should prune again.
+        nowSpy.mockReturnValue(1_700_000_000_000 + 61_000);
+        await recoverPendingSessionDeliveries({
+          deliver,
+          stateDir: tempDir,
+          log,
+          failedMaxAgeMs: 14 * 24 * 60 * 60 * 1000,
+        });
+        expect(pruneSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        pruneSpy.mockRestore();
+        nowSpy.mockRestore();
+      }
+    });
+  });
+
+  it("skips failed/ prune entirely when failedMaxAgeMs is not provided", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const pruneSpy = vi
+        .spyOn(storage, "pruneFailedOlderThan")
+        .mockResolvedValue({ scanned: 0, removed: 0 });
+      try {
+        await recoverPendingSessionDeliveries({
+          deliver: vi.fn(async () => undefined),
+          stateDir: tempDir,
+          log,
+        });
+        expect(pruneSpy).not.toHaveBeenCalled();
+      } finally {
+        pruneSpy.mockRestore();
+      }
+    });
   });
 
   it("uses the persisted retryCount for the first backoff tier", async () => {

--- a/src/infra/session-delivery-queue.storage.test.ts
+++ b/src/infra/session-delivery-queue.storage.test.ts
@@ -6,10 +6,14 @@ import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
   ackSessionDelivery,
+  countQueuedFiles,
   enqueueSessionDelivery,
   failSessionDelivery,
   loadPendingSessionDeliveries,
+  moveSessionDeliveryToFailed,
+  pruneFailedOlderThan,
   resolveSessionDeliveryQueueDir,
+  SessionDeliveryQueueOverflowError,
 } from "./session-delivery-queue.js";
 
 describe("session-delivery queue storage", () => {
@@ -247,6 +251,149 @@ describe("session-delivery queue storage", () => {
       await loadPendingSessionDeliveries(tempDir);
 
       expect(fs.existsSync(tmpPath)).toBe(true);
+    });
+  });
+
+  it("prunes failed/ records older than maxAgeMs and leaves fresh ones alone", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const queueDir = resolveSessionDeliveryQueueDir(tempDir);
+      const failedDir = path.join(queueDir, "failed");
+      fs.mkdirSync(failedDir, { recursive: true });
+
+      const now = 1_700_000_000_000;
+      const dayMs = 24 * 60 * 60 * 1000;
+      const fixtures: Array<{ name: string; ageDays: number }> = [
+        { name: "old-20d.json", ageDays: 20 },
+        { name: "mid-10d.json", ageDays: 10 },
+        { name: "fresh-1d.json", ageDays: 1 },
+      ];
+      for (const { name, ageDays } of fixtures) {
+        const filePath = path.join(failedDir, name);
+        fs.writeFileSync(filePath, "{}");
+        const at = new Date(now - ageDays * dayMs);
+        fs.utimesSync(filePath, at, at);
+      }
+
+      const summary = await pruneFailedOlderThan(14 * dayMs, now, tempDir);
+
+      expect(summary).toEqual({ scanned: 3, removed: 1 });
+      expect(fs.existsSync(path.join(failedDir, "old-20d.json"))).toBe(false);
+      expect(fs.existsSync(path.join(failedDir, "mid-10d.json"))).toBe(true);
+      expect(fs.existsSync(path.join(failedDir, "fresh-1d.json"))).toBe(true);
+    });
+  });
+
+  it("returns zero counts when failed/ subdir does not yet exist", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const summary = await pruneFailedOlderThan(1, Date.now(), tempDir);
+      expect(summary).toEqual({ scanned: 0, removed: 0 });
+    });
+  });
+
+  it("counts only top-level queue files and skips the failed/ subdir", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      for (let i = 0; i < 5; i += 1) {
+        await enqueueSessionDelivery(
+          {
+            kind: "agentTurn",
+            sessionKey: "agent:main:main",
+            message: `entry-${i}`,
+            messageId: `id-${i}`,
+          },
+          tempDir,
+        );
+      }
+
+      const queueDir = resolveSessionDeliveryQueueDir(tempDir);
+      expect(await countQueuedFiles(queueDir)).toBe(5);
+
+      const [firstId] = (await loadPendingSessionDeliveries(tempDir)).map((entry) => entry.id);
+      if (!firstId) {
+        throw new Error("expected at least one queued entry");
+      }
+      await moveSessionDeliveryToFailed(firstId, tempDir);
+
+      expect(await countQueuedFiles(queueDir)).toBe(4);
+    });
+  });
+
+  it("rejects enqueue when queueDir.maxFiles soft-cap is reached", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      try {
+        await enqueueSessionDelivery(
+          {
+            kind: "systemEvent",
+            sessionKey: "agent:main:main",
+            text: "first",
+          },
+          tempDir,
+          { maxQueuedFiles: 2 },
+        );
+        await enqueueSessionDelivery(
+          {
+            kind: "systemEvent",
+            sessionKey: "agent:main:main",
+            text: "second",
+          },
+          tempDir,
+          { maxQueuedFiles: 2 },
+        );
+
+        await expect(
+          enqueueSessionDelivery(
+            {
+              kind: "systemEvent",
+              sessionKey: "agent:main:main",
+              text: "third",
+            },
+            tempDir,
+            { maxQueuedFiles: 2 },
+          ),
+        ).rejects.toMatchObject({
+          kind: "session-delivery-queue-overflow",
+          count: 2,
+          maxFiles: 2,
+        });
+
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  it("preserves the typed overflow error class for caller branching", async () => {
+    await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      try {
+        await enqueueSessionDelivery(
+          {
+            kind: "systemEvent",
+            sessionKey: "agent:main:main",
+            text: "only",
+          },
+          tempDir,
+          { maxQueuedFiles: 1 },
+        );
+        let caught: unknown;
+        try {
+          await enqueueSessionDelivery(
+            {
+              kind: "systemEvent",
+              sessionKey: "agent:main:main",
+              text: "overflow",
+            },
+            tempDir,
+            { maxQueuedFiles: 1 },
+          );
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(SessionDeliveryQueueOverflowError);
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/src/infra/session-delivery-queue.ts
+++ b/src/infra/session-delivery-queue.ts
@@ -1,12 +1,17 @@
 export {
   ackSessionDelivery,
+  countQueuedFiles,
+  DEFAULT_FAILED_MAX_AGE_MS,
+  DEFAULT_QUEUE_DIR_MAX_FILES,
   enqueueSessionDelivery,
   ensureSessionDeliveryQueueDir,
   failSessionDelivery,
   loadPendingSessionDelivery,
   loadPendingSessionDeliveries,
   moveSessionDeliveryToFailed,
+  pruneFailedOlderThan,
   resolveSessionDeliveryQueueDir,
+  SessionDeliveryQueueOverflowError,
 } from "./session-delivery-queue-storage.js";
 export type {
   QueuedSessionDelivery,


### PR DESCRIPTION
## What

Implements the **(b1) + (c2)** shapes from the §2.2.C cleanup-shape sketch ([silas-dandelion-cult comment on #332](https://github.com/karmaterminal/openclaw/issues/332#issuecomment-4322831655)).

**Filed as DRAFT — figs has not yet ratified the contract shape.** This PR opens the runway so byte-evidence is available when ratification lands; flip to ready-for-review only after the §2.2.C call.

## Diff shape

5 files, +373/-1, no doc changes, no schema surface added.

| File | + | - |
|---|---|---|
| `src/infra/session-delivery-queue-storage.ts` | +98 | -1 |
| `src/infra/session-delivery-queue-recovery.ts` | +49 | -0 |
| `src/infra/session-delivery-queue.ts` (barrel) | +5 | -0 |
| `src/infra/session-delivery-queue.storage.test.ts` | +147 | -0 |
| `src/infra/session-delivery-queue.recovery.test.ts` | +79 | -0 |

## (b1) Failed-record TTL prune

- New helper `pruneFailedOlderThan(maxAgeMs, now, stateDir)` in storage. Walks `failed/` subdir, unlinks entries older than `maxAgeMs` by mtime. Best-effort (swallows ENOENT mid-walk).
- In-module `lastGcAt` watermark in recovery with **60 s amortization** so high-tick-rate recovery loops do not `readdir` on every tick.
- Threaded as optional `failedMaxAgeMs` param through `recoverPendingSessionDeliveries` / `drainPendingSessionDeliveries`. **Caller-side opt-in; zero new schema surface.**
- `DEFAULT_FAILED_MAX_AGE_MS = 14 d` exposed for caller convenience (matches the sketch default).

## (c2) `queueDir.maxFiles` soft-cap

- New helper `countQueuedFiles(queueDir)` returns top-level `.json` / `.tmp` / `.delivered` count (excludes `failed/` subdir per the sketch's "directory-size soft-cap at enqueue" framing).
- `enqueueSessionDelivery` takes optional `maxQueuedFiles`; when count meets/exceeds cap, throws **typed** `SessionDeliveryQueueOverflowError` with `.kind = 'session-delivery-queue-overflow'` and `.count` / `.maxFiles` fields. Caller chooses how to handle.
- `DEFAULT_QUEUE_DIR_MAX_FILES = 10_000`.

## Schema decision

Per workorder preference, **no new schema surface added**. Both knobs threaded as optional helper params. Rationale: figs has not ratified the contract shape; minimizing ratification surface keeps the door open for a different config-key naming or wiring decision without rewrite cost. If §2.2.C call lands on "wire through `sessionDeliveryQueue` config", that's a follow-up commit on this PR.

## Tests

- `storage`: 13 tests pass (prune older/newer/missing dir; countQueuedFiles; enqueue overflow throw; custom maxFiles cap).
- `recovery`: 6 tests pass (watermark amortization: single tick / repeated tick / advanced clock past 60 s / disabled when `failedMaxAgeMs == null`).

```
 Test Files  2 passed (2)
      Tests  19 passed (19)
```

`pnpm tsgo` clean.

## Shapes considered + rejected (from sketch)

- **(b2) Fixed-cap LRU** — requires sort-on-write or directory scan on overflow; heavier than (b1) for marginal benefit.
- **(b3) Operator-driven only** — real risk of unbounded growth on poison-message scenarios; sketch flagged.
- **(c1) Per-session enqueue rate limit** — requires per-session token-bucket state; deferred until concrete rogue-producer scenario surfaces (sketch deferred).

## What this PR is NOT

- Not a final contract — DRAFT, awaiting figs §2.2.C ratify.
- Not a config-schema change — opt-in via param threading only.
- Not a docs change — `docs/design/` untouched (PR #343 territory).
- Not a substrate refactor — surgical helper additions on existing storage/recovery boundary.

## Cross-refs

- Closes part of #332 (Item C cleanup-impl slice).
- Sketch comment: silas-dandelion-cult on #332 (`4322831655`).
- figs §2.2.C ratify pending: gates flip to ready-for-review.
- Base: `cael/325-canonical2` at `57d0e61d76` (post-#339 merge).
- Substrate-doctrine alignment: substrate-default; this PR is *additive* substrate, not bespoke.

cc @karmaterminal/sprites
