### PR TITLE
feat(continuation): #334 chunk 5a — per-turn cap reject reland

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2459,11 +2459,34 @@ export async function runReplyAgent(params: {
             `[continuation] Tool delegate rejected: maxDelegatesPerTurn exceeded (${maxDelegatesPerTurn}). Task: ${droppedDelegate.task}`,
             { sessionKey },
           );
-          // #334 Slice 2 chunk 5 — per-turn cap reject is a different
-          // cap-axis from chunk 4's per-chain (chain/cost) family and
-          // lands in its own sibling seam. Cohort design call
-          // (sprites-of-thornfield, 2026-04-27, 🩸): keep chunk 4 taxonomy
-          // crisp; don't braid two cap-axes on wiring proximity.
+          // #334 Slice 2 chunk 5a — per-turn cap reject span. Per-turn
+          // cap is a different cap-axis from chunk 4's per-chain
+          // (chain/cost) family but reuses `continuation.disabled` with
+          // `disabled.reason = "cap.delegates_per_turn"`. `chain.step.remaining`
+          // carries actual headroom (per-turn cap can fire while chain budget
+          // still has room).
+          {
+            const delegateMode = droppedDelegate.silentWake
+              ? "silent-wake"
+              : droppedDelegate.silent
+                ? "silent"
+                : "normal";
+            const delegateDelivery: "immediate" | "timer" =
+              droppedDelegate.delayMs && droppedDelegate.delayMs > 0 ? "timer" : "immediate";
+            emitContinuationDisabledSpan({
+              chainId: activeSessionEntry?.continuationChainId,
+              chainStepRemaining: Math.max(
+                0,
+                maxChainLength - (activeSessionEntry?.continuationChainCount ?? 0),
+              ),
+              disabledReason: "cap.delegates_per_turn",
+              signalKind: "tool-delegate",
+              delegateDelivery,
+              delegateMode,
+              reason: droppedDelegate.task,
+              log: defaultRuntime.log,
+            });
+          }
         }
 
         let currentChainCount = activeSessionEntry?.continuationChainCount ?? 0;

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -637,6 +637,30 @@ describe("continuation-tracer :: emitContinuationDisabledSpan helper (Slice 2 ch
     });
   });
 
+  it("per-turn cap reject for tool-delegate carries delegate axes and live headroom (chunk 5a)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDisabledSpan({
+      chainId: "019dcf57-b536-77cc-834b-b803d9262099",
+      chainStepRemaining: 12,
+      disabledReason: "cap.delegates_per_turn",
+      signalKind: "tool-delegate",
+      delegateDelivery: "timer",
+      delegateMode: "silent-wake",
+      reason: "poll PR #999 status",
+    });
+    expect(spans[0].options?.attributes).toMatchObject({
+      "disabled.reason": "cap.delegates_per_turn",
+      "signal.kind": "tool-delegate",
+      "delegate.delivery": "timer",
+      "delegate.mode": "silent-wake",
+      "chain.step.remaining": 12,
+      "chain.id": "019dcf57-b536-77cc-834b-b803d9262099",
+      "reason.preview": "poll PR #999 status",
+      "continuation.disabled": true,
+    });
+  });
+
   it("truncates reason to 80 chars", () => {
     const { tracer, spans } = makeRecordingTracer();
     setContinuationTracer(tracer);

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -377,9 +377,10 @@ export function emitContinuationDelegateSpan(args: {
  * `chain.id` / `chain.step.remaining` / `reason.preview` plumbing. Adds
  * three reject-specific axes:
  *
- *  - `disabled.reason` (`"cap.chain" | "cap.cost"`):
- *    which cap-gate produced the reject. Chunk 4 covers the per-chain
- *    (chain/cost) gate family only; per-turn cap lands in chunk 5.
+ *  - `disabled.reason` (`"cap.chain" | "cap.cost" | "cap.delegates_per_turn"`):
+ *    which cap-gate produced the reject. Per-chain (chain/cost) gates
+ *    landed in chunk 4; per-turn delegate-budget cap landed in chunk 5a
+ *    (cohort design 2026-04-27, 🌊): same span name, distinct taxonomy.
  *  - `signal.kind` (`"bracket-work" | "bracket-delegate" |
  *    "tool-delegate"`): the kind of signal that was rejected.
  *  - `delegate.delivery` / `delegate.mode`: only set when the rejected
@@ -402,7 +403,7 @@ export function emitContinuationDelegateSpan(args: {
 export function emitContinuationDisabledSpan(args: {
   chainId: string | undefined;
   chainStepRemaining: number;
-  disabledReason: "cap.chain" | "cap.cost";
+  disabledReason: "cap.chain" | "cap.cost" | "cap.delegates_per_turn";
   signalKind: "bracket-work" | "bracket-delegate" | "tool-delegate";
   delegateDelivery?: "immediate" | "timer" | undefined;
   delegateMode?: string | undefined;


### PR DESCRIPTION
Reland the per-turn delegate-cap reject site trimmed from chunk 4 (#384) to keep the chain/cost gate family taxonomically crisp.

## Shape

Per cohort design (sprites-of-thornfield, 2026-04-27, 🌊+🩸+🌻+🌫️):

- **Same span name** `continuation.disabled` — event-name unity preserved across cap-axes
- **`disabled.reason` enum extended** with `cap.delegates_per_turn` (was `cap.chain | cap.cost` after chunk-4 trim)
- **`chain.step.remaining` carries live headroom** — per-turn cap can fire while chain budget still has room (🌻's headroom-not-zero invariant)
- **`signal.kind`** always `tool-delegate` at this site
- **`delegate.delivery` + `delegate.mode`** carried per chunk-3 contract

## Why a separate chunk

Per-turn is a different cap-axis (turn-local quota) from chain/cost (per-chain budget). Splitting the chunks kept chunk 4's taxonomy crisp during review. This PR closes the chunk-5 deferral comment marker.

## Diff size

3 files, +57/-9. Helper enum, helper test, one wired site.

## Local verification

- vitest 36/36 green (was 35/35; +1 per-turn helper test)
- oxlint 0/0 / 7442 files

## Followups

- 5b: `continuation.delegate.fire` at setTimeout callback seams (design memo first)
- chunk 6: `queue.drain`, post-compaction sibling

Refs #334