### PR TITLE
feat(continuation): extract post-compaction delegate dispatch helper

### DIFF
--- a/NOTE.md
+++ b/NOTE.md
@@ -1,0 +1,164 @@
+# #343 (queue-drain-budget) — implementation note
+
+## Question (per TASK.md)
+
+Move chain-budget enforcement into the queue-drain layer so post-compaction
+releases can go through proper substrate adoption instead of direct
+`spawnSubagentDirect`. Tractable?
+
+## Verdict
+
+**Tractable, in two stages.** Stage 1 (this PR) is the structural
+prerequisite: extract chain-budget enforcement and the spawn from the
+agent-runner inline loop into a portable helper. Stage 2 (follow-up) wires
+the helper into the `session-delivery-queue` substrate via a new payload
+kind. The audit at `docs/design/332-item-b-post-compaction-release-audit.md`
+(branch `elliott/332-item-b-audit`) names Stage 2 as
+"substrate-extension; non-trivial cross-cutting change" — it is, and doing
+both stages atomically would exceed "smallest correct" for one PR.
+
+## What changed
+
+### Added: `src/auto-reply/reply/post-compaction-delegate-dispatch.ts`
+
+- `evaluatePostCompactionChainBudget({...})`: pure decision returning
+  `{ allow: true } | { allow: false; reason: "chain-length" | "cost-cap" }`.
+- `dispatchPostCompactionDelegate({...})`: encapsulates per-delegate
+  chain-budget enforcement, the `spawnSubagentDirect` call, and the
+  lifecycle log/`enqueueSystemEvent` side effects. Returns a discriminated
+  outcome the caller uses to drive aggregate counters and re-stage lists.
+
+### Changed: `src/auto-reply/reply/agent-runner.ts`
+
+- The post-compaction release loop in `runReplyAgent` (~line 2144) is now a
+  thin aggregator over `dispatchPostCompactionDelegate` outcomes. The
+  inline budget checks, `spawnSubagentDirect` call, and per-iteration
+  log/event emissions moved into the helper. Behavior is preserved: same
+  log strings, same system event strings, same re-stage trigger
+  (rejected-spawn / error → push to `postCompactionDelegatesToPreserve`).
+
+### Added: `src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts`
+
+- 12 unit tests covering: budget evaluation truth-table (4 cases), happy
+  path dispatch (1), chain-length rejection (1), cost-cap rejection (1),
+  spawn-rejection re-stage signal (1), spawn-error re-stage signal (1),
+  silent-flag derivation (legacy default + non-silent variants, 2).
+
+## Why this is a real Stage-1 win, not a no-op refactor
+
+The audit's bespoke retention is justified by: "chain-budget enforcement
+lives in agent-runner, requires synchronous spawn-result return, loop uses
+that return to gate the next iteration's budget check."
+
+After Stage 1:
+
+- Chain-budget enforcement no longer lives _inline in agent-runner_. It
+  lives in a portable helper that:
+  - takes chain state as inputs (no closure over agent-runner local vars);
+  - returns a discriminated outcome (no closure over loop counters);
+  - is invokable from any caller.
+- The next-iteration gate is now driven by the caller updating
+  `currentChainCount` from the helper's `nextChainCount` — i.e., the
+  in-process loop carry-over is now an explicit data contract, not an
+  implicit one. That is exactly what a queue-drain deliver callback would
+  need.
+
+A queue-drain deliver callback can read live `SessionEntry.continuationChainCount`
+and `continuationChainTokens` at delivery time, pass them into the helper,
+and act on the outcome — chain-budget enforcement runs at drain time
+without any further refactor of the helper itself.
+
+## Stage 2 sketch (follow-up; not in this PR)
+
+For full substrate adoption of post-compaction release:
+
+1. Extend `QueuedSessionDeliveryPayload` in
+   `src/infra/session-delivery-queue-storage.ts` with a third variant:
+
+   ```ts
+   | {
+       kind: "postCompactionDelegate";
+       sessionKey: string;
+       delegate: SessionPostCompactionDelegate;
+       originatingContext: PostCompactionDelegateOriginatingContext;
+       idempotencyKey?: string;
+     }
+   ```
+
+   Idempotency-key composition (per #335 §3.6 LOCKED spec):
+   `(sourceSessionId, targetSessionId, taskHash, scheduledAt)` —
+   `targetSessionId === sourceSessionId` here; `scheduledAt` =
+   compaction-completion timestamp.
+
+2. Add a deliver helper (new module, e.g.
+   `src/auto-reply/reply/post-compaction-delegate-deliver.ts`) that:
+   - reads `SessionEntry` for live chain state;
+   - reads runtime config via `resolveContinuationRuntimeConfig`;
+   - calls `dispatchPostCompactionDelegate({...})` (this PR's helper);
+   - persists chain-count update to the session store on dispatch;
+   - throws on `error`/`rejected-spawn` so the substrate retry path fires
+     (or, alternatively, returns void on `reStage` outcomes and lets the
+     payload remain for a later drain — TBD per backoff semantics).
+
+3. Modify `agent-runner.ts` post-compaction block: replace the per-delegate
+   `dispatchPostCompactionDelegate` call with `enqueueSessionDelivery({
+kind: "postCompactionDelegate", ... })`, then call
+   `drainPendingSessionDeliveries({...})` filtered by sessionKey + kind to
+   trigger immediate-drain for in-turn timing parity. Aggregate counters
+   become side-effect channels (or the drain returns per-entry decisions).
+
+4. Update `gateway/server-restart-sentinel.ts:deliverQueuedSessionDelivery`
+   to dispatch on the new kind (delegate to the deliver helper). Required
+   so `recoverPendingSessionDeliveries` at gateway start can drain
+   post-compaction-delegate entries that crashed mid-dispatch.
+
+5. Tests: substrate payload roundtrip; deliver-helper budget paths;
+   integration smoke through enqueue → drain → spawn.
+
+### Stage-2 blockers / risks
+
+- `drainPendingSessionDeliveries` returns `Promise<void>`, not per-entry
+  outcomes. Aggregating dispatched/dropped counters for the
+  `[system:post-compaction]` lifecycle event needs either a
+  side-effect aggregator closed over by the deliver callback or a new
+  drain helper that surfaces results.
+- Async drain semantics differ subtly from in-process loop: per-iteration
+  budget gating becomes "evaluate at delivery time against fresh state"
+  instead of "carry local var across iterations." Same end-result for
+  most cases; subtly better behavior under concurrent chain growth from
+  bracket/tool delegates.
+- Recovery-drain at gateway start (`recoverPendingSessionDeliveries` in
+  `server-restart-sentinel.ts`) currently delivers ALL queued kinds; the
+  new kind needs handling there too, otherwise restart drops queued
+  post-compaction-delegate spawns.
+
+## PR #343 disposition recommendation
+
+PR #343 in the actual repo (`fix: remove duplicate daemon-runtime imports`)
+is unrelated to this work — TASK.md uses #343 as a reference number for
+this branch's scope, not the literal GitHub PR. **No update is needed to
+the merged GH PR #343.**
+
+For the audit at `docs/design/332-item-b-post-compaction-release-audit.md`
+(currently on `elliott/332-item-b-audit`, not on this branch): once Stage 1
+lands, the "Concrete functional reason for bespoke at release" section can
+soften from "loop uses [spawn-result] to gate the next iteration's budget
+check" to "loop carries chain-count across iterations" (now an explicit
+contract on `dispatchPostCompactionDelegate`'s `nextChainCount` return,
+trivial to surface to a substrate-side deliver callback). The Verdict's
+"queue-with-bespoke-fallback" label still holds at v2026.4.24 — Stage 2
+flips it to "always-queue."
+
+## Verification
+
+- `pnpm tsgo:core --project tsconfig.core.json` — clean.
+- `pnpm test src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts`
+  — 12/12 passed.
+- `pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
+  — 36/36 passed.
+- `pnpm test src/auto-reply/reply/post-compaction-context.test.ts
+src/auto-reply/reply/session.test.ts
+src/auto-reply/continuation-delegate-store.test.ts` — 121/121 passed.
+- `pnpm check:changed` — typecheck/lint/cycles all green; one unrelated
+  flake in `extensions/amazon-bedrock/index.test.ts` (passes in isolation,
+  no surface touched by this change).

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -96,6 +96,7 @@ import {
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
+import { dispatchPostCompactionDelegate } from "./post-compaction-delegate-dispatch.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import {
   enqueueFollowupRun,
@@ -2142,76 +2143,33 @@ export async function runReplyAgent(params: {
           });
 
         // Dispatch compaction-triggered delegates (| post-compaction mode).
+        // Per-delegate chain-budget enforcement and spawn now live in the
+        // portable helper; agent-runner aggregates outcomes here. This is the
+        // structural prerequisite for routing post-compaction releases through
+        // the session-delivery-queue substrate (#332 Item B audit, path B).
         for (const delegate of releasedCompactionDelegates) {
-          if (currentCompactionChainCount >= maxCompactionChainLength) {
-            droppedCompactionDelegates += 1;
-            defaultRuntime.log(
-              `Post-compaction delegate rejected: chain length ${currentCompactionChainCount} >= ${maxCompactionChainLength} for session ${sessionKey}`,
-            );
-            enqueueSystemEvent(
-              `[continuation] Post-compaction delegate rejected: chain length ${maxCompactionChainLength} reached. Task: ${delegate.task}`,
-              { sessionKey },
-            );
+          const outcome = await dispatchPostCompactionDelegate({
+            delegate,
+            sessionKey,
+            currentChainCount: currentCompactionChainCount,
+            maxChainLength: maxCompactionChainLength,
+            chainTokens: compactionChainTokens,
+            costCapTokens: compactionCostCapTokens,
+            originatingContext: {
+              channel: followupRun.originatingChannel ?? undefined,
+              accountId: followupRun.originatingAccountId ?? undefined,
+              to: followupRun.originatingTo ?? undefined,
+              threadId: followupRun.originatingThreadId ?? undefined,
+            },
+          });
+          if (outcome.kind === "dispatched") {
+            currentCompactionChainCount = outcome.nextChainCount;
+            dispatchedCompactionDelegates += 1;
             continue;
           }
-
-          if (compactionCostCapTokens > 0 && compactionChainTokens > compactionCostCapTokens) {
-            droppedCompactionDelegates += 1;
-            defaultRuntime.log(
-              `Post-compaction delegate rejected: cost cap exceeded (${compactionChainTokens} > ${compactionCostCapTokens}) for session ${sessionKey}`,
-            );
-            enqueueSystemEvent(
-              `[continuation] Post-compaction delegate rejected: cost cap exceeded (${compactionChainTokens} > ${compactionCostCapTokens}). Task: ${delegate.task}`,
-              { sessionKey },
-            );
-            continue;
-          }
-
-          const nextCompactionChainCount = currentCompactionChainCount + 1;
-          defaultRuntime.log(
-            `Post-compaction delegate dispatch for session ${sessionKey}: ${delegate.task}`,
-          );
-          try {
-            const delegateWakeOnReturn = delegate.silentWake ?? true;
-            const delegateSilentAnnounce = delegate.silent ?? delegateWakeOnReturn;
-            const spawnResult = await spawnSubagentDirect(
-              {
-                task:
-                  `[continuation:post-compaction] ` +
-                  `[continuation:chain-hop:${nextCompactionChainCount}] ` +
-                  `Compaction just completed. Carry this working state to the post-compaction session: ${delegate.task}`,
-                ...(delegateSilentAnnounce ? { silentAnnounce: true } : {}),
-                ...(delegateWakeOnReturn ? { silentAnnounce: true, wakeOnReturn: true } : {}),
-                drainsContinuationDelegateQueue: true,
-              },
-              {
-                agentSessionKey: sessionKey,
-                agentChannel: followupRun.originatingChannel ?? undefined,
-                agentAccountId: followupRun.originatingAccountId ?? undefined,
-                agentTo: followupRun.originatingTo ?? undefined,
-                agentThreadId: followupRun.originatingThreadId ?? undefined,
-              },
-            );
-            if (spawnResult.status === "accepted") {
-              currentCompactionChainCount = nextCompactionChainCount;
-              dispatchedCompactionDelegates += 1;
-              enqueueSystemEvent(
-                `[continuation:compaction-delegate-spawned] Post-compaction shard dispatched: ${delegate.task}`,
-                { sessionKey },
-              );
-            } else {
-              droppedCompactionDelegates += 1;
-              postCompactionDelegatesToPreserve.push(delegate);
-              defaultRuntime.log(
-                `Post-compaction delegate rejected (${spawnResult.status}) for session ${sessionKey} (re-staged)`,
-              );
-            }
-          } catch (err) {
-            droppedCompactionDelegates += 1;
+          droppedCompactionDelegates += 1;
+          if (outcome.kind === "rejected-spawn" || outcome.kind === "error") {
             postCompactionDelegatesToPreserve.push(delegate);
-            defaultRuntime.log(
-              `Post-compaction delegate failed for session ${sessionKey} (re-staged): ${String(err)}`,
-            );
           }
         }
 

--- a/src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts
+++ b/src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnSubagentDirectMock = vi.hoisted(() => vi.fn());
+const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
+const runtimeLogMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+}));
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: (...args: unknown[]) => runtimeLogMock(...args),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+import {
+  dispatchPostCompactionDelegate,
+  evaluatePostCompactionChainBudget,
+} from "./post-compaction-delegate-dispatch.js";
+
+describe("evaluatePostCompactionChainBudget", () => {
+  it("allows when chain count is below max and tokens are within cap", () => {
+    expect(
+      evaluatePostCompactionChainBudget({
+        currentChainCount: 2,
+        maxChainLength: 10,
+        chainTokens: 1_000,
+        costCapTokens: 500_000,
+      }),
+    ).toEqual({ allow: true });
+  });
+
+  it("rejects on chain length when count meets max", () => {
+    expect(
+      evaluatePostCompactionChainBudget({
+        currentChainCount: 10,
+        maxChainLength: 10,
+        chainTokens: 0,
+        costCapTokens: 500_000,
+      }),
+    ).toEqual({ allow: false, reason: "chain-length" });
+  });
+
+  it("rejects on cost cap when tokens exceed cap", () => {
+    expect(
+      evaluatePostCompactionChainBudget({
+        currentChainCount: 0,
+        maxChainLength: 10,
+        chainTokens: 600_000,
+        costCapTokens: 500_000,
+      }),
+    ).toEqual({ allow: false, reason: "cost-cap" });
+  });
+
+  it("treats costCapTokens=0 as disabled (no cost-cap rejection)", () => {
+    expect(
+      evaluatePostCompactionChainBudget({
+        currentChainCount: 0,
+        maxChainLength: 10,
+        chainTokens: 9_000_000,
+        costCapTokens: 0,
+      }),
+    ).toEqual({ allow: true });
+  });
+
+  it("prefers chain-length rejection over cost-cap when both apply", () => {
+    expect(
+      evaluatePostCompactionChainBudget({
+        currentChainCount: 10,
+        maxChainLength: 10,
+        chainTokens: 9_000_000,
+        costCapTokens: 500_000,
+      }),
+    ).toEqual({ allow: false, reason: "chain-length" });
+  });
+});
+
+describe("dispatchPostCompactionDelegate", () => {
+  beforeEach(() => {
+    spawnSubagentDirectMock.mockReset();
+    enqueueSystemEventMock.mockReset();
+    runtimeLogMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const baseDelegate = {
+    task: "carry working state",
+    createdAt: 1,
+    silent: true,
+    silentWake: true,
+  };
+  const baseOriginating = {
+    channel: "telegram",
+    accountId: "acct-1",
+    to: "+15555550100",
+    threadId: "thread-1",
+  };
+
+  it("dispatches when budget allows and reports next chain count", async () => {
+    spawnSubagentDirectMock.mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:child",
+    });
+
+    const outcome = await dispatchPostCompactionDelegate({
+      delegate: baseDelegate,
+      sessionKey: "agent:main",
+      currentChainCount: 1,
+      maxChainLength: 10,
+      chainTokens: 100,
+      costCapTokens: 500_000,
+      originatingContext: baseOriginating,
+    });
+
+    expect(outcome).toEqual({
+      kind: "dispatched",
+      nextChainCount: 2,
+      childSessionKey: "agent:child",
+    });
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    const [spawnParams, spawnCtx] = spawnSubagentDirectMock.mock.calls[0];
+    expect(spawnParams.task).toContain("[continuation:post-compaction]");
+    expect(spawnParams.task).toContain("[continuation:chain-hop:2]");
+    expect(spawnParams.task).toContain("carry working state");
+    expect(spawnParams.silentAnnounce).toBe(true);
+    expect(spawnParams.wakeOnReturn).toBe(true);
+    expect(spawnParams.drainsContinuationDelegateQueue).toBe(true);
+    expect(spawnCtx).toEqual({
+      agentSessionKey: "agent:main",
+      agentChannel: "telegram",
+      agentAccountId: "acct-1",
+      agentTo: "+15555550100",
+      agentThreadId: "thread-1",
+    });
+    const enqueuedEvents = enqueueSystemEventMock.mock.calls.map((c) => c[0]);
+    expect(
+      enqueuedEvents.some((m) => m.startsWith("[continuation:compaction-delegate-spawned]")),
+    ).toBe(true);
+  });
+
+  it("rejects on chain-length without spawning", async () => {
+    const outcome = await dispatchPostCompactionDelegate({
+      delegate: baseDelegate,
+      sessionKey: "agent:main",
+      currentChainCount: 10,
+      maxChainLength: 10,
+      chainTokens: 100,
+      costCapTokens: 500_000,
+      originatingContext: baseOriginating,
+    });
+
+    expect(outcome).toEqual({ kind: "rejected-chain-length" });
+    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
+    const enqueuedEvents = enqueueSystemEventMock.mock.calls.map((c) => c[0]);
+    expect(enqueuedEvents).toHaveLength(1);
+    expect(enqueuedEvents[0]).toContain("chain length 10 reached");
+    expect(enqueuedEvents[0]).toContain("carry working state");
+  });
+
+  it("rejects on cost-cap without spawning", async () => {
+    const outcome = await dispatchPostCompactionDelegate({
+      delegate: baseDelegate,
+      sessionKey: "agent:main",
+      currentChainCount: 1,
+      maxChainLength: 10,
+      chainTokens: 600_000,
+      costCapTokens: 500_000,
+      originatingContext: baseOriginating,
+    });
+
+    expect(outcome).toEqual({ kind: "rejected-cost-cap" });
+    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
+    const enqueuedEvents = enqueueSystemEventMock.mock.calls.map((c) => c[0]);
+    expect(enqueuedEvents).toHaveLength(1);
+    expect(enqueuedEvents[0]).toContain("cost cap exceeded (600000 > 500000)");
+  });
+
+  it("returns rejected-spawn with reStage=true when spawn does not accept", async () => {
+    spawnSubagentDirectMock.mockResolvedValue({ status: "forbidden" });
+
+    const outcome = await dispatchPostCompactionDelegate({
+      delegate: baseDelegate,
+      sessionKey: "agent:main",
+      currentChainCount: 1,
+      maxChainLength: 10,
+      chainTokens: 100,
+      costCapTokens: 500_000,
+      originatingContext: baseOriginating,
+    });
+
+    expect(outcome).toEqual({ kind: "rejected-spawn", status: "forbidden", reStage: true });
+    expect(
+      enqueueSystemEventMock.mock.calls.some((c) =>
+        String(c[0]).startsWith("[continuation:compaction-delegate-spawned]"),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns error with reStage=true when spawn throws", async () => {
+    const boom = new Error("spawn boom");
+    spawnSubagentDirectMock.mockRejectedValue(boom);
+
+    const outcome = await dispatchPostCompactionDelegate({
+      delegate: baseDelegate,
+      sessionKey: "agent:main",
+      currentChainCount: 1,
+      maxChainLength: 10,
+      chainTokens: 100,
+      costCapTokens: 500_000,
+      originatingContext: baseOriginating,
+    });
+
+    expect(outcome).toEqual({ kind: "error", error: boom, reStage: true });
+  });
+
+  it("derives silentAnnounce/wakeOnReturn from delegate flags (legacy default = true)", async () => {
+    spawnSubagentDirectMock.mockResolvedValue({ status: "accepted" });
+
+    await dispatchPostCompactionDelegate({
+      delegate: { task: "legacy", createdAt: 1 },
+      sessionKey: "agent:main",
+      currentChainCount: 0,
+      maxChainLength: 10,
+      chainTokens: 0,
+      costCapTokens: 500_000,
+      originatingContext: baseOriginating,
+    });
+
+    const [spawnParams] = spawnSubagentDirectMock.mock.calls[0];
+    expect(spawnParams.silentAnnounce).toBe(true);
+    expect(spawnParams.wakeOnReturn).toBe(true);
+  });
+
+  it("omits silentAnnounce when delegate is non-silent", async () => {
+    spawnSubagentDirectMock.mockResolvedValue({ status: "accepted" });
+
+    await dispatchPostCompactionDelegate({
+      delegate: { task: "loud", createdAt: 1, silent: false, silentWake: false },
+      sessionKey: "agent:main",
+      currentChainCount: 0,
+      maxChainLength: 10,
+      chainTokens: 0,
+      costCapTokens: 500_000,
+      originatingContext: baseOriginating,
+    });
+
+    const [spawnParams] = spawnSubagentDirectMock.mock.calls[0];
+    expect(spawnParams.silentAnnounce).toBeUndefined();
+    expect(spawnParams.wakeOnReturn).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/post-compaction-delegate-dispatch.ts
+++ b/src/auto-reply/reply/post-compaction-delegate-dispatch.ts
@@ -1,0 +1,142 @@
+import { spawnSubagentDirect, type SpawnSubagentResult } from "../../agents/subagent-spawn.js";
+import type { SessionPostCompactionDelegate } from "../../config/sessions.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { defaultRuntime } from "../../runtime.js";
+
+// Origin context carried across the spawn boundary so the spawned shard
+// inherits the parent's reply-routing fields. Substrate-shape: only the
+// transport hints, no chain state.
+export type PostCompactionDelegateOriginatingContext = {
+  channel?: string;
+  accountId?: string;
+  to?: string;
+  threadId?: string | number;
+};
+
+export type ChainBudgetVerdict =
+  | { allow: true }
+  | { allow: false; reason: "chain-length" | "cost-cap" };
+
+export type EvaluatePostCompactionChainBudgetParams = {
+  currentChainCount: number;
+  maxChainLength: number;
+  chainTokens: number;
+  costCapTokens: number;
+};
+
+// Pure decision function. Splitting this out makes the chain-budget rule
+// testable in isolation and re-callable from any drain layer (today the
+// inline post-compaction loop in agent-runner; tomorrow a substrate-driven
+// deliver callback — see #335 §4.6 / #332 Item B audit).
+export function evaluatePostCompactionChainBudget(
+  params: EvaluatePostCompactionChainBudgetParams,
+): ChainBudgetVerdict {
+  if (params.currentChainCount >= params.maxChainLength) {
+    return { allow: false, reason: "chain-length" };
+  }
+  if (params.costCapTokens > 0 && params.chainTokens > params.costCapTokens) {
+    return { allow: false, reason: "cost-cap" };
+  }
+  return { allow: true };
+}
+
+export type DispatchPostCompactionDelegateParams = {
+  delegate: SessionPostCompactionDelegate;
+  sessionKey: string;
+  currentChainCount: number;
+  maxChainLength: number;
+  chainTokens: number;
+  costCapTokens: number;
+  originatingContext: PostCompactionDelegateOriginatingContext;
+};
+
+export type PostCompactionDelegateDispatchOutcome =
+  | { kind: "dispatched"; nextChainCount: number; childSessionKey?: string }
+  | { kind: "rejected-chain-length" }
+  | { kind: "rejected-cost-cap" }
+  | { kind: "rejected-spawn"; status: SpawnSubagentResult["status"]; reStage: true }
+  | { kind: "error"; error: unknown; reStage: true };
+
+// Single-delegate dispatcher. Encapsulates the chain-budget check, the
+// subagent spawn call, and the lifecycle log/system-event side effects.
+// The caller updates aggregate counters and re-stage lists from the outcome.
+export async function dispatchPostCompactionDelegate(
+  params: DispatchPostCompactionDelegateParams,
+): Promise<PostCompactionDelegateDispatchOutcome> {
+  const { sessionKey, delegate } = params;
+  const verdict = evaluatePostCompactionChainBudget({
+    currentChainCount: params.currentChainCount,
+    maxChainLength: params.maxChainLength,
+    chainTokens: params.chainTokens,
+    costCapTokens: params.costCapTokens,
+  });
+
+  if (!verdict.allow) {
+    if (verdict.reason === "chain-length") {
+      defaultRuntime.log(
+        `Post-compaction delegate rejected: chain length ${params.currentChainCount} >= ${params.maxChainLength} for session ${sessionKey}`,
+      );
+      enqueueSystemEvent(
+        `[continuation] Post-compaction delegate rejected: chain length ${params.maxChainLength} reached. Task: ${delegate.task}`,
+        { sessionKey },
+      );
+      return { kind: "rejected-chain-length" };
+    }
+    defaultRuntime.log(
+      `Post-compaction delegate rejected: cost cap exceeded (${params.chainTokens} > ${params.costCapTokens}) for session ${sessionKey}`,
+    );
+    enqueueSystemEvent(
+      `[continuation] Post-compaction delegate rejected: cost cap exceeded (${params.chainTokens} > ${params.costCapTokens}). Task: ${delegate.task}`,
+      { sessionKey },
+    );
+    return { kind: "rejected-cost-cap" };
+  }
+
+  const nextChainCount = params.currentChainCount + 1;
+  const wakeOnReturn = delegate.silentWake ?? true;
+  const silentAnnounce = delegate.silent ?? wakeOnReturn;
+
+  defaultRuntime.log(
+    `Post-compaction delegate dispatch for session ${sessionKey}: ${delegate.task}`,
+  );
+  try {
+    const spawnResult = await spawnSubagentDirect(
+      {
+        task:
+          `[continuation:post-compaction] ` +
+          `[continuation:chain-hop:${nextChainCount}] ` +
+          `Compaction just completed. Carry this working state to the post-compaction session: ${delegate.task}`,
+        ...(silentAnnounce ? { silentAnnounce: true } : {}),
+        ...(wakeOnReturn ? { silentAnnounce: true, wakeOnReturn: true } : {}),
+        drainsContinuationDelegateQueue: true,
+      },
+      {
+        agentSessionKey: sessionKey,
+        agentChannel: params.originatingContext.channel ?? undefined,
+        agentAccountId: params.originatingContext.accountId ?? undefined,
+        agentTo: params.originatingContext.to ?? undefined,
+        agentThreadId: params.originatingContext.threadId ?? undefined,
+      },
+    );
+    if (spawnResult.status === "accepted") {
+      enqueueSystemEvent(
+        `[continuation:compaction-delegate-spawned] Post-compaction shard dispatched: ${delegate.task}`,
+        { sessionKey },
+      );
+      return {
+        kind: "dispatched",
+        nextChainCount,
+        ...(spawnResult.childSessionKey ? { childSessionKey: spawnResult.childSessionKey } : {}),
+      };
+    }
+    defaultRuntime.log(
+      `Post-compaction delegate rejected (${spawnResult.status}) for session ${sessionKey} (re-staged)`,
+    );
+    return { kind: "rejected-spawn", status: spawnResult.status, reStage: true };
+  } catch (err) {
+    defaultRuntime.log(
+      `Post-compaction delegate failed for session ${sessionKey} (re-staged): ${String(err)}`,
+    );
+    return { kind: "error", error: err, reStage: true };
+  }
+}


### PR DESCRIPTION
## Summary
- rebase `cael/343-queue-drain-budget` onto `ce49d93113` (`main` after #358)
- extract post-compaction delegate dispatch into a portable helper
- add focused tests for helper behavior and preserve current runReplyAgent behavior

## Why
This is the prince-driven comparison lane for #343 queue-drain-budget work. It is intentionally narrower than the gpt2/codex sibling lane: this PR isolates the stage-1 extraction so the cohort can compare a minimal helper-first shape against the fuller queue-correctness/cap lane.

## What changed
- adds `post-compaction-delegate-dispatch.ts`
- moves inline chain-budget + spawn logic out of `agent-runner.ts`
- adds focused tests for helper outcomes, budget gates, and re-stage/error paths
- includes `NOTE.md` with the stage-1/stage-2 rationale and follow-up sketch

## Verification
- `pnpm test src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/post-compaction-context.test.ts src/auto-reply/reply/session.test.ts src/auto-reply/continuation-delegate-store.test.ts`
  - 169 passed

## Comparison surface
Sibling lane with fuller queue-model repairs:
- `frond-scribe/20260424/candidate-gpt2-354-codex-fixes`

This PR exists so the cohort can byte-compare the narrower extraction against the more complete repair lane and decide whether to converge, cherry-pick, or supersede.
