### PR TITLE
feat(continuation): #334 Slice 2 chunk 1 — Tracer surface + noopTracer (path-B, no OTEL deps)

### DIFF
--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getContinuationTracer,
+  noopTracer,
+  resetContinuationTracer,
+  setContinuationTracer,
+  type Span,
+  type SpanAttributes,
+  type SpanStatus,
+  type StartSpanOptions,
+  type Tracer,
+} from "./continuation-tracer.js";
+
+afterEach(() => {
+  resetContinuationTracer();
+});
+
+describe("continuation-tracer :: noop default contract (Slice 2)", () => {
+  it("default tracer is the no-op tracer (additive Slice-1 contract preserved)", () => {
+    expect(getContinuationTracer()).toBe(noopTracer);
+  });
+
+  it("noopTracer.startSpan returns a span with all methods callable as no-ops", () => {
+    const span = noopTracer.startSpan("continuation.work");
+    // None of these should throw — the no-op surface is the safety net for
+    // un-opted callers.
+    expect(() => span.setAttributes({ "chain.id": "x" })).not.toThrow();
+    expect(() => span.setStatus("OK")).not.toThrow();
+    expect(() => span.setStatus("ERROR", "boom")).not.toThrow();
+    expect(() => span.recordException(new Error("boom"))).not.toThrow();
+    expect(() => span.recordException("plain-string")).not.toThrow();
+    expect(() => span.end()).not.toThrow();
+    // end() is idempotent.
+    expect(() => span.end()).not.toThrow();
+  });
+
+  it("noopTracer ignores StartSpanOptions (attrs + traceparent) without throwing", () => {
+    const opts: StartSpanOptions = {
+      attributes: { "chain.id": "abc", "chain.step.remaining": 5 },
+      traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+    };
+    expect(() => noopTracer.startSpan("continuation.work", opts)).not.toThrow();
+  });
+});
+
+describe("continuation-tracer :: registry (set/get/reset)", () => {
+  it("setContinuationTracer installs a custom tracer; getContinuationTracer returns it", () => {
+    const calls: Array<{ name: string; opts?: StartSpanOptions }> = [];
+    const recorded: Array<{ method: string; args: unknown[] }> = [];
+
+    const recordingSpan: Span = {
+      setAttributes(attrs: SpanAttributes): void {
+        recorded.push({ method: "setAttributes", args: [attrs] });
+      },
+      setStatus(status: SpanStatus, message?: string): void {
+        recorded.push({ method: "setStatus", args: [status, message] });
+      },
+      recordException(err: unknown): void {
+        recorded.push({ method: "recordException", args: [err] });
+      },
+      end(): void {
+        recorded.push({ method: "end", args: [] });
+      },
+    };
+
+    const recordingTracer: Tracer = {
+      startSpan(name: string, opts?: StartSpanOptions): Span {
+        calls.push({ name, opts });
+        return recordingSpan;
+      },
+    };
+
+    setContinuationTracer(recordingTracer);
+    expect(getContinuationTracer()).toBe(recordingTracer);
+
+    const span = getContinuationTracer().startSpan("continuation.work", {
+      attributes: { "chain.id": "test-chain" },
+    });
+    span.setAttributes({ "chain.step.remaining": 4 });
+    span.setStatus("OK");
+    span.end();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.name).toBe("continuation.work");
+    expect(calls[0]?.opts?.attributes?.["chain.id"]).toBe("test-chain");
+    expect(recorded.map((r) => r.method)).toEqual(["setAttributes", "setStatus", "end"]);
+  });
+
+  it("setContinuationTracer(null) resets to the no-op default", () => {
+    const customTracer: Tracer = { startSpan: () => noopTracer.startSpan("x") };
+    setContinuationTracer(customTracer);
+    expect(getContinuationTracer()).toBe(customTracer);
+
+    setContinuationTracer(null);
+    expect(getContinuationTracer()).toBe(noopTracer);
+  });
+
+  it("setContinuationTracer(undefined) resets to the no-op default", () => {
+    const customTracer: Tracer = { startSpan: () => noopTracer.startSpan("x") };
+    setContinuationTracer(customTracer);
+    expect(getContinuationTracer()).toBe(customTracer);
+
+    setContinuationTracer(undefined);
+    expect(getContinuationTracer()).toBe(noopTracer);
+  });
+
+  it("resetContinuationTracer() resets to the no-op default", () => {
+    const customTracer: Tracer = { startSpan: () => noopTracer.startSpan("x") };
+    setContinuationTracer(customTracer);
+    expect(getContinuationTracer()).toBe(customTracer);
+
+    resetContinuationTracer();
+    expect(getContinuationTracer()).toBe(noopTracer);
+  });
+});
+
+describe("continuation-tracer :: harness contract pin (#370)", () => {
+  // These tests pin the canonical span names + attribute names the swim-37
+  // harness (`studies/swim-37/harness/swim-runner.test.ts`) asserts against.
+  // If a span name or attribute name renames, this file fails first — before
+  // the harness — giving a clearer signal at the source.
+
+  it("canonical continuation span names are accepted by the surface", () => {
+    const recorded: string[] = [];
+    setContinuationTracer({
+      startSpan: (name) => {
+        recorded.push(name);
+        return noopTracer.startSpan(name);
+      },
+    });
+
+    const tracer = getContinuationTracer();
+    tracer.startSpan("continuation.work");
+    tracer.startSpan("continuation.delegate.dispatch");
+    tracer.startSpan("continuation.queue.enqueue");
+    tracer.startSpan("continuation.queue.drain");
+    tracer.startSpan("continuation.compaction.released");
+    tracer.startSpan("continuation.disabled");
+    tracer.startSpan("heartbeat");
+
+    expect(recorded).toEqual([
+      "continuation.work",
+      "continuation.delegate.dispatch",
+      "continuation.queue.enqueue",
+      "continuation.queue.drain",
+      "continuation.compaction.released",
+      "continuation.disabled",
+      "heartbeat",
+    ]);
+  });
+
+  it("canonical attribute names round-trip through the surface", () => {
+    let captured: SpanAttributes | undefined;
+    setContinuationTracer({
+      startSpan: (_name, opts) => {
+        captured = opts?.attributes;
+        return noopTracer.startSpan(_name);
+      },
+    });
+
+    getContinuationTracer().startSpan("continuation.work", {
+      attributes: {
+        "chain.id": "01J0X0000000000000000000A0",
+        "chain.step.remaining": 4,
+        "delay.ms": 30000,
+        "reason.preview": "context-pressure handoff",
+      },
+    });
+
+    expect(captured?.["chain.id"]).toBe("01J0X0000000000000000000A0");
+    expect(captured?.["chain.step.remaining"]).toBe(4);
+    expect(captured?.["delay.ms"]).toBe(30000);
+    expect(captured?.["reason.preview"]).toBe("context-pressure handoff");
+  });
+});

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -4,6 +4,8 @@ import {
   noopTracer,
   resetContinuationTracer,
   setContinuationTracer,
+  type ContinuationSpanAttrs,
+  type ContinuationSpanName,
   type Span,
   type SpanAttributes,
   type SpanStatus,
@@ -171,5 +173,43 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
     expect(captured?.["chain.step.remaining"]).toBe(4);
     expect(captured?.["delay.ms"]).toBe(30000);
     expect(captured?.["reason.preview"]).toBe("context-pressure handoff");
+  });
+
+  // Type-level pin: ContinuationSpanAttrs is the load-bearing canonical
+  // attribute-name shape. If the OTEL adapter (Slice 3) ever drifts to
+  // chain_id / chainId / camelCase / etc., the assignment below fails
+  // compile, BEFORE the runtime harness assertions could catch it.
+  // (🌻's nuance, sprites-of-thornfield 2026-04-27.)
+  it("ContinuationSpanAttrs is structurally compatible with SpanAttributes", () => {
+    const canonical: ContinuationSpanAttrs = {
+      "chain.id": "abc",
+      "chain.step.remaining": 3,
+      "delay.ms": 1000,
+      "reason.preview": "x",
+      "delegate.mode": "silent-wake",
+      "continuation.disabled": false,
+    };
+    // Assignment to SpanAttributes is the compile-time pin: every
+    // ContinuationSpanAttrs MUST be a valid SpanAttributes for the shim
+    // surface to accept it.
+    const broad: SpanAttributes = canonical;
+    expect(broad["chain.id"]).toBe("abc");
+  });
+
+  it("ContinuationSpanName values are all accepted by startSpan", () => {
+    // Compile-time pin: each canonical name MUST be assignable to the
+    // ContinuationSpanName union.
+    const names: ContinuationSpanName[] = [
+      "continuation.work",
+      "continuation.delegate.dispatch",
+      "continuation.queue.enqueue",
+      "continuation.queue.drain",
+      "continuation.compaction.released",
+      "continuation.disabled",
+      "heartbeat",
+    ];
+    for (const name of names) {
+      expect(() => noopTracer.startSpan(name)).not.toThrow();
+    }
   });
 });

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -1,0 +1,180 @@
+// Continuation-tracer shim — Slice 2 surface for #334 OTEL chain-correlation.
+//
+// Per Slice-2 design checkpoint (sprites-of-thornfield, 2026-04-27, path B):
+// the substrate adds the **span-emission surface** here, not the wire. A
+// thin `Tracer` interface with a no-op default keeps the additive contract
+// from Slice 1 — callers that don't opt in see no behavior change, and the
+// real OTEL adapter lands in Slice 3 once the bauble policy conversation
+// resolves which deps may live in the gateway hot-path.
+//
+// The harness in `studies/swim-37/harness/swim-runner.test.ts` (#370) pins
+// against THIS module's surface — `tracer.startSpan(name, attrs)` — not
+// against `@opentelemetry/api`. That keeps the harness durable across
+// upstream-OTEL renames and across any future exporter swap.
+//
+// Naming pinned by Slice 1 substrate (`SystemEvent.traceparent`,
+// `ChainBudget.declineToCarry`, `chain.id`, `chain.step.remaining`). When
+// Slice 3 wires the real provider, no test in the harness or in this
+// module's tests should need to change.
+
+/**
+ * Span attribute values mirror the OTEL semantic-conventions primitive set:
+ * string | number | boolean (and arrays thereof). We intentionally restrict
+ * to scalars here — anything richer belongs in span events, not attributes.
+ */
+export type SpanAttributeValue =
+  | string
+  | number
+  | boolean
+  | readonly string[]
+  | readonly number[]
+  | readonly boolean[];
+
+export type SpanAttributes = Readonly<Record<string, SpanAttributeValue>>;
+
+/**
+ * Status code for a span. Mirrors OTEL's `SpanStatusCode` (UNSET=0, OK=1,
+ * ERROR=2) with explicit string names so callers don't depend on the
+ * numeric ordinal — keeps the surface OTEL-compatible without being
+ * OTEL-bound.
+ */
+export type SpanStatus = "UNSET" | "OK" | "ERROR";
+
+/**
+ * Active span returned by `Tracer.startSpan`. Callers MUST `end()` every
+ * span exactly once — the no-op tracer doesn't enforce this, but the real
+ * Slice-3 adapter will.
+ *
+ * The shape intentionally mirrors `@opentelemetry/api`'s `Span` interface
+ * surface (the subset we care about) so the Slice-3 adapter is a thin
+ * pass-through, not a re-implementation.
+ */
+export type Span = {
+  /**
+   * Add or overwrite attributes on the span. Calling with the same key
+   * replaces the previous value (matches OTEL semantics).
+   */
+  setAttributes(attrs: SpanAttributes): void;
+  /**
+   * Set the span status. Once set to ERROR, transitioning to OK is
+   * permitted (matches OTEL). Implementations SHOULD record the most
+   * recent status only.
+   */
+  setStatus(status: SpanStatus, message?: string): void;
+  /**
+   * Record an exception against the span. Pure-string variants are
+   * accepted for sites that don't carry an Error instance (matches OTEL's
+   * `recordException` permissive shape).
+   */
+  recordException(err: unknown): void;
+  /**
+   * End the span. Idempotent: subsequent calls are no-ops. Matches OTEL.
+   */
+  end(): void;
+};
+
+export type StartSpanOptions = {
+  /**
+   * Initial attributes attached at span creation. Equivalent to calling
+   * `setAttributes` immediately after `startSpan`.
+   */
+  attributes?: SpanAttributes;
+  /**
+   * W3C `traceparent` to anchor the span to an existing trace. When
+   * omitted the span starts a new trace. Slice 1 lifts this onto
+   * `SystemEvent.traceparent` so producer-side reconstruction at drain
+   * time has the field to read from.
+   */
+  traceparent?: string;
+};
+
+/**
+ * Tracer surface used by continuation primitives (`continue_work`,
+ * `continue_delegate`, heartbeat) to emit chain-correlated spans.
+ *
+ * Slice 2 ships this interface + `noopTracer`. Slice 3 ships an OTEL
+ * adapter that conforms to this same surface — the call sites don't change.
+ */
+export type Tracer = {
+  /**
+   * Start a span. Callers MUST `end()` the returned span exactly once.
+   *
+   * `name` SHOULD be one of the canonical continuation span names so the
+   * harness contract assertions hold:
+   *   - `continuation.work`
+   *   - `continuation.delegate.dispatch`
+   *   - `continuation.queue.enqueue`
+   *   - `continuation.queue.drain`
+   *   - `continuation.compaction.released`
+   *   - `continuation.disabled`
+   *   - `heartbeat`
+   *
+   * The `name` parameter is not type-narrowed to that union because some
+   * call sites (diagnostic / debug spans, future adapters) need
+   * arbitrary names; the harness pins the canonical set.
+   */
+  startSpan(name: string, options?: StartSpanOptions): Span;
+};
+
+const noopSpan: Span = Object.freeze({
+  setAttributes(_attrs: SpanAttributes): void {
+    /* no-op */
+  },
+  setStatus(_status: SpanStatus, _message?: string): void {
+    /* no-op */
+  },
+  recordException(_err: unknown): void {
+    /* no-op */
+  },
+  end(): void {
+    /* no-op */
+  },
+});
+
+/**
+ * Default tracer: every method is a no-op. Returned from
+ * `getContinuationTracer()` until a Slice-3 adapter is registered, which
+ * preserves the additive Slice-1 contract: callers that don't opt in see
+ * no behavior change.
+ */
+export const noopTracer: Tracer = Object.freeze({
+  startSpan(_name: string, _options?: StartSpanOptions): Span {
+    return noopSpan;
+  },
+});
+
+let activeTracer: Tracer = noopTracer;
+
+/**
+ * Get the active continuation-tracer. Defaults to the no-op tracer until
+ * `setContinuationTracer` is called by the bootstrap step (Slice 3).
+ *
+ * Hot-path callers SHOULD cache this once at module load — the indirection
+ * exists so test harnesses can swap in `InMemorySpanExporter`-backed
+ * tracers and so Slice 3's adapter can be installed without rewriting the
+ * primitives.
+ */
+export function getContinuationTracer(): Tracer {
+  return activeTracer;
+}
+
+/**
+ * Install a tracer. Used by:
+ *   - the Slice-3 OTEL bootstrap (real OTLP wire)
+ *   - the #370 swim-37 harness (in-memory exporter shim)
+ *   - per-test setup that wants to capture span emissions
+ *
+ * Calling with `noopTracer` (or `null`/`undefined`) resets to the no-op
+ * default — primarily for test teardown.
+ */
+export function setContinuationTracer(tracer: Tracer | null | undefined): void {
+  activeTracer = tracer ?? noopTracer;
+}
+
+/**
+ * Reset to the no-op default. Equivalent to `setContinuationTracer(null)`;
+ * provided as a clearer test-teardown affordance.
+ */
+export function resetContinuationTracer(): void {
+  activeTracer = noopTracer;
+}

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -33,6 +33,60 @@ export type SpanAttributeValue =
 export type SpanAttributes = Readonly<Record<string, SpanAttributeValue>>;
 
 /**
+ * Normative attribute-key set for continuation spans.
+ *
+ * **Pinning these names at the shim type — NOT at the adapter — is the
+ * load-bearing decision** (🌻's nuance, sprites-of-thornfield 2026-04-27):
+ * if the OTEL adapter (Slice 3) ever drifts to `chain_id` / `chainId` /
+ * etc., this type catches the drift at compile-time, before the #370
+ * harness contract assertions could detect it at runtime.
+ *
+ * All keys are optional because not every span carries every attribute
+ * (e.g. `heartbeat` carries `continuation.disabled` but no `delay.ms`).
+ * The `Readonly<Record<string, SpanAttributeValue>>` superset on
+ * `setAttributes` / `StartSpanOptions.attributes` permits diagnostic /
+ * adapter-internal attributes that aren't part of the canonical contract;
+ * `ContinuationSpanAttrs` is what the canonical-attribute-name pin tests
+ * (and #370 harness) assert against.
+ *
+ * Mirror in tests at `continuation-tracer.test.ts ::
+ * "canonical attribute names round-trip through the surface"`.
+ */
+export type ContinuationSpanAttrs = {
+  /** Stable id for the continuation chain this span belongs to. */
+  readonly "chain.id"?: string;
+  /** Remaining chain-step budget, post-decrement at this span. */
+  readonly "chain.step.remaining"?: number;
+  /** Scheduled delay (ms) until the next-turn / delegate fires. */
+  readonly "delay.ms"?: number;
+  /** First ≤80 chars of the tool-call `reason`, for operator readability. */
+  readonly "reason.preview"?: string;
+  /** Mode of a `continue_delegate` dispatch (normal/silent/silent-wake/post-compaction). */
+  readonly "delegate.mode"?: string;
+  /**
+   * `true` when `ChainBudget.declineToCarry` silenced emission for this
+   * step. Carried on the `continuation.disabled` event-span and on the
+   * `heartbeat` span when continuation context is present.
+   */
+  readonly "continuation.disabled"?: boolean;
+};
+
+/**
+ * Canonical span name set. Pinned at the type so a typo in a chunk-2+
+ * call site fails compile, not runtime. The harness assertion in
+ * `continuation-tracer.test.ts :: "canonical continuation span names are
+ * accepted by the surface"` mirrors this list.
+ */
+export type ContinuationSpanName =
+  | "continuation.work"
+  | "continuation.delegate.dispatch"
+  | "continuation.queue.enqueue"
+  | "continuation.queue.drain"
+  | "continuation.compaction.released"
+  | "continuation.disabled"
+  | "heartbeat";
+
+/**
  * Status code for a span. Mirrors OTEL's `SpanStatusCode` (UNSET=0, OK=1,
  * ERROR=2) with explicit string names so callers don't depend on the
  * numeric ordinal — keeps the surface OTEL-compatible without being
@@ -77,6 +131,10 @@ export type StartSpanOptions = {
   /**
    * Initial attributes attached at span creation. Equivalent to calling
    * `setAttributes` immediately after `startSpan`.
+   *
+   * The shim accepts `SpanAttributes` (the broader `Record<string,...>`)
+   * to permit diagnostic / adapter-internal attributes; canonical-contract
+   * keys are pinned by `ContinuationSpanAttrs` and the harness tests.
    */
   attributes?: SpanAttributes;
   /**


### PR DESCRIPTION
**Slice 2 / Chunk 1 of #334 OTEL chain-correlation. Tracking issue: #377. Path-B per cohort design checkpoint (sprites-of-thornfield 2026-04-27).**

## What this PR ships

Pure **surface** landing — no behavior change, no new deps.

- `src/infra/continuation-tracer.ts` — `Tracer` / `Span` / `SpanAttributes` / `SpanStatus` / `StartSpanOptions` types + `noopTracer` default + `get/set/resetContinuationTracer` registry
- `src/infra/continuation-tracer.test.ts` — 9 tests pinning:
  - no-op default contract (every method callable, idempotent `end()`)
  - registry round-trip (set/get/reset, `null` and `undefined` reset to default)
  - **harness contract pin (#370)**: canonical span names + attribute names

## What this PR does NOT ship

- ❌ No `@opentelemetry/*` direct deps (bauble policy deferred to Slice 3)
- ❌ No emission from primitives (`continue_work` / `continue_delegate` / heartbeat) — those land in Chunk 2 (continue_work emission), Chunk 3 (continue_delegate emission), Chunk 4 (heartbeat + `ChainBudget.declineToCarry` integration)
- ❌ No queue-lifecycle spans across the restart boundary — Chunk 5

## Why path-B (cohort decision, captured here)

🌊 framed it cleanly:
1. **Additive contract continuity** — symmetric with Slice 1 (substrate adds the field; un-opted callers see no change). Here: substrate adds the surface; un-installed callers see no spans.
2. **Bauble policy** — 5–8 first-party `@opentelemetry/*` deps in the gateway hot-path deserves its own conversation, not a side-effect of swim-37 substrate.
3. **Harness pin durability** — #370 pins against `tracer.startSpan`, not `@opentelemetry/api`. Stable across upstream-OTEL renames and future exporter swaps.

## Canonical spans + attrs pinned

| Span name                              | Where it'll fire (later chunks) |
|----------------------------------------|---------------------------------|
| `continuation.work`                    | Chunk 2 — `continue_work` tool execute |
| `continuation.delegate.dispatch`       | Chunk 3 — `continue_delegate` tool execute |
| `continuation.queue.enqueue`           | Chunk 5 — `enqueueSystemEvent` (with `traceparent` from Slice 1) |
| `continuation.queue.drain`             | Chunk 5 — drain at announce/deliver time |
| `continuation.compaction.released`     | Chunk 4 — post-compaction lich-shape release seam (#332 Item B) |
| `continuation.disabled`                | Chunk 4 — `ChainBudget.declineToCarry` silenced-by-cap signal |
| `heartbeat`                            | Chunk 4 — heartbeat emission with `continuation.disabled=<bool>` |

| Attribute name           | Type    | Source |
|--------------------------|---------|--------|
| `chain.id`               | string  | Slice 1 substrate |
| `chain.step.remaining`   | number  | `ChainBudgetState.chainStepBudgetRemaining` (Slice 1) |
| `delay.ms`               | number  | scheduling state |
| `reason.preview`         | string  | tool-call reason, ≤80 chars |

## Tests

```
pnpm vitest run src/infra/continuation-tracer.test.ts
✓ 9 tests · 7ms
```

## Review plan

Asking 🌊 + 🌻 because both reviewed Slice 1 cleanly and the contract continuity is the load-bearing claim here. 🩸 if you have time for a third pass on the registry-reset semantics that'd be good cover (path-B has fewer chances to catch a bug if the surface is wrong).

Refs #334 #366 #370 #377