### PR TITLE
feat(continuation): #334 Slice 2 chunk 3 — continuation.delegate.dispatch span at runner enqueue seam

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -20,7 +20,10 @@ import {
 import type { TypingMode } from "../../config/types.js";
 import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.fs.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
-import { emitContinuationWorkSpan } from "../../infra/continuation-tracer.js";
+import {
+  emitContinuationDelegateSpan,
+  emitContinuationWorkSpan,
+} from "../../infra/continuation-tracer.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
@@ -2187,7 +2190,7 @@ export async function runReplyAgent(params: {
                         `DELEGATE timer fired and spawned turn ${plannedHop}/${maxChainLength} for session ${sessionKey}: ${task}`,
                       );
                     }
-                    await persistContinuationChainState({
+                    const { chainId: persistedChainId } = await persistContinuationChainState({
                       count: Math.max(activeSessionEntry?.continuationChainCount ?? 0, plannedHop),
                       startedAt: options?.startedAt ?? chainStartedAt,
                       tokens: Math.max(
@@ -2195,6 +2198,26 @@ export async function runReplyAgent(params: {
                         activeSessionEntry?.continuationChainTokens ?? 0,
                       ),
                     });
+                    // #334 Slice 2 chunk 3 — emit `continuation.delegate.dispatch`
+                    // span at the immediate accept seam. Timer-deferred dispatches
+                    // already emitted at enqueue-time (before setTimeout); skip
+                    // re-emission when `timerTriggered` to preserve
+                    // exactly-one-span-per-accepted-dispatch.
+                    if (!options?.timerTriggered) {
+                      const delegateMode = options?.silentWake
+                        ? "silent-wake"
+                        : options?.silent
+                          ? "silent"
+                          : "normal";
+                      emitContinuationDelegateSpan({
+                        chainId: persistedChainId,
+                        chainStepRemaining: maxChainLength - plannedHop,
+                        delayMs: 0,
+                        delivery: "immediate",
+                        delegateMode,
+                        log: (message) => defaultRuntime.log(message),
+                      });
+                    }
                     enqueueSystemEvent(
                       `[continuation:delegate-spawned] Spawned turn ${plannedHop}/${maxChainLength}: ${task}`,
                       { sessionKey },
@@ -2244,11 +2267,32 @@ export async function runReplyAgent(params: {
                   silent: effectiveContinuationSignal.silent,
                   silentWake: effectiveContinuationSignal.silentWake,
                 });
-                await persistContinuationChainState({
+                const { chainId: persistedChainIdForTimer } = await persistContinuationChainState({
                   count: currentChainCount,
                   startedAt: chainStartedAt,
                   tokens: accumulatedChainTokens,
                 });
+                // #334 Slice 2 chunk 3 — emit `continuation.delegate.dispatch`
+                // span at the timer-deferred enqueue seam (after persist,
+                // before `setTimeout` arms). The chain-step is committed
+                // here, not at fire-time — cancelled-but-accepted dispatches
+                // (compaction, reset, gateway shutdown) still count as
+                // accepted and must not be silently underreported.
+                {
+                  const delegateMode = effectiveContinuationSignal.silentWake
+                    ? "silent-wake"
+                    : effectiveContinuationSignal.silent
+                      ? "silent"
+                      : "normal";
+                  emitContinuationDelegateSpan({
+                    chainId: persistedChainIdForTimer,
+                    chainStepRemaining: maxChainLength - nextChainCount,
+                    delayMs: clampedDelay,
+                    delivery: "timer",
+                    delegateMode,
+                    log: (message) => defaultRuntime.log(message),
+                  });
+                }
                 retainContinuationTimerRef(sessionKey);
                 const timerHandle = setTimeout(() => {
                   try {
@@ -2433,7 +2477,7 @@ export async function runReplyAgent(params: {
                   );
                 }
                 currentChainCount = Math.max(currentChainCount, plannedHop);
-                await persistContinuationChainState({
+                const { chainId: persistedChainId } = await persistContinuationChainState({
                   count: currentChainCount,
                   startedAt: options?.startedAt ?? chainStartedAt,
                   tokens: Math.max(
@@ -2441,6 +2485,25 @@ export async function runReplyAgent(params: {
                     activeSessionEntry?.continuationChainTokens ?? 0,
                   ),
                 });
+                // #334 Slice 2 chunk 3 — emit `continuation.delegate.dispatch`
+                // span at the immediate accept seam (tool-side). Timer-deferred
+                // dispatches already emitted at enqueue-time; skip when
+                // `timerTriggered` to preserve exactly-one-span-per-accepted-dispatch.
+                if (!options?.timerTriggered) {
+                  const delegateMode = options?.silentWake
+                    ? "silent-wake"
+                    : options?.silent
+                      ? "silent"
+                      : "normal";
+                  emitContinuationDelegateSpan({
+                    chainId: persistedChainId,
+                    chainStepRemaining: maxChainLength - plannedHop,
+                    delayMs: 0,
+                    delivery: "immediate",
+                    delegateMode,
+                    log: (message) => defaultRuntime.log(message),
+                  });
+                }
                 enqueueSystemEvent(
                   `[continuation:delegate-spawned] Tool delegate turn ${plannedHop}/${maxChainLength}: ${task}`,
                   { sessionKey },
@@ -2488,11 +2551,30 @@ export async function runReplyAgent(params: {
               silent: delegate.silent,
               silentWake: delegate.silentWake,
             });
-            await persistContinuationChainState({
+            const { chainId: persistedChainIdForTimer } = await persistContinuationChainState({
               count: currentChainCount,
               startedAt: chainStartedAt,
               tokens: accumulatedChainTokens,
             });
+            // #334 Slice 2 chunk 3 — emit `continuation.delegate.dispatch`
+            // span at the timer-deferred enqueue seam (tool-side, after
+            // persist, before `setTimeout` arms). Same enqueue-time
+            // semantic anchor as the bracket-timer site above.
+            {
+              const delegateMode = delegate.silentWake
+                ? "silent-wake"
+                : delegate.silent
+                  ? "silent"
+                  : "normal";
+              emitContinuationDelegateSpan({
+                chainId: persistedChainIdForTimer,
+                chainStepRemaining: maxChainLength - nextChainCount,
+                delayMs: clampedDelay,
+                delivery: "timer",
+                delegateMode,
+                log: (message) => defaultRuntime.log(message),
+              });
+            }
             retainContinuationTimerRef(sessionKey);
             const timerHandle = setTimeout(() => {
               try {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2204,6 +2204,7 @@ export async function runReplyAgent(params: {
                     // re-emission when `timerTriggered` to preserve
                     // exactly-one-span-per-accepted-dispatch.
                     if (!options?.timerTriggered) {
+                      // Ladder handles silent-wake / silent / normal only. The bracket+tool DELEGATE seams don't carry a `post-compaction` discriminator; that path lives in `persistPostCompactionDelegateChainState` and would emit from a sibling site (chunk 5+ candidate).
                       const delegateMode = options?.silentWake
                         ? "silent-wake"
                         : options?.silent
@@ -2279,6 +2280,7 @@ export async function runReplyAgent(params: {
                 // (compaction, reset, gateway shutdown) still count as
                 // accepted and must not be silently underreported.
                 {
+                  // Ladder handles silent-wake / silent / normal only — see immediate-arm comment above; post-compaction dispatches travel a separate persist path.
                   const delegateMode = effectiveContinuationSignal.silentWake
                     ? "silent-wake"
                     : effectiveContinuationSignal.silent
@@ -2490,6 +2492,7 @@ export async function runReplyAgent(params: {
                 // dispatches already emitted at enqueue-time; skip when
                 // `timerTriggered` to preserve exactly-one-span-per-accepted-dispatch.
                 if (!options?.timerTriggered) {
+                  // Ladder handles silent-wake / silent / normal only — the tool DELEGATE seam doesn't carry a `post-compaction` discriminator (separate persist path).
                   const delegateMode = options?.silentWake
                     ? "silent-wake"
                     : options?.silent
@@ -2561,6 +2564,7 @@ export async function runReplyAgent(params: {
             // persist, before `setTimeout` arms). Same enqueue-time
             // semantic anchor as the bracket-timer site above.
             {
+              // Ladder handles silent-wake / silent / normal only — see tool-immediate comment above; post-compaction path is a sibling, not handled here.
               const delegateMode = delegate.silentWake
                 ? "silent-wake"
                 : delegate.silent

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  emitContinuationDelegateSpan,
   emitContinuationWorkSpan,
   getContinuationTracer,
   noopTracer,
@@ -350,6 +351,173 @@ describe("continuation-tracer :: emitContinuationWorkSpan helper (Slice 2 chunk 
         chainStepRemaining: 1,
         delayMs: 0,
         reason: "r",
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("continuation-tracer :: emitContinuationDelegateSpan helper (Slice 2 chunk 3)", () => {
+  type RecordedSpan = {
+    name: string;
+    options?: StartSpanOptions;
+    setAttributesCalls: SpanAttributes[];
+    statusCalls: Array<{ status: SpanStatus; message?: string }>;
+    exceptionCalls: unknown[];
+    ended: boolean;
+  };
+
+  function makeRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+    const spans: RecordedSpan[] = [];
+    const tracer: Tracer = {
+      startSpan(name, options) {
+        const recorded: RecordedSpan = {
+          name,
+          options,
+          setAttributesCalls: [],
+          statusCalls: [],
+          exceptionCalls: [],
+          ended: false,
+        };
+        spans.push(recorded);
+        const span: Span = {
+          setAttributes(attrs) {
+            recorded.setAttributesCalls.push(attrs);
+          },
+          setStatus(status, message) {
+            recorded.statusCalls.push({ status, message });
+          },
+          recordException(err) {
+            recorded.exceptionCalls.push(err);
+          },
+          end() {
+            recorded.ended = true;
+          },
+        };
+        return span;
+      },
+    };
+    return { tracer, spans };
+  }
+
+  it("emits a continuation.delegate.dispatch span with all expected attrs", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateSpan({
+      chainId: "019dcf57-b536-77cc-834b-b803d9262032",
+      chainStepRemaining: 5,
+      delayMs: 60000,
+      delivery: "timer",
+      delegateMode: "silent-wake",
+      reason: "fan out three queries",
+    });
+    expect(spans).toHaveLength(1);
+    const span = spans[0];
+    expect(span.name).toBe("continuation.delegate.dispatch");
+    expect(span.options?.attributes).toEqual({
+      "delay.ms": 60000,
+      "chain.step.remaining": 5,
+      "delegate.delivery": "timer",
+      "chain.id": "019dcf57-b536-77cc-834b-b803d9262032",
+      "delegate.mode": "silent-wake",
+      "reason.preview": "fan out three queries",
+    });
+    expect(span.statusCalls).toEqual([{ status: "OK", message: undefined }]);
+    expect(span.ended).toBe(true);
+  });
+
+  it("immediate-delivery shape with no chainId or mode", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateSpan({
+      chainId: undefined,
+      chainStepRemaining: 0,
+      delayMs: 0,
+      delivery: "immediate",
+    });
+    expect(spans[0].options?.attributes).toEqual({
+      "delay.ms": 0,
+      "chain.step.remaining": 0,
+      "delegate.delivery": "immediate",
+    });
+  });
+
+  it("threads delegate.mode through unchanged", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    for (const mode of ["normal", "silent", "silent-wake", "post-compaction"] as const) {
+      emitContinuationDelegateSpan({
+        chainId: "abc",
+        chainStepRemaining: 1,
+        delayMs: 0,
+        delivery: "immediate",
+        delegateMode: mode,
+      });
+    }
+    expect(
+      spans.map((s) => (s.options?.attributes as ContinuationSpanAttrs)["delegate.mode"]),
+    ).toEqual(["normal", "silent", "silent-wake", "post-compaction"]);
+  });
+
+  it("truncates reason to 80 chars", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateSpan({
+      chainId: "abc",
+      chainStepRemaining: 1,
+      delayMs: 100,
+      delivery: "timer",
+      reason: "y".repeat(200),
+    });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["reason.preview"]).toBe(
+      "y".repeat(80),
+    );
+  });
+
+  it("rounds delayMs and clamps negative chainStepRemaining", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateSpan({
+      chainId: undefined,
+      chainStepRemaining: -2,
+      delayMs: 4567.89,
+      delivery: "timer",
+    });
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["delay.ms"]).toBe(4568);
+    expect(attrs["chain.step.remaining"]).toBe(0);
+  });
+
+  it("swallows tracer errors and forwards to log callback", () => {
+    const throwingTracer: Tracer = {
+      startSpan() {
+        throw new Error("kaboom");
+      },
+    };
+    setContinuationTracer(throwingTracer);
+    const messages: string[] = [];
+    expect(() =>
+      emitContinuationDelegateSpan({
+        chainId: "abc",
+        chainStepRemaining: 1,
+        delayMs: 0,
+        delivery: "immediate",
+        log: (m) => messages.push(m),
+      }),
+    ).not.toThrow();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("kaboom");
+    expect(messages[0]).toContain("continuation.delegate.dispatch");
+  });
+
+  it("is a no-op against the default noop tracer", () => {
+    expect(getContinuationTracer()).toBe(noopTracer);
+    expect(() =>
+      emitContinuationDelegateSpan({
+        chainId: "abc",
+        chainStepRemaining: 1,
+        delayMs: 0,
+        delivery: "immediate",
+        delegateMode: "normal",
       }),
     ).not.toThrow();
   });

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -64,6 +64,16 @@ export type ContinuationSpanAttrs = {
   /** Mode of a `continue_delegate` dispatch (normal/silent/silent-wake/post-compaction). */
   readonly "delegate.mode"?: string;
   /**
+   * Delivery shape of the delegate dispatch — `"immediate"` when no
+   * delay was requested (or delay was 0), `"timer"` when `setTimeout`
+   * armed for a non-zero clamped delay. Distinct from `delegate.mode`
+   * (which captures *intent*: normal/silent/silent-wake/post-compaction).
+   * Threaded so chunk 4's `continuation.disabled` reject-spans can
+   * distinguish cap-rejected-immediate (no timer ever armed) from
+   * cap-rejected-timer (timer armed then reaped).
+   */
+  readonly "delegate.delivery"?: string;
+  /**
    * `true` when `ChainBudget.declineToCarry` silenced emission for this
    * step. Carried on the `continuation.disabled` event-span and on the
    * `heartbeat` span when continuation context is present.
@@ -274,5 +284,67 @@ export function emitContinuationWorkSpan(args: {
     span.end();
   } catch (err) {
     args.log?.(`Failed to emit continuation.work span: ${String(err)}`);
+  }
+}
+
+/**
+ * Emit a `continuation.delegate.dispatch` span at the runner-side
+ * delegate accept seam (#334 Slice 2 chunk 3). Mirrors
+ * `emitContinuationWorkSpan` shape — same try/catch wrap, same
+ * `chain.id` / `chain.step.remaining` / `delay.ms` / `reason.preview`
+ * plumbing — plus two delegate-specific axes:
+ *
+ *  - `delegate.delivery` (`"immediate" | "timer"`): runner-internal
+ *    scheduling axis. `"immediate"` when no delay was requested or
+ *    the delay was 0 (no `setTimeout` armed); `"timer"` when a
+ *    non-zero clamped delay armed `setTimeout`.
+ *  - `delegate.mode` (`"normal" | "silent" | "silent-wake" |
+ *    "post-compaction"`): caller-intent semantic axis. Optional
+ *    because some call sites (e.g. bracket-`CONTINUE_DELEGATE` without
+ *    the `silent`/`silent-wake` modifier) emit without a mode
+ *    annotation; the attribute is omitted in that case.
+ *
+ * Per cohort design (sprites-of-thornfield, 2026-04-27): emit at the
+ * **enqueue/accept seam**, NOT at the timer-fire callback. The chain-step
+ * is committed when the runner accepts the dispatch into the chain;
+ * the `setTimeout` is a delivery mechanism, not a chain semantic.
+ * Cancelled-but-accepted dispatches (compaction, reset, gateway shutdown)
+ * still happened, and a fire-time span would underreport them.
+ * `continuation.delegate.fire` remains a future name, not preempted.
+ *
+ * Wraps tracer interactions in a try/catch and logs via the caller's
+ * `log` callback if provided — the accept path must never block on
+ * span emission.
+ */
+export function emitContinuationDelegateSpan(args: {
+  chainId: string | undefined;
+  chainStepRemaining: number;
+  delayMs: number;
+  delivery: "immediate" | "timer";
+  delegateMode?: string | undefined;
+  reason?: string | undefined;
+  log?: (message: string) => void;
+}): void {
+  try {
+    const reasonPreview = args.reason
+      ? args.reason.length > 80
+        ? args.reason.slice(0, 80)
+        : args.reason
+      : undefined;
+    const attrs: ContinuationSpanAttrs = {
+      "delay.ms": Math.round(args.delayMs),
+      "chain.step.remaining": Math.max(0, args.chainStepRemaining),
+      "delegate.delivery": args.delivery,
+      ...(args.chainId !== undefined && { "chain.id": args.chainId }),
+      ...(args.delegateMode !== undefined && { "delegate.mode": args.delegateMode }),
+      ...(reasonPreview !== undefined && { "reason.preview": reasonPreview }),
+    };
+    const span = activeTracer.startSpan("continuation.delegate.dispatch", {
+      attributes: attrs,
+    });
+    span.setStatus("OK");
+    span.end();
+  } catch (err) {
+    args.log?.(`Failed to emit continuation.delegate.dispatch span: ${String(err)}`);
   }
 }

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -299,10 +299,10 @@ export function emitContinuationWorkSpan(args: {
  *    the delay was 0 (no `setTimeout` armed); `"timer"` when a
  *    non-zero clamped delay armed `setTimeout`.
  *  - `delegate.mode` (`"normal" | "silent" | "silent-wake" |
- *    "post-compaction"`): caller-intent semantic axis. Optional
- *    because some call sites (e.g. bracket-`CONTINUE_DELEGATE` without
- *    the `silent`/`silent-wake` modifier) emit without a mode
- *    annotation; the attribute is omitted in that case.
+ *    "post-compaction"`): caller-intent semantic axis. Optional in
+ *    the helper signature so future call sites (e.g. an exporter
+ *    replaying a partial dispatch record) can emit without a mode
+ *    annotation; current runner wiring always supplies one.
  *
  * Per cohort design (sprites-of-thornfield, 2026-04-27): emit at the
  * **enqueue/accept seam**, NOT at the timer-fire callback. The chain-step


### PR DESCRIPTION
## Summary

Slice 2 chunk 3 of #334. Wires `emitContinuationDelegateSpan` helper across all four delegate accept sites in `agent-runner.ts`, mirroring chunk 2's WORK accept-seam shape.

Stacks atop `19797e7fa6` (#382, merged 2026-04-27 15:42Z).

## Helper additions (`src/infra/continuation-tracer.ts`)

- `emitContinuationDelegateSpan({chainId, chainStepRemaining, delayMs, delivery, delegateMode?, reason?, log?})`: same try/catch wrap as `emitContinuationWorkSpan`; same `chain.id` / `chain.step.remaining` / `delay.ms` / `reason.preview` plumbing; plus two delegate-specific axes:
  - `delegate.delivery` (`"immediate" | "timer"") — runner-internal scheduling axis (was `setTimeout` armed).
  - `delegate.mode` (`"normal" | "silent" | "silent-wake" | "post-compaction"") — caller-intent semantic axis.
- `ContinuationSpanAttrs` gains `"delegate.delivery"` (per 🌊's naming nit: distinct verb from `delegate.mode`, no collision at trace-read time).

## Call sites (`src/auto-reply/reply/agent-runner.ts`)

Four sites, all reading chainId from `persistContinuationChainState`'s return (read-or-mint-once invariant byte-visible at each callsite):

| Site | Path | Delivery | Gate |
|---|---|---|---|
| L~2190 | bracket-immediate (doSpawn accept arm) | `"immediate"` | `!timerTriggered` |
| L~2247 | bracket-timer (after persist, before setTimeout) | `"timer"` | always emit at enqueue |
| L~2436 | tool-immediate (doToolSpawn accept arm) | `"immediate"` | `!timerTriggered` |
| L~2491 | tool-timer (after persist, before setTimeout) | `"timer"` | always emit at enqueue |

## Design rationale (cohort, sprites-of-thornfield 2026-04-27)

**Enqueue-time, not fire-time.** The chain-step is committed when the runner accepts the dispatch into the chain; `setTimeout` is a delivery mechanism, not a chain semantic. Three reasons:

1. **Symmetry with WORK.** Chunk 2's `continuation.work` fires at the accept seam (post-cap-gate, post-persist). Delegate dispatch at enqueue keeps the same anchor: operators reading traces don't have to special-case work-vs-delegate timing.
2. **Cap-gate locality.** Cap-rejected dispatches must NOT emit `continuation.delegate.dispatch` (chunk 4 will give them `continuation.disabled`). Reject branches sit at the persist site; emitting alongside persist keeps accepted/rejected lexically adjacent.
3. **Cancelled-but-accepted dispatches still happened.** If the timer is cancelled (compaction, reset, gateway shutdown), the chain-step still occurred. A fire-time span would underreport accepted-but-cancelled dispatches.

`continuation.delegate.fire` remains a future name (chunk 5 candidate), not preempted by this PR.

## Two-axis attr split

Per 🌻 + 🌊 design exchange: `delegate.delivery` and `delegate.mode` answer different questions and should not be folded.

- `delegate.delivery` — *when* does the dispatch run (`immediate` vs `timer`)? Load-bearing for chunk 4 reject-attribution: cap-rejected-immediate (no timer ever armed) ≠ cap-rejected-timer-armed-then-reaped.
- `delegate.mode` — *what is* the dispatch *for* (caller intent)? Stays stable across `.dispatch` and any future `.fire` span.

Different verbs at trace-read time = no operator confusion.

## Tests

7 new helper tests in `continuation-tracer.test.ts`:
- canonical attr set with all axes present
- immediate-delivery shape with no chainId or mode
- all four `delegate.mode` values thread through unchanged
- reason truncated to 80 chars
- delayMs rounded; chain.step.remaining clamped
- error swallowing with log forward
- noop-default no-throw

**28/28 green** locally (`continuation-tracer.test.ts` 25 + `agent-runner.continuation-work-span.test.ts` 3 chunk-2 integration tests still pass unchanged).

## Refs

- #334 (parent)
- #382 (chunk 2, merged `19797e7fa6`)
- #366 (Slice 1)

cohort: 🌻 🩸 🌊
