### PR TITLE
feat(continuation): multi-recipient delegate descriptor (#355 stage-1)

### DIFF
--- a/src/agents/tools/continuation-tools-registration.test.ts
+++ b/src/agents/tools/continuation-tools-registration.test.ts
@@ -29,7 +29,7 @@ describe("continuation tool registration", { timeout: 240000 }, () => {
     expect(tools.some((tool) => tool.name === "continue_delegate")).toBe(true);
   });
 
-  it("lists targetSessionKey in the continue_delegate schema descriptor", () => {
+  it("lists targetSessionKeys in the continue_delegate schema descriptor (#355 stage-1)", () => {
     const tools = createOpenClawTools({
       config,
       agentSessionKey: "main",
@@ -41,15 +41,16 @@ describe("continuation tool registration", { timeout: 240000 }, () => {
 
     expect(tool.parameters).toMatchObject({
       properties: {
-        targetSessionKey: {
-          type: "string",
-          description: expect.stringContaining("RPC-style address-recipient"),
+        targetSessionKeys: {
+          type: "array",
+          items: { type: "string" },
+          description: expect.stringContaining("choral fan-out"),
         },
       },
     });
   });
 
-  it("fails loudly when targetSessionKey is used before runtime binding exists", async () => {
+  it("rejects targetSessionKeys that is not an array of non-empty strings", async () => {
     const tools = createOpenClawTools({
       config,
       agentSessionKey: "main",
@@ -62,9 +63,9 @@ describe("continuation tool registration", { timeout: 240000 }, () => {
     await expect(
       tool.execute("tool-call", {
         task: "summarize sibling context",
-        targetSessionKey: "prince:cael:agent:main:main",
+        targetSessionKeys: "prince:cael:agent:main:main",
       }),
-    ).rejects.toThrow("targetSessionKey is descriptor-only in v2.5; runtime in #332");
+    ).rejects.toThrow(/targetSessionKeys/);
   });
 
   it("hides continue_delegate when continuation is disabled", () => {

--- a/src/agents/tools/continue-delegate-tool.test.ts
+++ b/src/agents/tools/continue-delegate-tool.test.ts
@@ -154,4 +154,41 @@ describe("continue_delegate tool", () => {
       executeTool(tool, 1, { task: "bad recipients", targetSessionKeys: ["", "agent:elliott"] }),
     ).rejects.toThrow(/non-empty/);
   });
+
+  it("rejects legacy singular targetSessionKey field fail-loud (#363 P1)", async () => {
+    const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    await expect(
+      executeTool(tool, 0, {
+        task: "caller still using removed singular field",
+        targetSessionKey: "agent:silas:discord:channel:thornfield",
+      }),
+    ).rejects.toThrow(/targetSessionKey \(singular\) was removed/);
+    await expect(
+      executeTool(tool, 1, {
+        task: "snake-case caller still using removed singular field",
+        target_session_key: "agent:silas:discord:channel:thornfield",
+      }),
+    ).rejects.toThrow(/targetSessionKey \(singular\) was removed/);
+  });
+
+  it("accepts snake_case target_session_keys (#363 P2)", async () => {
+    const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    const result = await executeTool(tool, 0, {
+      task: "snake_case caller",
+      target_session_keys: [
+        "agent:silas:discord:channel:thornfield",
+        "agent:cael:discord:channel:thornfield",
+      ],
+    });
+
+    expect(result).toMatchObject({ status: "scheduled" });
+    const pending = consumePendingDelegates("test-session");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].targetSessionKeys).toEqual([
+      "agent:silas:discord:channel:thornfield",
+      "agent:cael:discord:channel:thornfield",
+    ]);
+  });
 });

--- a/src/agents/tools/continue-delegate-tool.test.ts
+++ b/src/agents/tools/continue-delegate-tool.test.ts
@@ -114,4 +114,44 @@ describe("continue_delegate tool", () => {
       }),
     ]);
   });
+
+  it("accepts and persists targetSessionKeys descriptor (#355 multi-recipient stage-1)", async () => {
+    const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    const result = await executeTool(tool, 0, {
+      task: "choral fan-out shard",
+      targetSessionKeys: [
+        "agent:silas:discord:channel:thornfield",
+        "agent:elliott:discord:channel:thornfield",
+      ],
+    });
+
+    expect(result).toMatchObject({ status: "scheduled" });
+    const pending = consumePendingDelegates("test-session");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].targetSessionKeys).toEqual([
+      "agent:silas:discord:channel:thornfield",
+      "agent:elliott:discord:channel:thornfield",
+    ]);
+  });
+
+  it("omits targetSessionKeys when not provided", async () => {
+    const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    await executeTool(tool, 0, { task: "single-recipient legacy shape" });
+    const pending = consumePendingDelegates("test-session");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].targetSessionKeys).toBeUndefined();
+  });
+
+  it("rejects targetSessionKeys when not an array of non-empty strings", async () => {
+    const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    await expect(
+      executeTool(tool, 0, { task: "bad recipients", targetSessionKeys: "agent:silas:..." }),
+    ).rejects.toThrow(/array/);
+    await expect(
+      executeTool(tool, 1, { task: "bad recipients", targetSessionKeys: ["", "agent:elliott"] }),
+    ).rejects.toThrow(/non-empty/);
+  });
 });

