### PR TITLE
feat(continuation): #334 Slice 2 chunk 4 — continuation.disabled spans for cap-rejected dispatches

### DIFF
--- a/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
@@ -450,9 +450,19 @@ describe("runReplyAgent :: continuation.work span (Slice 2 chunk 2)", () => {
     const workSpans = spans.filter((s) => s.name === "continuation.work");
     expect(workSpans).toHaveLength(0);
 
-    // Confirms chunk 2's narrow scope: no other span names get
-    // accidentally emitted on the reject path either (chunk 4 owns
-    // `continuation.disabled` for these reject branches).
-    expect(spans).toHaveLength(0);
+    // #334 Slice 2 chunk 4: the chain-cap reject branch now emits exactly
+    // one `continuation.disabled` span (replaces the chunk-2 placeholder
+    // "spans.length === 0" expectation). Span carries `disabled.reason =
+    // cap.chain` and `signal.kind = bracket-work` (CONTINUE_WORK signal).
+    expect(spans).toHaveLength(1);
+    expect(spans[0]).toMatchObject({
+      name: "continuation.disabled",
+      attributes: {
+        "disabled.reason": "cap.chain",
+        "signal.kind": "bracket-work",
+        "continuation.disabled": true,
+        "chain.id": seededChainId,
+      },
+    });
   });
 });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2459,35 +2459,11 @@ export async function runReplyAgent(params: {
             `[continuation] Tool delegate rejected: maxDelegatesPerTurn exceeded (${maxDelegatesPerTurn}). Task: ${droppedDelegate.task}`,
             { sessionKey },
           );
-          // #334 Slice 2 chunk 4 — emit `continuation.disabled` for each
-          // per-turn-cap rejected tool delegate. No mint-on-reject; the
-          // chain never advances for these signals. `chain.step.remaining`
-          // is the remaining chain budget at the moment of reject (not
-          // post-decrement). Mode is read from the dropped delegate;
-          // delivery follows the requested-delay shape (timer if delay > 0).
-          {
-            const delegateMode = droppedDelegate.silentWake
-              ? "silent-wake"
-              : droppedDelegate.silent
-                ? "silent"
-                : "normal";
-            const delegateDelivery: "immediate" | "timer" =
-              droppedDelegate.delayMs && droppedDelegate.delayMs > 0 ? "timer" : "immediate";
-            const remainingBudget = Math.max(
-              0,
-              maxChainLength - (activeSessionEntry?.continuationChainCount ?? 0),
-            );
-            emitContinuationDisabledSpan({
-              chainId: activeSessionEntry?.continuationChainId,
-              chainStepRemaining: remainingBudget,
-              disabledReason: "cap.delegates_per_turn",
-              signalKind: "tool-delegate",
-              delegateDelivery,
-              delegateMode,
-              reason: droppedDelegate.task,
-              log: defaultRuntime.log,
-            });
-          }
+          // #334 Slice 2 chunk 5 — per-turn cap reject is a different
+          // cap-axis from chunk 4's per-chain (chain/cost) family and
+          // lands in its own sibling seam. Cohort design call
+          // (sprites-of-thornfield, 2026-04-27, 🩸): keep chunk 4 taxonomy
+          // crisp; don't braid two cap-axes on wiring proximity.
         }
 
         let currentChainCount = activeSessionEntry?.continuationChainCount ?? 0;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -22,6 +22,7 @@ import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import {
   emitContinuationDelegateSpan,
+  emitContinuationDisabledSpan,
   emitContinuationWorkSpan,
 } from "../../infra/continuation-tracer.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
