### PR TITLE
feat(infra): add requireSessionKeyOrSkip helper for key-gated side-effects (#292)

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -105,9 +105,10 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error).toBeUndefined();
   });
 
-  it("emits [context-pressure:event-skipped] when sessionKey is missing on overflow path", async () => {
+  it("emits [session-key:missing] when sessionKey is missing on overflow path", async () => {
     // Same overflow trigger as the first test but with empty sessionKey — the
-    // enqueueSystemEvent gate should skip and leave a breadcrumb.
+    // enqueueSystemEvent gate should skip and leave a breadcrumb via the
+    // canonical session-key skip helper (#292).
     mockOverflowRetrySuccess({
       runEmbeddedAttempt: mockedRunEmbeddedAttempt,
       compactDirect: mockedCompactDirect,
@@ -120,11 +121,10 @@ describe("overflow compaction in run loop", () => {
     expect(mockedLog.warn).toHaveBeenCalledWith(
       expect.stringContaining("[context-pressure:fire] mid-turn trigger=overflow"),
     );
-    // But the system-event enqueue was skipped → breadcrumb emitted.
+    // But the system-event enqueue was skipped → canonical breadcrumb emitted.
     expect(mockedLog.warn).toHaveBeenCalledWith(
-      expect.stringContaining("[context-pressure:event-skipped]"),
+      expect.stringContaining("[session-key:missing] site=pi-runner.overflow-compaction"),
     );
-    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("trigger=overflow"));
   });
 
   it("retries after successful compaction on likely-overflow promptError variants", async () => {

--- a/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
@@ -524,9 +524,10 @@ describe("timeout-triggered compaction", () => {
     expect(result.payloads?.[0]?.text).toContain("timed out");
   });
 
-  it("emits [context-pressure:event-skipped] when sessionKey is missing on timeout path", async () => {
+  it("emits [session-key:missing] when sessionKey is missing on timeout path", async () => {
     // Same setup as the first test but with empty sessionKey — the
-    // enqueueSystemEvent gate should skip and leave a breadcrumb.
+    // enqueueSystemEvent gate should skip and leave a breadcrumb via the
+    // canonical session-key skip helper (#292).
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         timedOut: true,
@@ -551,11 +552,10 @@ describe("timeout-triggered compaction", () => {
     expect(mockedLog.warn).toHaveBeenCalledWith(
       expect.stringContaining("[context-pressure:fire] mid-turn trigger=timeout"),
     );
-    // But the system-event enqueue was skipped → breadcrumb emitted.
+    // But the system-event enqueue was skipped → canonical breadcrumb emitted.
     expect(mockedLog.warn).toHaveBeenCalledWith(
-      expect.stringContaining("[context-pressure:event-skipped]"),
+      expect.stringContaining("[session-key:missing] site=pi-runner.timeout-compaction"),
     );
-    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("trigger=timeout"));
   });
 
   it("uses prompt/input tokens for ratio, not total tokens", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -9,6 +9,7 @@ import { emitAgentPlanEvent } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { requireSessionKeyOrSkip } from "../../infra/session-keys.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
@@ -1071,7 +1072,11 @@ export async function runEmbeddedPiAgent(
                   `tokens=${Math.round((lastTurnPromptTokens ?? 0) / 1000)}k/${Math.round(ctxInfo.tokens / 1000)}k ` +
                   `sessionKey=${params.sessionKey ?? params.sessionId}`,
               );
-              const timeoutSessionKey = params.sessionKey?.trim();
+              const timeoutSessionKey = requireSessionKeyOrSkip(
+                params,
+                log,
+                "pi-runner.timeout-compaction",
+              );
               if (timeoutSessionKey) {
                 enqueueSystemEvent(
                   `[system:context-pressure] Mid-turn compaction triggered at ${Math.round(tokenUsedRatio * 100)}% ` +
@@ -1079,10 +1084,6 @@ export async function runEmbeddedPiAgent(
                     `Your last reply hit the provider timeout ceiling. Consider evacuating working state earlier via ` +
                     `continue_delegate(post-compaction) or memory files so the next turn starts with room to grow.`,
                   { sessionKey: timeoutSessionKey },
-                );
-              } else {
-                log.warn(
-                  `[context-pressure:event-skipped] no sessionKey trigger=timeout ratio=${Math.round(tokenUsedRatio * 100)}%`,
                 );
               }
               let timeoutCompactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
@@ -1236,7 +1237,11 @@ export async function runEmbeddedPiAgent(
                   `tokens=${observedOverflowTokens !== undefined ? Math.round(observedOverflowTokens / 1000) : "?"}k/${Math.round(ctxInfo.tokens / 1000)}k ` +
                   `sessionKey=${params.sessionKey ?? params.sessionId}`,
               );
-              const overflowSessionKey = params.sessionKey?.trim();
+              const overflowSessionKey = requireSessionKeyOrSkip(
+                params,
+                log,
+                "pi-runner.overflow-compaction",
+              );
               if (overflowSessionKey) {
                 enqueueSystemEvent(
                   `[system:context-pressure] Context-overflow compaction triggered mid-turn ` +
@@ -1245,10 +1250,6 @@ export async function runEmbeddedPiAgent(
                     `working state earlier via continue_delegate(post-compaction) or memory files; the ` +
                     `pre-run context-pressure band did not catch this growth pattern.`,
                   { sessionKey: overflowSessionKey },
-                );
-              } else {
-                log.warn(
-                  `[context-pressure:event-skipped] no sessionKey trigger=overflow attempt=${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
                 );
               }
               let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;

--- a/src/infra/session-keys.test.ts
+++ b/src/infra/session-keys.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { requireSessionKeyOrSkip } from "./session-keys.js";
+
+describe("requireSessionKeyOrSkip", () => {
+  it("returns the trimmed sessionKey when non-empty", () => {
+    const log = { warn: vi.fn() };
+    const out = requireSessionKeyOrSkip(
+      { sessionKey: "session-abc", sessionId: "sid-1" },
+      log,
+      "test.site",
+    );
+    expect(out).toBe("session-abc");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("trims whitespace and returns the inner value", () => {
+    const log = { warn: vi.fn() };
+    const out = requireSessionKeyOrSkip(
+      { sessionKey: "  session-xyz  ", sessionId: "sid-2" },
+      log,
+      "test.site",
+    );
+    expect(out).toBe("session-xyz");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns null and warns when sessionKey is missing", () => {
+    const log = { warn: vi.fn() };
+    const out = requireSessionKeyOrSkip(
+      { sessionId: "sid-3" },
+      log,
+      "test.missing",
+    );
+    expect(out).toBeNull();
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      "[session-key:missing] site=test.missing sessionId=sid-3",
+    );
+  });
+
+  it("returns null and warns when sessionKey is empty string", () => {
+    const log = { warn: vi.fn() };
+    const out = requireSessionKeyOrSkip(
+      { sessionKey: "", sessionId: "sid-4" },
+      log,
+      "test.empty",
+    );
+    expect(out).toBeNull();
+    expect(log.warn).toHaveBeenCalledOnce();
+  });
+
+  it("returns null and warns when sessionKey is whitespace only", () => {
+    const log = { warn: vi.fn() };
+    const out = requireSessionKeyOrSkip(
+      { sessionKey: "   ", sessionId: "sid-5" },
+      log,
+      "test.whitespace",
+    );
+    expect(out).toBeNull();
+    expect(log.warn).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to '?' for sessionId when also missing", () => {
+    const log = { warn: vi.fn() };
+    requireSessionKeyOrSkip({}, log, "test.bare");
+    expect(log.warn).toHaveBeenCalledWith(
+      "[session-key:missing] site=test.bare sessionId=?",
+    );
+  });
+
+  it("handles null sessionKey", () => {
+    const log = { warn: vi.fn() };
+    const out = requireSessionKeyOrSkip(
+      { sessionKey: null, sessionId: "sid-7" },
+      log,
+      "test.null",
+    );
+    expect(out).toBeNull();
+    expect(log.warn).toHaveBeenCalledOnce();
+  });
+});

--- a/src/infra/session-keys.ts
+++ b/src/infra/session-keys.ts
@@ -40,7 +40,9 @@ export function requireSessionKeyOrSkip(
   site: string,
 ): string | null {
   const sk = params.sessionKey?.trim();
-  if (sk) return sk;
+  if (sk) {
+    return sk;
+  }
   log.warn(
     `[session-key:missing] site=${site} sessionId=${params.sessionId ?? "?"}`,
   );

--- a/src/infra/session-keys.ts
+++ b/src/infra/session-keys.ts
@@ -1,0 +1,48 @@
+// Canonical guard for key-gated side-effects.
+//
+// Several call-sites need to skip (rather than throw) when sessionKey is
+// missing or blank — typically observability/persistence emissions where the
+// dropped call is a no-op rather than a correctness failure. Without a shared
+// helper, each site re-implements `params.sessionKey?.trim()` plus its own
+// log line, which makes "where did we skip a side-effect because key was
+// missing" hard to grep.
+//
+// Use this for caller-level guards that want to *skip and log*. For bottom-of-
+// stack invariants where the missing key is a programmer error, keep the
+// throwing `requireSessionKey` in `system-events.ts` instead.
+//
+// See issue #292 (cluster C1) for context.
+
+export type SessionKeyParams = {
+  sessionKey?: string | null;
+  sessionId?: string | null;
+};
+
+export type SessionKeyLogger = {
+  warn: (msg: string) => void;
+};
+
+/**
+ * Returns the trimmed `sessionKey` if non-empty, else logs a structured
+ * warning and returns `null`. Callers decide their fallback behavior
+ * explicitly (typically: early-return / skip the side-effect).
+ *
+ * The warning is anchored on `[session-key:missing]` so all skip sites can be
+ * grepped from one place.
+ *
+ * @param params object containing `sessionKey` (optional) and `sessionId` (optional, used for diagnostics)
+ * @param log    structured logger with `.warn`
+ * @param site   stable site identifier (e.g. `"pi-runner.timeout-compaction"`) used for grouping skip events
+ */
+export function requireSessionKeyOrSkip(
+  params: SessionKeyParams,
+  log: SessionKeyLogger,
+  site: string,
+): string | null {
+  const sk = params.sessionKey?.trim();
+  if (sk) return sk;
+  log.warn(
+    `[session-key:missing] site=${site} sessionId=${params.sessionId ?? "?"}`,
+  );
+  return null;
+}


### PR DESCRIPTION
Closes #292.

## Shape

Adds `src/infra/session-keys.ts` exporting `requireSessionKeyOrSkip(params, log, site)` — a canonical caller-level guard for skip-and-log when `sessionKey` is missing or blank.

Several call-sites had open-coded their own `params.sessionKey?.trim()` guards with bespoke breadcrumb anchors (e.g. `[context-pressure:event-skipped]`). One grep target now covers all skip sites: `[session-key:missing]`.

The bottom-of-stack throwing `requireSessionKey` in `system-events.ts` is unchanged (correct for that layer; helper is for callers one level up).

## Migration

Two call-sites in `src/agents/pi-embedded-runner/run.ts`:
- `pi-runner.timeout-compaction` (line ~1074)
- `pi-runner.overflow-compaction` (line ~1239)

Their existing skip-emission tests are retargeted to the new canonical anchor.

## Tests

- `src/infra/session-keys.test.ts`: 7 cases (happy, whitespace, missing, empty, null, fallback `?` for sessionId, returned trimmed value)
- `run.overflow-compaction.loop.test.ts` + `run.timeout-triggered-compaction.test.ts`: existing skip-emission asserts retargeted
- All 33 pi-runner tests pass locally (4.86s)
- Helper tests pass locally (501ms)

## Stats

- 5 files, +151/-20 (2 new infra files, 1 source migration, 2 test retargets)
- Branch off `cael/325-canonical2` head `b04484465a` (post-#351)
- Single commit `7292495e`

cc @figs