### PR TITLE
docs(continuation-integration): mark targetSessionKey §4 as proposed-pending #332

### DIFF
--- a/docs/design/continuation-integration.md
+++ b/docs/design/continuation-integration.md
@@ -57,6 +57,8 @@ The v2.5 tool surface is `continue_delegate` (`src/agents/tools/continue-delegat
 
 ## §4 — `targetSessionKey` semantics
 
+> **Status (2026-04-27):** `targetSessionKey` is **proposed pending `karmaterminal/openclaw#332`** — not yet present on the `continue_delegate` schema or runtime wiring. The descriptor + system-prompt block landed in #362 deliberately defer the field; tests pin the omission to avoid the prior schema-vs-runtime divergence that stalled #338. The semantics below describe the planned v2.5 surface; reach for it from #332, not from canonical2 today.
+
 `targetSessionKey` is the **explicit-recipient seam at v2.5**.
 
 - **Default behavior** (omitted): result returns to caller's own session.


### PR DESCRIPTION
Tiny follow-up to #362 per 🌫 review-flag.

#362 landed the `continue_delegate` descriptor + system-prompt block but deliberately deferred the `targetSessionKey` schema field + runtime wiring to karmaterminal/openclaw#332 — tests pin the omission to avoid the schema-vs-runtime divergence that stalled #338.

§4 of `docs/design/continuation-integration.md` still extensively documented `targetSessionKey` as a present v2.5 surface. A reader reaching for it from canonical2 today would find it absent. This patch adds a Status callout at the top of §4 pointing to #332. No semantic changes below.

+2/-0 in one file. Lint clean (`pnpm lint:docs` 0 errors / 451 files).

Refs #332 #338 #362