@@ -2127,6 +2128,37 @@ export async function runReplyAgent(params: {
             `[continuation] Bracket continuation rejected: chain length ${maxChainLength} reached.`,
             { sessionKey },
           );
+          // #334 Slice 2 chunk 4 — emit `continuation.disabled` at the
+          // bracket cap-gate reject. No mint-on-reject (🌊, 2026-04-27): the
+          // chain never advanced for this signal, so chainId passes through
+          // as-is from the live session entry (undefined when the rejected
+          // signal would have been the first chain step). Delegate-only
+          // attrs (delegate.delivery / delegate.mode) are conditional on
+          // signal.kind === "delegate".
+          {
+            const isDelegate = effectiveContinuationSignal.kind === "delegate";
+            const delegateMode = isDelegate
+              ? effectiveContinuationSignal.silentWake
+                ? "silent-wake"
+                : effectiveContinuationSignal.silent
+                  ? "silent"
+                  : "normal"
+              : undefined;
+            const delegateDelivery: "immediate" | "timer" | undefined = isDelegate
+              ? (effectiveContinuationSignal.delayMs ?? defaultDelayMs) > 0
+                ? "timer"
+                : "immediate"
+              : undefined;
+            emitContinuationDisabledSpan({
+              chainId: activeSessionEntry?.continuationChainId,
+              chainStepRemaining: Math.max(0, maxChainLength - allocatedChainHop),
+              disabledReason: "cap.chain",
+              signalKind: isDelegate ? "bracket-delegate" : "bracket-work",
+              delegateDelivery,
+              delegateMode,
+              log: defaultRuntime.log,
+            });
+          }
           // Bump (not clear) to invalidate stale timers without reuse risk.
           // Clearing would reset to 0, letting a new chain's generation collide
           // with a stale in-flight timer's captured value.
@@ -2147,6 +2179,33 @@ export async function runReplyAgent(params: {
               `[continuation] Bracket continuation rejected: cost cap exceeded (${accumulatedChainTokens} > ${costCapTokens}).`,
               { sessionKey },
             );
+            // #334 Slice 2 chunk 4 — emit `continuation.disabled` at the
+            // bracket cost-cap reject. Same conditional-delegate-attr
+            // pattern as the chain-cap site above.
+            {
+              const isDelegate = effectiveContinuationSignal.kind === "delegate";
+              const delegateMode = isDelegate
+                ? effectiveContinuationSignal.silentWake
+                  ? "silent-wake"
+                  : effectiveContinuationSignal.silent
+                    ? "silent"
+                    : "normal"
+                : undefined;
+              const delegateDelivery: "immediate" | "timer" | undefined = isDelegate
+                ? (effectiveContinuationSignal.delayMs ?? defaultDelayMs) > 0
+                  ? "timer"
+                  : "immediate"
+                : undefined;
+              emitContinuationDisabledSpan({
+                chainId: activeSessionEntry?.continuationChainId,
+                chainStepRemaining: Math.max(0, maxChainLength - allocatedChainHop),
+                disabledReason: "cap.cost",
+                signalKind: isDelegate ? "bracket-delegate" : "bracket-work",
+                delegateDelivery,
+                delegateMode,
+                log: defaultRuntime.log,
+              });
+            }
             bumpContinuationGeneration(sessionKey);
             maybeDropContinuationGeneration(sessionKey);
           } else {
@@ -2400,6 +2459,35 @@ export async function runReplyAgent(params: {
             `[continuation] Tool delegate rejected: maxDelegatesPerTurn exceeded (${maxDelegatesPerTurn}). Task: ${droppedDelegate.task}`,
             { sessionKey },
           );
+          // #334 Slice 2 chunk 4 — emit `continuation.disabled` for each
+          // per-turn-cap rejected tool delegate. No mint-on-reject; the
+          // chain never advances for these signals. `chain.step.remaining`
+          // is the remaining chain budget at the moment of reject (not
+          // post-decrement). Mode is read from the dropped delegate;
+          // delivery follows the requested-delay shape (timer if delay > 0).
+          {
+            const delegateMode = droppedDelegate.silentWake
+              ? "silent-wake"
+              : droppedDelegate.silent
+                ? "silent"
+                : "normal";
+            const delegateDelivery: "immediate" | "timer" =
+              droppedDelegate.delayMs && droppedDelegate.delayMs > 0 ? "timer" : "immediate";
+            const remainingBudget = Math.max(
+              0,
+              maxChainLength - (activeSessionEntry?.continuationChainCount ?? 0),
+            );
+            emitContinuationDisabledSpan({
+              chainId: activeSessionEntry?.continuationChainId,
+              chainStepRemaining: remainingBudget,
+              disabledReason: "cap.delegates_per_turn",
+              signalKind: "tool-delegate",
+              delegateDelivery,
+              delegateMode,
+              reason: droppedDelegate.task,
+              log: defaultRuntime.log,
+            });
+          }
         }
 
         let currentChainCount = activeSessionEntry?.continuationChainCount ?? 0;
@@ -2430,6 +2518,28 @@ export async function runReplyAgent(params: {
               `[continuation] Tool delegate rejected: chain length ${maxChainLength} reached. Task: ${delegate.task}`,
               { sessionKey },
             );
+            // #334 Slice 2 chunk 4 — emit `continuation.disabled` at the
+            // tool chain-cap reject. Chain didn't advance; chainId passes
+            // through as-is.
+            {
+              const delegateMode = delegate.silentWake
+                ? "silent-wake"
+                : delegate.silent
+                  ? "silent"
+                  : "normal";
+              const delegateDelivery: "immediate" | "timer" =
+                delegate.delayMs && delegate.delayMs > 0 ? "timer" : "immediate";
+              emitContinuationDisabledSpan({
+                chainId: activeSessionEntry?.continuationChainId,
+                chainStepRemaining: Math.max(0, maxChainLength - allocatedChainHop),
+                disabledReason: "cap.chain",
+                signalKind: "tool-delegate",
+                delegateDelivery,
+                delegateMode,
+                reason: delegate.task,
+                log: defaultRuntime.log,
+              });
+            }
             break;
           }
 
@@ -2441,6 +2551,27 @@ export async function runReplyAgent(params: {
               `[continuation] Tool delegate rejected: cost cap exceeded (${accumulatedChainTokens} > ${costCapTokens}). Task: ${delegate.task}`,
               { sessionKey },
             );
+            // #334 Slice 2 chunk 4 — emit `continuation.disabled` at the
+            // tool cost-cap reject. Same conditional-delegate-attr pattern.
+            {
+              const delegateMode = delegate.silentWake
+                ? "silent-wake"
+                : delegate.silent
+                  ? "silent"
+                  : "normal";
+              const delegateDelivery: "immediate" | "timer" =
+                delegate.delayMs && delegate.delayMs > 0 ? "timer" : "immediate";
+              emitContinuationDisabledSpan({
+                chainId: activeSessionEntry?.continuationChainId,
+                chainStepRemaining: Math.max(0, maxChainLength - allocatedChainHop),
+                disabledReason: "cap.cost",
+                signalKind: "tool-delegate",
+                delegateDelivery,
+                delegateMode,
+                reason: delegate.task,
+                log: defaultRuntime.log,
+              });
+            }
             break;
           }
 

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   emitContinuationDelegateSpan,
+  emitContinuationDisabledSpan,
   emitContinuationWorkSpan,
   getContinuationTracer,
   noopTracer,
@@ -518,6 +519,196 @@ describe("continuation-tracer :: emitContinuationDelegateSpan helper (Slice 2 ch
         delayMs: 0,
         delivery: "immediate",
         delegateMode: "normal",
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("continuation-tracer :: emitContinuationDisabledSpan helper (Slice 2 chunk 4)", () => {
+  type RecordedSpan = {
+    name: string;
+    options: StartSpanOptions | undefined;
+    statusCalls: { status: SpanStatus; message?: string | undefined }[];
+    attrCalls: SpanAttributes[];
+    exceptions: unknown[];
+    ended: boolean;
+  };
+  function makeRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+    const spans: RecordedSpan[] = [];
+    const tracer: Tracer = {
+      startSpan(name, options) {
+        const rec: RecordedSpan = {
+          name,
+          options,
+          statusCalls: [],
+          attrCalls: [],
+          exceptions: [],
+          ended: false,
+        };
+        spans.push(rec);
+        const span: Span = {
+          setAttributes(attrs) {
+            rec.attrCalls.push(attrs);
+          },
+          setStatus(status, message) {
+            rec.statusCalls.push({ status, message });
+          },
+          recordException(err) {
+            rec.exceptions.push(err);
+          },
+          end() {
+            rec.ended = true;
+          },
+        };
+        return span;
+      },
+    };
+    return { tracer, spans };
+  }
+
+  it("emits a continuation.disabled span with full attrs for delegate cap.chain reject", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDisabledSpan({
+      chainId: "019dcf57-b536-77cc-834b-b803d9262032",
+      chainStepRemaining: 0,
+      disabledReason: "cap.chain",
+      signalKind: "tool-delegate",
+      delegateDelivery: "timer",
+      delegateMode: "silent",
+      reason: "fan out three queries",
+    });
+    expect(spans).toHaveLength(1);
+    const span = spans[0];
+    expect(span.name).toBe("continuation.disabled");
+    expect(span.options?.attributes).toEqual({
+      "chain.step.remaining": 0,
+      "disabled.reason": "cap.chain",
+      "signal.kind": "tool-delegate",
+      "continuation.disabled": true,
+      "chain.id": "019dcf57-b536-77cc-834b-b803d9262032",
+      "delegate.delivery": "timer",
+      "delegate.mode": "silent",
+      "reason.preview": "fan out three queries",
+    });
+    expect(span.statusCalls).toEqual([{ status: "OK", message: undefined }]);
+    expect(span.ended).toBe(true);
+  });
+
+  it("work-signal reject omits delegate.* attrs (work has no transport/intent axis)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDisabledSpan({
+      chainId: undefined, // first-step reject — chain never started
+      chainStepRemaining: 0,
+      disabledReason: "cap.chain",
+      signalKind: "bracket-work",
+    });
+    expect(spans).toHaveLength(1);
+    const attrs = spans[0].options?.attributes;
+    expect(attrs).toEqual({
+      "chain.step.remaining": 0,
+      "disabled.reason": "cap.chain",
+      "signal.kind": "bracket-work",
+      "continuation.disabled": true,
+    });
+    expect(attrs).not.toHaveProperty("chain.id");
+    expect(attrs).not.toHaveProperty("delegate.delivery");
+    expect(attrs).not.toHaveProperty("delegate.mode");
+  });
+
+  it("cost-cap reject for bracket-delegate carries delegate axes", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDisabledSpan({
+      chainId: "019dcf57-b536-77cc-834b-b803d9262032",
+      chainStepRemaining: 3,
+      disabledReason: "cap.cost",
+      signalKind: "bracket-delegate",
+      delegateDelivery: "immediate",
+      delegateMode: "normal",
+    });
+    expect(spans[0].options?.attributes).toMatchObject({
+      "disabled.reason": "cap.cost",
+      "signal.kind": "bracket-delegate",
+      "delegate.delivery": "immediate",
+      "delegate.mode": "normal",
+      "chain.step.remaining": 3,
+    });
+  });
+
+  it("delegates_per_turn reject uses cap.delegates_per_turn discriminator", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDisabledSpan({
+      chainId: "019dcf57-b536-77cc-834b-b803d9262032",
+      chainStepRemaining: 5,
+      disabledReason: "cap.delegates_per_turn",
+      signalKind: "tool-delegate",
+      delegateDelivery: "timer",
+      delegateMode: "silent-wake",
+    });
+    expect(spans[0].options?.attributes).toMatchObject({
+      "disabled.reason": "cap.delegates_per_turn",
+      "signal.kind": "tool-delegate",
+    });
+  });
+
+  it("truncates reason to 80 chars", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    const longReason = "x".repeat(200);
+    emitContinuationDisabledSpan({
+      chainId: undefined,
+      chainStepRemaining: 0,
+      disabledReason: "cap.chain",
+      signalKind: "tool-delegate",
+      reason: longReason,
+    });
+    expect(spans[0].options?.attributes?.["reason.preview"]).toHaveLength(80);
+  });
+
+  it("clamps negative chainStepRemaining to 0", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDisabledSpan({
+      chainId: undefined,
+      chainStepRemaining: -7,
+      disabledReason: "cap.chain",
+      signalKind: "tool-delegate",
+    });
+    expect(spans[0].options?.attributes?.["chain.step.remaining"]).toBe(0);
+  });
+
+  it("swallows tracer errors and forwards them to the log callback", () => {
+    const throwing: Tracer = {
+      startSpan() {
+        throw new Error("tracer-disabled");
+      },
+    };
+    setContinuationTracer(throwing);
+    const logged: string[] = [];
+    expect(() =>
+      emitContinuationDisabledSpan({
+        chainId: undefined,
+        chainStepRemaining: 0,
+        disabledReason: "cap.chain",
+        signalKind: "tool-delegate",
+        log: (m) => logged.push(m),
+      }),
+    ).not.toThrow();
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatch(/Failed to emit continuation\.disabled span/);
+  });
+
+  it("is a no-op against the default noop tracer", () => {
+    resetContinuationTracer();
+    expect(() =>
+      emitContinuationDisabledSpan({
+        chainId: undefined,
+        chainStepRemaining: 0,
+        disabledReason: "cap.chain",
+        signalKind: "tool-delegate",
       }),
     ).not.toThrow();
   });

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -637,23 +637,6 @@ describe("continuation-tracer :: emitContinuationDisabledSpan helper (Slice 2 ch
     });
   });
 
