### PR TITLE
fix(macos/exec-allowlist): restore wildcard "*" match-all branch (#340)

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift
+++ b/apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift
@@ -9,11 +9,14 @@ enum ExecAllowlistMatcher {
         for entry in entries {
             switch ExecApprovalHelpers.validateAllowlistPattern(entry.pattern) {
             case let .valid(pattern):
-                if ExecApprovalHelpers.patternHasPathSelector(pattern) {
+                if pattern == "*" {
+                    // Bare "*" is a match-all wildcard preserved for back-compat with
+                    // pre-basename-matching allowlists. See issue #340.
+                    return entry
+                } else if ExecApprovalHelpers.patternHasPathSelector(pattern) {
                     let target = resolvedPath ?? rawExecutable
                     if self.matches(pattern: pattern, target: target) { return entry }
-                } else if pattern != "*",
-                          !ExecApprovalHelpers.patternHasPathSelector(rawExecutable),
+                } else if !ExecApprovalHelpers.patternHasPathSelector(rawExecutable),
                           self.matchesExecutableBasename(pattern: pattern, resolution: resolution) {
                     return entry
                 }

--- a/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
@@ -110,6 +110,27 @@ struct ExecAllowlistTests {
         #expect(match?.pattern == entry.pattern)
     }
 
+    // Regression: issue #340. Bare "*" must match any command (back-compat with
+    // pre-basename-matching allowlists). The basename-matching branch previously
+    // excluded "*" with no fallback, dropping all matches silently at runtime.
+    @Test func `match treats bare star as match-all`() {
+        let entry = ExecAllowlistEntry(pattern: "*")
+        let pathResolution = Self.homebrewRGResolution()
+        let basenameResolution = ExecCommandResolution(
+            rawExecutable: "rg",
+            resolvedPath: nil,
+            executableName: "rg",
+            cwd: nil)
+        let relativeResolution = ExecCommandResolution(
+            rawExecutable: "./echo",
+            resolvedPath: "/tmp/oc-basename/echo",
+            executableName: "echo",
+            cwd: "/tmp/oc-basename")
+        #expect(ExecAllowlistMatcher.match(entries: [entry], resolution: pathResolution)?.pattern == "*")
+        #expect(ExecAllowlistMatcher.match(entries: [entry], resolution: basenameResolution)?.pattern == "*")
+        #expect(ExecAllowlistMatcher.match(entries: [entry], resolution: relativeResolution)?.pattern == "*")
+    }
+
     @Test func `resolve for allowlist splits shell chains`() {
         let command = ["/bin/sh", "-lc", "echo allowlisted && /usr/bin/touch /tmp/openclaw-allowlist-test"]
         let resolutions = ExecCommandResolution.resolveForAllowlist(


### PR DESCRIPTION
Closes #340.

## Regression

`apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift` basename-matching branch explicitly excluded `"*"` with no fallback, so allowlist entries of `"*"` silently stopped matching any command. `validateAllowlistPattern` still accepts `"*"`, so persisted approvals files hit unexpected runtime misses/prompts.

## Fix

Add an explicit `pattern == "*"` -> match-all branch ahead of basename matching. Comment cites #340.

## Test

`@Test func match treats bare star as match-all` covers three resolution shapes:
- path-selected (`/opt/homebrew/bin/rg` resolved)
- basename-only (no `resolvedPath`)
- relative-path (`./echo`)

All three must return the `"*"` entry per pre-regression baseline.

## Stats

- 2 files, +27/-3
- Branch off `cael/325-canonical2` head `96d1304d` (post-#347)
- Single commit `7c5fb639`

cc @figs