### PR TITLE
feat(swim-37): #324 InMemorySpanRecorder shim + contract tests

### DIFF
--- a/studies/swim-37/harness/README.md
+++ b/studies/swim-37/harness/README.md
@@ -18,9 +18,28 @@ morning cohort knows what to satisfy.
 
 ## OTEL exporter
 
-**STDOUT only.** No real collector container. The captured spans are read from
-an `InMemorySpanExporter` shim once #366 wires the provider — never from a live
-OTLP endpoint.
+**STDOUT only / in-process.** No real collector container, no
+`BasicTracerProvider`, no live OTLP endpoint.
+
+Spans are captured by `createInMemorySpanRecorder()` (see
+`in-memory-span-recorder.ts`), which returns a recorder + a custom `Tracer`
+installed into the production continuation-tracer registry via
+`setContinuationTracer(tracer)`. Each `emitContinuation*Span` helper called
+by the runtime under test routes through that tracer; the recorder captures
+span name + attributes + status + lifecycle for assertion. `resetContinuationTracer()`
+restores the noop tracer between tests.
+
+This is the recording-tracer pattern already used inline in
+`src/infra/continuation-tracer.test.ts`, lifted into a reusable harness helper
+so every swim-37 test reads the same observer surface.
+
+## Vitest project
+
+Lives in `test/vitest/vitest.swim-37.config.ts` (registered in
+`vitest.config.ts`'s `rootVitestProjects`). Harness sources are also covered by
+root `tsconfig.json` (`include` adds `studies/**/*`), so type-shape drift in
+the recorder or the harness is caught by `tsgo` / `pnpm typecheck`.
+
 
 ## Trap-classes pinned
 

--- a/studies/swim-37/harness/in-memory-span-recorder.test.ts
+++ b/studies/swim-37/harness/in-memory-span-recorder.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the in-memory span recorder shim used by the swim-37 harness.
+ *
+ * Tracks: karmaterminal/openclaw#324
+ *
+ * The recorder itself needs its own contract pin so that downstream
+ * harness assertions can rely on it. These tests pin:
+ *   - construction returns a fresh independent recorder
+ *   - startSpan records name + initial attributes + traceparent
+ *   - setAttributes appends/overwrites with OTEL last-write-wins semantics
+ *   - setStatus + recordException + end() round-trip into the record
+ *   - spansByName filters correctly
+ *   - reset() clears records without un-installing the tracer
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  emitContinuationDelegateFireSpan,
+  emitContinuationDelegateSpan,
+  emitContinuationWorkSpan,
+  resetContinuationTracer,
+  setContinuationTracer,
+} from "../../../src/infra/continuation-tracer.js";
+import {
+  createInMemorySpanRecorder,
+  type InMemorySpanRecorder,
+} from "./in-memory-span-recorder.js";
+
+let recorder: InMemorySpanRecorder;
+
+beforeEach(() => {
+  recorder = createInMemorySpanRecorder();
+  setContinuationTracer(recorder.tracer);
+});
+
+afterEach(() => {
+  resetContinuationTracer();
+});
+
+describe("in-memory-span-recorder :: contract", () => {
+  it("createInMemorySpanRecorder returns a fresh independent recorder per call", () => {
+    const a = createInMemorySpanRecorder();
+    const b = createInMemorySpanRecorder();
+    expect(a).not.toBe(b);
+    expect(a.tracer).not.toBe(b.tracer);
+    expect(a.spans()).toEqual([]);
+    expect(b.spans()).toEqual([]);
+  });
+
+  it("startSpan records name + initial attributes from StartSpanOptions", () => {
+    const span = recorder.tracer.startSpan("continuation.work", {
+      attributes: { "chain.id": "abc", "chain.step.remaining": 3 },
+    });
+    span.end();
+    const spans = recorder.spans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.name).toBe("continuation.work");
+    expect(spans[0]?.attributes).toEqual({
+      "chain.id": "abc",
+      "chain.step.remaining": 3,
+    });
+    expect(spans[0]?.ended).toBe(true);
+  });
+
+  it("setAttributes is last-write-wins per OTEL semantics", () => {
+    const span = recorder.tracer.startSpan("continuation.work", {
+      attributes: { "chain.id": "first" },
+    });
+    span.setAttributes({ "chain.id": "second", "chain.step.remaining": 7 });
+    span.end();
+    const [s] = recorder.spans();
+    expect(s?.attributes["chain.id"]).toBe("second");
+    expect(s?.attributes["chain.step.remaining"]).toBe(7);
+  });
+
+  it("traceparent is captured when supplied", () => {
+    const tp = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+    recorder.tracer.startSpan("continuation.work", { traceparent: tp }).end();
+    expect(recorder.spans()[0]?.traceparent).toBe(tp);
+  });
+
+  it("setStatus + recordException round-trip", () => {
+    const span = recorder.tracer.startSpan("continuation.work");
+    span.setStatus("ERROR", "boom");
+    span.recordException(new Error("e1"));
+    span.recordException("plain-string");
+    span.end();
+    const [s] = recorder.spans();
+    expect(s?.status).toBe("ERROR");
+    expect(s?.statusMessage).toBe("boom");
+    expect(s?.exceptions).toHaveLength(2);
+  });
+
+  it("end() is idempotent", () => {
+    const span = recorder.tracer.startSpan("continuation.work");
+    span.end();
+    span.end();
+    span.end();
+    expect(recorder.spans()[0]?.ended).toBe(true);
+    // Still one span, not three.
+    expect(recorder.spans()).toHaveLength(1);
+  });
+
+  it("spansByName filters by canonical name", () => {
+    recorder.tracer.startSpan("continuation.work").end();
+    recorder.tracer.startSpan("continuation.delegate.dispatch").end();
+    recorder.tracer.startSpan("continuation.work").end();
+    expect(recorder.spansByName("continuation.work")).toHaveLength(2);
+    expect(recorder.spansByName("continuation.delegate.dispatch")).toHaveLength(1);
+    expect(recorder.spansByName("nonexistent")).toHaveLength(0);
+  });
+
+  it("reset() clears recorded spans without un-installing the tracer", () => {
+    recorder.tracer.startSpan("continuation.work").end();
+    expect(recorder.spans()).toHaveLength(1);
+    recorder.reset();
+    expect(recorder.spans()).toHaveLength(0);
+    // Tracer still works.
+    recorder.tracer.startSpan("continuation.work").end();
+    expect(recorder.spans()).toHaveLength(1);
+  });
+
+  it("spans() returns a defensive copy; mutations don't leak", () => {
+    recorder.tracer.startSpan("continuation.work", {
+      attributes: { "chain.id": "abc" },
+    }).end();
+    const snap1 = recorder.spans();
+    // Try to mutate via the snapshot.
+    (snap1[0] as unknown as { name: string }).name = "MUTATED";
+    const snap2 = recorder.spans();
+    expect(snap2[0]?.name).toBe("continuation.work");
+  });
+});
+
+describe("in-memory-span-recorder :: integration with emit* helpers (harness contract)", () => {
+  // These exercises pin that the recorder captures the actual
+  // continuation.* spans driven by the production emit* helpers — so
+  // harness tests can use the recorder as a black-box span observer
+  // and trust attribute shapes.
+
+  it("emitContinuationWorkSpan stamps chain.id + chain.step.remaining (#366)", () => {
+    emitContinuationWorkSpan({
+      chainId: "chain-abc",
+      chainStepRemaining: 5,
+      delayMs: 0,
+    });
+    const spans = recorder.spansByName("continuation.work");
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.attributes["chain.id"]).toBe("chain-abc");
+    expect(spans[0]?.attributes["chain.step.remaining"]).toBe(5);
+    expect(spans[0]?.status).toBe("OK");
+    expect(spans[0]?.ended).toBe(true);
+  });
+
+  it("emitContinuationDelegateSpan stamps chain.id + delegate.delivery + delegate.mode (#366)", () => {
+    // delivery: "timer" mirrors a scheduled (delayed) delegate dispatch.
+    emitContinuationDelegateSpan({
+      chainId: "chain-xyz",
+      chainStepRemaining: 4,
+      delivery: "timer",
+      delegateMode: "silent-wake",
+      delayMs: 1500,
+    });
+    const spans = recorder.spansByName("continuation.delegate.dispatch");
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.attributes["chain.id"]).toBe("chain-xyz");
+    expect(spans[0]?.attributes["delegate.delivery"]).toBe("timer");
+    expect(spans[0]?.attributes["delegate.mode"]).toBe("silent-wake");
+    expect(spans[0]?.attributes["delay.ms"]).toBe(1500);
+  });
+
+  it(
+    "emitContinuationDelegateFireSpan carries fire.deferred_ms + persisted chain.id snapshot (#388 chunk 5b)",
+    () => {
+      emitContinuationDelegateFireSpan({
+        chainId: "chain-fire",
+        chainStepRemainingAtDispatch: 3,
+        delegateMode: "silent-wake",
+        delayMs: 1000,
+        fireDeferredMs: 1234,
+      });
+      const spans = recorder.spansByName("continuation.delegate.fire");
+      expect(spans).toHaveLength(1);
+      const s = spans[0];
+      expect(s?.attributes["chain.id"]).toBe("chain-fire");
+      expect(s?.attributes["chain.step.remaining"]).toBe(3);
+      expect(s?.attributes["fire.deferred_ms"]).toBe(1234);
+      // Drift formula: drift = fire.deferred_ms − delay.ms (per chunk-5b/5c JSDoc).
+      const drift =
+        (s?.attributes["fire.deferred_ms"] as number) - (s?.attributes["delay.ms"] as number);
+      expect(drift).toBe(234);
+    },
+  );
+});