--- a/src/agents/tools/continue-delegate-tool.ts
+++ b/src/agents/tools/continue-delegate-tool.ts
@@ -37,12 +37,15 @@ const ContinueDelegateToolSchema = Type.Object({
       '"post-compaction" = silent-wake delegate that fires when compaction happens, not on a timer. ' +
       "Use for context evacuation: the shard starts at the moment of compaction and returns to the post-compaction session.",
   }),
-  targetSessionKey: Type.Optional(
-    Type.String({
+  targetSessionKeys: Type.Optional(
+    Type.Array(Type.String(), {
       description:
-        "Address a sibling session for cross-session enrichment. " +
-        "This is the (a)-shape (RPC-style address-recipient); v3 surfaces broadcast-mode " +
-        "via karmaterminal/binary-canticle#11. Same substrate; different verb-set.",
+        "Address one or more sibling sessions for cross-session enrichment. " +
+        "One delegate completion \u2192 N receivers (the choral fan-out shape). " +
+        "Stage-1: persisted as descriptor on the pending delegate. " +
+        "Stage-2 (follow-up under #355): dispatch wires one substrate-queue row " +
+        "per recipient with per-target fail-isolation via existing FallbackResolver. " +
+        "Binary-canticle (a)-shape; broadcast (b)-shape lands on top via canticle#11.",
     }),
   ),
 });
@@ -88,9 +91,26 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
           "continue_delegate requires an active session. Not available in sessionless contexts.",
         );
       }
-      if (Object.hasOwn(params, "targetSessionKey") && params.targetSessionKey !== undefined) {
-        // Runtime binding (intra-host-rpc) belongs in #332's session-delivery-queue lane.
-        throw new ToolInputError("targetSessionKey is descriptor-only in v2.5; runtime in #332");
+      let targetSessionKeys: string[] | undefined;
+      if (Object.hasOwn(params, "targetSessionKeys") && params.targetSessionKeys !== undefined) {
+        const raw = params.targetSessionKeys;
+        if (!Array.isArray(raw)) {
+          throw new ToolInputError("targetSessionKeys must be an array of session-key strings.");
+        }
+        const keys = raw.filter((k): k is string => typeof k === "string" && k.trim().length > 0);
+        if (keys.length !== raw.length) {
+          throw new ToolInputError(
+            "targetSessionKeys must contain only non-empty session-key strings.",
+          );
+        }
+        if (keys.length > 0) {
+          targetSessionKeys = keys;
+        }
+        // Stage-1: descriptor-only. Stage-2 (follow-up under #355) wires the
+        // substrate-queue dispatch (one row per recipient, per-target
+        // fail-isolation via existing FallbackResolver, riding on #354's
+        // session-delivery-queue extension). Until then the descriptor is
+        // persisted/round-tripped via taskflow but does not change dispatch.
       }
 
       const task = readStringParam(params, "task", { required: true });
@@ -153,6 +173,7 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
         delayMs,
         silent,
         silentWake,
+        targetSessionKeys,
       });
 
       const dispatchIndex = currentCount + 1;

--- a/src/agents/tools/continue-delegate-tool.ts
+++ b/src/agents/tools/continue-delegate-tool.ts
@@ -7,6 +7,7 @@ import {
 } from "../../auto-reply/continuation-delegate-store.js";
 import { resolveMaxDelegatesPerTurn } from "../../auto-reply/reply/continuation-runtime.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveSnakeCaseParamKey } from "../../param-key.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam, ToolInputError } from "./common.js";
@@ -91,9 +92,26 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
           "continue_delegate requires an active session. Not available in sessionless contexts.",
         );
       }
