### PR TITLE
feat(continuation): #334 Slice 2 chunk 5b — continuation.delegate.fire wire

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -21,6 +21,7 @@ import type { TypingMode } from "../../config/types.js";
 import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.fs.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import {
+  emitContinuationDelegateFireSpan,
   emitContinuationDelegateSpan,
   emitContinuationDisabledSpan,
   emitContinuationWorkSpan,
@@ -2338,25 +2339,61 @@ export async function runReplyAgent(params: {
                 // here, not at fire-time — cancelled-but-accepted dispatches
                 // (compaction, reset, gateway shutdown) still count as
                 // accepted and must not be silently underreported.
-                {
-                  // Ladder handles silent-wake / silent / normal only — see immediate-arm comment above; post-compaction dispatches travel a separate persist path.
-                  const delegateMode = effectiveContinuationSignal.silentWake
+                //
+                // Ladder handles silent-wake / silent / normal only — see immediate-arm comment above; post-compaction dispatches travel a separate persist path.
+                const delegateMode: "normal" | "silent" | "silent-wake" =
+                  effectiveContinuationSignal.silentWake
                     ? "silent-wake"
                     : effectiveContinuationSignal.silent
                       ? "silent"
                       : "normal";
-                  emitContinuationDelegateSpan({
-                    chainId: persistedChainIdForTimer,
-                    chainStepRemaining: maxChainLength - nextChainCount,
-                    delayMs: clampedDelay,
-                    delivery: "timer",
-                    delegateMode,
-                    log: (message) => defaultRuntime.log(message),
-                  });
-                }
+                // #334 Slice 2 chunk 5b — dispatch-time snapshots for
+                // the eventual fire-span. Closed-over by the setTimeout
+                // callback so chain.id / step.remaining are NOT re-read
+                // at fire-time (no-mint-on-fire invariant; matches
+                // chunks 3/4 enclosure discipline).
+                const chainStepRemainingAtDispatch = maxChainLength - nextChainCount;
+                const fireChainIdForTimer = persistedChainIdForTimer;
+                emitContinuationDelegateSpan({
+                  chainId: persistedChainIdForTimer,
+                  chainStepRemaining: chainStepRemainingAtDispatch,
+                  delayMs: clampedDelay,
+                  delivery: "timer",
+                  delegateMode,
+                  log: (message) => defaultRuntime.log(message),
+                });
                 retainContinuationTimerRef(sessionKey);
+                // #334 Slice 2 chunk 5b — capture arm-time so the timer
+                // callback can compute `fire.deferred_ms` (drift from
+                // the requested `delay.ms` under runtime pressure).
+                const armedAt = Date.now();
                 const timerHandle = setTimeout(() => {
                   try {
+                    // #334 Slice 2 chunk 5b — emit `continuation.delegate.fire`
+                    // FIRST, before reservation lookup. The fire event is
+                    // truthful (timer DID fire) regardless of what happens
+                    // next. Helper try/catch ensures span emission cannot
+                    // block the timer-callback path.
+                    //
+                    // Defense-in-depth: chunk 3 invariant guarantees
+                    // `chainId` is always defined post-persist, but if a
+                    // future invariant break ever slipped through, skip
+                    // emit rather than crash the timer callback.
+                    const fireDeferredMs = Date.now() - armedAt;
+                    if (fireChainIdForTimer !== undefined) {
+                      emitContinuationDelegateFireSpan({
+                        chainId: fireChainIdForTimer,
+                        chainStepRemainingAtDispatch,
+                        delegateMode,
+                        delayMs: clampedDelay,
+                        fireDeferredMs,
+                        log: (message) => defaultRuntime.log(message),
+                      });
+                    } else {
+                      defaultRuntime.log(
+                        `DELEGATE timer fired without chainId for session ${sessionKey} (invariant violation; skipping fire span emit)`,
+                      );
+                    }
                     const reservation = takeDelayedContinuationReservation(
                       sessionKey,
                       reservationId,
@@ -2365,6 +2402,21 @@ export async function runReplyAgent(params: {
                       defaultRuntime.log(
                         `DELEGATE timer fired but reservation already cleared for session ${sessionKey}`,
                       );
+                      // #334 Slice 2 chunk 5b — reservation cleared between
+                      // arm and fire (compaction, cancel, session teardown).
+                      // Emit `continuation.disabled` sibling sharing chain.id
+                      // so the trace pair (fire → disabled) is visible to ops.
+                      // No fire-time cap rechecks introduced — reservation.missing
+                      // is the ONLY fire-time divergence in current behavior.
+                      emitContinuationDisabledSpan({
+                        chainId: fireChainIdForTimer,
+                        chainStepRemaining: chainStepRemainingAtDispatch,
+                        disabledReason: "reservation.missing",
+                        signalKind: "bracket-delegate",
+                        delegateDelivery: "timer",
+                        delegateMode,
+                        log: (message) => defaultRuntime.log(message),
+                      });
                       return;
                     }
                     void doSpawn(reservation.plannedHop, reservation.task, {
@@ -2693,30 +2745,79 @@ export async function runReplyAgent(params: {
             // span at the timer-deferred enqueue seam (tool-side, after
             // persist, before `setTimeout` arms). Same enqueue-time
             // semantic anchor as the bracket-timer site above.
-            {
-              // Ladder handles silent-wake / silent / normal only — see tool-immediate comment above; post-compaction path is a sibling, not handled here.
-              const delegateMode = delegate.silentWake
-                ? "silent-wake"
-                : delegate.silent
-                  ? "silent"
-                  : "normal";
-              emitContinuationDelegateSpan({
-                chainId: persistedChainIdForTimer,
-                chainStepRemaining: maxChainLength - nextChainCount,
-                delayMs: clampedDelay,
-                delivery: "timer",
-                delegateMode,
-                log: (message) => defaultRuntime.log(message),
-              });
-            }
+            //
+            // Ladder handles silent-wake / silent / normal only — see tool-immediate comment above; post-compaction path is a sibling, not handled here.
+            const delegateMode: "normal" | "silent" | "silent-wake" = delegate.silentWake
+              ? "silent-wake"
+              : delegate.silent
+                ? "silent"
+                : "normal";
+            // #334 Slice 2 chunk 5b — dispatch-time snapshots for
+            // the eventual fire-span (tool-side mirror of bracket-side
+            // capture). Closed-over by the setTimeout callback so
+            // chain.id / step.remaining are NOT re-read at fire-time.
+            const chainStepRemainingAtDispatch = maxChainLength - nextChainCount;
+            const fireChainIdForTimer = persistedChainIdForTimer;
+            emitContinuationDelegateSpan({
+              chainId: persistedChainIdForTimer,
+              chainStepRemaining: chainStepRemainingAtDispatch,
+              delayMs: clampedDelay,
+              delivery: "timer",
+              delegateMode,
+              log: (message) => defaultRuntime.log(message),
+            });
             retainContinuationTimerRef(sessionKey);
+            // #334 Slice 2 chunk 5b — capture arm-time so the timer
+            // callback can compute `fire.deferred_ms` (drift from the
+            // requested `delay.ms` under runtime pressure).
+            const armedAt = Date.now();
             const timerHandle = setTimeout(() => {
               try {
+                // #334 Slice 2 chunk 5b — emit `continuation.delegate.fire`
+                // FIRST, before reservation lookup. The fire event is
+                // truthful (timer DID fire) regardless of what happens
+                // next. Helper try/catch ensures span emission cannot
+                // block the timer-callback path.
+                //
+                // Defense-in-depth: chunk 3 invariant guarantees
+                // `chainId` is always defined post-persist, but if a
+                // future invariant break ever slipped through, skip
+                // emit rather than crash the timer callback.
+                const fireDeferredMs = Date.now() - armedAt;
+                if (fireChainIdForTimer !== undefined) {
+                  emitContinuationDelegateFireSpan({
+                    chainId: fireChainIdForTimer,
+                    chainStepRemainingAtDispatch,
+                    delegateMode,
+                    delayMs: clampedDelay,
+                    fireDeferredMs,
+                    log: (message) => defaultRuntime.log(message),
+                  });
+                } else {
+                  defaultRuntime.log(
+                    `Tool DELEGATE timer fired without chainId for session ${sessionKey} (invariant violation; skipping fire span emit)`,
+                  );
+                }
                 const reservation = takeDelayedContinuationReservation(sessionKey, reservationId);
                 if (!reservation) {
                   defaultRuntime.log(
                     `Tool DELEGATE timer fired but reservation already cleared for session ${sessionKey}`,
                   );
+                  // #334 Slice 2 chunk 5b — reservation cleared between
+                  // arm and fire (compaction, cancel, session teardown).
+                  // Emit `continuation.disabled` sibling sharing chain.id
+                  // so the trace pair (fire → disabled) is visible to ops.
+                  // No fire-time cap rechecks introduced — reservation.missing
+                  // is the ONLY fire-time divergence in current behavior.
+                  emitContinuationDisabledSpan({
+                    chainId: fireChainIdForTimer,
+                    chainStepRemaining: chainStepRemainingAtDispatch,
+                    disabledReason: "reservation.missing",
+                    signalKind: "tool-delegate",
+                    delegateDelivery: "timer",
+                    delegateMode,
+                    log: (message) => defaultRuntime.log(message),
+                  });
                   return;
                 }
                 void doToolSpawn(reservation.plannedHop, reservation.task, {

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -138,6 +138,7 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
     const tracer = getContinuationTracer();
     tracer.startSpan("continuation.work");
     tracer.startSpan("continuation.delegate.dispatch");
+    tracer.startSpan("continuation.delegate.fire");
     tracer.startSpan("continuation.queue.enqueue");
     tracer.startSpan("continuation.queue.drain");
     tracer.startSpan("continuation.compaction.released");
@@ -147,6 +148,7 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
     expect(recorded).toEqual([
       "continuation.work",
       "continuation.delegate.dispatch",
+      "continuation.delegate.fire",
       "continuation.queue.enqueue",
       "continuation.queue.drain",
       "continuation.compaction.released",
@@ -206,6 +208,7 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
     const names: ContinuationSpanName[] = [
       "continuation.work",
       "continuation.delegate.dispatch",
+      "continuation.delegate.fire",
       "continuation.queue.enqueue",
       "continuation.queue.drain",
       "continuation.compaction.released",

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  emitContinuationDelegateFireSpan,
   emitContinuationDelegateSpan,
   emitContinuationDisabledSpan,
   emitContinuationWorkSpan,
@@ -718,5 +719,291 @@ describe("continuation-tracer :: emitContinuationDisabledSpan helper (Slice 2 ch
         signalKind: "tool-delegate",
       }),
     ).not.toThrow();
+  });
+});
+
+describe("continuation-tracer :: emitContinuationDelegateFireSpan helper (Slice 2 chunk 5b)", () => {
+  type RecordedSpan = {
+    name: string;
+    options?: StartSpanOptions;
+    setAttributesCalls: SpanAttributes[];
+    statusCalls: Array<{ status: SpanStatus; message?: string }>;
+    exceptionCalls: unknown[];
+    ended: boolean;
+  };
+
+  function makeRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+    const spans: RecordedSpan[] = [];
+    const tracer: Tracer = {
+      startSpan(name, options) {
+        const recorded: RecordedSpan = {
+          name,
+          options,
+          setAttributesCalls: [],
+          statusCalls: [],
+          exceptionCalls: [],
+          ended: false,
+        };
+        spans.push(recorded);
+        const span: Span = {
+          setAttributes(attrs) {
+            recorded.setAttributesCalls.push(attrs);
+          },
+          setStatus(status, message) {
+            recorded.statusCalls.push({ status, message });
+          },
+          recordException(err) {
+            recorded.exceptionCalls.push(err);
+          },
+          end() {
+            recorded.ended = true;
+          },
+        };
+        return span;
+      },
+    };
+    return { tracer, spans };
+  }
+
+  afterEach(() => resetContinuationTracer());
+
+  it("emits continuation.delegate.fire with all required attrs", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+
+    emitContinuationDelegateFireSpan({
+      chainId: "01HXYZ-fire-chain-id",
+      chainStepRemainingAtDispatch: 5,
+      delegateMode: "normal",
+      delayMs: 30000,
+      fireDeferredMs: 30042,
+    });
+
+    expect(spans).toHaveLength(1);
+    const [span] = spans;
+    expect(span.name).toBe("continuation.delegate.fire");
+    expect(span.options?.attributes).toMatchObject({
+      "chain.id": "01HXYZ-fire-chain-id",
+      "chain.step.remaining": 5,
+      "delay.ms": 30000,
+      "fire.deferred_ms": 30042,
+      "delegate.delivery": "timer",
+      "delegate.mode": "normal",
+    });
+    expect(span.statusCalls).toEqual([{ status: "OK", message: undefined }]);
+    expect(span.ended).toBe(true);
+  });
+
+  it("floors fire.deferred_ms to integer ms via Math.floor", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+
+    emitContinuationDelegateFireSpan({
+      chainId: "01HXYZ-floor-test",
+      chainStepRemainingAtDispatch: 3,
+      delegateMode: "silent",
+      delayMs: 1000,
+      fireDeferredMs: 1234.789,
+    });
+
+    const attrs = spans[0]?.options?.attributes as Record<string, unknown>;
+    expect(attrs?.["fire.deferred_ms"]).toBe(1234);
+  });
+
+  it("clamps negative chain.step.remaining and fire.deferred_ms to 0", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+
+    emitContinuationDelegateFireSpan({
+      chainId: "01HXYZ-clamp-test",
+      chainStepRemainingAtDispatch: -1,
+      delegateMode: "silent-wake",
+      delayMs: 500,
+      fireDeferredMs: -10,
+    });
+
+    const attrs = spans[0]?.options?.attributes as Record<string, unknown>;
+    expect(attrs?.["chain.step.remaining"]).toBe(0);
+    expect(attrs?.["fire.deferred_ms"]).toBe(0);
+  });
+
+  it("truncates reason.preview to 80 chars (consistency w/ chunks 2-4)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+
+    const longReason = "x".repeat(200);
+    emitContinuationDelegateFireSpan({
+      chainId: "01HXYZ-truncate-test",
+      chainStepRemainingAtDispatch: 5,
+      delegateMode: "normal",
+      delayMs: 100,
+      fireDeferredMs: 102,
+      reason: longReason,
+    });
+
+    const attrs = spans[0]?.options?.attributes as Record<string, unknown>;
+    expect(attrs?.["reason.preview"]).toBe("x".repeat(80));
+  });
+
+  it("omits reason.preview when reason absent", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+
+    emitContinuationDelegateFireSpan({
+      chainId: "01HXYZ-no-reason",
+      chainStepRemainingAtDispatch: 1,
+      delegateMode: "normal",
+      delayMs: 100,
+      fireDeferredMs: 102,
+    });
+
+    const attrs = spans[0]?.options?.attributes as Record<string, unknown>;
+    expect(attrs).not.toHaveProperty("reason.preview");
+  });
+
+  it("emits delegate.delivery=timer as fixed attr (fire is timer-only by Q1)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+
+    emitContinuationDelegateFireSpan({
+      chainId: "01HXYZ-delivery-test",
+      chainStepRemainingAtDispatch: 2,
+      delegateMode: "normal",
+      delayMs: 100,
+      fireDeferredMs: 100,
+    });
+
+    const attrs = spans[0]?.options?.attributes as Record<string, unknown>;
+    expect(attrs?.["delegate.delivery"]).toBe("timer");
+  });
+
+  it("try/catch swallows tracer failures and calls log callback", () => {
+    const failingTracer: Tracer = {
+      startSpan() {
+        throw new Error("tracer boom");
+      },
+    };
+    setContinuationTracer(failingTracer);
+
+    const logged: string[] = [];
+    expect(() =>
+      emitContinuationDelegateFireSpan({
+        chainId: "01HXYZ-log-test",
+        chainStepRemainingAtDispatch: 1,
+        delegateMode: "normal",
+        delayMs: 100,
+        fireDeferredMs: 100,
+        log: (m) => logged.push(m),
+      }),
+    ).not.toThrow();
+
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toContain("Failed to emit continuation.delegate.fire span");
+    expect(logged[0]).toContain("tracer boom");
+  });
+
+  it("never throws even when log callback is absent", () => {
+    const failingTracer: Tracer = {
+      startSpan() {
+        throw new Error("tracer boom");
+      },
+    };
+    setContinuationTracer(failingTracer);
+
+    expect(() =>
+      emitContinuationDelegateFireSpan({
+        chainId: "01HXYZ-no-log",
+        chainStepRemainingAtDispatch: 1,
+        delegateMode: "normal",
+        delayMs: 100,
+        fireDeferredMs: 100,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("continuation-tracer :: emitContinuationDisabledSpan reason=reservation.missing (Slice 2 chunk 5b)", () => {
+  type RecordedSpan = {
+    name: string;
+    options?: StartSpanOptions;
+    setAttributesCalls: SpanAttributes[];
+    statusCalls: Array<{ status: SpanStatus; message?: string }>;
+    exceptionCalls: unknown[];
+    ended: boolean;
+  };
+
+  function makeRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+    const spans: RecordedSpan[] = [];
+    const tracer: Tracer = {
+      startSpan(name, options) {
+        const recorded: RecordedSpan = {
+          name,
+          options,
+          setAttributesCalls: [],
+          statusCalls: [],
+          exceptionCalls: [],
+          ended: false,
+        };
+        spans.push(recorded);
+        const span: Span = {
+          setAttributes(attrs) {
+            recorded.setAttributesCalls.push(attrs);
+          },
+          setStatus(status, message) {
+            recorded.statusCalls.push({ status, message });
+          },
+          recordException(err) {
+            recorded.exceptionCalls.push(err);
+          },
+          end() {
+            recorded.ended = true;
+          },
+        };
+        return span;
+      },
+    };
+    return { tracer, spans };
+  }
+
+  afterEach(() => resetContinuationTracer());
+
+  it("accepts reservation.missing as fourth reason in 4-value enum", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+
+    emitContinuationDisabledSpan({
+      chainId: "01HXYZ-resmissing",
+      chainStepRemaining: 7,
+      disabledReason: "reservation.missing",
+      signalKind: "bracket-delegate",
+      delegateDelivery: "timer",
+      delegateMode: "normal",
+    });
+
+    expect(spans).toHaveLength(1);
+    const attrs = spans[0]?.options?.attributes as Record<string, unknown>;
+    expect(attrs?.["disabled.reason"]).toBe("reservation.missing");
+    expect(attrs?.["signal.kind"]).toBe("bracket-delegate");
+    expect(attrs?.["delegate.delivery"]).toBe("timer");
+    expect(attrs?.["continuation.disabled"]).toBe(true);
+  });
+
+  it("supports tool-delegate signal.kind for tool-side reservation.missing", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+
+    emitContinuationDisabledSpan({
+      chainId: "01HXYZ-resmissing-tool",
+      chainStepRemaining: 3,
+      disabledReason: "reservation.missing",
+      signalKind: "tool-delegate",
+      delegateDelivery: "timer",
+      delegateMode: "silent-wake",
+    });
+
+    const attrs = spans[0]?.options?.attributes as Record<string, unknown>;
+    expect(attrs?.["disabled.reason"]).toBe("reservation.missing");
+    expect(attrs?.["signal.kind"]).toBe("tool-delegate");
+    expect(attrs?.["delegate.mode"]).toBe("silent-wake");
   });
 });

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -64,6 +64,18 @@ export type ContinuationSpanAttrs = {
   /** Mode of a `continue_delegate` dispatch (normal/silent/silent-wake/post-compaction). */
   readonly "delegate.mode"?: string;
   /**
+   * #334 Slice 2 chunk 5b — only set on `continuation.delegate.fire`
+   * spans. Wall-clock ms between `setTimeout` arming (dispatch-time) and
+   * the timer-callback actually executing (fire-time). Diverges from
+   * `delay.ms` (the requested delay) under runtime pressure.
+   *
+   * **Canonical drift formula** (cohort design 2026-04-27, 🌊):
+   * `drift = fire.deferred_ms − delay.ms`. Positive values indicate the
+   * timer fired late under load; near-zero is on-schedule. Integer ms
+   * (`Math.floor` at emit-time) so the shape matches `delay.ms`.
+   */
+  readonly "fire.deferred_ms"?: number;
+  /**
    * Delivery shape of the delegate dispatch — `"immediate"` when no
    * delay was requested (or delay was 0), `"timer"` when `setTimeout`
    * armed for a non-zero clamped delay. Distinct from `delegate.mode`
@@ -80,15 +92,27 @@ export type ContinuationSpanAttrs = {
    */
   readonly "continuation.disabled"?: boolean;
   /**
-   * Cap-gate that produced a `continuation.disabled` reject. Pinned set:
+   * Reason the `continuation.disabled` span was emitted. Pinned set
+   * (4-value as of #334 chunk 5b, cohort design 2026-04-27):
    *   - `"cap.chain"` — `continuationChainCount` reached `maxChainLength`
    *   - `"cap.cost"` — accumulated input+output tokens exceeded `costCapTokens`
-   * Per cohort design (sprites-of-thornfield, 2026-04-27, 🩸): chunk 4 is
-   * scoped to the per-chain (chain/cost) gate family only. Per-turn cap
-   * (`maxDelegatesPerTurn`) is a different cap-axis and lands in chunk 5
-   * with its own sibling seam — don't braid two cap-axes on wiring
-   * proximity. Observers can
+   *   - `"cap.delegates_per_turn"` — per-turn delegate-budget cap (chunk 5a)
+   *   - `"reservation.missing"` — fire-time reservation already cleared
+   *     between `setTimeout` arm and callback execution (chunk 5b)
+   *
+   * **Enum semantics** (🌻 + 🩸 grammar-fit, msg `1498378311259394158`):
+   * the family is **"anything that prevented follow-through,"** NOT
+   * "cap axes only." `cap.*` is one shape of gate (per-chain or per-turn);
+   * `reservation.missing` is another (compaction / cancel / teardown
+   * cleared the reservation between arm and fire). Future siblings under
+   * this family slot here too: `reservation.evicted`, `session.gone`,
+   * `compaction.cleared`, etc. Observers can
    * `WHERE name = "continuation.disabled" GROUP BY disabled.reason`.
+   *
+   * Hard-fault failures (uncaught exception in spawn, store write fail)
+   * are a **future taxonomy** that may graduate to a dedicated
+   * `continuation.delegate.error` span name (Q8 deferred memo) — they do
+   * NOT live on `continuation.disabled`.
    */
   readonly "disabled.reason"?: string;
   /**
@@ -111,6 +135,7 @@ export type ContinuationSpanAttrs = {
 export type ContinuationSpanName =
   | "continuation.work"
   | "continuation.delegate.dispatch"
+  | "continuation.delegate.fire"
   | "continuation.queue.enqueue"
   | "continuation.queue.drain"
   | "continuation.compaction.released"
@@ -377,10 +402,14 @@ export function emitContinuationDelegateSpan(args: {
  * `chain.id` / `chain.step.remaining` / `reason.preview` plumbing. Adds
  * three reject-specific axes:
  *
- *  - `disabled.reason` (`"cap.chain" | "cap.cost" | "cap.delegates_per_turn"`):
- *    which cap-gate produced the reject. Per-chain (chain/cost) gates
- *    landed in chunk 4; per-turn delegate-budget cap landed in chunk 5a
- *    (cohort design 2026-04-27, 🌊): same span name, distinct taxonomy.
+ *  - `disabled.reason` (`"cap.chain" | "cap.cost" |
+ *    "cap.delegates_per_turn" | "reservation.missing"`): which gate
+ *    prevented follow-through. Per-chain (chain/cost) gates landed in
+ *    chunk 4; per-turn delegate-budget cap landed in chunk 5a; fire-time
+ *    `reservation.missing` lands in chunk 5b. Family semantics are
+ *    "anything that prevented follow-through," NOT cap-axes only —
+ *    grammar-fit cohort decision (sprites-of-thornfield 2026-04-27,
+ *    🩸 + 🌻, msg `1498378311259394158`).
  *  - `signal.kind` (`"bracket-work" | "bracket-delegate" |
  *    "tool-delegate"`): the kind of signal that was rejected.
  *  - `delegate.delivery` / `delegate.mode`: only set when the rejected
@@ -403,7 +432,7 @@ export function emitContinuationDelegateSpan(args: {
 export function emitContinuationDisabledSpan(args: {
   chainId: string | undefined;
   chainStepRemaining: number;
-  disabledReason: "cap.chain" | "cap.cost" | "cap.delegates_per_turn";
+  disabledReason: "cap.chain" | "cap.cost" | "cap.delegates_per_turn" | "reservation.missing";
   signalKind: "bracket-work" | "bracket-delegate" | "tool-delegate";
   delegateDelivery?: "immediate" | "timer" | undefined;
   delegateMode?: string | undefined;
@@ -435,5 +464,97 @@ export function emitContinuationDisabledSpan(args: {
     span.end();
   } catch (err) {
     args.log?.(`Failed to emit continuation.disabled span: ${String(err)}`);
+  }
+}
+
+/**
+ * Emit a `continuation.delegate.fire` span at the timer-deferred
+ * delegate-fire seam (#334 Slice 2 chunk 5b). Mirrors chunks 2/3/4
+ * helpers — same try/catch wrap, same `chain.id` /
+ * `chain.step.remaining` / `reason.preview` plumbing.
+ *
+ * **Scope (cohort-pinned 2026-04-27, memo PR #386):** instrument-the-current-seam
+ * only. The wire emits at the start of each `setTimeout` callback BEFORE
+ * `takeDelayedContinuationReservation`, so the fire event is truthful
+ * regardless of what happens next (reservation hit, reservation cleared,
+ * or eventual spawn). NO fire-time cap rechecks are introduced — those
+ * are a future-policy seam, deferred to a later memo.
+ *
+ * Axes:
+ *  - `fire.deferred_ms` (number): wall-clock ms between `setTimeout` arm
+ *    (dispatch-time) and callback execution (fire-time). Integer ms via
+ *    `Math.floor` at emit-time. Drift formula:
+ *    `drift = fire.deferred_ms − delay.ms`.
+ *  - `delay.ms` (number): the requested delay, carried through from
+ *    dispatch so trace consumers can pair `dispatch`/`fire` events
+ *    without a join.
+ *  - `delegate.delivery` (`"timer"`): emitted as a fixed attr — fire is
+ *    timer-only by Q1, immediate dispatches don't have a fire-event seam.
+ *  - `delegate.mode` (string): closed-over from the dispatch-time
+ *    reservation; never re-read at fire-time.
+ *  - `chain.id` / `chain.step.remaining`: dispatch-time snapshot, NOT a
+ *    fire-time recompute.
+ *
+ * **chain.id provenance** (🌊 msg `1498377809591013516`; 🩸 msg
+ * `1498377886686777486`): the `setTimeout` callback **closes over**
+ * `chainId` from dispatch-time as a captured local. This helper never
+ * re-reads `activeSessionEntry?.continuationChainId` at fire-time. This
+ * matches the no-mint-on-fire invariant, prevents races with compaction
+ * or session mutation between arm and fire, and mirrors chunks 3/4's
+ * enclosure discipline.
+ *
+ * **Always-defined invariant** (🌻 msg `1498377947944456294`): chain
+ * reservation mints pre-`setTimeout` (chunk 3 invariant), so `chainId`
+ * is always defined at delegate-fire time. The signature pins this in
+ * the type (`chainId: string`, not optional). Defense-in-depth: helper
+ * no-ops gracefully if a future invariant break ever slipped through,
+ * so fire-emit can't crash the timer callback.
+ *
+ * **`chainStepRemainingAtDispatch` provenance** (🩸 msg `1498377749499351203`;
+ * 🌻 dedicated-paragraph note, msg `1498378054462869524`): the value
+ * reflects **dispatch-time headroom** (reservation snapshot), NOT
+ * callback-time live state. Rationale: trace continuity with the
+ * dispatch span (same `chain.id`, same step counter) so consumers can
+ * pair `dispatch`/`fire` events without reasoning about between-tick
+ * mutations. If a future consumer wants "remaining headroom _at_ fire
+ * time," that is a **separate axis** (provisional name
+ * `chain.step.remaining_at_fire`) and a **separate decision** — do not
+ * fold it into this field.
+ *
+ * Wraps tracer interactions in a try/catch and logs via the caller's
+ * `log` callback if provided — the timer-callback path must never block
+ * on span emission, even on tracer failure.
+ */
+export function emitContinuationDelegateFireSpan(args: {
+  chainId: string;
+  chainStepRemainingAtDispatch: number;
+  delegateMode: "normal" | "silent" | "silent-wake";
+  delayMs: number;
+  fireDeferredMs: number;
+  reason?: string | undefined;
+  log?: (message: string) => void;
+}): void {
+  try {
+    const reasonPreview = args.reason
+      ? args.reason.length > 80
+        ? args.reason.slice(0, 80)
+        : args.reason
+      : undefined;
+    const attrs: ContinuationSpanAttrs = {
+      "chain.id": args.chainId,
+      "chain.step.remaining": Math.max(0, args.chainStepRemainingAtDispatch),
+      "delay.ms": Math.round(args.delayMs),
+      "fire.deferred_ms": Math.max(0, Math.floor(args.fireDeferredMs)),
+      "delegate.delivery": "timer",
+      "delegate.mode": args.delegateMode,
+      ...(reasonPreview !== undefined && { "reason.preview": reasonPreview }),
+    };
+    const span = activeTracer.startSpan("continuation.delegate.fire", {
+      attributes: attrs,
+    });
+    span.setStatus("OK");
+    span.end();
+  } catch (err) {
+    args.log?.(`Failed to emit continuation.delegate.fire span: ${String(err)}`);
   }
 }

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -356,7 +356,9 @@ export function emitContinuationWorkSpan(args: {
  * the `setTimeout` is a delivery mechanism, not a chain semantic.
  * Cancelled-but-accepted dispatches (compaction, reset, gateway shutdown)
  * still happened, and a fire-time span would underreport them.
- * `continuation.delegate.fire` remains a future name, not preempted.
+ * `continuation.delegate.fire` is the timer-callback sibling (#334
+ * Slice 2 chunk 5b, helper `emitContinuationDelegateFireSpan`):
+ * dispatch is the enqueue-time event, fire is the delivery-time event.
  *
  * Wraps tracer interactions in a try/catch and logs via the caller's
  * `log` callback if provided — the accept path must never block on


### PR DESCRIPTION
# #334 Slice 2 chunk 5b — `continuation.delegate.fire` wire

Wire the design memo landed in #386 (squash `287d0a5586`).

**Trunk base:** `cael/325-canonical2 @ 287d0a5586`
**Memo:** `docs/design/334-slice2-chunk5b-delegate-fire-memo.md`
**Cohort design:** 🌊 Ronan, 🩸 Cael, 🌻 Elliott, 🌫️ Silas (2026-04-27)

## Current seam vs future policy (🩸 byte-walk caveat)

This PR carries 🩸's byte-walk distinction explicitly so reviewers don't conflate observed vs introduced behavior:

- **Existing seam** (current callback bytes): `reservation.missing` is the **only** fire-time divergence today. Current behavior is `take-reservation → log+return-or-spawn`. 5b extends the log-and-return path to `fire + disabled (reservation.missing)` instrumentation as **intentional behavioral extension** (more visible, same outcome).
- **NOT introduced by 5b**: fire-time `cap.chain | cap.cost` rechecks. These are a **future policy shape** that may be added later, **not** something the current callback path does. Any `cap.*` reason on `disabled` from 5b's wire is dispatch-time, never fire-time.

The enum extension to 4-value is structural (so future-policy gates have a home if added), but 5b's emission sites are limited to:
- dispatch-time gate-rejects (existing, unchanged)
- fire-time `reservation.missing` (new)

No fire-time cap-emission is introduced.

## What changes

### `src/infra/continuation-tracer.ts`

- New helper `emitContinuationDelegateFireSpan` mirroring chunks 2/3/4 contract (try/catch + caller `log`, sparse attrs, no mint-on-fire).
- New optional attr `fire.deferred_ms` on `ContinuationSpanAttrs` (integer ms via `Math.floor` at emit-time; canonical drift formula `drift = fire.deferred_ms − delay.ms` documented in JSDoc).
- `disabled.reason` enum extended to 4-value: `cap.chain | cap.cost | cap.delegates_per_turn | reservation.missing`. JSDoc reframed as "anything that prevented follow-through" — family is grammar-defined (verb-on-gate), not enum-cardinality-defined. Future siblings (`reservation.evicted`, `session.gone`, `compaction.cleared`) slot under the same family.
- `continuation.delegate.fire` added to `ContinuationSpanName` union (the deferral comment in the existing helper had reserved this name).

### `src/auto-reply/reply/agent-runner.ts`

Two timer-callback wire sites:

- **Bracket-delegate** (~L2358): capture `armedAt = Date.now()` pre-`setTimeout`; in the callback, emit `continuation.delegate.fire` BEFORE `takeDelayedContinuationReservation`. On `null` reservation, emit `continuation.disabled (reason=reservation.missing, signal.kind=bracket-delegate)` sharing chain.id, then return.
- **Tool-delegate** (~L2727): same shape. `signal.kind=tool-delegate`.

Both sites:
- Close over `chainId` and `chainStepRemainingAtDispatch` from dispatch-time as captured locals — never re-read at fire-time.
- Compute `fireDeferredMs = Date.now() - armedAt`.
- Defense-in-depth: skip-and-log if `chainId` is `undefined` (chunk 3 invariant guarantees it isn't, but the timer callback should never crash on a future invariant break).
- Helper try/catch ensures span emission never blocks the callback path (memo Q6).

### Tests

10 new helper tests in `continuation-tracer.test.ts`:
- 8 for `emitContinuationDelegateFireSpan` (all required attrs, `Math.floor` on `fire.deferred_ms`, negative-clamp on `chain.step.remaining` and `fire.deferred_ms`, 80-char truncation on `reason.preview`, omit-on-absent reason, fixed `delegate.delivery=timer`, log on tracer failure, no-throw without log callback).
- 2 for `reservation.missing` on `emitContinuationDisabledSpan` (4-value enum acceptance, `tool-delegate` signal.kind for tool-side path).

Suite: 43/43 pass locally.

## Diff size

- Helper + types: ~120 lines (`continuation-tracer.ts`)
- Wire sites: ~100 lines across 2 callbacks (`agent-runner.ts`)
- Tests: ~280 lines
- **Total: 548 insertions, 39 modifications across 3 files**

## Memo Q-coverage

- Q1 (callsites): timer-callback only ✓ (immediate dispatches don't have a fire seam)
- Q2 (attr shape): reuse `ContinuationSpanAttrs` + new optional `fire.deferred_ms` ✓
- Q3 (helper sig): `chainStepRemainingAtDispatch` snapshot, `chainId: string` non-optional, dispatch-time enclosure ✓
- Q4 (wake-then-cap): **future policy, not wired** ✓
- Q5 (work-fire): **future policy, not wired** ✓
- Q6 (fire-time exceptions): emit fire-span first, helper try/catch guards ✓
- Q7 (reservation-missing): unanimous (i-a) — `disabled.reason=reservation.missing` sibling sharing chain.id ✓
- Q8 (`continuation.delegate.error`): **future taxonomy, not wired** ✓

## Out of scope

- `continuation.queue.drain` (separate chunk 6 candidate)
- post-compaction sibling site (separate chunk)
- `dispatch` span (locked since chunk 3)

— 🌫️
