### PR TITLE
docs(swim-37): bump harness README canonical2 base to 47016eb417 (post-chunk-5 stack)

### DIFF
--- a/studies/swim-37/harness/README.md
+++ b/studies/swim-37/harness/README.md
@@ -1,7 +1,7 @@
 # swim-37 integration test harness
 
 **Status:** scaffold. Closes #324 (skeleton); fills out as #366 (Slice 2 spans) lands.
-**Base:** canonical2 = `092f502032f6547380ae5082765dd4ab4d0368bb`
+**Base:** canonical2 = `47016eb417` (post-Slice-2 chunk-5 stack: 5a `6656138126`, chunk-4 `4719e86345`, chunk-3 `3655b0667a`, chunk-5b memo `287d0a5586` + wire `e959d2c177`, runtime-pin drift `01abb3defc`, chunk-5c memo `a13b3baca7` + wire `47016eb417`)
 **Trap-class source:** `cael/swim-37-trap-classes` tip `2adf17448ee`
 
 ## What this is


### PR DESCRIPTION
## Why

`studies/swim-37/harness/README.md` pinned canonical2 base at `092f502032`, which is now ~14 commits stale. The full Slice 2 chunk-5 stack just landed today:

| chunk | role | PR | SHA |
|---|---|---|---|
| 5a | per-turn cap reject reland | #385 | `6656138126` |
| 5b | `delegate.fire` memo | #386 | `287d0a5586` |
| 5b | `delegate.fire` wire | #388 | `e959d2c177` |
| drift | runtime canonical-name pin | #389 | `01abb3defc` |
| 5c | `work.fire` memo | #390 | `a13b3baca7` |
| 5c | `work.fire` wire | #391 | `47016eb417` ← new tip |

The full `continuation.{work,delegate}.{,fire}` primitive quartet plus `continuation.disabled` (chunk-4) is now byte-emitted on canonical2 — meaning the H1+D1 family of `it.todo` entries in `swim-runner.test.ts` can soon be converted to live assertions against an InMemorySpanExporter shim. This README bump is the prep step.

## What

One-line update to the README header pin. Provenance of each landed sub-chunk inlined for forensic clarity (sha-and-PR-number).

## Scope

- Pure documentation. No code touched.
- Behavior unchanged.
- No tests added/modified (deferred to follow-up that wires the InMemorySpanExporter shim).

## Verification

`git diff` shows exactly the README header line change.

Refs #324 #334