### PR TITLE
feat(continuation): #334 Slice 2 chunk 6b — wire continuation.compaction.released span

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -21,6 +21,7 @@ import type { TypingMode } from "../../config/types.js";
 import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.fs.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import {
+  emitContinuationCompactionReleasedSpan,
   emitContinuationDelegateFireSpan,
   emitContinuationDelegateSpan,
   emitContinuationDisabledSpan,
@@ -1944,6 +1945,7 @@ export async function runReplyAgent(params: {
 
       // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {
+        const releasedCount = activeSessionEntry?.pendingPostCompactionDelegates?.length ?? 0;
         await dispatchPostCompactionDelegates({
           cfg,
           compactionCount: count,
@@ -1954,6 +1956,10 @@ export async function runReplyAgent(params: {
           sessionKey,
           sessionStore: activeSessionStore,
           storePath,
+        });
+        emitContinuationCompactionReleasedSpan({
+          releasedCount,
+          log: (message) => defaultRuntime.log(message),
         });
       }
 

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  emitContinuationCompactionReleasedSpan,
   emitContinuationDelegateFireSpan,
   emitContinuationDelegateSpan,
   emitContinuationDisabledSpan,
@@ -221,6 +222,42 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
     ];
     for (const name of names) {
       expect(() => noopTracer.startSpan(name)).not.toThrow();
+    }
+  });
+
+  it("signal.kind canonical values round-trip through the surface (runtime pin)", () => {
+    const canonicalSignalKinds = [
+      "work",
+      "bracket-delegate",
+      "tool-delegate",
+      "compaction-release",
+    ];
+    let captured: SpanAttributes | undefined;
+    setContinuationTracer({
+      startSpan: (_name, opts) => {
+        captured = opts?.attributes;
+        return noopTracer.startSpan(_name);
+      },
+    });
+    for (const kind of canonicalSignalKinds) {
+      getContinuationTracer().startSpan("heartbeat", {
+        attributes: { "signal.kind": kind },
+      });
+      expect(captured?.["signal.kind"]).toBe(kind);
+    }
+  });
+
+  it("signal.kind canonical values are type-compatible with ContinuationSpanAttrs (type-pin)", () => {
+    const values: Array<NonNullable<ContinuationSpanAttrs["signal.kind"]>> = [
+      "work",
+      "bracket-delegate",
+      "tool-delegate",
+      "compaction-release",
+    ];
+    for (const v of values) {
+      const attrs: ContinuationSpanAttrs = { "signal.kind": v };
+      const broad: SpanAttributes = attrs;
+      expect(broad["signal.kind"]).toBe(v);
     }
   });
 });
@@ -1120,5 +1157,112 @@ describe("continuation-tracer :: emitContinuationQueueDrainSpan helper (Slice 2 
         drainedContinuationCount: 0,
       }),
     ).not.toThrow();
