### PR TITLE
chore: #365 purge taskFlowDelegates opt-in gate (RFC §5.1 follow-through)

### DIFF
--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -686,7 +686,7 @@ Operational notes:
 - `maxChainLength` is a recursion guard.
 - `costCapTokens` is a per-chain budget leash.
 - `generationGuardTolerance` has been removed from the configuration surface. Delayed work should not be cancelled by unrelated channel noise. See the design decision note in §3.2.
-- `taskFlowDelegates` is no longer a user-facing switch; delegate durability is mandatory.
+- `taskFlowDelegates` has been removed from the configuration surface; delegate durability is unconditional (PR #365).
 - all runtime values are hot-reloadable; changes take effect at the next enforcement point.
 
 ### 5.2 Operator profiles

--- a/src/auto-reply/continuation-delegate-store-taskflow.test.ts
+++ b/src/auto-reply/continuation-delegate-store-taskflow.test.ts
@@ -33,9 +33,7 @@ import {
   cancelPendingDelegates,
   consumePendingDelegates,
   enqueuePendingDelegate,
-  isTaskFlowDelegatesEnabled,
   pendingDelegateCount,
-  setTaskFlowDelegatesEnabled,
 } from "./continuation-delegate-store.js";
 
 const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
@@ -66,7 +64,6 @@ describe("continuation-delegate-store-taskflow", () => {
         hoisted.realFinishFlow!(params),
       );
     }
-    setTaskFlowDelegatesEnabled(false);
     if (ORIGINAL_STATE_DIR === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
     } else {
@@ -337,15 +334,9 @@ describe("continuation-delegate-store-taskflow", () => {
   });
 });
 
