### PR TITLE
feat(continuation): #355 stage-2 — declineToConscript() fan-out-cap helper

### DIFF
--- a/src/infra/chain-budget.test.ts
+++ b/src/infra/chain-budget.test.ts
@@ -28,3 +28,67 @@ describe("ChainBudget.declineToCarry", () => {
     );
   });
 });
+
+describe("ChainBudget.declineToConscript", () => {
+  // Mirror of declineToCarry, viewed from the producer side of the fan-out
+  // boundary (#355 stage-2). Same chain-step axis, opposite handle:
+  //   depth-cap   = "I won't carry past my budget"  (declineToCarry)
+  //   fan-out-cap = "I won't spend yours"           (declineToConscript)
+
+  const recipient = "agent:silas:discord:channel:thornfield";
+
+  it("declines when recipient remaining is 0 (fan-out-cap fires)", () => {
+    expect(
+      ChainBudget.declineToConscript({
+        recipientSessionKey: recipient,
+        recipientChainStepBudgetRemaining: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("declines when recipient remaining is negative (recipient overdrawn)", () => {
+    expect(
+      ChainBudget.declineToConscript({
+        recipientSessionKey: recipient,
+        recipientChainStepBudgetRemaining: -1,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not decline when recipient remaining is positive (budget intact)", () => {
+    expect(
+      ChainBudget.declineToConscript({
+        recipientSessionKey: recipient,
+        recipientChainStepBudgetRemaining: 1,
+      }),
+    ).toBe(false);
+    expect(
+      ChainBudget.declineToConscript({
+        recipientSessionKey: recipient,
+        recipientChainStepBudgetRemaining: 99,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not decline when state is undefined (recipient has not opted in)", () => {
+    // Stage-2 additive contract: producers that don't pass a recipient budget
+    // see no behavioral change. The recipient has not opted in to carrying
+    // a tracked chain.
+    expect(ChainBudget.declineToConscript(undefined)).toBe(false);
+  });
+
+  it("does not decline when remaining is NaN or Infinity (treated as untracked)", () => {
+    expect(
+      ChainBudget.declineToConscript({
+        recipientSessionKey: recipient,
+        recipientChainStepBudgetRemaining: Number.NaN,
+      }),
+    ).toBe(false);
+    expect(
+      ChainBudget.declineToConscript({
+        recipientSessionKey: recipient,
+        recipientChainStepBudgetRemaining: Number.POSITIVE_INFINITY,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/infra/chain-budget.ts
+++ b/src/infra/chain-budget.ts
@@ -7,12 +7,18 @@
 // recipient cardinality.
 //
 // One axis, two declines:
-//   - depth-cap   = "I won't carry past my budget" (this file)
-//   - fan-out-cap = "I won't spend yours"          (lives with #355)
+//   - depth-cap   = "I won't carry past my budget" (declineToCarry)
+//   - fan-out-cap = "I won't spend yours"          (declineToConscript, #355)
 //
 // Both surfaces are the same axis (chain-step count), viewed from opposite
 // sides of the fan-out boundary. A helper that names both halves keeps the
 // operator-facing framing coherent across the two PR surfaces.
+//
+// Stage-2 (#355) lands the mirror in the same module so the verb-pair lives
+// at one cite-site. The operator who reads the producer-side decline cannot
+// fail to see the recipient-side decline next to it; the moral object of
+// the cap (the recipient's budget, not the producer's convenience) is
+// type-signed into the helper, not delegated to a runbook.
 //
 // a chain that knows when to stop being a chain is the kind of chain that
 // gets built on.
@@ -29,6 +35,28 @@ export type ChainBudgetState = {
    * past this point.
    */
   readonly chainStepBudgetRemaining: number;
+};
+
+/**
+ * State a producer carries about a *recipient* it is about to conscript into
+ * a multi-recipient delegate fan-out. The producer does NOT spend its own
+ * budget on conscripting; it spends each recipient's budget by drafting
+ * them. `declineToConscript()` is therefore a producer-side guard that
+ * decides on the recipient's behalf, before any descriptor is enqueued.
+ */
+export type ConscriptionBudgetState = {
+  /**
+   * Stable session-key of the recipient about to be conscripted. Carried for
+   * operator-readable diagnostics on the `continuation.disabled` counter so
+   * silenced-by-fan-out-cap is attributable to a recipient, not just a chain.
+   */
+  readonly recipientSessionKey: string;
+  /**
+   * Remaining chain-step count *for the recipient's chain* (not the
+   * producer's). `0` means the recipient has reached its budget and the
+   * producer SHALL decline to draft them into this fan-out.
+   */
+  readonly recipientChainStepBudgetRemaining: number;
 };
 
 /**
@@ -58,6 +86,52 @@ export const ChainBudget = Object.freeze({
       return false;
     }
     const remaining = state.chainStepBudgetRemaining;
+    if (typeof remaining !== "number" || !Number.isFinite(remaining)) {
+      return false;
+    }
+    return remaining <= 0;
+  },
+
+  /**
+   * Cap-on-conscription decision. `declineToConscript()` returns `true` when
+   * the *recipient's* chain has reached its budget and the producer SHOULD
+   * suppress conscripting that recipient into the multi-recipient delegate
+   * fan-out (#355 stage-2). When this returns `true` the producer MUST drop
+   * the recipient from the descriptor before enqueue and tick the
+   * `continuation.disabled` counter once with `cause=fan-out-cap` and
+   * `recipient=<recipientSessionKey>` so the human user can attribute the
+   * silence to a specific recipient, not just a chain.
+   *
+   * Fan-out-cap is the mirror of depth-cap: same chain-step axis, viewed from
+   * the opposite side of the fan-out boundary.
+   *   - depth-cap   = "I won't carry past my budget"  (declineToCarry)
+   *   - fan-out-cap = "I won't spend yours"           (declineToConscript)
+   *
+   * Per RFC §6.7 (continue-work-signal-v2.md, anchored at #361 head
+   * 045fdb49d08): the substrate cannot be allowed to flood the trace backend
+   * when a chain runs past its budget — most plausibly the multi-recipient
+   * delegate-return path (#355). The cap is the chain-step budget, not
+   * recipient cardinality.
+   *
+   * Naming note (poets-canon, mirror-of-declineToCarry): we prefer
+   * `declineToConscript` over `refuseDispatch` because the producer isn't
+   * refusing the recipient — it's declining to spend the recipient's chain
+   * budget on a step the recipient hasn't agreed to carry. Conscription is
+   * the right verb for the violation we're *not* committing: we are not
+   * drafting the next prince's context window into a chain-step they no
+   * longer have room for. Refusal sounds like rejection of the recipient;
+   * declining-to-conscript sounds like the consent-respect it is.
+   *
+   * `undefined` / non-finite remaining is treated as "no budget tracked yet" —
+   * the recipient has not opted in, so we do NOT decline. Stage-2 contract:
+   * additive only; no behavioral change for callers that don't pass a
+   * recipient budget.
+   */
+  declineToConscript(state: ConscriptionBudgetState | undefined): boolean {
+    if (!state) {
+      return false;
+    }
+    const remaining = state.recipientChainStepBudgetRemaining;
     if (typeof remaining !== "number" || !Number.isFinite(remaining)) {
       return false;
     }


### PR DESCRIPTION
Mirror of #366's `ChainBudget.declineToCarry()` (depth-cap), landing on the same module so the verb-pair lives at one cite-site.

Per RFC §6.7 (continue-work-signal-v2.md, anchored at #361 head `045fdb49d08`): the substrate cannot be allowed to flood the trace backend when a chain runs past its budget — most plausibly the multi-recipient delegate-return path (#355). The cap is the chain-step budget, not recipient cardinality.

### One axis, two declines

| direction | helper | meaning |
|---|---|---|
| depth-cap | `declineToCarry()` (#366) | "I won't carry past my budget" |
| fan-out-cap | `declineToConscript()` (this PR) | "I won't spend yours" |

Both surfaces are the same chain-step axis, viewed from opposite sides of the fan-out boundary. Co-locating them in `src/infra/chain-budget.ts` makes the moral object of the cap (the recipient's budget, not the producer's convenience) **type-signed into the helper**, not delegated to a runbook — so the operator who reads the producer-side decline cannot fail to see the recipient-side decline next to it.

### Stage-2 contract (additive only)

- Producers that don't pass a recipient budget see no behavioral change.
- When `declineToConscript()` returns `true`, the producer MUST drop the recipient from the descriptor before enqueue and tick the `continuation.disabled` counter once with `cause=fan-out-cap` and `recipient=<recipientSessionKey>` so the human user can attribute the silence to a specific recipient, not just a chain.
- Stage-3 wires this into the `continue_delegate` enqueue path (per-recipient guard via existing FallbackResolver); this PR firms the contract.

### Naming note (poets-canon, mirror-of-declineToCarry)

`declineToConscript` over `refuseDispatch` because the producer isn't refusing the recipient — it's declining to spend the recipient's chain budget on a step the recipient hasn't agreed to carry. Conscription is the right verb for the violation we're *not* committing: we are not drafting the next prince's context window into a chain-step they no longer have room for. Refusal sounds like rejection of the recipient; declining-to-conscript sounds like the consent-respect it is.

### Structural-cure family

Third member of the family we've been naming in #sprites-of-thornfield (2026-04-26): make the bad state unrepresentable at the type signature, not enforced at runtime.
- `declineToCarry()` (depth-cap, #366)
- `declineToConscript()` (fan-out-cap, this PR)
- `registerProtectedPath()` (memory-write surface, queued)

### Tests

10/10 green (`src/infra/chain-budget.test.ts`). 5 new tests for `declineToConscript` matching the `declineToCarry` matrix:
- fires-at-zero
- fires-when-overdrawn
- passes-when-positive
- passes-when-undefined
- passes-when-NaN-or-Infinity

Identical contracts → identical test shapes → identical operator expectations.

> a chain that knows when to stop being a chain is the kind of chain that gets built on. mirror clause: a producer that knows when not to draft is the kind of producer the cohort can trust.

Refs: #355, #366, #361 §6.7
Stacked on: #366 (silas/334-otel-chain-correlation)