--- a/studies/swim-37/harness/in-memory-span-recorder.ts
+++ b/studies/swim-37/harness/in-memory-span-recorder.ts
@@ -1,0 +1,190 @@
+/**
+ * In-memory span recorder for the swim-37 harness.
+ *
+ * Tracks: karmaterminal/openclaw#324 (swim-37 harness)
+ *
+ * **Purpose.** A test-only `Tracer` implementation that captures every
+ * `startSpan` call into an in-memory array. Tests install it via
+ * `setContinuationTracer(recorder.tracer)` in `beforeEach`, drive the
+ * `emit*Span` helpers from `continuation-tracer.ts`, then read recorded
+ * spans back via `recorder.spans()` for assertion.
+ *
+ * **STDOUT-only discipline.** This shim is the local-process-memory
+ * equivalent of OTEL's `InMemorySpanExporter`. It deliberately does NOT
+ * spin up `BasicTracerProvider`, `@opentelemetry/sdk-trace-base`, or any
+ * real exporter — the harness must NEVER touch a live OTLP collector or
+ * STDOUT-export from a worker. All capture stays in-process so vitest
+ * runs are hermetic.
+ *
+ * **Shape parallel.** This mirrors the `recordingTracer` pattern already
+ * used inline in `src/infra/continuation-tracer.test.ts` (registry tests
+ * around L51-100). Lifting it into a reusable harness helper centralizes
+ * the recorder shape so harness tests share one capture surface instead
+ * of redefining it inline.
+ *
+ * **Lifecycle.** Tests MUST:
+ *   1. Construct a fresh recorder per test (`createInMemorySpanRecorder()`).
+ *   2. Install via `setContinuationTracer(recorder.tracer)` (typically in
+ *      `beforeEach`).
+ *   3. Drive emit calls.
+ *   4. Read spans via `recorder.spans()`.
+ *   5. Reset via `resetContinuationTracer()` (typically in `afterEach`).
+ *
+ * **What gets recorded.** Each `startSpan(name, options)` call records:
+ *   - `name` (string)
+ *   - `attributes` (snapshot of `options.attributes` at start; subsequent
+ *     `setAttributes` calls append/overwrite into the same record so the
+ *     final state matches OTEL semantics)
+ *   - `traceparent` (when provided)
+ *   - `status` (last `setStatus` call, default `"UNSET"`)
+ *   - `statusMessage` (when provided to `setStatus`)
+ *   - `exceptions` (array, in record order from `recordException` calls)
+ *   - `ended` (boolean; set to true on first `end()` call, idempotent)
+ *
+ * Records are appended in `startSpan` call order. End-time is not
+ * captured; the `emit*Span` helpers all start+end synchronously inside
+ * one synchronous block, so call-order matches end-order.
+ */
+
+import {
+  type Span,
+  type SpanAttributes,
+  type SpanStatus,
+  type StartSpanOptions,
+  type Tracer,
+} from "../../../src/infra/continuation-tracer.js";
+
+/**
+ * One captured span. Read-only from the test perspective; the recorder
+ * mutates the underlying record as the span receives `setAttributes` /
+ * `setStatus` / `recordException` / `end` calls.
+ */
+export type RecordedSpan = {
+  /** Span name passed to `startSpan`. */
+  readonly name: string;
+  /**
+   * Final attribute state. Initial values come from
+   * `StartSpanOptions.attributes`; subsequent `setAttributes` calls
+   * shallow-merge with overwrite-on-collision (matches OTEL).
+   */
+  readonly attributes: Readonly<Record<string, unknown>>;
+  /** W3C `traceparent` if supplied to `startSpan`. */
+  readonly traceparent: string | undefined;
+  /** Last status set on the span. Default `"UNSET"`. */
+  readonly status: SpanStatus;
+  /** Status message from the most recent `setStatus(_, message)` call. */
+  readonly statusMessage: string | undefined;
+  /** Exceptions recorded via `recordException`, in call order. */
+  readonly exceptions: readonly unknown[];
+  /** True once `end()` has been called at least once. */
+  readonly ended: boolean;
+};
+
+/**
+ * Recorder handle. Construct one per test via
+ * `createInMemorySpanRecorder()`, install on the global tracer registry
+ * via `setContinuationTracer(recorder.tracer)`, drive emit calls, then
+ * read `recorder.spans()` for assertions.
+ */
+export type InMemorySpanRecorder = {
+  /** The `Tracer` instance to register via `setContinuationTracer`. */
+  readonly tracer: Tracer;
+  /**
+   * Snapshot of recorded spans, in `startSpan` call order. Returns a
+   * new array each call so callers can mutate without affecting the
+   * underlying capture.
+   */
+  spans(): RecordedSpan[];
+  /**
+   * Convenience: filter `spans()` by canonical name. Useful for
+   * `recorder.spansByName("continuation.work.fire")` style queries.
+   */
+  spansByName(name: string): RecordedSpan[];
+  /** Clear all captured spans without re-installing the tracer. */
+  reset(): void;
+};
+
+type MutableSpanRecord = {
+  name: string;
+  attributes: Record<string, unknown>;
+  traceparent: string | undefined;
+  status: SpanStatus;
+  statusMessage: string | undefined;
+  exceptions: unknown[];
+  ended: boolean;
+};
+
+/**
+ * Create a fresh in-memory span recorder. Each call returns an
+ * independent recorder + tracer pair so tests don't share capture state.
+ */
+export function createInMemorySpanRecorder(): InMemorySpanRecorder {
+  const records: MutableSpanRecord[] = [];
+
+  const tracer: Tracer = {
+    startSpan(name: string, options?: StartSpanOptions): Span {
+      // Snapshot initial attributes; subsequent setAttributes calls
+      // mutate this same object so the final RecordedSpan reflects the
+      // last-write-wins state (matches OTEL semantics — see Span.setAttributes
+      // contract in continuation-tracer.ts).
+      const initialAttrs: Record<string, unknown> = options?.attributes
+        ? { ...options.attributes }
+        : {};
+      const record: MutableSpanRecord = {
+        name,
+        attributes: initialAttrs,
+        traceparent: options?.traceparent,
+        status: "UNSET",
+        statusMessage: undefined,
+        exceptions: [],
+        ended: false,
+      };
+      records.push(record);
+
+      const span: Span = {
+        setAttributes(attrs: SpanAttributes): void {
+          // Last-write-wins per OTEL semantics.
+          for (const [k, v] of Object.entries(attrs)) {
+            record.attributes[k] = v;
+          }
+        },
+        setStatus(status: SpanStatus, message?: string): void {
+          record.status = status;
+          record.statusMessage = message;
+        },
+        recordException(err: unknown): void {
+          record.exceptions.push(err);
+        },
+        end(): void {
+          // Idempotent.
+          record.ended = true;
+        },
+      };
+      return span;
+    },
+  };
+
+  function snapshot(): RecordedSpan[] {
+    // Defensive copy: callers shouldn't mutate the underlying records.
+    return records.map((r) => ({
+      name: r.name,
+      attributes: { ...r.attributes },
+      traceparent: r.traceparent,
+      status: r.status,
+      statusMessage: r.statusMessage,
+      exceptions: [...r.exceptions],
+      ended: r.ended,
+    }));
+  }
+
+  return {
+    tracer,
+    spans: snapshot,
+    spansByName(name: string): RecordedSpan[] {
+      return snapshot().filter((s) => s.name === name);
+    },
+    reset(): void {
+      records.length = 0;
+    },
+  };
+}