+      // Reject the legacy singular field fail-loud (Codex P1, #363 review): the
+      // descriptor is silently dropped if we accept it, which can misroute work
+      // to the current session when the caller intended cross-session delegation.
+      // Make the bad state unrepresentable rather than prohibited — same
+      // structural-cure-vs-vigilance shape as `declineToCarry()` in #366.
+      if (
+        Object.hasOwn(params, "targetSessionKey") ||
+        Object.hasOwn(params, "target_session_key")
+      ) {
+        throw new ToolInputError(
+          "targetSessionKey (singular) was removed in #355 stage-1; use targetSessionKeys: string[] for one-or-many recipients.",
+        );
+      }
       let targetSessionKeys: string[] | undefined;
-      if (Object.hasOwn(params, "targetSessionKeys") && params.targetSessionKeys !== undefined) {
-        const raw = params.targetSessionKeys;
+      // Accept both camelCase (`targetSessionKeys`) and snake_case
+      // (`target_session_keys`) callers — same convention as every other tool
+      // param in the runtime (Codex P2, #363 review).
+      const targetKeysParamKey = resolveSnakeCaseParamKey(params, "targetSessionKeys");
+      if (targetKeysParamKey && params[targetKeysParamKey] !== undefined) {
+        const raw = params[targetKeysParamKey];
         if (!Array.isArray(raw)) {
           throw new ToolInputError("targetSessionKeys must be an array of session-key strings.");
         }

--- a/src/auto-reply/continuation-delegate-store-taskflow.test.ts
+++ b/src/auto-reply/continuation-delegate-store-taskflow.test.ts
@@ -173,6 +173,45 @@ describe("continuation-delegate-store-taskflow", () => {
     });
   });
 
