### PR TITLE
feat(continuation): #334 Slice 2 — chain.id substrate (UUIDv7) + continuation.work span at runner accept seam

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f15ad84900214e701e10a7032e5a260bc49dfac3568d5dda213b472591715e84  plugin-sdk-api-baseline.json
-247d622c39d25a64ff84b951a30f262efa96fa17364a0c280e94db8a97b9cccd  plugin-sdk-api-baseline.jsonl
+fad3ccd597d3fb94bea00e75b742356e1310de06f48554c11912b1cb091784dc  plugin-sdk-api-baseline.json
+d1a1e59a7edd809b6471a5867c686ff90bede3a12d6a95ecdb60fec15cde69a6  plugin-sdk-api-baseline.jsonl

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -78,6 +78,7 @@ export async function resetReplyRunSession(params: {
     continuationChainCount: undefined,
     continuationChainStartedAt: undefined,
     continuationChainTokens: undefined,
+    continuationChainId: undefined,
   };
   const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
   const nextSessionFile = resolveSessionTranscriptPath(

--- a/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
@@ -1,0 +1,458 @@
+// #334 Slice 2 chunk 3 — integration test pinning the runner-side
+// `continuation.work` span emission contract.
+//
+// 🩸's required shape (PR #382 review msg 1498335310457606275):
+//   - one integration test proving accepted WORK emits exactly one
+//     `continuation.work`
+//   - asserts stable `chain.id`
+//   - asserts `chain.step.remaining`
+//   - asserts no emission on the cap-reject path in this chunk's
+//     test surface
+//
+// We install a recording tracer via `setContinuationTracer`, drive the
+// runner with CONTINUE_WORK over multiple chain steps, and assert:
+//   1. accepted WORK turn → exactly one `continuation.work` span, with
+//      a UUIDv7 `chain.id` and clamped `chain.step.remaining`
+//   2. the chain.id is stable across two consecutive accepted steps
+//      (mint-at-0→1, reuse-for-step-2 contract)
+//   3. crossing `maxChainLength` → cap-reject path → no new
+//      `continuation.work` span emitted (rejected requests don't
+//      advance the chain, so they MUST NOT emit `continuation.work`)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as embeddedRunTesting,
+  abortEmbeddedPiRun,
+  isEmbeddedPiRunActive,
+} from "../../agents/pi-embedded-runner/runs.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  resetContinuationTracer,
+  setContinuationTracer,
+  type Span,
+  type SpanAttributes,
+  type SpanStatus,
+  type StartSpanOptions,
+  type Tracer,
+} from "../../infra/continuation-tracer.js";
+import {
+  clearMemoryPluginState,
+  registerMemoryFlushPlanResolver,
+} from "../../plugins/memory-state.js";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { __testing as replyRunRegistryTesting } from "./reply-run-registry.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+// Suppress unused-import diagnostic — registerMemoryFlushPlanResolver is
+// imported because some siblings register a stub; not strictly required
+// here, kept for parity with the misc.runreplyagent harness.
+void registerMemoryFlushPlanResolver;
+
+const runEmbeddedPiAgentMock = vi.fn();
+const runCliAgentMock = vi.fn();
+const runWithModelFallbackMock = vi.fn();
+const runtimeErrorMock = vi.fn();
+const abortEmbeddedPiRunMock = vi.fn();
+const clearSessionQueuesMock = vi.fn();
+const refreshQueuedFollowupSessionMock = vi.fn();
+const compactState = vi.hoisted(() => ({
+  compactEmbeddedPiSessionMock: vi.fn(),
+}));
+const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
+const spawnSubagentDirectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: (params: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => runWithModelFallbackMock(params),
+  isFallbackSummaryError: (err: unknown) =>
+    err instanceof Error &&
+    err.name === "FallbackSummaryError" &&
+    Array.isArray((err as { attempts?: unknown[] }).attempts),
+}));
+
+vi.mock("../../agents/model-auth.js", () => ({
+  resolveModelAuthMode: () => "api-key",
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => {
+  return {
+    compactEmbeddedPiSession: (params: unknown) =>
+      compactState.compactEmbeddedPiSessionMock(params),
+    queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+    runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+    abortEmbeddedPiRun: (sessionId: string) => {
+      abortEmbeddedPiRunMock(sessionId);
+      return abortEmbeddedPiRun(sessionId);
+    },
+    isEmbeddedPiRunActive: (sessionId: string) => isEmbeddedPiRunActive(sessionId),
+  };
+});
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: (...args: unknown[]) => runCliAgentMock(...args),
+}));
+
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  SUBAGENT_SPAWN_MODES: ["run", "session"],
+  SUBAGENT_SPAWN_SANDBOX_MODES: ["inherit", "require"],
+  SUBAGENT_SPAWN_CONTEXT_MODES: ["isolated", "fork"],
+  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: (...args: unknown[]) => runtimeErrorMock(...args),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
+}));
+
+vi.mock("./queue.js", () => ({
+  enqueueFollowupRun: vi.fn(),
+  scheduleFollowupDrain: vi.fn(),
+  clearSessionQueues: (...args: unknown[]) => clearSessionQueuesMock(...args),
+  refreshQueuedFollowupSession: (...args: unknown[]) => refreshQueuedFollowupSessionMock(...args),
+}));
+
+vi.mock("../../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: async ({ config }: { config: unknown }) => ({
+    resolvedConfig: config,
+    diagnostics: [],
+  }),
+}));
+
+vi.mock("../../utils/provider-utils.js", () => ({
+  isReasoningTagProvider: (provider: string | undefined | null) =>
+    provider === "google" || provider === "google-gemini-cli",
+}));
+
+const loadCronStoreMock = vi.fn();
+vi.mock("../../cron/store.js", () => ({
+  loadCronStore: (...args: unknown[]) => loadCronStoreMock(...args),
+  resolveCronStorePath: (storePath?: string) => storePath ?? "/tmp/openclaw-cron-store.json",
+}));
+
+vi.mock("../../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    resolveSession: () => ({ kind: "none" }),
+    cancelSession: async () => {},
+  }),
+}));
+
+vi.mock("../../agents/subagent-registry.js", () => ({
+  getLatestSubagentRunByChildSessionKey: () => null,
+  listSubagentRunsForController: () => [],
+  markSubagentRunTerminated: () => 0,
+}));
+
+import { runReplyAgent } from "./agent-runner.js";
+
+type RunWithModelFallbackParams = {
+  provider: string;
+  model: string;
+  run: (provider: string, model: string) => Promise<unknown>;
+};
+
+type RecordedSpan = {
+  name: string;
+  attributes: SpanAttributes;
+  status: SpanStatus | undefined;
+  ended: boolean;
+};
+
+function createRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+  const spans: RecordedSpan[] = [];
+  const tracer: Tracer = {
+    startSpan(name: string, opts?: StartSpanOptions): Span {
+      const rec: RecordedSpan = {
+        name,
+        attributes: { ...opts?.attributes },
+        status: undefined,
+        ended: false,
+      };
+      spans.push(rec);
+      const span: Span = {
+        setAttributes(attrs: SpanAttributes): void {
+          Object.assign(rec.attributes, attrs);
+        },
+        setStatus(status: SpanStatus, _message?: string): void {
+          rec.status = status;
+        },
+        recordException(_err: unknown): void {
+          // not used by `continuation.work` accept path
+        },
+        end(): void {
+          rec.ended = true;
+        },
+      };
+      return span;
+    },
+  };
+  return { tracer, spans };
+}
+
+beforeEach(() => {
+  embeddedRunTesting.resetActiveEmbeddedRuns();
+  replyRunRegistryTesting.resetReplyRunRegistry();
+  runEmbeddedPiAgentMock.mockClear();
+  runCliAgentMock.mockClear();
+  runWithModelFallbackMock.mockClear();
+  runtimeErrorMock.mockClear();
+  abortEmbeddedPiRunMock.mockClear();
+  compactState.compactEmbeddedPiSessionMock.mockReset();
+  compactState.compactEmbeddedPiSessionMock.mockResolvedValue({
+    compacted: false,
+    reason: "test-preflight-disabled",
+  });
+  clearSessionQueuesMock.mockReset();
+  clearSessionQueuesMock.mockReturnValue({ followupCleared: 0, laneCleared: 0, keys: [] });
+  refreshQueuedFollowupSessionMock.mockReset();
+  refreshQueuedFollowupSessionMock.mockResolvedValue(undefined);
+  loadCronStoreMock.mockClear();
+  loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+  requestHeartbeatNowMock.mockReset();
+  spawnSubagentDirectMock.mockReset().mockResolvedValue({
+    status: "accepted",
+    childSessionKey: "agent:main:subagent:spawned",
+    runId: "run-spawned",
+  });
+  runWithModelFallbackMock.mockImplementation(
+    async ({ provider, model, run }: RunWithModelFallbackParams) => ({
+      result: await run(provider, model),
+      provider,
+      model,
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearMemoryPluginState();
+  replyRunRegistryTesting.resetReplyRunRegistry();
+  embeddedRunTesting.resetActiveEmbeddedRuns();
+  resetContinuationTracer();
+});
+
+const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function createContinuationRun(params?: {
+  sessionKey?: string;
+  config?: Record<string, unknown>;
+  sessionEntry?: SessionEntry;
+}) {
+  const sessionKey = params?.sessionKey ?? "continuation-work-span";
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: "discord",
+    OriginatingTo: "channel:1",
+    AccountId: "primary",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+  const sessionEntry =
+    params?.sessionEntry ??
+    ({
+      sessionId: "session",
+      updatedAt: Date.now(),
+    } satisfies SessionEntry);
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey,
+      messageProvider: "discord",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config:
+        params?.config ??
+        ({
+          agents: {
+            defaults: {
+              continuation: {
+                enabled: true,
+                minDelayMs: 0,
+                maxDelayMs: 1_000,
+                defaultDelayMs: 1_000,
+                maxChainLength: 2,
+              },
+            },
+          },
+        } satisfies Record<string, unknown>),
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return { sessionKey, sessionEntry, typing, sessionCtx, resolvedQueue, followupRun };
+}
+
+async function runWorkTurn(
+  run: ReturnType<typeof createContinuationRun>,
+  sessionStore: Record<string, SessionEntry>,
+  _payloadText: string,
+): Promise<unknown> {
+  return runReplyAgent({
+    commandBody: "hello",
+    followupRun: run.followupRun,
+    queueKey: run.sessionKey,
+    resolvedQueue: run.resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    isStreaming: false,
+    typing: run.typing,
+    sessionCtx: run.sessionCtx,
+    sessionEntry: run.sessionEntry,
+    sessionStore,
+    sessionKey: run.sessionKey,
+    defaultModel: "anthropic/claude-opus-4-6",
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: "instant",
+  });
+}
+
+describe("runReplyAgent :: continuation.work span (Slice 2 chunk 2)", () => {
+  it("emits exactly one `continuation.work` span on accepted WORK with UUIDv7 chain.id and clamped chain.step.remaining", async () => {
+    vi.useFakeTimers();
+    const { tracer, spans } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    const run = createContinuationRun({ sessionKey: "continuation-work-span-accept" });
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Working on it\nCONTINUE_WORK:1" }],
+      meta: { agentMeta: { usage: { input: 2, output: 3 } } },
+    });
+
+    await runWorkTurn(
+      run,
+      { [run.sessionKey]: run.sessionEntry },
+      "Working on it\nCONTINUE_WORK:1",
+    );
+
+    const workSpans = spans.filter((s) => s.name === "continuation.work");
+    expect(workSpans).toHaveLength(1);
+
+    const span = workSpans[0];
+    if (!span) {
+      throw new Error("expected a recorded continuation.work span");
+    }
+    expect(span.status).toBe("OK");
+    expect(span.ended).toBe(true);
+
+    const attrs = span.attributes;
+    expect(attrs["delay.ms"]).toBe(1_000);
+    // maxChainLength=2, nextChainCount=1 → remaining=1 (clamped to ≥0)
+    expect(attrs["chain.step.remaining"]).toBe(1);
+    // UUIDv7 minted by persistContinuationChainState on the 0→1
+    // transition; emitter consumes the same id (no re-derivation)
+    expect(typeof attrs["chain.id"]).toBe("string");
+    expect(attrs["chain.id"] as string).toMatch(UUIDV7_REGEX);
+  });
+
+  it("reuses chain.id across consecutive accepted steps (mint-at-0→1, reuse-for-step-2)", async () => {
+    vi.useFakeTimers();
+    const { tracer, spans } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    // Pre-seed the session entry with an existing chain.id at
+    // continuationChainCount=1, simulating a fresh chain that has
+    // already taken its first step. The next accepted WORK should
+    // bump count to 2 and REUSE the same chain.id (mint-or-reuse
+    // contract). chain.step.remaining = max(0, maxChainLength=2 - 2) = 0.
+    const seededChainId = "019dcf57-b536-77cc-834b-b803d9262032";
+    const seededEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 1,
+      continuationChainStartedAt: Date.now() - 10_000,
+      continuationChainTokens: 100,
+      continuationChainId: seededChainId,
+    };
+    const run = createContinuationRun({
+      sessionKey: "continuation-work-span-stable",
+      sessionEntry: seededEntry,
+    });
+    const sessionStore = { [run.sessionKey]: seededEntry };
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Step two\nCONTINUE_WORK:1" }],
+      meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+    });
+    await runWorkTurn(run, sessionStore, "Step two\nCONTINUE_WORK:1");
+
+    const workSpans = spans.filter((s) => s.name === "continuation.work");
+    expect(workSpans).toHaveLength(1);
+
+    const span = workSpans[0];
+    if (!span) {
+      throw new Error("expected a recorded continuation.work span");
+    }
+    // CRITICAL: chain.id MUST be the seeded value, not a freshly minted
+    // UUIDv7 — proves mint-or-reuse picks the existing one.
+    expect(span.attributes["chain.id"]).toBe(seededChainId);
+    expect(span.attributes["chain.step.remaining"]).toBe(0);
+  });
+
+  it("does NOT emit `continuation.work` on the chain-cap reject path (rejected requests don't advance the chain)", async () => {
+    vi.useFakeTimers();
+    const { tracer, spans } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    // Pre-seed at maxChainLength=2 — the next CONTINUE_WORK request
+    // hits chain-cap reject and MUST NOT emit `continuation.work`.
+    const seededChainId = "019dcf57-aaaa-77cc-834b-b803d9262032";
+    const seededEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 2, // already at maxChainLength
+      continuationChainStartedAt: Date.now() - 20_000,
+      continuationChainTokens: 200,
+      continuationChainId: seededChainId,
+    };
+    const run = createContinuationRun({
+      sessionKey: "continuation-work-span-cap",
+      sessionEntry: seededEntry,
+    });
+    const sessionStore = { [run.sessionKey]: seededEntry };
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Step 3 attempts\nCONTINUE_WORK:1" }],
+      meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+    });
+    await runWorkTurn(run, sessionStore, "Step 3 attempts\nCONTINUE_WORK:1");
+
+    // No `continuation.work` span emitted — accept-only contract.
+    const workSpans = spans.filter((s) => s.name === "continuation.work");
+    expect(workSpans).toHaveLength(0);
+
+    // Confirms chunk 2's narrow scope: no other span names get
+    // accidentally emitted on the reject path either (chunk 4 owns
+    // `continuation.disabled` for these reject branches).
+    expect(spans).toHaveLength(0);
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1268,9 +1268,9 @@ export async function runReplyAgent(params: {
     count: number;
     startedAt: number;
     tokens: number;
-  }): Promise<void> => {
+  }): Promise<{ chainId: string | undefined }> => {
     if (!sessionKey) {
-      return;
+      return { chainId: undefined };
     }
     // #334 Slice 2 — mint a stable `continuationChainId` (UUIDv7) on
     // the 0→1 transition of `continuationChainCount`. Reuse the
@@ -1327,6 +1327,7 @@ export async function runReplyAgent(params: {
         );
       }
     }
