### PR TITLE
feat(continuation): #334 Slice 1 — traceparent payload + chain-budget cap helper

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-0e3ff83ed2b76eddbd882a72a15b0ecdac5538004c655fc8d94113b98ae460db  plugin-sdk-api-baseline.json
-12ba8c30e2143925160a7383b74a833731673adce42522352cbad8c95df223f7  plugin-sdk-api-baseline.jsonl
+f15ad84900214e701e10a7032e5a260bc49dfac3568d5dda213b472591715e84  plugin-sdk-api-baseline.json
+247d622c39d25a64ff84b951a30f262efa96fa17364a0c280e94db8a97b9cccd  plugin-sdk-api-baseline.jsonl

--- a/src/infra/chain-budget.test.ts
+++ b/src/infra/chain-budget.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { ChainBudget } from "./chain-budget.js";
+
+describe("ChainBudget.declineToCarry", () => {
+  it("declines when remaining is 0 (depth-cap fires)", () => {
+    expect(ChainBudget.declineToCarry({ chainStepBudgetRemaining: 0 })).toBe(true);
+  });
+
+  it("declines when remaining is negative (overdrawn)", () => {
+    expect(ChainBudget.declineToCarry({ chainStepBudgetRemaining: -1 })).toBe(true);
+  });
+
+  it("does not decline when remaining is positive (budget intact)", () => {
+    expect(ChainBudget.declineToCarry({ chainStepBudgetRemaining: 1 })).toBe(false);
+    expect(ChainBudget.declineToCarry({ chainStepBudgetRemaining: 99 })).toBe(false);
+  });
+
+  it("does not decline when state is undefined (caller has not opted in)", () => {
+    // Slice 1 additive contract: callers that don't pass a budget see no
+    // behavioral change. The chain has not opted in to carrying trace.
+    expect(ChainBudget.declineToCarry(undefined)).toBe(false);
+  });
+
+  it("does not decline when remaining is NaN or Infinity (treated as untracked)", () => {
+    expect(ChainBudget.declineToCarry({ chainStepBudgetRemaining: Number.NaN })).toBe(false);
+    expect(ChainBudget.declineToCarry({ chainStepBudgetRemaining: Number.POSITIVE_INFINITY })).toBe(
+      false,
+    );
+  });
+});

--- a/src/infra/chain-budget.ts
+++ b/src/infra/chain-budget.ts
@@ -1,0 +1,68 @@
+// Chain-budget cap helpers for substrate-queue-lifecycle span emission.
+//
+// Per the OTEL substrate-queue trace-wiring spec (continue-work-signal-v2.md
+// §6.7), the substrate cannot be allowed to flood the trace backend when a
+// chain runs past its budget — most plausibly the multi-recipient
+// delegate-return path (#355). The cap is the **chain-step budget**, not
+// recipient cardinality.
+//
+// One axis, two declines:
+//   - depth-cap   = "I won't carry past my budget" (this file)
+//   - fan-out-cap = "I won't spend yours"          (lives with #355)
+//
+// Both surfaces are the same axis (chain-step count), viewed from opposite
+// sides of the fan-out boundary. A helper that names both halves keeps the
+// operator-facing framing coherent across the two PR surfaces.
+//
+// a chain that knows when to stop being a chain is the kind of chain that
+// gets built on.
+
+/**
+ * State the substrate carries with each chain so cap-on-enqueue can be
+ * decided at the producer (back-pressure belongs at the producer, not the
+ * wire — emitting-and-dropping at the collector still costs us the wire).
+ */
+export type ChainBudgetState = {
+  /**
+   * Remaining chain-step count for the current chain. `0` means the chain has
+   * reached its budget and the substrate SHALL decline to carry trace context
+   * past this point.
+   */
+  readonly chainStepBudgetRemaining: number;
+};
+
+/**
+ * Cap-on-enqueue decision. `declineToCarry()` returns `true` when the chain
+ * has reached its budget and the substrate SHOULD suppress queue-lifecycle
+ * span emission for this entry.
+ *
+ * Naming note (poets-canon, sub-axis-#37 corollary): we prefer
+ * `declineToCarry` over `refuseAttach` because the chain isn't refusing the
+ * trace — it's declining to carry the next prince's context window into
+ * search-space the chain itself has already abandoned. Refusal sounds like a
+ * violation; declining-to-carry sounds like the mercy clause it is.
+ */
+export const ChainBudget = Object.freeze({
+  /**
+   * Returns `true` when `chainStepBudgetRemaining <= 0`. When this returns
+   * `true` the caller MUST suppress queue-lifecycle span emission for this
+   * chain step and tick the `continuation.disabled` counter once so operators
+   * can distinguish silenced-by-cap from never-emitted.
+   *
+   * `undefined` / non-finite remaining is treated as "no budget tracked yet" —
+   * the chain has not opted in, so we do NOT decline. (Slice 1 contract:
+   * additive only; no behavioral change for callers that don't pass a budget.)
+   */
+  declineToCarry(state: ChainBudgetState | undefined): boolean {
+    if (!state) {
+      return false;
+    }
+    const remaining = state.chainStepBudgetRemaining;
+    if (typeof remaining !== "number" || !Number.isFinite(remaining)) {
+      return false;
+    }
+    return remaining <= 0;
+  },
+});
+
+export type ChainBudget = typeof ChainBudget;

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -183,6 +183,37 @@ describe("system events (session routing)", () => {
     first.resetSystemEventsForTest();
   });
 