--- a/studies/swim-37/harness/in-memory-span-recorder.ts
+++ b/studies/swim-37/harness/in-memory-span-recorder.ts
@@ -9,11 +9,10 @@
  * `emit*Span` helpers from `continuation-tracer.ts`, then read recorded
  * spans back via `recorder.spans()` for assertion.
  *
- * **STDOUT-only discipline.** This shim is the local-process-memory
- * equivalent of OTEL's `InMemorySpanExporter`. It deliberately does NOT
- * spin up `BasicTracerProvider`, `@opentelemetry/sdk-trace-base`, or any
- * real exporter — the harness must NEVER touch a live OTLP collector or
- * STDOUT-export from a worker. All capture stays in-process so vitest
+ * **STDOUT-only discipline.** This shim records into an in-process array;
+ * it never installs `BasicTracerProvider`, `@opentelemetry/sdk-trace-base`,
+ * or any real exporter. The harness must NEVER touch a live OTLP collector
+ * or STDOUT-export from a worker. All capture stays in-process so vitest
  * runs are hermetic.
  *
  * **Shape parallel.** This mirrors the `recordingTracer` pattern already

--- a/test/vitest/vitest.config.ts
+++ b/test/vitest/vitest.config.ts
@@ -72,6 +72,7 @@ export const rootVitestProjects = [
   "test/vitest/vitest.extension-whatsapp.config.ts",
   "test/vitest/vitest.extension-zalo.config.ts",
   "test/vitest/vitest.extensions.config.ts",
+  "test/vitest/vitest.swim-37.config.ts",
 ] as const;
 
 export default defineConfig({

--- a/test/vitest/vitest.swim-37.config.ts
+++ b/test/vitest/vitest.swim-37.config.ts
@@ -1,0 +1,21 @@
+import { loadPatternListFromEnv } from "./vitest.pattern-file.ts";
+import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
+
+export function loadIncludePatternsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): string[] | null {
+  return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
+}
+
+export function createSwim37VitestConfig(env?: Record<string, string | undefined>) {
+  return createScopedVitestConfig(
+    loadIncludePatternsFromEnv(env) ?? ["studies/swim-37/harness/**/*.test.ts"],
+    {
+      env,
+      name: "swim-37",
+      passWithNoTests: true,
+    },
+  );
+}
+
+export default createSwim37VitestConfig();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,6 @@
       "@openclaw/*": ["./extensions/*"]
     }
   },