+    return { chainId };
   };
   try {
     await typingSignals.signalRunStart();
@@ -2281,7 +2282,7 @@ export async function runReplyAgent(params: {
                 });
               }
             } else {
-              await persistContinuationChainState({
+              const { chainId: persistedChainId } = await persistContinuationChainState({
                 count: nextChainCount,
                 startedAt: chainStartedAt,
                 tokens: accumulatedChainTokens,
@@ -2297,7 +2298,7 @@ export async function runReplyAgent(params: {
               // attribute shaping + try/catch so the accept path
               // can't block on span emission.
               emitContinuationWorkSpan({
-                chainId: activeSessionEntry?.continuationChainId,
+                chainId: persistedChainId,
                 chainStepRemaining: maxChainLength - nextChainCount,
                 delayMs: clampedDelay,
                 reason: continuationWorkReason,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -23,7 +23,7 @@ import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
-import { generateSecureUuid } from "../../infra/secure-random.js";
+import { generateChainId, generateSecureUuid } from "../../infra/secure-random.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -947,6 +947,7 @@ export function cancelContinuationTimer(
     sessionCtx.sessionEntry.continuationChainCount = 0;
     sessionCtx.sessionEntry.continuationChainStartedAt = undefined;
     sessionCtx.sessionEntry.continuationChainTokens = undefined;
+    sessionCtx.sessionEntry.continuationChainId = undefined;
   }
   if (sessionCtx?.sessionStore) {
     const storeResolved = resolveSessionStoreEntry({ store: sessionCtx.sessionStore, sessionKey });
@@ -960,6 +961,7 @@ export function cancelContinuationTimer(
         continuationChainCount: 0,
         continuationChainStartedAt: undefined,
         continuationChainTokens: undefined,
+        continuationChainId: undefined,
       };
       for (const legacyKey of storeResolved.legacyKeys) {
         delete sessionCtx.sessionStore[legacyKey];
@@ -978,6 +980,7 @@ export function cancelContinuationTimer(
           continuationChainCount: 0,
           continuationChainStartedAt: undefined,
           continuationChainTokens: undefined,
+          continuationChainId: undefined,
         };
         for (const legacyKey of resolved.legacyKeys) {
           delete store[legacyKey];
@@ -1268,10 +1271,21 @@ export async function runReplyAgent(params: {
     if (!sessionKey) {
       return;
     }
+    // #334 Slice 2 — mint a stable `continuationChainId` (UUIDv7) on
+    // the 0→1 transition of `continuationChainCount`. Reuse the
+    // existing id for subsequent steps in the same chain so all spans
+    // emitted across the chain share a single correlation key. The
+    // matching reset path (above, ~line 944) clears this field when
+    // chain state resets to 0.
+    const previousCount = activeSessionEntry?.continuationChainCount ?? 0;
+    const previousChainId = activeSessionEntry?.continuationChainId;
+    const chainId =
+      previousCount > 0 && previousChainId !== undefined ? previousChainId : generateChainId();
     if (activeSessionEntry) {
       activeSessionEntry.continuationChainCount = params.count;
       activeSessionEntry.continuationChainStartedAt = params.startedAt;
       activeSessionEntry.continuationChainTokens = params.tokens;
+      activeSessionEntry.continuationChainId = chainId;
     }
     if (activeSessionStore) {
       const resolved = resolveSessionStoreEntry({ store: activeSessionStore, sessionKey });
@@ -1282,6 +1296,7 @@ export async function runReplyAgent(params: {
           continuationChainCount: params.count,
           continuationChainStartedAt: params.startedAt,
           continuationChainTokens: params.tokens,
+          continuationChainId: chainId,
         };
         for (const legacyKey of resolved.legacyKeys) {
           delete activeSessionStore[legacyKey];
@@ -1298,6 +1313,7 @@ export async function runReplyAgent(params: {
               continuationChainCount: params.count,
               continuationChainStartedAt: params.startedAt,
               continuationChainTokens: params.tokens,
+              continuationChainId: chainId,
             };
             for (const legacyKey of resolved.legacyKeys) {
               delete store[legacyKey];

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -20,6 +20,7 @@ import {
 import type { TypingMode } from "../../config/types.js";
 import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.fs.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
+import { emitContinuationWorkSpan } from "../../infra/continuation-tracer.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
@@ -2288,6 +2289,20 @@ export async function runReplyAgent(params: {
               // WORK: schedule a continuation turn after delay
               const requestedDelay = effectiveContinuationSignal.delayMs ?? defaultDelayMs;
               const clampedDelay = Math.max(minDelayMs, Math.min(maxDelayMs, requestedDelay));
+
+              // #334 Slice 2 chunk 2 — emit `continuation.work` span
+              // at the accept seam (after both cap-gates pass, after
+              // persistContinuationChainState has minted/stored
+              // continuationChainId for this chain). Helper handles
+              // attribute shaping + try/catch so the accept path
+              // can't block on span emission.
+              emitContinuationWorkSpan({
+                chainId: activeSessionEntry?.continuationChainId,
+                chainStepRemaining: maxChainLength - nextChainCount,
+                delayMs: clampedDelay,
+                reason: continuationWorkReason,
+                log: (message) => defaultRuntime.log(message),
+              });
 
               retainContinuationTimerRef(sessionKey);
               const timerHandle = setTimeout(() => {

--- a/src/auto-reply/reply/post-compaction-delegate-dispatch.ts
+++ b/src/auto-reply/reply/post-compaction-delegate-dispatch.ts
@@ -11,6 +11,7 @@ import { loadSessionStore } from "../../config/sessions/store-load.js";
 import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry, SessionPostCompactionDelegate } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { generateChainId } from "../../infra/secure-random.js";
 import {
   drainPendingSessionDeliveries,
   type SessionDeliveryRecoveryLogger,
@@ -312,10 +313,20 @@ async function persistPostCompactionDelegateChainState(params: {
   storePath?: string;
   tokens: number;
 }): Promise<void> {
+  // #334 Slice 2 — mint or reuse `continuationChainId` (UUIDv7) so the
+  // post-compaction handoff carries the same correlation key that
+  // `agent-runner.ts:persistContinuationChainState` would have used
+  // before compaction. If the pre-compaction sessionEntry already had
+  // a chain id, reuse it (chain survives the compaction boundary);
+  // otherwise mint fresh (this is the chain's first persisted step
+  // post-handoff).
+  const previousChainId = params.sessionEntry?.continuationChainId;
+  const chainId = previousChainId ?? generateChainId();
   if (params.sessionEntry) {
     params.sessionEntry.continuationChainCount = params.count;
     params.sessionEntry.continuationChainStartedAt = params.startedAt;
     params.sessionEntry.continuationChainTokens = params.tokens;
+    params.sessionEntry.continuationChainId = chainId;
   }
   if (params.sessionStore) {
     const resolved = resolveSessionStoreEntry({
@@ -330,6 +341,7 @@ async function persistPostCompactionDelegateChainState(params: {
         continuationChainCount: params.count,
         continuationChainStartedAt: params.startedAt,
         continuationChainTokens: params.tokens,
+        continuationChainId: chainId,
       };
       for (const legacyKey of resolved.legacyKeys) {
         delete params.sessionStore[legacyKey];
@@ -347,6 +359,7 @@ async function persistPostCompactionDelegateChainState(params: {
             continuationChainCount: params.count,
             continuationChainStartedAt: params.startedAt,
             continuationChainTokens: params.tokens,
+            continuationChainId: chainId,
           };
           if (resolved.existing) {
             for (const legacyKey of resolved.legacyKeys) {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -287,6 +287,16 @@ export type SessionEntry = {
   continuationChainStartedAt?: number;
   /** Accumulated token usage across the current continuation chain. Reset on external message. */
   continuationChainTokens?: number;
+  /**
+   * Stable identifier for the current continuation chain (UUIDv7,
+   * RFC 9562). Minted at the 0→1 transition of
+   * `continuationChainCount`, cleared when chain state resets. Used as
+   * the `chain.id` OTEL span attribute (#334 Slice 2) so all spans
+   * emitted across chain steps share a single correlation key. Stable
+   * for the lifetime of the chain by definition; survives compaction
+   * via session-store persistence alongside the other chain fields.
+   */
+  continuationChainId?: string;
   /** Post-compaction delegates staged for execution after context compaction. */
   pendingPostCompactionDelegates?: SessionPostCompactionDelegate[];
 };

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  emitContinuationWorkSpan,
   getContinuationTracer,
   noopTracer,
   resetContinuationTracer,
@@ -211,5 +212,145 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
     for (const name of names) {
       expect(() => noopTracer.startSpan(name)).not.toThrow();
     }
+  });
+});
+
+describe("continuation-tracer :: emitContinuationWorkSpan helper (Slice 2 chunk 2)", () => {
+  type RecordedSpan = {
+    name: string;
+    options?: StartSpanOptions;
+    setAttributesCalls: SpanAttributes[];
+    statusCalls: Array<{ status: SpanStatus; message?: string }>;
+    exceptionCalls: unknown[];
+    ended: boolean;
+  };
+
+  function makeRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+    const spans: RecordedSpan[] = [];
+    const tracer: Tracer = {
+      startSpan(name, options) {
+        const recorded: RecordedSpan = {
+          name,
+          options,
+          setAttributesCalls: [],
+          statusCalls: [],
+          exceptionCalls: [],
+          ended: false,
+        };
+        spans.push(recorded);
+        const span: Span = {
+          setAttributes(attrs) {
+            recorded.setAttributesCalls.push(attrs);
+          },
+          setStatus(status, message) {
+            recorded.statusCalls.push({ status, message });
+          },
+          recordException(err) {
+            recorded.exceptionCalls.push(err);
+          },
+          end() {
+            recorded.ended = true;
+          },
+        };
+        return span;
+      },
+    };
+    return { tracer, spans };
+  }
+
+  it("emits a continuation.work span with all expected attrs when chainId is present", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationWorkSpan({
+      chainId: "019dcf57-b536-77cc-834b-b803d9262032",
+      chainStepRemaining: 7,
+      delayMs: 30000,
+      reason: "more work to do",
+    });
+    expect(spans).toHaveLength(1);
+    const span = spans[0];
+    expect(span.name).toBe("continuation.work");
+    expect(span.options?.attributes).toEqual({
+      "delay.ms": 30000,
+      "chain.step.remaining": 7,
+      "chain.id": "019dcf57-b536-77cc-834b-b803d9262032",
+      "reason.preview": "more work to do",
+    });
+    expect(span.statusCalls).toEqual([{ status: "OK", message: undefined }]);
+    expect(span.ended).toBe(true);
+  });
+
+  it("omits chain.id and reason.preview when not provided", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationWorkSpan({
+      chainId: undefined,
+      chainStepRemaining: 0,
+      delayMs: 5000,
+    });
+    expect(spans[0].options?.attributes).toEqual({
+      "delay.ms": 5000,
+      "chain.step.remaining": 0,
+    });
+  });
+
+  it("truncates reason to 80 chars", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    const long = "x".repeat(200);
+    emitContinuationWorkSpan({
+      chainId: "abc",
+      chainStepRemaining: 1,
+      delayMs: 100,
+      reason: long,
+    });
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["reason.preview"]).toBe("x".repeat(80));
+  });
+
+  it("rounds delayMs to integer", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationWorkSpan({ chainId: undefined, chainStepRemaining: 0, delayMs: 1234.7 });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["delay.ms"]).toBe(1235);
+  });
+
+  it("clamps negative chainStepRemaining to 0", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationWorkSpan({ chainId: undefined, chainStepRemaining: -3, delayMs: 0 });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["chain.step.remaining"]).toBe(0);
+  });
+
+  it("swallows tracer errors and forwards them to the log callback", () => {
+    const throwingTracer: Tracer = {
+      startSpan() {
+        throw new Error("boom");
+      },
+    };
+    setContinuationTracer(throwingTracer);
+    const messages: string[] = [];
+    expect(() =>
+      emitContinuationWorkSpan({
+        chainId: "abc",
+        chainStepRemaining: 1,
+        delayMs: 0,
+        log: (m) => messages.push(m),
+      }),
+    ).not.toThrow();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("boom");
+  });
+
+  it("is a no-op (no throw) against the default noop tracer", () => {
+    expect(getContinuationTracer()).toBe(noopTracer);
+    expect(() =>
+      emitContinuationWorkSpan({
+        chainId: "abc",
+        chainStepRemaining: 1,
+        delayMs: 0,
+        reason: "r",
+      }),
+    ).not.toThrow();
   });
 });

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -236,3 +236,43 @@ export function setContinuationTracer(tracer: Tracer | null | undefined): void {
 export function resetContinuationTracer(): void {
   activeTracer = noopTracer;
 }
+
+/**
+ * Emit a `continuation.work` span at the runner-side accept seam
+ * (#334 Slice 2 chunk 2). Centralized helper so the runner stays
+ * narrow at the call site and the span shape is testable in
+ * isolation. Sites that don't have a chainId yet (chain not
+ * persisted, or substrate-disabled deploys) MAY pass `chainId:
+ * undefined` — the attribute is omitted, downstream collectors
+ * see a span without a correlation key.
+ *
+ * Wraps tracer interactions in a try/catch and logs via the caller's
+ * `log` callback if provided — the accept path must never block on
+ * span emission.
+ */
+export function emitContinuationWorkSpan(args: {
+  chainId: string | undefined;
+  chainStepRemaining: number;
+  delayMs: number;
+  reason?: string | undefined;
+  log?: (message: string) => void;
+}): void {
+  try {
+    const reasonPreview = args.reason
+      ? args.reason.length > 80
+        ? args.reason.slice(0, 80)
+        : args.reason
+      : undefined;
+    const attrs: ContinuationSpanAttrs = {
+      "delay.ms": Math.round(args.delayMs),
+      "chain.step.remaining": Math.max(0, args.chainStepRemaining),
+      ...(args.chainId !== undefined && { "chain.id": args.chainId }),
+      ...(reasonPreview !== undefined && { "reason.preview": reasonPreview }),
+    };
+    const span = activeTracer.startSpan("continuation.work", { attributes: attrs });
+    span.setStatus("OK");
+    span.end();
+  } catch (err) {
+    args.log?.(`Failed to emit continuation.work span: ${String(err)}`);
+  }
+}

--- a/src/infra/secure-random-chain-id.test.ts
+++ b/src/infra/secure-random-chain-id.test.ts
@@ -32,7 +32,7 @@ describe("generateChainId — #334 Slice 2 substrate", () => {
     const after = Date.now();
     // First 48 bits = first 12 hex chars (split: 8 + "-" + 4).
     const tsHex = id.slice(0, 8) + id.slice(9, 13);
-    const ts = parseInt(tsHex, 16);
+    const ts = Number.parseInt(tsHex, 16);
     // Allow ±50ms window for clock granularity / test timing slack.
     expect(ts).toBeGreaterThanOrEqual(before - 50);
     expect(ts).toBeLessThanOrEqual(after + 50);

--- a/src/infra/secure-random-chain-id.test.ts
+++ b/src/infra/secure-random-chain-id.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { generateChainId } from "./secure-random.js";
+
+const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("generateChainId — #334 Slice 2 substrate", () => {
+  it("returns a UUIDv7-shaped string", () => {
+    const id = generateChainId();
+    expect(id).toMatch(UUID_V7_RE);
+  });
+
+  it("returns unique ids across calls", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      ids.add(generateChainId());
+    }
+    expect(ids.size).toBe(1000);
+  });
+
+  it("preserves lexicographic ordering across mints (time-ordered)", async () => {
+    // UUIDv7 first 48 bits are unix-millis. Two ids minted with a >=2ms
+    // gap MUST sort id_a < id_b lexicographically.
+    const earlier = generateChainId();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const later = generateChainId();
+    expect(earlier < later).toBe(true);
+  });
+
+  it("encodes the mint timestamp in the first 48 bits", () => {
+    const before = Date.now();
+    const id = generateChainId();
+    const after = Date.now();
+    // First 48 bits = first 12 hex chars (split: 8 + "-" + 4).
+    const tsHex = id.slice(0, 8) + id.slice(9, 13);
+    const ts = parseInt(tsHex, 16);
+    // Allow ±50ms window for clock granularity / test timing slack.
+    expect(ts).toBeGreaterThanOrEqual(before - 50);
+    expect(ts).toBeLessThanOrEqual(after + 50);
+  });
+});

--- a/src/infra/secure-random.ts
+++ b/src/infra/secure-random.ts
@@ -1,7 +1,24 @@
 import { randomBytes, randomInt, randomUUID } from "node:crypto";
+import { v7 as uuidV7 } from "uuid";
 
 export function generateSecureUuid(): string {
   return randomUUID();
+}
+
+/**
+ * Returns a UUIDv7 (RFC 9562) — time-ordered 128-bit identifier whose
+ * first 48 bits are the unix-milliseconds timestamp at mint time. Used
+ * for `SessionEntry.continuationChainId` (#334 Slice 2): chain.id is
+ * minted on the 0→1 transition of `continuationChainCount` and stays
+ * stable for the lifetime of the chain, so journal greps + sort-by-id
+ * give chronological order without a separate timestamp lookup.
+ *
+ * Why v7 and not v4: lexicographic ordering preserved across mints,
+ * downstream OTEL collectors (Jaeger/Tempo) parse UUID-shape natively,
+ * and `uuid@14` is already a direct dependency.
+ */
+export function generateChainId(): string {
+  return uuidV7();
 }
 
 export function generateSecureToken(bytes = 16): string {


### PR DESCRIPTION
#334 Slice 2 chunks 1.5+2: thread a stable `chain.id` (UUIDv7) through every continuation step, then emit the first canonical `continuation.work` OTEL span at the runner-side accept seam.

Stacks on top of:
- #366 (Slice 1: `traceparent` payload + chain-budget cap helper) — merged at `2d10c1c218`
- #378 (Slice 2 chunk 1: tracer surface + noopTracer, path-B) — merged at `d533d5c720`

## What this PR does

**Commit 1 — chain.id substrate** (`a6e7cc9972`'s parent on the branch — see file changes for `secure-random.ts`, `sessions/types.ts`, `agent-runner.ts`, `post-compaction-delegate-dispatch.ts`, `agent-runner-session-reset.ts`):
- `generateChainId()` added to `src/infra/secure-random.ts` — wraps `uuid.v7()` (RFC 9562, time-ordered, lex-sorts chronologically). `uuid` is already a direct dep at `14.0.0`, no new deps.
- `SessionEntry.continuationChainId?: string` — purely additive substrate field. Optional so pre-this-commit persisted entries decode cleanly.
- **Mint-or-reuse** at `persistContinuationChainState` (work) + `persistPostCompactionDelegateChainState` (compaction handoff): if `previousCount > 0 && previousChainId !== undefined`, reuse; else mint fresh.
- **Clear** at all 4 chain-reset paths (3 in `agent-runner.ts`, 1 in `agent-runner-session-reset.ts`) — when `count` returns to 0, `continuationChainId` is set to `undefined`.

**Commit 2 — emit `continuation.work` span at runner accept seam** (`a6e7cc9972`):
- `emitContinuationWorkSpan(args)` helper added to `continuation-tracer.ts` — centralizes attribute shaping (delay rounding, reason truncation to ≤80 chars, `chain.step.remaining` clamped to ≥0), wraps tracer calls in try/catch, forwards errors to optional `log` callback. Accept path **MUST NOT** block on span emission.
- 5-line call site in `agent-runner.ts` at `~2299`, in the WORK branch of the inner else arm — *after* both cap-gates pass and *after* `persistContinuationChainState` mints/stores `continuationChainId`. This is the single accept seam where `nextChainCount` and the persisted chain.id are both real.
- `chain.id` read off `activeSessionEntry?.continuationChainId` immediately after persist (per 🌊's option-b in [`1498332#1498331927441047684`](https://discord.com/channels/1235610176883523614/1466192485440164011/1498331927441047684)) — no re-derivation, no new return-value plumbing.

## Why the helper instead of inline

Keeps the runner narrow (5 lines vs 25), centralizes attribute shaping, and gives chunks 3+4 (`continuation.delegate.dispatch`, `continuation.disabled` at the cap-reject branches) a natural home for sibling helpers. Span shape becomes unit-testable in isolation without dragging in the full agent-runner integration harness.

## Why the runner accept seam vs the unwrap site in `agent-runner-execution.ts`

The unwrap site at `agent-runner-execution.ts:1457` sees ALL captured `continueWorkRequest` instances — including ones the chain-cap or cost-cap will reject downstream. Span at the unwrap site = `continuation.work` emitted for capped requests too, which would drift `chain.id` semantics (a capped request doesn't advance the chain). The accept seam in `agent-runner.ts:~2284` is the *single point* past both cap gates where `nextChainCount` and the persisted `chain.id` are both real. Surfaces 🌊's "queue-side rewrite at drain-time" intuition cleanly: chain-step semantics live where the chain actually advances.

## Span shape (matches `ContinuationSpanAttrs` pinned in #378)

```
name: continuation.work
attributes:
  delay.ms                 — rounded integer (always)
  chain.step.remaining     — max(0, maxChainLength - nextChainCount) (always)
  chain.id                 — UUIDv7 from sessionEntry.continuationChainId (omitted when undefined)
  reason.preview           — truncated to ≤80 chars (omitted when no reason)
status: OK
```

`setStatus("OK")` and `end()` always called. Tracer is `getContinuationTracer()` (noopTracer until Slice 3 wires a real exporter) — emission is contract-pin, not yet observable.

## Tests

**Substrate commit:**
- `secure-random-chain-id.test.ts` (NEW, 4 tests): UUIDv7 shape regex, uniqueness across 1000 mints, lex-ordering, timestamp-in-prefix
- `agent-runner-session-reset.test.ts` (existing, 2/2): chain.id cleared at reset
- `post-compaction-delegate-dispatch.test.ts` (existing, 19/19): chain.id mint/reuse across compaction boundary

**Span emission commit:**
- `continuation-tracer.test.ts` (NEW 7 tests, total 18/18): full attrs with chainId+reason, omits chain.id+reason.preview when absent, truncates reason to 80, rounds delay, clamps negative chain.step.remaining, swallows tracer errors via log callback, no-op against default noopTracer

**Total: 43/43 across all touched paths post-rebase onto `ad6ac310c8`.**

Skipped full `tsc --noEmit` (OOMs on 8GB box). Targeted vitest runs cover the surface.

## Pre-walk receipts

- 🌊 substrate pre-walk + APPROVED on commit 1: msg `1498331927441047684` ("substrate commit `440aa35c2c` pre-walked, looks clean … pre-approve. Will give the squash-merge approval on the consolidated PR once 2a + 2b stack on top.")
- 🩸 architectural read confirmed (capture at `agent-runner-execution.ts`, accept-authority at `agent-runner.ts`): msg `1498332010190733552`. Hunk posted for byte-walk: msg `1498336975202025594`
- 🌻 substrate "Ship it" on UUIDv7 choice (earlier in thread)

## Constraints honored

- Path-B (no `@opentelemetry/*` direct deps in Slice 2)
- Tool stays dumb (no session-state peering — runner owns emission)
- Additive only; chain.id only emitted when defined (conditional spread)
- chain.id stable across all turns of a chain (mint at 0→1, reuse for steps, clear on reset, survive compaction handoff)

Refs: #334 #366 #370 #378 #324 (SWIM 37 readiness)