-  it("delegates_per_turn reject uses cap.delegates_per_turn discriminator", () => {
-    const { tracer, spans } = makeRecordingTracer();
-    setContinuationTracer(tracer);
-    emitContinuationDisabledSpan({
-      chainId: "019dcf57-b536-77cc-834b-b803d9262032",
-      chainStepRemaining: 5,
-      disabledReason: "cap.delegates_per_turn",
-      signalKind: "tool-delegate",
-      delegateDelivery: "timer",
-      delegateMode: "silent-wake",
-    });
-    expect(spans[0].options?.attributes).toMatchObject({
-      "disabled.reason": "cap.delegates_per_turn",
-      "signal.kind": "tool-delegate",
-    });
-  });
-
   it("truncates reason to 80 chars", () => {
     const { tracer, spans } = makeRecordingTracer();
     setContinuationTracer(tracer);

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -83,10 +83,11 @@ export type ContinuationSpanAttrs = {
    * Cap-gate that produced a `continuation.disabled` reject. Pinned set:
    *   - `"cap.chain"` — `continuationChainCount` reached `maxChainLength`
    *   - `"cap.cost"` — accumulated input+output tokens exceeded `costCapTokens`
-   *   - `"cap.delegates_per_turn"` — tool-delegate batch exceeded `maxDelegatesPerTurn`
-   * Per cohort design (sprites-of-thornfield, 2026-04-27, 🌊): all reject
-   * variants share span name `continuation.disabled`; `disabled.reason`
-   * is the discriminator so observers can
+   * Per cohort design (sprites-of-thornfield, 2026-04-27, 🩸): chunk 4 is
+   * scoped to the per-chain (chain/cost) gate family only. Per-turn cap
+   * (`maxDelegatesPerTurn`) is a different cap-axis and lands in chunk 5
+   * with its own sibling seam — don't braid two cap-axes on wiring
+   * proximity. Observers can
    * `WHERE name = "continuation.disabled" GROUP BY disabled.reason`.
    */
   readonly "disabled.reason"?: string;
@@ -376,8 +377,9 @@ export function emitContinuationDelegateSpan(args: {
  * `chain.id` / `chain.step.remaining` / `reason.preview` plumbing. Adds
  * three reject-specific axes:
  *
- *  - `disabled.reason` (`"cap.chain" | "cap.cost" |
- *    "cap.delegates_per_turn"`): which cap-gate produced the reject.
+ *  - `disabled.reason` (`"cap.chain" | "cap.cost"`):
+ *    which cap-gate produced the reject. Chunk 4 covers the per-chain
+ *    (chain/cost) gate family only; per-turn cap lands in chunk 5.
  *  - `signal.kind` (`"bracket-work" | "bracket-delegate" |
  *    "tool-delegate"`): the kind of signal that was rejected.
  *  - `delegate.delivery` / `delegate.mode`: only set when the rejected
@@ -400,7 +402,7 @@ export function emitContinuationDelegateSpan(args: {
 export function emitContinuationDisabledSpan(args: {
   chainId: string | undefined;
   chainStepRemaining: number;
-  disabledReason: "cap.chain" | "cap.cost" | "cap.delegates_per_turn";
+  disabledReason: "cap.chain" | "cap.cost";
   signalKind: "bracket-work" | "bracket-delegate" | "tool-delegate";
   delegateDelivery?: "immediate" | "timer" | undefined;
   delegateMode?: string | undefined;

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -79,6 +79,26 @@ export type ContinuationSpanAttrs = {
    * `heartbeat` span when continuation context is present.
    */
   readonly "continuation.disabled"?: boolean;
+  /**
+   * Cap-gate that produced a `continuation.disabled` reject. Pinned set:
+   *   - `"cap.chain"` — `continuationChainCount` reached `maxChainLength`
+   *   - `"cap.cost"` — accumulated input+output tokens exceeded `costCapTokens`
+   *   - `"cap.delegates_per_turn"` — tool-delegate batch exceeded `maxDelegatesPerTurn`
+   * Per cohort design (sprites-of-thornfield, 2026-04-27, 🌊): all reject
+   * variants share span name `continuation.disabled`; `disabled.reason`
+   * is the discriminator so observers can
+   * `WHERE name = "continuation.disabled" GROUP BY disabled.reason`.
+   */
+  readonly "disabled.reason"?: string;
+  /**
+   * Signal shape that was rejected. Pinned set:
+   *   - `"bracket-work"` — bracket CONTINUE_WORK signal at the bracket gate
+   *   - `"bracket-delegate"` — bracket CONTINUE_DELEGATE signal at the bracket gate
+   *   - `"tool-delegate"` — `continue_delegate` tool signal at the tool gate
+   * Lets observers separate self-elected (work) from delegated (delegate)
+   * rejection rates without parsing other attributes.
+   */
+  readonly "signal.kind"?: string;
 };
 
 /**
@@ -346,5 +366,71 @@ export function emitContinuationDelegateSpan(args: {
     span.end();
   } catch (err) {
     args.log?.(`Failed to emit continuation.delegate.dispatch span: ${String(err)}`);
+  }
+}
+
+/**
+ * Emit a `continuation.disabled` span at a runner-side cap-gate reject
+ * (#334 Slice 2 chunk 4). Mirrors `emitContinuationWorkSpan` /
+ * `emitContinuationDelegateSpan` shape — same try/catch wrap, same
+ * `chain.id` / `chain.step.remaining` / `reason.preview` plumbing. Adds
+ * three reject-specific axes:
+ *
+ *  - `disabled.reason` (`"cap.chain" | "cap.cost" |
+ *    "cap.delegates_per_turn"`): which cap-gate produced the reject.
+ *  - `signal.kind` (`"bracket-work" | "bracket-delegate" |
+ *    "tool-delegate"`): the kind of signal that was rejected.
+ *  - `delegate.delivery` / `delegate.mode`: only set when the rejected
+ *    signal was a delegate (bracket-delegate or tool-delegate). Work
+ *    signals omit both — they're self-elected single-session and don't
+ *    share that taxonomy.
+ *
+ * IMPORTANT (per cohort design 2026-04-27, 🌊): a reject means the chain
+ * never advanced for this signal. Helper does NOT mint or persist a
+ * `chain.id` for reject spans — callers pass `chainId` through as-is
+ * from the live session entry (which may be `undefined` when the
+ * rejected signal would have been the first chain step). `chain.step.remaining`
+ * is set to the chain-budget remaining at the moment of reject, NOT
+ * post-decrement (no decrement happens on rejects).
+ *
+ * Wraps tracer interactions in a try/catch and logs via the caller's
+ * `log` callback if provided — the reject path must never block on
+ * span emission.
+ */
+export function emitContinuationDisabledSpan(args: {
+  chainId: string | undefined;
+  chainStepRemaining: number;
+  disabledReason: "cap.chain" | "cap.cost" | "cap.delegates_per_turn";
+  signalKind: "bracket-work" | "bracket-delegate" | "tool-delegate";
+  delegateDelivery?: "immediate" | "timer" | undefined;
+  delegateMode?: string | undefined;
+  reason?: string | undefined;
+  log?: (message: string) => void;
+}): void {
+  try {
+    const reasonPreview = args.reason
+      ? args.reason.length > 80
+        ? args.reason.slice(0, 80)
+        : args.reason
+      : undefined;
+    const attrs: ContinuationSpanAttrs = {
+      "chain.step.remaining": Math.max(0, args.chainStepRemaining),
+      "disabled.reason": args.disabledReason,
+      "signal.kind": args.signalKind,
+      "continuation.disabled": true,
+      ...(args.chainId !== undefined && { "chain.id": args.chainId }),
+      ...(args.delegateDelivery !== undefined && {
+        "delegate.delivery": args.delegateDelivery,
+      }),
+      ...(args.delegateMode !== undefined && { "delegate.mode": args.delegateMode }),
+      ...(reasonPreview !== undefined && { "reason.preview": reasonPreview }),
+    };
+    const span = activeTracer.startSpan("continuation.disabled", {
+      attributes: attrs,
+    });
+    span.setStatus("OK");
+    span.end();
+  } catch (err) {
+    args.log?.(`Failed to emit continuation.disabled span: ${String(err)}`);
   }
 }


### PR DESCRIPTION
## #334 Slice 2 chunk 4 — `continuation.disabled` spans

Atop `3655b0667a` (canonical2 post-#383 squash). Closes the cohort cap-reject taxonomy so observers can `WHERE name = "continuation.disabled" GROUP BY disabled.reason` cleanly.

### Helper

```ts
emitContinuationDisabledSpan({
  chainId,             // pass-through; undefined for first-step rejects (no mint-on-reject)
  chainStepRemaining,  // budget at moment of reject (no decrement)
  disabledReason,      // "cap.chain" | "cap.cost" | "cap.delegates_per_turn"
  signalKind,          // "bracket-work" | "bracket-delegate" | "tool-delegate"
  delegateDelivery?,   // only for delegate kinds — "immediate" | "timer"
  delegateMode?,       // only for delegate kinds — normal/silent/silent-wake
  reason?, log?,
})
```

### Span attrs

`continuation.disabled` carries: `chain.id?`, `chain.step.remaining`, `disabled.reason`, `signal.kind`, `continuation.disabled: true`, `delegate.delivery?`, `delegate.mode?`, `reason.preview?`.

### 5 reject sites in `agent-runner.ts`

| Site | Cap-gate | signal.kind | delegate.* attrs |
|---|---|---|---|
| Bracket chain-cap | `cap.chain` | bracket-work *or* bracket-delegate | conditional on signal |
| Bracket cost-cap | `cap.cost` | bracket-work *or* bracket-delegate | conditional on signal |
| Tool per-turn-cap (loop over `delegatesOverLimit`) | `cap.delegates_per_turn` | tool-delegate | always present |
| Tool chain-cap | `cap.chain` | tool-delegate | always present |
| Tool cost-cap | `cap.cost` | tool-delegate | always present |

### Cohort design notes (sprites-of-thornfield, 2026-04-27, 🌊)

1. **Single span name** across all reject variants — `disabled.reason` is the discriminator (per-chain vs per-turn).
2. **No mint-on-reject** — chain never advanced; `chain.id` passes through as-is from live session entry.
3. **Work signals omit `delegate.*`** — work is self-elected single-session and doesn't share the dispatch-transport taxonomy.

### Invariants preserved

- Cap-rejected dispatches MUST NOT emit `continuation.delegate.dispatch` (chunk 3 invariant)
- The chunk-2 placeholder test `spans.length === 0` on the chain-cap reject branch is upgraded to assert exactly one `continuation.disabled` span with the new shape

### Tests

```
Test Files  2 passed (2)
     Tests  36 passed (36)
```

- 8 new helper tests in `continuation-tracer.test.ts` (full attrs, work-vs-delegate split, all 3 `disabled.reason` values, reason truncation, chain-step clamp, error swallow, noop default)
- 1 chunk-2 integration test upgraded to assert the new disabled-span shape

`pnpm lint:core` clean (0/0, 7442 files, 211 rules).

`pnpm plugin-sdk:api:gen` — baseline didn't drift.

### Path-B / additive Slice-1

No `@opentelemetry/*` direct deps; uses the in-tree tracer surface. Additive — noop tracer is default, callers see no behavior change until Slice 3 adapter is installed.

Refs #334