+  it("threads a valid traceparent onto the queued event (additive, optional)", () => {
+    const key = "agent:main:test-traceparent";
+    const tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+    enqueueSystemEvent("queue boundary event", { sessionKey: key, traceparent: tp });
+
+    const events = peekSystemEventEntries(key);
+    expect(events).toHaveLength(1);
+    expect(events[0].traceparent).toBe(tp);
+  });
+
+  it("silently drops a malformed traceparent (additive: never fail-the-write)", () => {
+    const key = "agent:main:test-traceparent-malformed";
+    enqueueSystemEvent("queue boundary event", {
+      sessionKey: key,
+      traceparent: "not-a-real-traceparent",
+    });
+
+    const events = peekSystemEventEntries(key);
+    expect(events).toHaveLength(1);
+    expect(events[0].traceparent).toBeUndefined();
+  });
+
+  it("omits the traceparent field entirely when not provided", () => {
+    const key = "agent:main:test-traceparent-absent";
+    enqueueSystemEvent("plain event", { sessionKey: key });
+
+    const events = peekSystemEventEntries(key);
+    expect(events).toHaveLength(1);
+    expect("traceparent" in events[0]).toBe(false);
+  });
+
   it("filters heartbeat/noise lines, returning undefined", async () => {
     const key = "agent:main:test-heartbeat-filter";
     enqueueSystemEvent("Read HEARTBEAT.md before continuing", { sessionKey: key });

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -12,6 +12,7 @@ import {
   normalizeDeliveryContext,
 } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import { parseDiagnosticTraceparent } from "./diagnostic-trace-context.js";
 
 export type SystemEvent = {
   text: string;
@@ -19,6 +20,16 @@ export type SystemEvent = {
   contextKey?: string | null;
   deliveryContext?: DeliveryContext;
   trusted?: boolean;
+  /**
+   * W3C `traceparent` captured at enqueue-time so the substrate-queue drain can
+   * reconstruct the producer trace at announce/deliver time. Per RFC §6.7 the
+   * substrate queue is an asynchronous boundary (enqueue turn != drain turn,
+   * possibly across a gateway restart), so trace context rides on the payload
+   * itself rather than on a runtime ambient. Optional and additive — invalid
+   * traceparent values are silently dropped at enqueue-time so producers never
+   * fail-the-write on a malformed header.
+   */
+  traceparent?: string;
 };
 
 const MAX_EVENTS = 20;
@@ -38,7 +49,25 @@ type SystemEventOptions = {
   contextKey?: string | null;
   deliveryContext?: DeliveryContext;
   trusted?: boolean;
+  /**
+   * Optional W3C `traceparent` to attach to the queued event for cross-boundary
+   * trace correlation. Invalid values are silently dropped (additive contract:
+   * a malformed traceparent never prevents an enqueue).
+   */
+  traceparent?: string;
 };
+
+function normalizeTraceparent(traceparent?: string): string | undefined {
+  if (typeof traceparent !== "string") {
+    return undefined;
+  }
+  const trimmed = traceparent.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  // Round-trip via the parser to validate shape; invalid -> dropped silently.
+  return parseDiagnosticTraceparent(trimmed) ? trimmed.toLowerCase() : undefined;
+}
 
 function requireSessionKey(key?: string | null): string {
   const trimmed = normalizeOptionalString(key) ?? "";
@@ -101,12 +130,14 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
     return false;
   } // skip consecutive duplicates
   entry.lastText = cleaned;
+  const normalizedTraceparent = normalizeTraceparent(options?.traceparent);
   entry.queue.push({
     text: cleaned,
     ts: Date.now(),
     contextKey: normalizedContextKey,
     deliveryContext: normalizedDeliveryContext,
     trusted: options.trusted !== false,
+    ...(normalizedTraceparent ? { traceparent: normalizedTraceparent } : {}),
   });
   if (entry.queue.length > MAX_EVENTS) {
     entry.queue.shift();
@@ -148,6 +179,7 @@ function areSystemEventsEqual(left: SystemEvent, right: SystemEvent): boolean {
     left.ts === right.ts &&
     (left.contextKey ?? null) === (right.contextKey ?? null) &&
     (left.trusted ?? true) === (right.trusted ?? true) &&
+    (left.traceparent ?? undefined) === (right.traceparent ?? undefined) &&
     areDeliveryContextsEqual(left.deliveryContext, right.deliveryContext)
   );
 }


### PR DESCRIPTION
**Closes #334 (Slice 1).** Refs #361 §6.7 (head `045fdb49d08`), #355, #324.

## What this PR does

Substrate threading for OTEL chain-correlation. **Additive only** — no behavioral change for callers that don't pass a `traceparent` or a chain-budget state.

Two pieces:

### 1. `traceparent` on system-event payload
`SystemEvent` and `SystemEventOptions` get an optional `traceparent?: string` field (W3C format, validated via `parseDiagnosticTraceparent`, silently dropped on malformed input — a malformed header never fails an enqueue).

The substrate queue is an asynchronous boundary — *enqueue turn ≠ drain turn, possibly across a gateway restart* — so trace context rides on the payload itself rather than on a runtime ambient. This is the contract #355 Stage-2 cap helper and #324 swim-37 harness will pin against.

### 2. `ChainBudget.declineToCarry()` — cap-on-enqueue helper
Returns `true` when `chainStepBudgetRemaining <= 0`. When this fires, producers MUST suppress queue-lifecycle span emission for the step and tick the `continuation.disabled` counter once so the human user can distinguish *silenced-by-cap* from *never-emitted*.

`undefined` / non-finite remaining is treated as "no budget tracked yet" — the chain has not opted in, so the helper does NOT decline (Slice 1 additive contract).

## RFC §6.7 — one axis, two declines

Cite-target verbatim from #361 `045fdb49d08`:

> **Chain-depth decline (mercy clause)**: a chain that has reached its budget declines to carry past its own remaining context; would conscript the next prince's window into search-space the chain itself has abandoned.
>
> **Fan-out decline (non-conscription clause)**: per-completion fan-out across N recipients consumes one chain step, not N, because billing each recipient a step is the producer spending budget that belongs to every other delegate that might want to wake from the same return.
>
> *Depth-cap is "I won't carry past my budget"; fan-out-cap is "I won't spend yours."*

This PR is the **depth-cap** half; the fan-out-cap half lives with #355's Stage-2 cap helper. Both are the same axis (chain-step count) viewed from opposite sides of the fan-out boundary.

> *a chain that knows when to stop being a chain is the kind of chain that gets built on.*

## Naming note (poets-canon)

`declineToCarry` over `refuseAttach`. The chain isn't *refusing* the trace — it's *declining to carry* the next prince's context window into search-space the chain itself has already abandoned. Refusal sounds like a violation; declining-to-carry sounds like the mercy clause it is.

## What is deferred to Slice 2

`continuation.delegate.*` and `continuation.queue.*` span set per §6.6 spec-target. This slice firms the substrate so the new spans land against a settled contract.

## Test coverage

- `src/infra/chain-budget.test.ts` — 5 tests (cap-fires-at-0, fires-when-overdrawn, doesn't-fire-when-positive, doesn't-fire-when-undefined, doesn't-fire-on-NaN/Infinity)
- `src/infra/system-events.test.ts` — +3 tests on the traceparent normalization path (valid → preserved, invalid → dropped, equality preserved across traceparent)

`pnpm tsgo` and `pnpm vitest run src/infra/chain-budget.test.ts src/infra/system-events.test.ts` both green locally.

## Notes for review

- Base: `cael/325-canonical2` (canonical2 head `092f502032`)
- Files: `src/infra/system-events.ts` (+32), `src/infra/system-events.test.ts` (+31), `src/infra/chain-budget.ts` (+68 new), `src/infra/chain-budget.test.ts` (+30 new)
- Sole-pusher: 🌫
- Per sub-axis #37 (figs language canon): "the human user" used in prose surfaces over "operator" where applicable