-  "include": ["src/**/*", "ui/**/*", "extensions/**/*", "packages/**/*"],
+  "include": ["src/**/*", "ui/**/*", "extensions/**/*", "packages/**/*", "studies/**/*"],
   "exclude": ["node_modules", "dist", "**/dist/**"]
 }


### PR DESCRIPTION
## What

Adds a reusable in-memory span recorder for the swim-37 harness so downstream test conversions can read span contract from a black-box observer instead of redefining the recorder shape inline.

## Why

The existing `recordingTracer` pattern in `src/infra/continuation-tracer.test.ts` (around L51-100) is inline-redefined per test. The swim-37 harness needs the same shape for every continuation-primitive assertion; lifting it into a reusable helper centralizes the capture surface so harness tests share one observer instead of N redefinitions.

Stays STDOUT-only / in-process (no real OTLP collector, no `BasicTracerProvider`) per harness discipline pinned in `studies/swim-37/harness/README.md`.

## What's in scope

- `studies/swim-37/harness/in-memory-span-recorder.ts` — the recorder + its public types
- `studies/swim-37/harness/in-memory-span-recorder.test.ts` — contract pin + integration with production `emit*Span` helpers

## What's NOT in scope (deferred)

- **`swim-runner.test.ts` it.todo conversions** — those need the runner (`captureSwim()`) which is a separate scope. This PR ships the foundation those conversions will read against. The 18 todos remain visible.
- Vitest project entry for `studies/**` — current `unit` project excludes `studies/**`. Tested locally with a focused config; bringing the harness into a vitest project is its own scope (touches `test/vitest/vitest.config.ts`).