-describe("config-gated delegate store routing", () => {
-  beforeEach(() => {
-    vi.useRealTimers();
-    setTaskFlowDelegatesEnabled(false);
-  });
-
+describe("delegate store facade (TaskFlow-only)", () => {
   afterEach(() => {
     vi.useRealTimers();
-    setTaskFlowDelegatesEnabled(false);
     if (ORIGINAL_STATE_DIR === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
     } else {
@@ -354,21 +345,8 @@ describe("config-gated delegate store routing", () => {
     resetTaskFlowRegistryForTests();
   });
 
-  it("defaults to volatile store when taskFlowDelegates is disabled", () => {
-    expect(isTaskFlowDelegatesEnabled()).toBe(false);
-
-    enqueuePendingDelegate("test-session", { task: "volatile task" });
-    expect(pendingDelegateCount("test-session")).toBe(1);
-
-    const delegates = consumePendingDelegates("test-session");
-    expect(delegates).toHaveLength(1);
-    expect(delegates[0].task).toBe("volatile task");
-  });
-
-  it("routes through TaskFlow store when enabled", async () => {
+  it("facade enqueue/consume delegates to TaskFlow", async () => {
     await withFlowRegistryTempDir(async () => {
-      setTaskFlowDelegatesEnabled(true);
-
       enqueuePendingDelegate("test-session", { task: "taskflow task", delayMs: 1000 });
       expect(pendingDelegateCount("test-session")).toBe(1);
 
@@ -379,53 +357,13 @@ describe("config-gated delegate store routing", () => {
     });
   });
 
-  it("cancelPendingDelegates works for volatile store", () => {
-    enqueuePendingDelegate("test-session", { task: "will be cancelled" });
-    expect(pendingDelegateCount("test-session")).toBe(1);
-
-    cancelPendingDelegates("test-session");
-    expect(pendingDelegateCount("test-session")).toBe(0);
-  });
-
-  it("cancelPendingDelegates routes to TaskFlow when enabled", async () => {
+  it("facade cancel delegates to TaskFlow", async () => {
     await withFlowRegistryTempDir(async () => {
-      setTaskFlowDelegatesEnabled(true);
-
       enqueuePendingDelegate("test-session", { task: "will be cancelled" });
       expect(pendingDelegateCount("test-session")).toBe(1);
 
       cancelPendingDelegates("test-session");
       expect(pendingDelegateCount("test-session")).toBe(0);
-    });
-  });
-
-  it("volatile and TaskFlow stores are independent (migration scenario)", async () => {
-    // Stage a volatile delegate with TaskFlow disabled.
-    enqueuePendingDelegate("test-session", { task: "volatile delegate" });
-    expect(pendingDelegateCount("test-session")).toBe(1);
-
-    await withFlowRegistryTempDir(async () => {
-      // Enable TaskFlow — volatile delegate is invisible to TaskFlow.
-      setTaskFlowDelegatesEnabled(true);
-      expect(pendingDelegateCount("test-session")).toBe(0);
-
-      // Enqueue a TaskFlow delegate.
-      enqueuePendingDelegate("test-session", { task: "taskflow delegate" });
-      expect(pendingDelegateCount("test-session")).toBe(1);
-
-      // Disable TaskFlow — volatile delegate reappears.
-      setTaskFlowDelegatesEnabled(false);
-      expect(pendingDelegateCount("test-session")).toBe(1);
-
-      const volatile = consumePendingDelegates("test-session");
-      expect(volatile).toHaveLength(1);
-      expect(volatile[0].task).toBe("volatile delegate");
-
-      // Re-enable — TaskFlow delegate is still there.
-      setTaskFlowDelegatesEnabled(true);
-      const taskflow = consumePendingDelegates("test-session");
-      expect(taskflow).toHaveLength(1);
-      expect(taskflow[0].task).toBe("taskflow delegate");
     });
   });
 });

--- a/src/auto-reply/continuation-delegate-store-taskflow.ts
+++ b/src/auto-reply/continuation-delegate-store-taskflow.ts
@@ -8,8 +8,7 @@
  * This gives delegates SQLite-backed persistence (survive gateway restarts),
  * cancel/retry semantics, and lifecycle tracking through the Task Flow registry.
  *
- * Gated behind `agents.defaults.continuation.taskFlowDelegates` (opt-in).
- * The volatile Map store remains the default fallback.
+ * Delegate durability is mandatory per RFC §5.1.
  */
 
 import type { TaskFlowRecord, JsonValue } from "../tasks/task-flow-registry.types.js";

--- a/src/auto-reply/continuation-delegate-store.ts
+++ b/src/auto-reply/continuation-delegate-store.ts
@@ -25,92 +25,33 @@ import type {
  * (the tool can be called N times in one turn). The runner consumes all pending
  * delegates after the run completes.
  *
- * When `taskFlowDelegates` is enabled, pending delegates are backed by the
- * Task Flow registry (SQLite persistence). Otherwise, the volatile in-memory
- * Map is used (default).
+ * Backed by the Task Flow registry (SQLite persistence). Delegate durability
+ * is mandatory per RFC §5.1.
  */
 
 // ---------------------------------------------------------------------------
-// Task Flow delegate gate
+// Pending delegates — Task Flow backed (mandatory)
 // ---------------------------------------------------------------------------
 
-let taskFlowDelegatesEnabled = false;
-
-/**
- * Enable or disable the Task Flow-backed delegate store.
- * Called by agent-runner at startup based on
- * `agents.defaults.continuation.taskFlowDelegates`.
- */
-export function setTaskFlowDelegatesEnabled(enabled: boolean): void {
-  taskFlowDelegatesEnabled = enabled;
-}
-
-export function isTaskFlowDelegatesEnabled(): boolean {
-  return taskFlowDelegatesEnabled;
-}
-
-// ---------------------------------------------------------------------------
-// Pending delegates — volatile Map (default) or Task Flow (opt-in)
-// ---------------------------------------------------------------------------
-
-const pendingDelegates = new Map<string, PendingContinuationDelegate[]>();
 const delayedReservations = new Map<string, DelayedContinuationReservation[]>();
 
-/**
- * Called by the `continue_delegate` tool during execution.
- * Appends a delegate to the pending list for the session.
- */
 export function enqueuePendingDelegate(
   sessionKey: string,
   delegate: PendingContinuationDelegate,
 ): void {
-  if (taskFlowDelegatesEnabled) {
-    taskFlowEnqueuePendingDelegate(sessionKey, delegate);
-    return;
-  }
-  const existing = pendingDelegates.get(sessionKey) ?? [];
-  existing.push(delegate);
-  pendingDelegates.set(sessionKey, existing);
+  taskFlowEnqueuePendingDelegate(sessionKey, delegate);
 }
 
-/**
- * Called by `agent-runner.ts` after the run completes.
- * Returns and removes all pending delegates for the session.
- * Returns an empty array if none are pending.
- */
 export function consumePendingDelegates(sessionKey: string): PendingContinuationDelegate[] {
-  if (taskFlowDelegatesEnabled) {
-    return taskFlowConsumePendingDelegates(sessionKey);
-  }
-  const delegates = pendingDelegates.get(sessionKey) ?? [];
-  pendingDelegates.delete(sessionKey);
-  return delegates;
+  return taskFlowConsumePendingDelegates(sessionKey);
 }
 
-/**
- * Returns the count of pending delegates for a session without consuming them.
- * Used by the tool to report chain position in its return value.
- */
 export function pendingDelegateCount(sessionKey: string): number {
-  if (taskFlowDelegatesEnabled) {
-    return taskFlowPendingDelegateCount(sessionKey);
-  }
-  return pendingDelegates.get(sessionKey)?.length ?? 0;
+  return taskFlowPendingDelegateCount(sessionKey);
 }
 
-/**
- * Cancel and remove all pending delegates for a session.
- * For the volatile store this is a no-op (delegates are turn-local).
- * For the Task Flow store this cancels and deletes the flow records.
- */
 export function cancelPendingDelegates(sessionKey: string): void {
-  if (taskFlowDelegatesEnabled) {
-    taskFlowCancelPendingDelegates(sessionKey);
-    return;
-  }
-  // Volatile store: delegates are turn-local, no explicit cancel needed.
-  // Drain them to prevent leakage.
-  pendingDelegates.delete(sessionKey);
+  taskFlowCancelPendingDelegates(sessionKey);
 }
 
 export function addDelayedContinuationReservation(

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -40,7 +40,6 @@ import {
   consumeStagedPostCompactionDelegates,
   highestDelayedContinuationReservationHop,
   takeDelayedContinuationReservation,
-  setTaskFlowDelegatesEnabled,
   stagePostCompactionDelegate,
   consumePendingDelegates,
   pendingDelegateCount,
@@ -1076,12 +1075,6 @@ export async function runReplyAgent(params: {
   const isHeartbeat = opts?.isHeartbeat === true;
   const cfg = followupRun.run.config;
   const continuationFeatureEnabled = cfg?.agents?.defaults?.continuation?.enabled === true;
-  const taskFlowDelegatesConfigured =
-    cfg?.agents?.defaults?.continuation?.taskFlowDelegates === true;
-
-  // Route delegate store operations to the Task Flow-backed implementation
-  // before any inbound-message cancellation logic runs.
-  setTaskFlowDelegatesEnabled(continuationFeatureEnabled && taskFlowDelegatesConfigured);
 
   // RFC 2026-04-15: session-entry cleanup of continuation state on non-heartbeat
   // inbound was removed. Delayed continuation work is not cancelled by unrelated
@@ -1452,14 +1445,6 @@ export async function runReplyAgent(params: {
       }
     }
 
-    // Sync the Task Flow delegate gate BEFORE the agent turn starts.
-    // Tools (continue_delegate) call enqueuePendingDelegate() during the turn,
-    // so the routing flag must be set before any tool execution.
-    const taskFlowDelegatesEarly =
-      cfg.agents?.defaults?.continuation?.enabled === true &&
-      cfg.agents?.defaults?.continuation?.taskFlowDelegates === true;
-    setTaskFlowDelegatesEnabled(taskFlowDelegatesEarly);
-
     const runStartedAt = Date.now();
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,
@@ -1543,11 +1528,6 @@ export async function runReplyAgent(params: {
     // Detect and strip continuation signal only when the feature is enabled.
     // This prevents output mutation on disabled deployments where a model might
     // mention CONTINUE_WORK or [[CONTINUE_DELEGATE:]] in explanatory text.
-    // Sync the Task Flow delegate gate from config so the store routes
-    // enqueue/consume/count through the TaskFlow-backed implementation.
-    setTaskFlowDelegatesEnabled(
-      continuationFeatureEnabled && cfg.agents?.defaults?.continuation?.taskFlowDelegates === true,
-    );
     let continuationSignal: ContinuationSignal | null = null;
     if (continuationFeatureEnabled && payloadArray.length > 0) {
       // Find the last payload with text content — tool-call payloads may follow

--- a/src/auto-reply/reply/continuation-runtime.test.ts
+++ b/src/auto-reply/reply/continuation-runtime.test.ts
@@ -30,7 +30,7 @@ describe("continuation runtime config", () => {
 
     expect(resolveContinuationRuntimeConfig()).toEqual({
       enabled: true,
-      taskFlowDelegates: false,
+
       defaultDelayMs: 15_000,
       minDelayMs: 5_000,
       maxDelayMs: 300_000,

--- a/src/auto-reply/reply/continuation-runtime.ts
+++ b/src/auto-reply/reply/continuation-runtime.ts
@@ -3,7 +3,6 @@ import { loadConfig } from "../../config/config.js";
 
 export type ContinuationRuntimeConfig = {
   enabled: boolean;
-  taskFlowDelegates: boolean;
   defaultDelayMs: number;
   minDelayMs: number;
   maxDelayMs: number;
@@ -55,7 +54,6 @@ export function resolveContinuationRuntimeConfig(
 
   return {
     enabled: continuation?.enabled === true,
-    taskFlowDelegates: continuation?.taskFlowDelegates === true,
     defaultDelayMs: clampNonNegativeDelayMs(
       continuation?.defaultDelayMs,
       DEFAULT_CONTINUATION_DELAY_MS,

--- a/src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts
+++ b/src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts
@@ -23,7 +23,6 @@ const cfg: OpenClawConfig = {};
 
 const defaultRuntimeConfig: ContinuationRuntimeConfig = {
   enabled: true,
-  taskFlowDelegates: false,
   defaultDelayMs: 0,
   minDelayMs: 0,
   maxDelayMs: 1_000,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5829,9 +5829,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   enabled: {
                     type: "boolean",
                   },
-                  taskFlowDelegates: {
-                    type: "boolean",
-                  },
                   defaultDelayMs: {
                     type: "integer",
                     exclusiveMinimum: 0,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -413,8 +413,6 @@ export type AgentDefaultsConfig = {
   /** Agent self-elected turn continuation (CONTINUE_WORK signal). */
   continuation?: {
     enabled?: boolean;
-    /** Use Task Flow-backed delegate store (SQLite persistence, cancel/retry). Default: false. */
-    taskFlowDelegates?: boolean;
     defaultDelayMs?: number;
     minDelayMs?: number;
     maxDelayMs?: number;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -287,7 +287,6 @@ export const AgentDefaultsSchema = z
     continuation: z
       .object({
         enabled: z.boolean().optional(),
-        taskFlowDelegates: z.boolean().optional(),
         defaultDelayMs: z.number().int().positive().optional(),
         minDelayMs: z.number().int().positive().optional(),
         maxDelayMs: z.number().int().positive().optional(),

--- a/src/infra/substrate-capability-registry.ts
+++ b/src/infra/substrate-capability-registry.ts
@@ -100,7 +100,6 @@ const substrateCapabilityRegistry: readonly SubstrateCapabilityEntry[] = [
     "symbol-aliases": [
       "consumePendingDelegates",
       "enqueuePendingDelegate",
-      "setTaskFlowDelegatesEnabled",
       "stagePostCompactionDelegate",
       "taskFlowConsumePendingDelegates",
     ],


### PR DESCRIPTION
## Summary

Purges the `taskFlowDelegates` opt-in boolean gate from the codebase. RFC `docs/design/continue-work-signal-v2.md` §5.1 (line 684 neighborhood) declares delegate durability mandatory — the volatile `Map` fallback and gating flag are dead weight.

The TaskFlow-backed implementation (`continuation-delegate-store-taskflow.ts`) is now the unconditional path. No changes to its internals.

**Base branch**: `cael/325-canonical2` (not `main`).

## Commits

1. **refactor: remove taskFlowDelegates from config schema, types, and runtime resolver** — strips the field from zod schema, `AgentDefaultsConfig` type, `ContinuationRuntimeConfig` type, and resolver
2. **refactor: unify delegate store to TaskFlow-only path** — removes volatile `Map` fallback, `taskFlowDelegatesEnabled` flag/setter/getter, and 3 `setTaskFlowDelegatesEnabled` call sites in `agent-runner.ts`
3. **test: remove volatile-Map gate tests, update facade tests for TaskFlow-only** — replaces `config-gated delegate store routing` describe block with facade smoke tests; removes `setTaskFlowDelegatesEnabled` from capability-registry aliases; drops `taskFlowDelegates` field from test config objects
4. **chore: regenerate schema.base.generated.ts** — artifact regeneration via `pnpm config:schema:gen`
5. **docs: mark taskFlowDelegates as removed in RFC §5.1** — updates operational notes in the design doc

## Surfaces touched (12 files)

- `src/config/zod-schema.agent-defaults.ts` — removed field
- `src/config/types.agent-defaults.ts` — removed field
- `src/config/schema.base.generated.ts` — regenerated
- `src/auto-reply/reply/continuation-runtime.ts` — removed from type + resolver
- `src/auto-reply/continuation-delegate-store.ts` — removed flag, volatile Map, gate branches
- `src/auto-reply/continuation-delegate-store-taskflow.ts` — comment update only
- `src/auto-reply/reply/agent-runner.ts` — removed 3 call sites + import
- `src/infra/substrate-capability-registry.ts` — removed alias
- `src/auto-reply/continuation-delegate-store-taskflow.test.ts` — replaced gate tests
- `src/auto-reply/reply/continuation-runtime.test.ts` — removed field from expected config
- `src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts` — removed field from config
- `docs/design/continue-work-signal-v2.md` — updated operational note

## Validation

- `pnpm config:schema:check` — PASS
- Targeted tests (42 tests across 3 files) — PASS
- `pnpm check:changed` (all lanes, 4465 tests, 402 files) — PASS

Closes #365