### PR TITLE
feat(continuation): #334 Slice 2 chunk 6a — wire continuation.queue.drain span

### DIFF
--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -1,12 +1,14 @@
 import { resolveUserTimezone } from "../../agents/date-time.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { buildChannelSummary } from "../../infra/channel-summary.js";
+import { emitContinuationQueueDrainSpan } from "../../infra/continuation-tracer.js";
 import {
   formatUtcTimestamp,
   formatZonedTimestamp,
   resolveTimezone,
 } from "../../infra/format-time/format-datetime.ts";
 import { drainSystemEventEntries } from "../../infra/system-events.js";
+import { defaultRuntime } from "../../runtime.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -84,6 +86,18 @@ export async function drainFormattedSystemEvents(params: {
 
   const systemLines: string[] = [];
   const queued = drainSystemEventEntries(params.sessionKey);
+  // #334 Slice 2 chunk 6a — emit `continuation.queue.drain` span on every
+  // drain (including empty drains; absence-of-work is still a drain tick).
+  // Best-effort continuation-prefix detection per memo PR #393; structural
+  // traceparent reconstruction belongs to Slice 3's adapter.
+  const drainedContinuationCount = queued.filter((event) =>
+    event.text.startsWith("[continuation:"),
+  ).length;
+  emitContinuationQueueDrainSpan({
+    drainedCount: queued.length,
+    drainedContinuationCount,
+    log: (message) => defaultRuntime.log(message),
+  });
   systemLines.push(
     ...queued.flatMap((event) => {
       const compacted = compactSystemEvent(event.text);

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1065,6 +1065,21 @@ describe("continuation-tracer :: emitContinuationQueueDrainSpan helper (Slice 2 
     expect(attrs["queue.drained_continuation_count"]).toBe(0);
   });
 
+  it("caps drainedContinuationCount by drainedCount (\u2264 invariant defense-in-depth)", () => {
+    // Per \ud83e\ude78's PR #395 byte-walk nit (msg `1498427153543335967`):
+    // wire site already guarantees continuation ≤ total (filter over same array),
+    // but a less-disciplined caller could violate. Helper enforces the invariant.
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationQueueDrainSpan({
+      drainedCount: 2,
+      drainedContinuationCount: 5,
+    });
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["queue.drained_count"]).toBe(2);
+    expect(attrs["queue.drained_continuation_count"]).toBe(2);
+  });
+
   it("floors fractional counts to integers (OTLP integer round-trip)", () => {
     const { tracer, spans } = makeRecordingTracer();
     setContinuationTracer(tracer);

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -3,6 +3,7 @@ import {
   emitContinuationDelegateFireSpan,
   emitContinuationDelegateSpan,
   emitContinuationDisabledSpan,
+  emitContinuationQueueDrainSpan,
   emitContinuationWorkSpan,
   getContinuationTracer,
   noopTracer,
@@ -956,6 +957,152 @@ describe("continuation-tracer :: emitContinuationDelegateFireSpan helper (Slice 
         delegateMode: "normal",
         delayMs: 0,
         fireDeferredMs: 0,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("continuation-tracer :: emitContinuationQueueDrainSpan helper (Slice 2 chunk 6a)", () => {
+  type RecordedSpan = {
+    name: string;
+    options?: StartSpanOptions;
+    setAttributesCalls: SpanAttributes[];
+    statusCalls: Array<{ status: SpanStatus; message?: string }>;
+    exceptionCalls: unknown[];
+    ended: boolean;
+  };
+
+  function makeRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+    const spans: RecordedSpan[] = [];
+    const tracer: Tracer = {
+      startSpan(name, options) {
+        const recorded: RecordedSpan = {
+          name,
+          options,
+          setAttributesCalls: [],
+          statusCalls: [],
+          exceptionCalls: [],
+          ended: false,
+        };
+        spans.push(recorded);
+        const span: Span = {
+          setAttributes(attrs) {
+            recorded.setAttributesCalls.push(attrs);
+          },
+          setStatus(status, message) {
+            recorded.statusCalls.push({ status, message });
+          },
+          recordException(err) {
+            recorded.exceptionCalls.push(err);
+          },
+          end() {
+            recorded.ended = true;
+          },
+        };
+        return span;
+      },
+    };
+    return { tracer, spans };
+  }
+
+  it("emits a continuation.queue.drain span with the canonical attrs", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationQueueDrainSpan({
+      drainedCount: 3,
+      drainedContinuationCount: 1,
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0].name).toBe("continuation.queue.drain");
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["queue.drained_count"]).toBe(3);
+    expect(attrs["queue.drained_continuation_count"]).toBe(1);
+    expect(spans[0].statusCalls).toEqual([{ status: "OK", message: undefined }]);
+    expect(spans[0].ended).toBe(true);
+  });
+
+  it("emits a 0/0 span on empty drain (absence-of-work, not rejection)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationQueueDrainSpan({
+      drainedCount: 0,
+      drainedContinuationCount: 0,
+    });
+    expect(spans).toHaveLength(1);
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["queue.drained_count"]).toBe(0);
+    expect(attrs["queue.drained_continuation_count"]).toBe(0);
+    // No `continuation.disabled` attr on empty drain — drain has no gate.
+    expect(attrs["continuation.disabled"]).toBeUndefined();
+    expect(attrs["disabled.reason"]).toBeUndefined();
+  });
+
+  it("does NOT carry chain.id or chain.step.remaining (multi-chain seam)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationQueueDrainSpan({
+      drainedCount: 5,
+      drainedContinuationCount: 2,
+    });
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["chain.id"]).toBeUndefined();
+    expect(attrs["chain.step.remaining"]).toBeUndefined();
+    expect(attrs["delay.ms"]).toBeUndefined();
+    expect(attrs["fire.deferred_ms"]).toBeUndefined();
+    expect(attrs["delegate.mode"]).toBeUndefined();
+    expect(attrs["signal.kind"]).toBeUndefined();
+  });
+
+  it("clamps negative counts to 0 (defense-in-depth on integer hygiene)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationQueueDrainSpan({
+      drainedCount: -1,
+      drainedContinuationCount: -3,
+    });
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["queue.drained_count"]).toBe(0);
+    expect(attrs["queue.drained_continuation_count"]).toBe(0);
+  });
+
+  it("floors fractional counts to integers (OTLP integer round-trip)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationQueueDrainSpan({
+      drainedCount: 4.7,
+      drainedContinuationCount: 2.9,
+    });
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["queue.drained_count"]).toBe(4);
+    expect(attrs["queue.drained_continuation_count"]).toBe(2);
+  });
+
+  it("swallows tracer errors and forwards them to the log callback", () => {
+    const throwing: Tracer = {
+      startSpan() {
+        throw new Error("kaboom-drain");
+      },
+    };
+    setContinuationTracer(throwing);
+    const logged: string[] = [];
+    expect(() =>
+      emitContinuationQueueDrainSpan({
+        drainedCount: 1,
+        drainedContinuationCount: 0,
+        log: (m) => logged.push(m),
+      }),
+    ).not.toThrow();
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatch(/Failed to emit continuation\.queue\.drain span/);
+    expect(logged[0]).toContain("kaboom-drain");
+  });
+
+  it("is a no-op against the default noop tracer", () => {
+    resetContinuationTracer();
+    expect(() =>
+      emitContinuationQueueDrainSpan({
+        drainedCount: 0,
+        drainedContinuationCount: 0,
       }),
     ).not.toThrow();
   });

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -122,6 +122,27 @@ export type ContinuationSpanAttrs = {
    * cleanly through OTLP without rounding ambiguity.
    */
   readonly "fire.deferred_ms"?: number;
+  /**
+   * #334 chunk 6a — only set on `continuation.queue.drain` spans. Total
+   * count of system-event entries pulled from the substrate queue at this
+   * drain tick (`drainSystemEventEntries(...).length`). Integer ≥ 0.
+   *
+   * Aggregate, not per-event: one `continuation.queue.drain` span per
+   * `drainFormattedSystemEvents` call regardless of how many entries the
+   * pull returned. Per-event surfacing is deferred to OTEL `addEvent` on
+   * the single drain span (Slice 3), not to additional spans.
+   */
+  readonly "queue.drained_count"?: number;
+  /**
+   * #334 chunk 6a — only set on `continuation.queue.drain` spans. Subset
+   * of `queue.drained_count` whose entry text begins with the
+   * continuation-prefix marker (`[continuation:`). Best-effort prefix
+   * match at emit-time; structural `traceparent` reconstruction belongs
+   * to Slice 3's adapter, not Slice 2 instrumentation.
+   *
+   * Always `≤ queue.drained_count`. Integer ≥ 0.
+   */
+  readonly "queue.drained_continuation_count"?: number;
 };
 
 /**
@@ -637,5 +658,56 @@ export function emitContinuationWorkFireSpan(args: {
     span.end();
   } catch (err) {
     args.log?.(`Failed to emit continuation.work.fire span: ${String(err)}`);
+  }
+}
+
+/**
+ * Emit a `continuation.queue.drain` span at the substrate system-events
+ * queue consumer seam (#334 Slice 2 chunk 6a). Fired once per
+ * `drainFormattedSystemEvents` call, regardless of how many entries the
+ * synchronous bulk-pull returned (including empty drains).
+ *
+ * **Cohort 4/4 contract (PR #393 memo, sprites-of-thornfield 2026-04-27):**
+ *  - **Naming:** `continuation.queue.drain` (parallel grammar with
+ *    `continuation.queue.enqueue` — producer-verb / consumer-verb on the
+ *    substrate queue mechanical pair).
+ *  - **Attrs:** `queue.drained_count` (total) and
+ *    `queue.drained_continuation_count` (best-effort continuation-prefix
+ *    subset). NO `chain.id` — the substrate queue is session-scoped and
+ *    multi-chain at drain time; attaching a single `chain.id` would lie.
+ *  - **Live counts (no snapshot):** drain is a single-tick synchronous
+ *    bulk-pull. There is no temporal gap to bridge.
+ *  - **No `disabled` sibling on empty drain:** a 0-count drain is the
+ *    absence of work, not the rejection of work. The
+ *    `continuation.disabled` family is reserved for gates that prevented
+ *    follow-through (cap.*, reservation.missing).
+ *  - **Aggregate emit:** one span per drain call. Per-event recordation,
+ *    if cohort wants it later, slots under OTEL `addEvent` on this single
+ *    span \u2014 NOT additional spans. Deferred to Slice 3.
+ *
+ * Wraps tracer interactions in a try/catch and forwards exceptions to the
+ * caller's `log` callback if provided \u2014 the drain path must never block
+ * on span emission, and must not perturb drain semantics (the span fires
+ * AFTER the drain completes; emit failure is invisible to the consumer).
+ */
+export function emitContinuationQueueDrainSpan(args: {
+  drainedCount: number;
+  drainedContinuationCount: number;
+  log?: (message: string) => void;
+}): void {
+  try {
+    const drainedCount = Math.max(0, Math.floor(args.drainedCount));
+    const drainedContinuationCount = Math.max(0, Math.floor(args.drainedContinuationCount));
+    const attrs: ContinuationSpanAttrs = {
+      "queue.drained_count": drainedCount,
+      "queue.drained_continuation_count": drainedContinuationCount,
+    };
+    const span = activeTracer.startSpan("continuation.queue.drain", {
+      attributes: attrs,
+    });
+    span.setStatus("OK");
+    span.end();
+  } catch (err) {
+    args.log?.(`Failed to emit continuation.queue.drain span: ${String(err)}`);
   }
 }

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -697,7 +697,15 @@ export function emitContinuationQueueDrainSpan(args: {
 }): void {
   try {
     const drainedCount = Math.max(0, Math.floor(args.drainedCount));
-    const drainedContinuationCount = Math.max(0, Math.floor(args.drainedContinuationCount));
+    // Defense-in-depth: cap continuation subset by total drained count.
+    // The wire site at session-system-events.ts already guarantees this
+    // (continuation count is a filter over the same array we measured),
+    // but a less-disciplined caller could violate the `≤` invariant.
+    // Per 🩸's byte-walk on PR #395 (msg `1498427153543335967`).
+    const drainedContinuationCount = Math.min(
+      drainedCount,
+      Math.max(0, Math.floor(args.drainedContinuationCount)),
+    );
     const attrs: ContinuationSpanAttrs = {
       "queue.drained_count": drainedCount,
       "queue.drained_continuation_count": drainedContinuationCount,

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -259,6 +259,73 @@ describe("system events (session routing)", () => {
   });
 });
 
+describe("drainFormattedSystemEvents :: continuation.queue.drain span emission (#334 chunk 6a)", () => {
+  beforeEach(() => {
+    resetSystemEventsForTest();
+  });
+
+  type RecordedSpan = {
+    name: string;
+    attributes?: Record<string, unknown>;
+  };
+
+  async function captureSpansDuringDrain(
+    sessionKey: string,
+    enqueueFn: () => void,
+  ): Promise<RecordedSpan[]> {
+    const tracer = await import("./continuation-tracer.js");
+    const recorded: RecordedSpan[] = [];
+    tracer.setContinuationTracer({
+      startSpan: (name, opts) => {
+        recorded.push({
+          name,
+          attributes: opts?.attributes as Record<string, unknown> | undefined,
+        });
+        return tracer.noopTracer.startSpan(name, opts);
+      },
+    });
+    try {
+      enqueueFn();
+      await drainFormattedEvents(sessionKey);
+    } finally {
+      tracer.resetContinuationTracer();
+    }
+    return recorded.filter((s) => s.name === "continuation.queue.drain");
+  }
+
+  it("emits exactly one continuation.queue.drain span per drain call", async () => {
+    const key = "agent:main:test-queue-drain-span-emit";
+    const drainSpans = await captureSpansDuringDrain(key, () => {
+      enqueueSystemEvent("Node connected", { sessionKey: key });
+    });
+    expect(drainSpans).toHaveLength(1);
+  });
+
+  it("populates queue.drained_count + queue.drained_continuation_count attrs", async () => {
+    const key = "agent:main:test-queue-drain-attrs";
+    const drainSpans = await captureSpansDuringDrain(key, () => {
+      enqueueSystemEvent("[continuation:wake] Turn 1/100. Reason: x", { sessionKey: key });
+      enqueueSystemEvent("Node connected", { sessionKey: key });
+      enqueueSystemEvent("[continuation:delegate-spawned] Tool delegate turn 2", {
+        sessionKey: key,
+      });
+    });
+    expect(drainSpans).toHaveLength(1);
+    expect(drainSpans[0].attributes?.["queue.drained_count"]).toBe(3);
+    expect(drainSpans[0].attributes?.["queue.drained_continuation_count"]).toBe(2);
+  });
+
+  it("emits a 0/0 span on empty drain (absence-of-work, not rejection)", async () => {
+    const key = "agent:main:test-queue-drain-empty";
+    const drainSpans = await captureSpansDuringDrain(key, () => {
+      // intentionally enqueue nothing
+    });
+    expect(drainSpans).toHaveLength(1);
+    expect(drainSpans[0].attributes?.["queue.drained_count"]).toBe(0);
+    expect(drainSpans[0].attributes?.["queue.drained_continuation_count"]).toBe(0);
+  });
+});
+
 describe("isCronSystemEvent", () => {
   it.each([
     "",


### PR DESCRIPTION
Implements the cohort-acked design from memo PR #393 (4/4 approval).

## Memo-locked contract

- **Span name:** `continuation.queue.drain` (already in `ContinuationSpanName` union, forward-declared at substrate landing in chunks 2/3)
- **Attrs:** `queue.drained_count` (total events drained) + `queue.drained_continuation_count` (best-effort `[continuation:` prefix subset)
- **NO `chain.id`** — substrate queue is session-scoped and multi-chain at drain time
- **NO `queue.depth`** — retired during cohort review (🌫 reversal)
- **NO snapshot-vs-live distinction** — drain is synchronous bulk-pull
- **NO `disabled` sibling on empty drain** — 0-count drain is absence-of-work, not rejection
- **Aggregate emit:** one span per `drainFormattedSystemEvents` call

## Files changed

- `src/infra/continuation-tracer.ts` (+72 LOC) — 2 new `ContinuationSpanAttrs` fields, `emitContinuationQueueDrainSpan` helper with full JSDoc pinning Q1-Q5 contract
- `src/auto-reply/reply/session-system-events.ts` (+14 LOC) — emit after `drainSystemEventEntries` returns, best-effort prefix filter for continuation subset
- `src/infra/continuation-tracer.test.ts` (+147 LOC) — 7-test helper block (canonical attrs, empty-drain 0/0, no-chain-id, clamp/floor hygiene, error fallback, no-op tracer)
- `src/infra/system-events.test.ts` (+67 LOC) — 3-test wire-site block (one-span-per-drain, attr round-trip with mixed continuation/non-continuation, empty-drain emit)

**Total: +300 LOC across 4 files.** Pure instrumentation-of-status-quo; no production behavior changes.

## Read-only sites (per memo §Family-Grammar reframed pin)

Per memo PR #393's reframed canonical-pin discipline, this PR does **NOT** touch:
- `src/infra/continuation-tracer.test.ts` canonical-name array (~L141)
- `src/infra/continuation-tracer.test.ts` type-pin loop (~L211)
- `src/infra/continuation-tracer.ts` `ContinuationSpanName` union member ordering

All three names (`continuation.queue.enqueue`, `continuation.queue.drain`, `continuation.compaction.released`) were already pin-asserted at both sites by earlier substrate chunks; touching them is gratuitous churn.

## Test results

- `src/infra/continuation-tracer.test.ts` — **51 pass** (44 pre-existing + 7 new)
- `src/infra/system-events.test.ts` — **31 pass** (28 pre-existing + 3 new)
- `src/auto-reply/reply/session.test.ts` — **75 pass** (regression-clean)
- `src/agents/bash-tools.test.ts` — **28 pass** (regression-clean, exercises drainFormattedSystemEvents indirectly)
- `pnpm lint:core` — **0 errors, 0 warnings** across 7443 files

## Out of scope (explicit per memo)

- Chunk 6b — `continuation.compaction.released` (different mechanical seam: `post-compaction-delegate-dispatch.ts`, separate memo)
- Chunk 6.5 — `continuation.queue.enqueue` (producer-side twin, separate memo with predicate-scope question)

## Seam-reality gaps

None surfaced. The wire site shape, attr surface, and helper signature matched the memo exactly. Best-effort prefix detection on `[continuation:` covers all continuation-bearing system events I could identify in the codebase (chain-hop, delegate-spawned, wake, post-compaction, compaction-delegate-spawned).

Refs #324, #334