+  });
+});
+
+describe("continuation-tracer :: emitContinuationCompactionReleasedSpan helper (Slice 2 chunk 6b)", () => {
+  type RecordedSpan = {
+    name: string;
+    options?: StartSpanOptions;
+    setAttributesCalls: SpanAttributes[];
+    statusCalls: Array<{ status: SpanStatus; message?: string }>;
+    exceptionCalls: unknown[];
+    ended: boolean;
+  };
+
+  function makeRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+    const spans: RecordedSpan[] = [];
+    const tracer: Tracer = {
+      startSpan(name, options) {
+        const recorded: RecordedSpan = {
+          name,
+          options,
+          setAttributesCalls: [],
+          statusCalls: [],
+          exceptionCalls: [],
+          ended: false,
+        };
+        spans.push(recorded);
+        const span: Span = {
+          setAttributes(attrs) {
+            recorded.setAttributesCalls.push(attrs);
+          },
+          setStatus(status, message) {
+            recorded.statusCalls.push({ status, message });
+          },
+          recordException(err) {
+            recorded.exceptionCalls.push(err);
+          },
+          end() {
+            recorded.ended = true;
+          },
+        };
+        return span;
+      },
+    };
+    return { tracer, spans };
+  }
+
+  it("emits a continuation.compaction.released span with canonical attrs (happy path)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationCompactionReleasedSpan({ releasedCount: 3 });
+    expect(spans).toHaveLength(1);
+    const span = spans[0];
+    expect(span.name).toBe("continuation.compaction.released");
+    expect(span.options?.attributes).toEqual({
+      "signal.kind": "compaction-release",
+      "compaction.released": 3,
+    });
+    expect(span.statusCalls).toEqual([{ status: "OK", message: undefined }]);
+    expect(span.ended).toBe(true);
+  });
+
+  it("emits span with compaction.released: 0 on zero-release (compaction event still recorded)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationCompactionReleasedSpan({ releasedCount: 0 });
+    expect(spans).toHaveLength(1);
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["compaction.released"]).toBe(0);
+    expect(attrs["signal.kind"]).toBe("compaction-release");
+  });
+
+  it("floors fractional releasedCount to integer (OTLP integer round-trip)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationCompactionReleasedSpan({ releasedCount: 3.7 });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["compaction.released"]).toBe(3);
+  });
+
+  it("clamps negative releasedCount to 0 (defense-in-depth)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationCompactionReleasedSpan({ releasedCount: -1 });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["compaction.released"]).toBe(0);
+  });
+
+  it("swallows tracer errors and forwards them to the log callback", () => {
+    const throwing: Tracer = {
+      startSpan() {
+        throw new Error("kaboom-compaction");
+      },
+    };
+    setContinuationTracer(throwing);
+    const logged: string[] = [];
+    expect(() =>
+      emitContinuationCompactionReleasedSpan({
+        releasedCount: 1,
+        log: (m) => logged.push(m),
+      }),
+    ).not.toThrow();
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toMatch(/Failed to emit continuation\.compaction\.released span/);
+    expect(logged[0]).toContain("kaboom-compaction");
+  });
+
+  it("is a no-op against the default noop tracer", () => {
+    resetContinuationTracer();
+    expect(() => emitContinuationCompactionReleasedSpan({ releasedCount: 0 })).not.toThrow();
   });
 });

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -98,12 +98,13 @@ export type ContinuationSpanAttrs = {
    */
   readonly "disabled.reason"?: string;
   /**
-   * Signal shape that was rejected. Pinned set:
+   * Signal-family classifier. Pinned set:
    *   - `"bracket-work"` — bracket CONTINUE_WORK signal at the bracket gate
    *   - `"bracket-delegate"` — bracket CONTINUE_DELEGATE signal at the bracket gate
    *   - `"tool-delegate"` — `continue_delegate` tool signal at the tool gate
-   * Lets observers separate self-elected (work) from delegated (delegate)
-   * rejection rates without parsing other attributes.
+   *   - `"compaction-release"` — post-compaction delegates released for dispatch (#334 chunk 6b)
+   * On `continuation.disabled` spans, identifies the rejected signal shape.
+   * On `continuation.compaction.released` spans, classifies the release event.
    */
   readonly "signal.kind"?: string;
   /**
@@ -143,6 +144,18 @@ export type ContinuationSpanAttrs = {
    * Always `≤ queue.drained_count`. Integer ≥ 0.
    */
   readonly "queue.drained_continuation_count"?: number;
+  /**
+   * #334 chunk 6b — only set on `continuation.compaction.released` spans.
+   * Aggregate count of staged post-compaction delegates released for
+   * dispatch by a single auto-compaction event. Snapshotted from
+   * `sessionEntry.pendingPostCompactionDelegates.length` at the moment
+   * `dispatchPostCompactionDelegates` is invoked.
+   *
+   * Integer ≥ 0. May be 0 when auto-compaction occurred but no delegates
+   * were staged (the dispatch still runs to consume staged-but-unflushed
+   * state); the span is still emitted to mark the compaction event itself.
+   */
+  readonly "compaction.released"?: number;
 };
 
 /**
@@ -717,5 +730,41 @@ export function emitContinuationQueueDrainSpan(args: {
     span.end();
   } catch (err) {
     args.log?.(`Failed to emit continuation.queue.drain span: ${String(err)}`);
+  }
+}
+
+/**
+ * Emit a `continuation.compaction.released` span at the agent-runner
+ * post-compaction-delegate dispatch seam (#334 Slice 2 chunk 6b). Fired
+ * once per `autoCompactionCount > 0` branch, after
+ * `dispatchPostCompactionDelegates` returns, with the released-count
+ * snapshotted before the dispatch call.
+ *
+ * Mirrors `emitContinuationQueueDrainSpan` shape — separate-helper rule
+ * (chunk 6a precedent). Integer hygiene (`Math.max(0, Math.floor(...))`)
+ * per chunk-6a defense-in-depth: helper enforces invariant even though
+ * the caller snapshots from a `.length` (structurally non-negative).
+ *
+ * Wraps tracer interactions in a try/catch and forwards exceptions to the
+ * caller's `log` callback if provided — the release path must never block
+ * on span emission.
+ */
+export function emitContinuationCompactionReleasedSpan(args: {
+  releasedCount: number;
+  log?: (message: string) => void;
+}): void {
+  try {
+    const releasedCount = Math.max(0, Math.floor(args.releasedCount));
+    const attrs: ContinuationSpanAttrs = {
+      "signal.kind": "compaction-release",
+      "compaction.released": releasedCount,
+    };
+    const span = activeTracer.startSpan("continuation.compaction.released", {
+      attributes: attrs,
+    });
+    span.setStatus("OK");
+    span.end();
+  } catch (err) {
+    args.log?.(`Failed to emit continuation.compaction.released span: ${String(err)}`);
   }
 }