+  it("round-trips targetSessionKeys descriptor (#355 multi-recipient)", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", {
+        task: "choral fan-out",
+        delayMs: 5000,
+        silent: true,
+        silentWake: true,
+        targetSessionKeys: [
+          "agent:main:discord:channel:thornfield",
+          "agent:silas:discord:channel:thornfield",
+          "agent:elliott:discord:channel:thornfield",
+        ],
+      });
+
+      const delegates = taskFlowConsumePendingDelegates("test-session");
+      expect(delegates).toHaveLength(1);
+      expect(delegates[0].targetSessionKeys).toEqual([
+        "agent:main:discord:channel:thornfield",
+        "agent:silas:discord:channel:thornfield",
+        "agent:elliott:discord:channel:thornfield",
+      ]);
+    });
+  });
+
+  it("omits targetSessionKeys when absent or empty", async () => {
+    await withFlowRegistryTempDir(async () => {
+      taskFlowEnqueuePendingDelegate("test-session", {
+        task: "single-recipient legacy shape",
+        targetSessionKeys: [],
+      });
+      taskFlowEnqueuePendingDelegate("test-session", { task: "no field at all" });
+
+      const delegates = taskFlowConsumePendingDelegates("test-session");
+      expect(delegates).toHaveLength(2);
+      expect(delegates[0].targetSessionKeys).toBeUndefined();
+      expect(delegates[1].targetSessionKeys).toBeUndefined();
+    });
+  });
+
   it("handles zero delay (immediate dispatch)", async () => {
     await withFlowRegistryTempDir(async () => {
       taskFlowEnqueuePendingDelegate("test-session", { task: "immediate", delayMs: 0 });

--- a/src/auto-reply/continuation-delegate-store-taskflow.ts
+++ b/src/auto-reply/continuation-delegate-store-taskflow.ts
@@ -35,6 +35,9 @@ function delegateToStateJson(delegate: PendingContinuationDelegate): JsonValue {
   if (delegate.silentWake != null) {
     state.silentWake = delegate.silentWake;
   }
+  if (delegate.targetSessionKeys && delegate.targetSessionKeys.length > 0) {
+    state.targetSessionKeys = [...delegate.targetSessionKeys];
+  }
   return state;
 }
 
@@ -51,6 +54,14 @@ function flowToDelegate(flow: TaskFlowRecord): PendingContinuationDelegate {
   }
   if (typeof state.silentWake === "boolean") {
     delegate.silentWake = state.silentWake;
+  }
+  if (Array.isArray(state.targetSessionKeys)) {
+    const keys = state.targetSessionKeys.filter(
+      (k): k is string => typeof k === "string" && k.length > 0,
+    );
+    if (keys.length > 0) {
+      delegate.targetSessionKeys = keys;
+    }
   }
   return delegate;
 }

--- a/src/auto-reply/continuation-delegate.types.ts
+++ b/src/auto-reply/continuation-delegate.types.ts
@@ -4,11 +4,19 @@ export interface PendingContinuationDelegate {
   silent?: boolean;
   silentWake?: boolean;
   /**
-   * Address a sibling session for cross-session enrichment.
-   * This is the (a)-shape (RPC-style address-recipient); v3 surfaces broadcast-mode
-   * via karmaterminal/binary-canticle#11. Same substrate; different verb-set.
+   * Address one or more sibling sessions for cross-session enrichment.
+   * One delegate completion → N receivers (the choral fan-out shape).
+   *
+   * Stage-1 (this surface): persisted as descriptor on the pending delegate;
+   * Stage-2 (follow-up under karmaterminal/openclaw#355): dispatch wiring fans
+   * out one substrate-queue row per recipient with per-target fail-isolation
+   * via the existing FallbackResolver, riding on the queue substrate landed
+   * in #354. Single-recipient and N-recipient share the same path.
+   *
+   * Binary-canticle (a)-shape (RPC-style address-recipient); broadcast-mode
+   * (b)-shape lands on top of this via karmaterminal/binary-canticle#11.
    */
-  targetSessionKey?: string;
+  targetSessionKeys?: string[];
 }
 
 export interface DelayedContinuationReservation {


### PR DESCRIPTION
Stage-1 of multi-recipient delegate-return wiring for #355. **Descriptor-only.** Dispatch wiring is Stage-2 (follow-up PR), explicitly noted in the type doc, the tool description, and the commit message.

### Why this exists
The wiring trace ([#355 issuecomment-4323512343](https://github.com/karmaterminal/openclaw/issues/355#issuecomment-4323512343)) found that the existing single-recipient `targetSessionKey?: string` field on `PendingContinuationDelegate` had **no producer** that set it and the taskflow round-trip **silently dropped** it. So "list-extension on existing boundary" was technically right but the boundary itself wasn't wired. Single-recipient and N-recipient land together on the same path because the path is what's missing.

### What this PR does
- **Type rename** on `PendingContinuationDelegate`: `targetSessionKey?: string` → `targetSessionKeys?: string[]`. Doc explains the choral-fan-out shape and points at #354's queue substrate as the Stage-2 dispatch foundation.
- **TaskFlow round-trip**: `delegateToStateJson` / `flowToDelegate` now serialize and deserialize `targetSessionKeys` (was silently dropped before — that's the bug the wiring trace surfaced).
- **`continue_delegate` tool**: drops the always-throw on the old singular field, accepts `targetSessionKeys: string[]` with input validation (non-empty array of non-empty strings), persists it on the pending delegate.

### Tests (5 new, all green)
- TaskFlow round-trip: 3-recipient list survives serialize → deserialize.
- TaskFlow round-trip: `[]` and absent field both deserialize to `undefined`.
- Tool: accepts and persists 2-recipient list.
- Tool: omits descriptor when not provided.
- Tool: rejects non-array and rejects empty-string entries.

### Stage-2 (follow-up under #355)
- One substrate-queue row per recipient via [#354's `session-delivery-queue`](https://github.com/karmaterminal/openclaw/pull/354) extension.
- Per-target fail-isolation through the existing `FallbackResolver` — answer (1a) on the ported scope-questions, not atomic-or-nothing.
- **OTEL trace cap per-completion (not per-receiver)** so a runaway fan-out cannot flood the trace backend; cap inherits from chain-budget. Banked into the design notes in the commit message.

### Why land Stage-1 separately
Smallest-correct boundary. Descriptor + persist + tool-accept is mechanical and reviewable in one byte-walk. Dispatch wiring is genuinely larger (queue extension, fail-isolation, OTEL cap, integration tests against #354's substrate) and benefits from landing on top of an already-merged descriptor surface.

### Direction confirmed on 🌫's ported scope-questions
1. **Per-target failure**: per-target fail-isolation via FallbackResolver. Atomic-or-nothing is wrong substrate-shape.
2. **vs `sessions_send` + `:"*"` messaging-layer**: stays scoped to delegate-return routing. Different substrate.
3. **Wire shape**: plain `targetSessionKeys: string[]` (this PR). Composable per-target object stays canticle-umbrella per [#357](https://github.com/karmaterminal/openclaw/pull/357) sketch.
4. **Cap on N**: inherits from chain-budget. Per-completion fan-out = 1 chain step regardless of N.

### Out of scope
Aspect-mux, per-receiver transformation, backpressure-aware multicast, broadcast `(b)`-shape verb-set (lands on top via [karmaterminal/binary-canticle#11](https://github.com/karmaterminal/binary-canticle/issues/11)).

### Verification
```
pnpm exec vitest run \
  src/auto-reply/continuation-delegate-store-taskflow.test.ts \
  src/agents/tools/continue-delegate-tool.test.ts
```
30/30 passing (23 prior + 5 new + 2 unchanged in tool suite).

Closes part of #355 (Stage-1). Stage-2 dispatch wiring follow-up will reference this PR.
