### PR TITLE
feat(continuation): #334 chunk 5b — continuation.delegate.fire wire

### DIFF
--- a/src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts
@@ -1,0 +1,492 @@
+// #334 Slice 2 chunk 5b — integration test pinning the runner-side
+// `continuation.delegate.fire` span emission contract at the timer-callback
+// seam (BEFORE `takeDelayedContinuationReservation`).
+//
+// Per memo `docs/design/334-slice2-chunk5b-delegate-fire-memo.md`:
+//   - bracket-delegate timer fire → exactly one `continuation.delegate.fire`
+//   - tool-delegate timer fire → exactly one `continuation.delegate.fire`
+//   - `fire.deferred_ms` non-negative, roughly matches `delay.ms`
+//   - `chain.id` matches the dispatch span's `chain.id` (trace stitches)
+//   - reservation-missing path: timer-fire emits AND sibling
+//     `continuation.disabled (reason=reservation.missing)` emits, both
+//     sharing chain.id
+//
+// The harness mirrors the chunk-2/4/5a integration tests: install a
+// recording tracer via `setContinuationTracer`, drive the runner with
+// either a `[[CONTINUE_DELEGATE:...]]` payload (bracket path) or a
+// `enqueuePendingDelegate(...)` injection inside the model mock (tool
+// path), then `vi.advanceTimersByTimeAsync` past the clamped delay to
+// fire the timer.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as embeddedRunTesting,
+  abortEmbeddedPiRun,
+  isEmbeddedPiRunActive,
+} from "../../agents/pi-embedded-runner/runs.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  resetContinuationTracer,
+  setContinuationTracer,
+  type Span,
+  type SpanAttributes,
+  type SpanStatus,
+  type StartSpanOptions,
+  type Tracer,
+} from "../../infra/continuation-tracer.js";
+import {
+  clearMemoryPluginState,
+  registerMemoryFlushPlanResolver,
+} from "../../plugins/memory-state.js";
+import {
+  clearDelayedContinuationReservations,
+  enqueuePendingDelegate,
+} from "../continuation-delegate-store.js";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { __testing as replyRunRegistryTesting } from "./reply-run-registry.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+void registerMemoryFlushPlanResolver;
+
+const runEmbeddedPiAgentMock = vi.fn();
+const runCliAgentMock = vi.fn();
+const runWithModelFallbackMock = vi.fn();
+const runtimeErrorMock = vi.fn();
+const abortEmbeddedPiRunMock = vi.fn();
+const clearSessionQueuesMock = vi.fn();
+const refreshQueuedFollowupSessionMock = vi.fn();
+const compactState = vi.hoisted(() => ({
+  compactEmbeddedPiSessionMock: vi.fn(),
+}));
+const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
+const spawnSubagentDirectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: (params: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => runWithModelFallbackMock(params),
+  isFallbackSummaryError: (err: unknown) =>
+    err instanceof Error &&
+    err.name === "FallbackSummaryError" &&
+    Array.isArray((err as { attempts?: unknown[] }).attempts),
+}));
+
+vi.mock("../../agents/model-auth.js", () => ({
+  resolveModelAuthMode: () => "api-key",
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  compactEmbeddedPiSession: (params: unknown) => compactState.compactEmbeddedPiSessionMock(params),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+  abortEmbeddedPiRun: (sessionId: string) => {
+    abortEmbeddedPiRunMock(sessionId);
+    return abortEmbeddedPiRun(sessionId);
+  },
+  isEmbeddedPiRunActive: (sessionId: string) => isEmbeddedPiRunActive(sessionId),
+}));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: (...args: unknown[]) => runCliAgentMock(...args),
+}));
+
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  SUBAGENT_SPAWN_MODES: ["run", "session"],
+  SUBAGENT_SPAWN_SANDBOX_MODES: ["inherit", "require"],
+  SUBAGENT_SPAWN_CONTEXT_MODES: ["isolated", "fork"],
+  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: (...args: unknown[]) => runtimeErrorMock(...args),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
+}));
+
+vi.mock("./queue.js", () => ({
+  enqueueFollowupRun: vi.fn(),
+  scheduleFollowupDrain: vi.fn(),
+  clearSessionQueues: (...args: unknown[]) => clearSessionQueuesMock(...args),
+  refreshQueuedFollowupSession: (...args: unknown[]) => refreshQueuedFollowupSessionMock(...args),
+}));
+
+vi.mock("../../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: async ({ config }: { config: unknown }) => ({
+    resolvedConfig: config,
+    diagnostics: [],
+  }),
+}));
+
+vi.mock("../../utils/provider-utils.js", () => ({
+  isReasoningTagProvider: (provider: string | undefined | null) =>
+    provider === "google" || provider === "google-gemini-cli",
+}));
+
+const loadCronStoreMock = vi.fn();
+vi.mock("../../cron/store.js", () => ({
+  loadCronStore: (...args: unknown[]) => loadCronStoreMock(...args),
+  resolveCronStorePath: (storePath?: string) => storePath ?? "/tmp/openclaw-cron-store.json",
+}));
+
+vi.mock("../../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    resolveSession: () => ({ kind: "none" }),
+    cancelSession: async () => {},
+  }),
+}));
+
+vi.mock("../../agents/subagent-registry.js", () => ({
+  getLatestSubagentRunByChildSessionKey: () => null,
+  listSubagentRunsForController: () => [],
+  markSubagentRunTerminated: () => 0,
+}));
+
+import { runReplyAgent } from "./agent-runner.js";
+
+type RunWithModelFallbackParams = {
+  provider: string;
+  model: string;
+  run: (provider: string, model: string) => Promise<unknown>;
+};
+
+type RecordedSpan = {
+  name: string;
+  attributes: SpanAttributes;
+  status: SpanStatus | undefined;
+  ended: boolean;
+};
+
+function createRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+  const spans: RecordedSpan[] = [];
+  const tracer: Tracer = {
+    startSpan(name: string, opts?: StartSpanOptions): Span {
+      const rec: RecordedSpan = {
+        name,
+        attributes: { ...opts?.attributes },
+        status: undefined,
+        ended: false,
+      };
+      spans.push(rec);
+      const span: Span = {
+        setAttributes(attrs: SpanAttributes): void {
+          Object.assign(rec.attributes, attrs);
+        },
+        setStatus(status: SpanStatus, _message?: string): void {
+          rec.status = status;
+        },
+        recordException(_err: unknown): void {
+          // unused
+        },
+        end(): void {
+          rec.ended = true;
+        },
+      };
+      return span;
+    },
+  };
+  return { tracer, spans };
+}
+
+beforeEach(() => {
+  embeddedRunTesting.resetActiveEmbeddedRuns();
+  replyRunRegistryTesting.resetReplyRunRegistry();
+  runEmbeddedPiAgentMock.mockClear();
+  runCliAgentMock.mockClear();
+  runWithModelFallbackMock.mockClear();
+  runtimeErrorMock.mockClear();
+  abortEmbeddedPiRunMock.mockClear();
+  compactState.compactEmbeddedPiSessionMock.mockReset();
+  compactState.compactEmbeddedPiSessionMock.mockResolvedValue({
+    compacted: false,
+    reason: "test-preflight-disabled",
+  });
+  clearSessionQueuesMock.mockReset();
+  clearSessionQueuesMock.mockReturnValue({ followupCleared: 0, laneCleared: 0, keys: [] });
+  refreshQueuedFollowupSessionMock.mockReset();
+  refreshQueuedFollowupSessionMock.mockResolvedValue(undefined);
+  loadCronStoreMock.mockClear();
+  loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+  requestHeartbeatNowMock.mockReset();
+  spawnSubagentDirectMock.mockReset().mockResolvedValue({
+    status: "accepted",
+    childSessionKey: "agent:main:subagent:spawned",
+    runId: "run-spawned",
+  });
+  runWithModelFallbackMock.mockImplementation(
+    async ({ provider, model, run }: RunWithModelFallbackParams) => ({
+      result: await run(provider, model),
+      provider,
+      model,
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearMemoryPluginState();
+  replyRunRegistryTesting.resetReplyRunRegistry();
+  embeddedRunTesting.resetActiveEmbeddedRuns();
+  resetContinuationTracer();
+});
+
+const UUIDV7_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function createContinuationRun(params?: {
+  sessionKey?: string;
+  config?: Record<string, unknown>;
+  sessionEntry?: SessionEntry;
+}) {
+  const sessionKey = params?.sessionKey ?? "continuation-delegate-fire-span";
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: "discord",
+    OriginatingTo: "channel:1",
+    AccountId: "primary",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+  const sessionEntry =
+    params?.sessionEntry ??
+    ({
+      sessionId: "session",
+      updatedAt: Date.now(),
+    } satisfies SessionEntry);
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey,
+      messageProvider: "discord",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config:
+        params?.config ??
+        ({
+          agents: {
+            defaults: {
+              continuation: {
+                enabled: true,
+                minDelayMs: 0,
+                maxDelayMs: 5_000,
+                defaultDelayMs: 1_000,
+                maxChainLength: 4,
+                maxDelegatesPerTurn: 4,
+              },
+            },
+          },
+        } satisfies Record<string, unknown>),
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return { sessionKey, sessionEntry, typing, sessionCtx, resolvedQueue, followupRun };
+}
+
+async function runDelegateTurn(
+  run: ReturnType<typeof createContinuationRun>,
+  sessionStore: Record<string, SessionEntry>,
+): Promise<unknown> {
+  return runReplyAgent({
+    commandBody: "hello",
+    followupRun: run.followupRun,
+    queueKey: run.sessionKey,
+    resolvedQueue: run.resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    isStreaming: false,
+    typing: run.typing,
+    sessionCtx: run.sessionCtx,
+    sessionEntry: run.sessionEntry,
+    sessionStore,
+    sessionKey: run.sessionKey,
+    defaultModel: "anthropic/claude-opus-4-6",
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: "instant",
+  });
+}
+
+describe("runReplyAgent :: continuation.delegate.fire span (Slice 2 chunk 5b)", () => {
+  it("bracket-delegate timer fire emits exactly one `continuation.delegate.fire` with chain.id matching the dispatch span", async () => {
+    vi.useFakeTimers();
+    const { tracer, spans } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    const run = createContinuationRun({ sessionKey: "continuation-delegate-fire-bracket" });
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Reply\n[[CONTINUE_DELEGATE: inspect logs +1s]]" }],
+      meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+    });
+
+    await runDelegateTurn(run, { [run.sessionKey]: run.sessionEntry });
+
+    // Before timer fires: dispatch span recorded, fire span not yet.
+    const dispatchSpans = spans.filter((s) => s.name === "continuation.delegate.dispatch");
+    expect(dispatchSpans).toHaveLength(1);
+    expect(spans.filter((s) => s.name === "continuation.delegate.fire")).toHaveLength(0);
+
+    // Advance past the clamped delay (1000ms) to fire the timer callback.
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const fireSpans = spans.filter((s) => s.name === "continuation.delegate.fire");
+    expect(fireSpans).toHaveLength(1);
+
+    const fire = fireSpans[0];
+    if (!fire) {
+      throw new Error("expected a recorded continuation.delegate.fire span");
+    }
+    expect(fire.status).toBe("OK");
+    expect(fire.ended).toBe(true);
+
+    const dispatchChainId = dispatchSpans[0]?.attributes["chain.id"];
+    expect(typeof dispatchChainId).toBe("string");
+    expect(dispatchChainId as string).toMatch(UUIDV7_REGEX);
+    // Trace stitches: fire.chain.id === dispatch.chain.id
+    expect(fire.attributes["chain.id"]).toBe(dispatchChainId);
+    expect(fire.attributes["delay.ms"]).toBe(1_000);
+    expect(fire.attributes["delegate.delivery"]).toBe("timer");
+    expect(typeof fire.attributes["delegate.mode"]).toBe("string");
+    expect(typeof fire.attributes["fire.deferred_ms"]).toBe("number");
+    // Loose floor: fake timers advance synchronously, so drift is small
+    // but should be non-negative and bounded.
+    const fireDeferredMs = fire.attributes["fire.deferred_ms"] as number;
+    expect(fireDeferredMs).toBeGreaterThanOrEqual(0);
+    expect(fireDeferredMs).toBeLessThan(1_000 + 5_000);
+  });
+
+  it("tool-delegate timer fire emits exactly one `continuation.delegate.fire` with chain.id matching the dispatch span", async () => {
+    vi.useFakeTimers();
+    const { tracer, spans } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    const sessionKey = "continuation-delegate-fire-tool";
+    const run = createContinuationRun({ sessionKey });
+    // Tool-delegate path: the model mock injects a pending delegate via
+    // `enqueuePendingDelegate` during the run (mirrors the real
+    // `continue_delegate` tool behavior). The agent-runner then consumes
+    // pending delegates via `consumePendingDelegates(sessionKey)` and
+    // arms the tool-side timer callback.
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      enqueuePendingDelegate(sessionKey, {
+        task: "poll PR #999 status",
+        delayMs: 1_000,
+        silent: false,
+        silentWake: false,
+      });
+      return {
+        payloads: [{ text: "Spawning a delegate to handle this." }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    await runDelegateTurn(run, { [sessionKey]: run.sessionEntry });
+
+    const dispatchSpans = spans.filter((s) => s.name === "continuation.delegate.dispatch");
+    expect(dispatchSpans).toHaveLength(1);
+    expect(spans.filter((s) => s.name === "continuation.delegate.fire")).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const fireSpans = spans.filter((s) => s.name === "continuation.delegate.fire");
+    expect(fireSpans).toHaveLength(1);
+
+    const fire = fireSpans[0];
+    if (!fire) {
+      throw new Error("expected a recorded continuation.delegate.fire span");
+    }
+    expect(fire.status).toBe("OK");
+    expect(fire.ended).toBe(true);
+
+    const dispatchChainId = dispatchSpans[0]?.attributes["chain.id"];
+    expect(typeof dispatchChainId).toBe("string");
+    expect(dispatchChainId as string).toMatch(UUIDV7_REGEX);
+    expect(fire.attributes["chain.id"]).toBe(dispatchChainId);
+    expect(fire.attributes["delay.ms"]).toBe(1_000);
+    expect(fire.attributes["delegate.delivery"]).toBe("timer");
+    const fireDeferredMs = fire.attributes["fire.deferred_ms"] as number;
+    expect(fireDeferredMs).toBeGreaterThanOrEqual(0);
+    expect(fireDeferredMs).toBeLessThan(1_000 + 5_000);
+  });
+
+  it("reservation-missing path: timer fire emits `continuation.delegate.fire` AND sibling `continuation.disabled (reason=reservation.missing)` sharing chain.id", async () => {
+    vi.useFakeTimers();
+    const { tracer, spans } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    const run = createContinuationRun({ sessionKey: "continuation-delegate-fire-resv-missing" });
+    const sessionStore = { [run.sessionKey]: run.sessionEntry };
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Reply\n[[CONTINUE_DELEGATE: inspect logs +1s]]" }],
+      meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+    });
+
+    await runDelegateTurn(run, sessionStore);
+
+    // Clear the reservation between arm and fire WITHOUT cancelling the
+    // timer (which would call clearTimeout and prevent the callback). This
+    // models the existing fire-time divergence: timer fires (wall-clock
+    // truth) but `takeDelayedContinuationReservation` returns null because
+    // some other path (compaction, explicit cancel via a different code
+    // path, session teardown) already cleared the reservation.
+    clearDelayedContinuationReservations(run.sessionKey);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const fireSpans = spans.filter((s) => s.name === "continuation.delegate.fire");
+    expect(fireSpans).toHaveLength(1);
+    const fire = fireSpans[0];
+    if (!fire) {
+      throw new Error("expected a recorded continuation.delegate.fire span");
+    }
+
+    const reservationMissingSpans = spans.filter(
+      (s) =>
+        s.name === "continuation.disabled" &&
+        s.attributes["disabled.reason"] === "reservation.missing",
+    );
+    expect(reservationMissingSpans).toHaveLength(1);
+    const sibling = reservationMissingSpans[0];
+    if (!sibling) {
+      throw new Error("expected a reservation.missing continuation.disabled sibling");
+    }
+
+    // Both share chain.id — trace consumers can pair fire+disabled events.
+    expect(fire.attributes["chain.id"]).toBeDefined();
+    expect(sibling.attributes["chain.id"]).toBe(fire.attributes["chain.id"]);
+    expect(sibling.attributes["signal.kind"]).toBe("bracket-delegate");
+    expect(sibling.attributes["delegate.delivery"]).toBe("timer");
+    expect(sibling.attributes["continuation.disabled"]).toBe(true);
+
+    // No spawn happened on reservation-missing: the only tool-spawn paths
+    // are `doSpawn` (bracket) → `spawnSubagentDirect`. Neither runs after
+    // a cleared reservation.
+    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -21,6 +21,7 @@ import type { TypingMode } from "../../config/types.js";
 import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.fs.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import {
+  emitContinuationDelegateFireSpan,
   emitContinuationDelegateSpan,
   emitContinuationDisabledSpan,
   emitContinuationWorkSpan,
@@ -2354,8 +2355,44 @@ export async function runReplyAgent(params: {
                     log: (message) => defaultRuntime.log(message),
                   });
                 }
+                // #334 Slice 2 chunk 5b — snapshot dispatch-time inputs for
+                // the fire-span emission inside the timer callback. `armedAt`
+                // captured immediately before `setTimeout` so
+                // `fireDeferredMs = Date.now() - armedAt` measures wall-clock
+                // drift between arming and callback execution.
+                // `chainStepRemainingAtDispatch` is a snapshot, NOT a
+                // fire-time recompute — keeps the dispatch/fire trace pair
+                // coherent (same `chain.id`, same step counter).
+                const fireDelegateMode: "normal" | "silent" | "silent-wake" =
+                  effectiveContinuationSignal.silentWake
+                    ? "silent-wake"
+                    : effectiveContinuationSignal.silent
+                      ? "silent"
+                      : "normal";
+                const chainStepRemainingAtDispatch = maxChainLength - nextChainCount;
                 retainContinuationTimerRef(sessionKey);
+                const armedAt = Date.now();
                 const timerHandle = setTimeout(() => {
+                  // #334 Slice 2 chunk 5b — emit `continuation.delegate.fire`
+                  // FIRST, before reservation lookup. The fire event is
+                  // wall-clock truth ("the timer fired"); whatever happens
+                  // next (spawn, reservation-missing log-and-return) is a
+                  // separate concern. 5b is instrumentation-of-status-quo
+                  // only — no fire-time cap rechecks.
+                  const fireDeferredMs = Date.now() - armedAt;
+                  emitContinuationDelegateFireSpan({
+                    // Invariant: persistedChainIdForTimer is always a string
+                    // here — `persistContinuationChainState` only returns
+                    // undefined when `sessionKey` is falsy, but this branch
+                    // is gated on `sessionKey` being truthy (chunk 3).
+                    // Helper's defense-in-depth no-ops if undefined slips.
+                    chainId: persistedChainIdForTimer as string,
+                    chainStepRemainingAtDispatch,
+                    delegateMode: fireDelegateMode,
+                    delayMs: clampedDelay,
+                    fireDeferredMs,
+                    log: (message) => defaultRuntime.log(message),
+                  });
                   try {
                     const reservation = takeDelayedContinuationReservation(
                       sessionKey,
@@ -2365,6 +2402,20 @@ export async function runReplyAgent(params: {
                       defaultRuntime.log(
                         `DELEGATE timer fired but reservation already cleared for session ${sessionKey}`,
                       );
+                      // #334 Slice 2 chunk 5b — fire-time reservation-missing
+                      // is the ONLY fire-time divergence in current bytes
+                      // (per cohort byte-walk, 2026-04-27). Sibling span
+                      // sharing chain.id so consumers can pair fire+disabled
+                      // events on a single trace.
+                      emitContinuationDisabledSpan({
+                        chainId: persistedChainIdForTimer,
+                        chainStepRemaining: chainStepRemainingAtDispatch,
+                        disabledReason: "reservation.missing",
+                        signalKind: "bracket-delegate",
+                        delegateDelivery: "timer",
+                        delegateMode: fireDelegateMode,
+                        log: (message) => defaultRuntime.log(message),
+                      });
                       return;
                     }
                     void doSpawn(reservation.plannedHop, reservation.task, {
@@ -2709,14 +2760,57 @@ export async function runReplyAgent(params: {
                 log: (message) => defaultRuntime.log(message),
               });
             }
+            // #334 Slice 2 chunk 5b — fire-span snapshots for the tool-delegate
+            // timer callback. Same enclosure discipline as the bracket-delegate
+            // site: `delegateMode` and `chainStepRemainingAtDispatch` are
+            // dispatch-time captures, NOT fire-time recomputes; `armedAt` is
+            // captured immediately before `setTimeout` so wall-clock drift
+            // measurement starts at arming.
+            const fireDelegateMode: "normal" | "silent" | "silent-wake" = delegate.silentWake
+              ? "silent-wake"
+              : delegate.silent
+                ? "silent"
+                : "normal";
+            const chainStepRemainingAtDispatch = maxChainLength - nextChainCount;
             retainContinuationTimerRef(sessionKey);
+            const armedAt = Date.now();
             const timerHandle = setTimeout(() => {
+              // #334 Slice 2 chunk 5b — fire-span emits FIRST, before
+              // reservation lookup. Wall-clock truth: timer DID fire; what
+              // happens next (spawn or reservation-missing) is a separate
+              // sibling event. 5b is instrumentation-of-status-quo only.
+              const fireDeferredMs = Date.now() - armedAt;
+              emitContinuationDelegateFireSpan({
+                // Invariant: persistedChainIdForTimer is always a string
+                // here — `persistContinuationChainState` only returns
+                // undefined when `sessionKey` is falsy, but this branch
+                // is gated on `sessionKey` being truthy (chunk 3).
+                // Helper's defense-in-depth no-ops if undefined slips.
+                chainId: persistedChainIdForTimer as string,
+                chainStepRemainingAtDispatch,
+                delegateMode: fireDelegateMode,
+                delayMs: clampedDelay,
+                fireDeferredMs,
+                log: (message) => defaultRuntime.log(message),
+              });
               try {
                 const reservation = takeDelayedContinuationReservation(sessionKey, reservationId);
                 if (!reservation) {
                   defaultRuntime.log(
                     `Tool DELEGATE timer fired but reservation already cleared for session ${sessionKey}`,
                   );
+                  // #334 Slice 2 chunk 5b — sibling `continuation.disabled`
+                  // for the existing log-and-return divergence; same chain.id
+                  // as the fire span so consumers can pair them.
+                  emitContinuationDisabledSpan({
+                    chainId: persistedChainIdForTimer,
+                    chainStepRemaining: chainStepRemainingAtDispatch,
+                    disabledReason: "reservation.missing",
+                    signalKind: "tool-delegate",
+                    delegateDelivery: "timer",
+                    delegateMode: fireDelegateMode,
+                    log: (message) => defaultRuntime.log(message),
+                  });
                   return;
                 }
                 void doToolSpawn(reservation.plannedHop, reservation.task, {

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  emitContinuationDelegateFireSpan,
   emitContinuationDelegateSpan,
   emitContinuationDisabledSpan,
   emitContinuationWorkSpan,
@@ -205,6 +206,7 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
     const names: ContinuationSpanName[] = [
       "continuation.work",
       "continuation.delegate.dispatch",
+      "continuation.delegate.fire",
       "continuation.queue.enqueue",
       "continuation.queue.drain",
       "continuation.compaction.released",
@@ -716,6 +718,239 @@ describe("continuation-tracer :: emitContinuationDisabledSpan helper (Slice 2 ch
         chainStepRemaining: 0,
         disabledReason: "cap.chain",
         signalKind: "tool-delegate",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts disabledReason='reservation.missing' (chunk 5b enum extension)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDisabledSpan({
+      chainId: "019dcf57-b536-77cc-834b-b803d9262099",
+      chainStepRemaining: 4,
+      disabledReason: "reservation.missing",
+      signalKind: "tool-delegate",
+      delegateDelivery: "timer",
+      delegateMode: "silent-wake",
+    });
+    expect(spans[0].options?.attributes).toMatchObject({
+      "disabled.reason": "reservation.missing",
+      "signal.kind": "tool-delegate",
+      "delegate.delivery": "timer",
+      "delegate.mode": "silent-wake",
+      "chain.id": "019dcf57-b536-77cc-834b-b803d9262099",
+      "continuation.disabled": true,
+    });
+  });
+});
+
+describe("continuation-tracer :: emitContinuationDelegateFireSpan helper (Slice 2 chunk 5b)", () => {
+  type RecordedSpan = {
+    name: string;
+    options: StartSpanOptions | undefined;
+    statusCalls: { status: SpanStatus; message?: string | undefined }[];
+    attrCalls: SpanAttributes[];
+    exceptions: unknown[];
+    ended: boolean;
+  };
+  function makeRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+    const spans: RecordedSpan[] = [];
+    const tracer: Tracer = {
+      startSpan(name, options) {
+        const rec: RecordedSpan = {
+          name,
+          options,
+          statusCalls: [],
+          attrCalls: [],
+          exceptions: [],
+          ended: false,
+        };
+        spans.push(rec);
+        const span: Span = {
+          setAttributes(attrs) {
+            rec.attrCalls.push(attrs);
+          },
+          setStatus(status, message) {
+            rec.statusCalls.push({ status, message });
+          },
+          recordException(err) {
+            rec.exceptions.push(err);
+          },
+          end() {
+            rec.ended = true;
+          },
+        };
+        return span;
+      },
+    };
+    return { tracer, spans };
+  }
+
+  it("emits a continuation.delegate.fire span with all required attrs", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateFireSpan({
+      chainId: "019dcf57-b536-77cc-834b-b803d9262032",
+      chainStepRemainingAtDispatch: 4,
+      delegateMode: "silent-wake",
+      delayMs: 60_000,
+      fireDeferredMs: 60_017,
+      reason: "fan out three queries",
+    });
+    expect(spans).toHaveLength(1);
+    const span = spans[0];
+    expect(span.name).toBe("continuation.delegate.fire");
+    expect(span.options?.attributes).toEqual({
+      "chain.id": "019dcf57-b536-77cc-834b-b803d9262032",
+      "chain.step.remaining": 4,
+      "delay.ms": 60_000,
+      "fire.deferred_ms": 60_017,
+      "delegate.delivery": "timer",
+      "delegate.mode": "silent-wake",
+      "reason.preview": "fan out three queries",
+    });
+    expect(span.statusCalls).toEqual([{ status: "OK", message: undefined }]);
+    expect(span.ended).toBe(true);
+  });
+
+  it("carries fire.deferred_ms with Math.floor (integer ms, drift formula consumer-ready)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateFireSpan({
+      chainId: "abc",
+      chainStepRemainingAtDispatch: 1,
+      delegateMode: "normal",
+      delayMs: 1_000,
+      fireDeferredMs: 1_234.9, // floored to 1234
+    });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["fire.deferred_ms"]).toBe(1234);
+  });
+
+  it("clamps negative fireDeferredMs to 0 (defense; should never happen in practice)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateFireSpan({
+      chainId: "abc",
+      chainStepRemainingAtDispatch: 1,
+      delegateMode: "normal",
+      delayMs: 0,
+      fireDeferredMs: -3,
+    });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["fire.deferred_ms"]).toBe(0);
+  });
+
+  it("truncates reason.preview to 80 chars", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateFireSpan({
+      chainId: "abc",
+      chainStepRemainingAtDispatch: 0,
+      delegateMode: "silent",
+      delayMs: 100,
+      fireDeferredMs: 105,
+      reason: "z".repeat(200),
+    });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["reason.preview"]).toBe(
+      "z".repeat(80),
+    );
+  });
+
+  it("clamps negative chainStepRemainingAtDispatch to 0", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateFireSpan({
+      chainId: "abc",
+      chainStepRemainingAtDispatch: -2,
+      delegateMode: "normal",
+      delayMs: 0,
+      fireDeferredMs: 1,
+    });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["chain.step.remaining"]).toBe(0);
+  });
+
+  it("threads each delegateMode through unchanged", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    for (const mode of ["normal", "silent", "silent-wake"] as const) {
+      emitContinuationDelegateFireSpan({
+        chainId: "abc",
+        chainStepRemainingAtDispatch: 1,
+        delegateMode: mode,
+        delayMs: 0,
+        fireDeferredMs: 0,
+      });
+    }
+    expect(
+      spans.map((s) => (s.options?.attributes as ContinuationSpanAttrs)["delegate.mode"]),
+    ).toEqual(["normal", "silent", "silent-wake"]);
+  });
+
+  it("always emits delegate.delivery='timer' as a fixed attr (not arg-driven)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationDelegateFireSpan({
+      chainId: "abc",
+      chainStepRemainingAtDispatch: 0,
+      delegateMode: "normal",
+      delayMs: 0,
+      fireDeferredMs: 0,
+    });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["delegate.delivery"]).toBe(
+      "timer",
+    );
+  });
+
+  it("swallows tracer errors and forwards them to the log callback", () => {
+    const throwing: Tracer = {
+      startSpan() {
+        throw new Error("kaboom-fire");
+      },
+    };
+    setContinuationTracer(throwing);
+    const logged: string[] = [];
+    expect(() =>
+      emitContinuationDelegateFireSpan({
+        chainId: "abc",
+        chainStepRemainingAtDispatch: 0,
+        delegateMode: "normal",
+        delayMs: 0,
+        fireDeferredMs: 0,
+        log: (m) => logged.push(m),
+      }),
+    ).not.toThrow();
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatch(/Failed to emit continuation\.delegate\.fire span/);
+    expect(logged[0]).toContain("kaboom-fire");
+  });
+
+  it("defense-in-depth: undefined chainId no-ops + logs (invariant break must not crash fire-emit)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    const logged: string[] = [];
+    emitContinuationDelegateFireSpan({
+      // Sig says `chainId: string`, but a future invariant break could
+      // let undefined slip through; cast through unknown to simulate.
+      chainId: undefined as unknown as string,
+      chainStepRemainingAtDispatch: 0,
+      delegateMode: "normal",
+      delayMs: 0,
+      fireDeferredMs: 0,
+      log: (m) => logged.push(m),
+    });
+    expect(spans).toHaveLength(0);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatch(/chainId invariant violated/);
+  });
+
+  it("is a no-op against the default noop tracer", () => {
+    resetContinuationTracer();
+    expect(() =>
+      emitContinuationDelegateFireSpan({
+        chainId: "abc",
+        chainStepRemainingAtDispatch: 1,
+        delegateMode: "normal",
+        delayMs: 0,
+        fireDeferredMs: 0,
       }),
     ).not.toThrow();
   });

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -80,14 +80,20 @@ export type ContinuationSpanAttrs = {
    */
   readonly "continuation.disabled"?: boolean;
   /**
-   * Cap-gate that produced a `continuation.disabled` reject. Pinned set:
+   * Gate-axis that produced a `continuation.disabled` reject. Pinned set:
    *   - `"cap.chain"` — `continuationChainCount` reached `maxChainLength`
    *   - `"cap.cost"` — accumulated input+output tokens exceeded `costCapTokens`
-   * Per cohort design (sprites-of-thornfield, 2026-04-27, 🩸): chunk 4 is
-   * scoped to the per-chain (chain/cost) gate family only. Per-turn cap
-   * (`maxDelegatesPerTurn`) is a different cap-axis and lands in chunk 5
-   * with its own sibling seam — don't braid two cap-axes on wiring
-   * proximity. Observers can
+   *   - `"cap.delegates_per_turn"` — per-turn delegate-budget cap (chunk 5a)
+   *   - `"reservation.missing"` — fire-time: reservation already cleared
+   *     (compaction, explicit cancel, session teardown) between
+   *     `setTimeout` arming and callback fire (chunk 5b)
+   *
+   * **Family semantics** (🌻's framing, sprites-of-thornfield 2026-04-27):
+   * the enum captures **anything that prevented follow-through**, not only
+   * cap axes. Cap is one shape of gate; reservation-loss is another. Future
+   * siblings (`reservation.evicted`, `session.gone`, `compaction.cleared`)
+   * slot under the same span name — the family is grammar-defined
+   * (verb-on-gate), not enum-cardinality-defined. Observers can
    * `WHERE name = "continuation.disabled" GROUP BY disabled.reason`.
    */
   readonly "disabled.reason"?: string;
@@ -100,6 +106,22 @@ export type ContinuationSpanAttrs = {
    * rejection rates without parsing other attributes.
    */
   readonly "signal.kind"?: string;
+  /**
+   * #334 chunk 5b — only set on `continuation.delegate.fire` spans.
+   * Wall-clock ms between `setTimeout` arming (immediately before the
+   * timer is scheduled at the dispatch site) and the callback actually
+   * executing. Diverges from `delay.ms` (the requested delay) under
+   * runtime pressure — event-loop blockage, GC pauses, etc.
+   *
+   * **Canonical drift formula** (🌊, sprites-of-thornfield 2026-04-27):
+   * `drift = fire.deferred_ms − delay.ms`. Positive values indicate the
+   * timer fired late under load; near-zero is on-schedule. Pinned in JSDoc
+   * so every consumer doesn't rediscover the formula.
+   *
+   * Integer ms (`Math.floor` at emit-time) so the attr round-trips
+   * cleanly through OTLP without rounding ambiguity.
+   */
+  readonly "fire.deferred_ms"?: number;
 };
 
 /**
@@ -111,6 +133,7 @@ export type ContinuationSpanAttrs = {
 export type ContinuationSpanName =
   | "continuation.work"
   | "continuation.delegate.dispatch"
+  | "continuation.delegate.fire"
   | "continuation.queue.enqueue"
   | "continuation.queue.drain"
   | "continuation.compaction.released"
@@ -377,10 +400,14 @@ export function emitContinuationDelegateSpan(args: {
  * `chain.id` / `chain.step.remaining` / `reason.preview` plumbing. Adds
  * three reject-specific axes:
  *
- *  - `disabled.reason` (`"cap.chain" | "cap.cost" | "cap.delegates_per_turn"`):
- *    which cap-gate produced the reject. Per-chain (chain/cost) gates
- *    landed in chunk 4; per-turn delegate-budget cap landed in chunk 5a
- *    (cohort design 2026-04-27, 🌊): same span name, distinct taxonomy.
+ *  - `disabled.reason` (`"cap.chain" | "cap.cost" |
+ *    "cap.delegates_per_turn" | "reservation.missing"`): which gate
+ *    prevented follow-through. Per-chain (chain/cost) gates landed in
+ *    chunk 4; per-turn delegate-budget cap landed in chunk 5a;
+ *    `reservation.missing` (fire-time reservation already cleared) lands
+ *    in chunk 5b. Family semantics (🌻, 2026-04-27): "anything that
+ *    prevented follow-through," not "cap axes only" — the family is
+ *    grammar-defined (verb-on-gate), not enum-cardinality-defined.
  *  - `signal.kind` (`"bracket-work" | "bracket-delegate" |
  *    "tool-delegate"`): the kind of signal that was rejected.
  *  - `delegate.delivery` / `delegate.mode`: only set when the rejected
@@ -403,7 +430,7 @@ export function emitContinuationDelegateSpan(args: {
 export function emitContinuationDisabledSpan(args: {
   chainId: string | undefined;
   chainStepRemaining: number;
-  disabledReason: "cap.chain" | "cap.cost" | "cap.delegates_per_turn";
+  disabledReason: "cap.chain" | "cap.cost" | "cap.delegates_per_turn" | "reservation.missing";
   signalKind: "bracket-work" | "bracket-delegate" | "tool-delegate";
   delegateDelivery?: "immediate" | "timer" | undefined;
   delegateMode?: string | undefined;
@@ -435,5 +462,101 @@ export function emitContinuationDisabledSpan(args: {
     span.end();
   } catch (err) {
     args.log?.(`Failed to emit continuation.disabled span: ${String(err)}`);
+  }
+}
+
+/**
+ * Emit a `continuation.delegate.fire` span at the runner-side delegate
+ * timer-callback start (#334 Slice 2 chunk 5b). The verb-on-timer
+ * counterpart to `emitContinuationDelegateSpan`'s verb-on-decision: this
+ * span fires at the moment a deferred delegate's `setTimeout` callback
+ * actually runs, so consumers can pair `dispatch`/`fire` events on the
+ * same `chain.id` and observe scheduling drift / fire-time divergences.
+ *
+ * **Callsite invariants** (cohort design, sprites-of-thornfield 2026-04-27):
+ *
+ *  - Emit BEFORE `takeDelayedContinuationReservation` runs — the fire
+ *    event is wall-clock truth ("the timer fired"); whatever happens next
+ *    (spawn, reservation-missing log-and-return) is a separate concern
+ *    and gets its own sibling span (`continuation.disabled` with
+ *    `reason = reservation.missing` for the existing log-and-return
+ *    divergence; future `continuation.delegate.error` for hard faults).
+ *  - `chainId` is **closed-over from dispatch-time** as a captured local
+ *    in the `setTimeout` closure. The helper never re-reads
+ *    `activeSessionEntry?.continuationChainId` at fire-time. This matches
+ *    the no-mint-on-fire invariant and prevents races with compaction or
+ *    session mutation between arm and fire (mirrors chunks 3/4's
+ *    enclosure discipline).
+ *  - `chainId` is **always defined** at delegate-fire time — chain
+ *    reservation mints pre-`setTimeout` (chunk 3 invariant). Sig encodes
+ *    this with the non-optional `string` type. **Defense-in-depth:**
+ *    helper no-ops gracefully (logs + returns) if `undefined` slips
+ *    through anyway, so a future invariant break never crashes
+ *    fire-emit.
+ *  - `delegate.delivery: "timer"` is implicit — fire spans only emit on
+ *    the timer-deferred path (immediate-delivery dispatches don't
+ *    arm a timer, so there's no fire event for them). The helper sets
+ *    the attr internally rather than taking it as an arg.
+ *  - 5b is **instrumentation-of-status-quo only**: the helper does NOT
+ *    re-evaluate any cap (`cap.chain | cap.cost | cap.delegates_per_turn`)
+ *    at fire-time. Fire-time gating is a future-policy seam, deferred to
+ *    a future memo.
+ *
+ * **`chainStepRemainingAtDispatch` provenance** (🌻 dedicated-paragraph
+ * note, sprites-of-thornfield 2026-04-27): this value reflects
+ * **dispatch-time headroom** (reservation snapshot), NOT callback-time
+ * live state. Rationale: trace continuity with the dispatch span (same
+ * `chain.id`, same step counter) so consumers can pair `dispatch` /
+ * `fire` events without reasoning about between-tick mutations. If a
+ * future consumer wants "remaining headroom _at_ fire time," that is a
+ * **separate axis** (provisional name `chain.step.remaining_at_fire`)
+ * and a **separate decision** — do not fold it into this field.
+ *
+ * Wraps tracer interactions in a try/catch and logs via the caller's
+ * `log` callback if provided — the fire path must never block on span
+ * emission.
+ */
+export function emitContinuationDelegateFireSpan(args: {
+  chainId: string;
+  chainStepRemainingAtDispatch: number;
+  delegateMode: "normal" | "silent" | "silent-wake";
+  delayMs: number;
+  fireDeferredMs: number;
+  reason?: string | undefined;
+  log?: (message: string) => void;
+}): void {
+  // Defense-in-depth: invariant says chainId is always defined at
+  // delegate-fire time (chunk 3 mints pre-setTimeout). Sig encodes the
+  // invariant via non-optional `string`, but a future change that lets
+  // `undefined` slip through must NOT crash fire-emit. No-op + log so
+  // the divergence is visible without taking down the timer callback.
+  if (args.chainId === undefined || args.chainId === null) {
+    args.log?.(
+      "Failed to emit continuation.delegate.fire span: chainId invariant violated (undefined)",
+    );
+    return;
+  }
+  try {
+    const reasonPreview = args.reason
+      ? args.reason.length > 80
+        ? args.reason.slice(0, 80)
+        : args.reason
+      : undefined;
+    const attrs: ContinuationSpanAttrs = {
+      "chain.id": args.chainId,
+      "chain.step.remaining": Math.max(0, args.chainStepRemainingAtDispatch),
+      "delay.ms": Math.round(args.delayMs),
+      "fire.deferred_ms": Math.max(0, Math.floor(args.fireDeferredMs)),
+      "delegate.delivery": "timer",
+      "delegate.mode": args.delegateMode,
+      ...(reasonPreview !== undefined && { "reason.preview": reasonPreview }),
+    };
+    const span = activeTracer.startSpan("continuation.delegate.fire", {
+      attributes: attrs,
+    });
+    span.setStatus("OK");
+    span.end();
+  } catch (err) {
+    args.log?.(`Failed to emit continuation.delegate.fire span: ${String(err)}`);
   }
 }


### PR DESCRIPTION
## Summary

Wires the design from [`docs/design/334-slice2-chunk5b-delegate-fire-memo.md`](docs/design/334-slice2-chunk5b-delegate-fire-memo.md). Emits `continuation.delegate.fire` at timer-callback start (BEFORE `takeDelayedContinuationReservation`) at bracket-delegate (~L2358) and tool-delegate (~L2713) sites. Extends `disabled.reason` enum with `reservation.missing` for the existing log-and-return divergence.

- `chainId` closed-over from dispatch-time (`persistedChainIdForTimer`).
- `chainStepRemainingAtDispatch` is a snapshot, not fire-time live state.
- `fire.deferred_ms = Date.now() - armedAt` — wall-clock from `setTimeout`-arm to callback-fire.
- New helper `emitContinuationDelegateFireSpan` mirrors existing helpers' try/catch + `reason.preview` truncation + sparse attrs + defense-in-depth `chainId` undefined no-op.

## Wire-PR framing requirement (verbatim from memo §"Wire-PR framing requirement", 🩸 byte-walk caveat, msg `1498379735493775560`)

The wire PR description **must** carry this distinction explicitly so reviewers don't conflate observed vs introduced behavior:

- **Existing seam (current callback bytes):** `reservation.missing` is the only fire-time divergence today. Current behavior is log-and-return; 5b extends to `fire + disabled (reservation.missing)` instrumentation as **intentional behavioral extension** (more visible, same outcome).
- **NOT introduced by 5b:** fire-time `cap.chain | cap.cost` rechecks. These are a **future policy shape** that may be added later, **not** something the current callback path does. Any `cap.*` reason on `disabled` from 5b's wire is dispatch-time, never fire-time.

The enum extension to 4-value is structural (so future-policy gates have a home if added), but 5b's emission sites are limited to: dispatch-time gate-rejects (existing) + fire-time reservation-missing (new). No fire-time cap-emission introduced.

## Files

- `src/infra/continuation-tracer.ts` — span name union, `disabled.reason` enum extension to 4-value, `fire.deferred_ms` attr, `emitContinuationDelegateFireSpan` helper.
- `src/infra/continuation-tracer.test.ts` — helper unit tests (44 total passing).
- `src/auto-reply/reply/agent-runner.ts` — bracket-delegate + tool-delegate timer-callback wire sites; sibling `continuation.disabled (reason=reservation.missing)` on reservation-missing path.
- `src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts` (new) — integration tests for both wire sites + reservation-missing path (3 tests passing).

## Test plan

- [x] `pnpm test src/infra/continuation-tracer.test.ts` — 44/44 pass
- [x] `pnpm test src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts` — 3/3 pass
- [x] `pnpm tsgo:core` — clean
- [x] `pnpm tsgo:test` — clean
- [x] `pnpm format:check` (touched files) — clean
- [x] `pnpm lint` (touched files) — 0 warnings, 0 errors

Refs #334