### PR DESCRIPTION
## Summary

- New `emitContinuationCompactionReleasedSpan` helper in `continuation-tracer.ts` — mirrors chunk 6a's `emitContinuationQueueDrainSpan` shape (try/catch, integer hygiene, log callback)
- New `"compaction.released"?: number` attr on `ContinuationSpanAttrs`; `signal.kind` JSDoc extended to 4-value pinned set (`bracket-work` / `bracket-delegate` / `tool-delegate` / `compaction-release`)
- Single callsite in `agent-runner.ts` after `dispatchPostCompactionDelegates` — snapshot-at-dispatch (`releasedCount` read BEFORE await, span emitted AFTER), eta-expansion `(message) => defaultRuntime.log(message)` per chunk 5c `this`-binding rule

**Design memo:** #396 (merge commit `f767fe21614`)

## Scope

| What | Count |
|------|-------|
| New helper | 1 (`emitContinuationCompactionReleasedSpan`) |
| Callsite | 1 (agent-runner post-compaction block) |
| New attr | 1 (`compaction.released`) |
| signal.kind extension | 3→4 values (+`compaction-release`) |
| New tests | 4 (happy path, zero-release, Math.floor, negative clamp) |
| Pin-loop extensions | 2 (runtime + type-pin for signal.kind) |

**NOT in scope** (per memo discipline): `compaction.id` (6c), per-delegate spans, `chain.id`, cap-gate rechecks.

## 🌫 / 🩸 / 🌻 byte-walk notes

- 🌫 `signal.kind: "compaction-release"` — 4th value, verb-on-event naming parallel to `bracket-delegate` / `tool-delegate`
- 🩸 Unconditional emit when `autoCompactionCount > 0` (Q4) — `compaction.released: 0` is a load-bearing signal
- 🌻 `compaction.id` deferred to 6c per per-chunk single-addition discipline (Q3)

## Test plan

- [x] `pnpm test src/infra/continuation-tracer.test.ts` — 60 tests pass (4 new + 2 pin-loops)
- [x] `pnpm lint:core` — 0 warnings, 0 errors
- [x] `pnpm tsgo:core` — clean
- [x] Pre-existing `extensions/codex` typecheck errors (unrelated `@mariozechner/pi-agent-core` duplicate) — not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)