### PR TITLE
ci(workflow-sanity): run generated-doc-baselines on PRs (#297)

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -82,7 +82,7 @@ jobs:
         run: node scripts/check-no-conflict-markers.mjs
 
   generated-doc-baselines:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #297.

## Regression

`generated-doc-baselines` job in `.github/workflows/workflow-sanity.yml` was gated on `if: github.event_name == "workflow_dispatch"`, so it only ran on manual dispatch — never on PRs or pushes. Baseline drift in `docs/.generated/config-baseline.sha256` and `docs/.generated/plugin-sdk-api-baseline.sha256` could land silently (caught the hard way on PR #295 after three scribe passes missed it).

## Fix

Invert the guard to match every other job in this workflow (`no-tabs`, `actionlint`, `no-conflict-markers`):

```yaml
-    if: github.event_name == workflow_dispatch
+    if: github.event_name != workflow_dispatch
```

Now runs on `pull_request` + `push` to `main`, skips only on manual dispatch (which is the inverse of what was there).

## Stats

- 1 file, +1/-1
- Branch off `cael/325-canonical2` head `25ff4f0138` (post-#350)
- Commit `9cd92646`

cc @figs