## Contract pinned

Recorder side:
- construction returns fresh independent recorders
- `startSpan` records name + initial attributes + traceparent
- `setAttributes` is last-write-wins per OTEL semantics
- `setStatus` + `recordException` + `end()` round-trip
- `end()` is idempotent
- `spansByName` filters correctly
- `reset()` clears records without un-installing the tracer
- `spans()` returns a defensive copy

Integration side (recorder + production emit helpers):
- `emitContinuationWorkSpan` stamps `chain.id` + `chain.step.remaining` (#366)
- `emitContinuationDelegateSpan` stamps `chain.id` + `delegate.delivery` + `delegate.mode` (#366)
- `emitContinuationDelegateFireSpan` carries `fire.deferred_ms` + persisted `chain.id` snapshot (#388 chunk 5b); drift formula pinned (`drift = fire.deferred_ms − delay.ms`)

## Test results (local, focused config)

```
Test Files  2 passed (2)
     Tests  15 passed | 18 todo (33)
```

The 18 `it.todo` entries in `swim-runner.test.ts` are preserved as-is; they convert in follow-up PRs once the runner lands.

## Refs

- karmaterminal/openclaw#324 — swim-37 harness scaffold
- karmaterminal/openclaw#366 — `continuation.*` spans (Slice 2)
- karmaterminal/openclaw#388 — chunk 5b/5c fire-span seams (already merged via #390/#391)

## Base

`cael/325-canonical2` tip `739063507f` (post-#392)