### PR TITLE
feat(continuation): #334 Slice 2 chunk 6c — signal.kind SSOT + compaction.id cross-cutting attr (release-side wire)

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1959,6 +1959,7 @@ export async function runReplyAgent(params: {
         });
         emitContinuationCompactionReleasedSpan({
           releasedCount,
+          compactionId: count,
           log: (message) => defaultRuntime.log(message),
         });
       }

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  CONTINUATION_SIGNAL_KINDS,
   emitContinuationCompactionReleasedSpan,
   emitContinuationDelegateFireSpan,
   emitContinuationDelegateSpan,
@@ -10,6 +11,8 @@ import {
   noopTracer,
   resetContinuationTracer,
   setContinuationTracer,
+  type ContinuationDisabledSignalKind,
+  type ContinuationSignalKind,
   type ContinuationSpanAttrs,
   type ContinuationSpanName,
   type Span,
@@ -225,13 +228,8 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
     }
   });
 
-  it("signal.kind canonical values round-trip through the surface (runtime pin)", () => {
-    const canonicalSignalKinds = [
-      "work",
-      "bracket-delegate",
-      "tool-delegate",
-      "compaction-release",
-    ];
+  it("signal.kind canonical values round-trip through the surface (runtime pin, SSOT-derived)", () => {
+    // Derived from CONTINUATION_SIGNAL_KINDS SSOT — no inline re-enumeration.
     let captured: SpanAttributes | undefined;
     setContinuationTracer({
       startSpan: (_name, opts) => {
@@ -239,7 +237,7 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
         return noopTracer.startSpan(_name);
       },
     });
-    for (const kind of canonicalSignalKinds) {
+    for (const kind of CONTINUATION_SIGNAL_KINDS) {
       getContinuationTracer().startSpan("heartbeat", {
         attributes: { "signal.kind": kind },
       });
@@ -247,14 +245,9 @@ describe("continuation-tracer :: harness contract pin (#370)", () => {
     }
   });
 
-  it("signal.kind canonical values are type-compatible with ContinuationSpanAttrs (type-pin)", () => {
-    const values: Array<NonNullable<ContinuationSpanAttrs["signal.kind"]>> = [
-      "work",
-      "bracket-delegate",
-      "tool-delegate",
-      "compaction-release",
-    ];
-    for (const v of values) {
+  it("signal.kind canonical values are type-compatible with ContinuationSpanAttrs (type-pin, SSOT-derived)", () => {
+    // Derived from CONTINUATION_SIGNAL_KINDS SSOT — no inline re-enumeration.
+    for (const v of CONTINUATION_SIGNAL_KINDS) {
       const attrs: ContinuationSpanAttrs = { "signal.kind": v };
       const broad: SpanAttributes = attrs;
       expect(broad["signal.kind"]).toBe(v);
@@ -1206,13 +1199,14 @@ describe("continuation-tracer :: emitContinuationCompactionReleasedSpan helper (
   it("emits a continuation.compaction.released span with canonical attrs (happy path)", () => {
     const { tracer, spans } = makeRecordingTracer();
     setContinuationTracer(tracer);
-    emitContinuationCompactionReleasedSpan({ releasedCount: 3 });
+    emitContinuationCompactionReleasedSpan({ releasedCount: 3, compactionId: 1 });
     expect(spans).toHaveLength(1);
     const span = spans[0];
     expect(span.name).toBe("continuation.compaction.released");
     expect(span.options?.attributes).toEqual({
       "signal.kind": "compaction-release",
       "compaction.released": 3,
+      "compaction.id": 1,
     });
     expect(span.statusCalls).toEqual([{ status: "OK", message: undefined }]);
     expect(span.ended).toBe(true);
@@ -1221,11 +1215,12 @@ describe("continuation-tracer :: emitContinuationCompactionReleasedSpan helper (
   it("emits span with compaction.released: 0 on zero-release (compaction event still recorded)", () => {
     const { tracer, spans } = makeRecordingTracer();
     setContinuationTracer(tracer);
-    emitContinuationCompactionReleasedSpan({ releasedCount: 0 });
+    emitContinuationCompactionReleasedSpan({ releasedCount: 0, compactionId: 2 });
     expect(spans).toHaveLength(1);
     const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
     expect(attrs["compaction.released"]).toBe(0);
     expect(attrs["signal.kind"]).toBe("compaction-release");
+    expect(attrs["compaction.id"]).toBe(2);
   });
 
   it("floors fractional releasedCount to integer (OTLP integer round-trip)", () => {
@@ -1264,5 +1259,205 @@ describe("continuation-tracer :: emitContinuationCompactionReleasedSpan helper (
   it("is a no-op against the default noop tracer", () => {
     resetContinuationTracer();
     expect(() => emitContinuationCompactionReleasedSpan({ releasedCount: 0 })).not.toThrow();
+  });
+});
+
+describe("continuation-tracer :: CONTINUATION_SIGNAL_KINDS SSOT pin (Slice 2 chunk 6c §A)", () => {
+  it("SSOT array has exactly 5 members with the canonical values", () => {
+    expect(CONTINUATION_SIGNAL_KINDS).toHaveLength(5);
+    expect([...CONTINUATION_SIGNAL_KINDS]).toEqual([
+      "work",
+      "bracket-work",
+      "bracket-delegate",
+      "tool-delegate",
+      "compaction-release",
+    ]);
+  });
+
+  it("ContinuationSignalKind union covers all SSOT members (type-level pin)", () => {
+    // Compile-time pin: every SSOT member must be assignable to
+    // ContinuationSignalKind. If a member is added to the const array
+    // without updating the derived type, this block would fail typecheck
+    // (the derived type auto-tracks, so this tests the derivation).
+    const kinds: ContinuationSignalKind[] = [...CONTINUATION_SIGNAL_KINDS];
+    expect(kinds).toHaveLength(5);
+  });
+
+  it("ContinuationDisabledSignalKind narrows to exactly 3 disabled-span signal kinds (type-level pin)", () => {
+    // Compile-time pin: Extract<> narrows to exactly the 3 disabled-span signal kinds.
+    const disabled: ContinuationDisabledSignalKind[] = [
+      "bracket-work",
+      "bracket-delegate",
+      "tool-delegate",
+    ];
+    expect(disabled).toHaveLength(3);
+    // Runtime confirmation: these are a subset of CONTINUATION_SIGNAL_KINDS.
+    for (const d of disabled) {
+      expect(CONTINUATION_SIGNAL_KINDS).toContain(d);
+    }
+    // "work" and "compaction-release" must NOT be assignable to ContinuationDisabledSignalKind.
+    // This is a compile-time invariant; the runtime assertion below is a belt-and-suspenders
+    // guard that the Extract<> narrows correctly.
+    const disabledSet = new Set<string>(disabled);
+    expect(disabledSet.has("work")).toBe(false);
+    expect(disabledSet.has("compaction-release")).toBe(false);
+  });
+});
+
+describe("continuation-tracer :: compaction.id cross-cutting attr (Slice 2 chunk 6c §B)", () => {
+  type RecordedSpan = {
+    name: string;
+    options?: StartSpanOptions;
+    setAttributesCalls: SpanAttributes[];
+    statusCalls: Array<{ status: SpanStatus; message?: string }>;
+    exceptionCalls: unknown[];
+    ended: boolean;
+  };
+
+  function makeRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+    const spans: RecordedSpan[] = [];
+    const tracer: Tracer = {
+      startSpan(name, options) {
+        const recorded: RecordedSpan = {
+          name,
+          options,
+          setAttributesCalls: [],
+          statusCalls: [],
+          exceptionCalls: [],
+          ended: false,
+        };
+        spans.push(recorded);
+        const span: Span = {
+          setAttributes(attrs) {
+            recorded.setAttributesCalls.push(attrs);
+          },
+          setStatus(status, message) {
+            recorded.statusCalls.push({ status, message });
+          },
+          recordException(err) {
+            recorded.exceptionCalls.push(err);
+          },
+          end() {
+            recorded.ended = true;
+          },
+        };
+        return span;
+      },
+    };
+    return { tracer, spans };
+  }
+
+  it("happy: compactionId 7 + releasedCount 3 emits both attrs with signal.kind", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationCompactionReleasedSpan({ releasedCount: 3, compactionId: 7 });
+    expect(spans).toHaveLength(1);
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["signal.kind"]).toBe("compaction-release");
+    expect(attrs["compaction.released"]).toBe(3);
+    expect(attrs["compaction.id"]).toBe(7);
+  });
+
+  it("compactionId 1 lower bound emits compaction.id: 1", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationCompactionReleasedSpan({ releasedCount: 1, compactionId: 1 });
+    expect((spans[0].options?.attributes as ContinuationSpanAttrs)["compaction.id"]).toBe(1);
+  });
+
+  it("compactionId 0 ordinal-valid: emits compaction.id: 0 (NOT clamped, NOT dropped)", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    emitContinuationCompactionReleasedSpan({ releasedCount: 0, compactionId: 0 });
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["compaction.id"]).toBe(0);
+    // Signal.kind and compaction.released still present.
+    expect(attrs["signal.kind"]).toBe("compaction-release");
+    expect(attrs["compaction.released"]).toBe(0);
+  });
+
+  it("invariant non-integer: compactionId 7.9 drops attr, logs warning, span survives", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    const logged: string[] = [];
+    emitContinuationCompactionReleasedSpan({
+      releasedCount: 2,
+      compactionId: 7.9,
+      log: (m) => logged.push(m),
+    });
+    expect(spans).toHaveLength(1);
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    // compaction.id dropped due to non-integer invariant.
+    expect(attrs["compaction.id"]).toBeUndefined();
+    // Span still has signal.kind + compaction.released.
+    expect(attrs["signal.kind"]).toBe("compaction-release");
+    expect(attrs["compaction.released"]).toBe(2);
+    // Log callback received warning.
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toContain("invalid compaction.id");
+    expect(logged[0]).toContain("7.9");
+  });
+
+  it("invariant negative: compactionId -1 drops attr, logs warning, span survives", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    const logged: string[] = [];
+    emitContinuationCompactionReleasedSpan({
+      releasedCount: 1,
+      compactionId: -1,
+      log: (m) => logged.push(m),
+    });
+    expect(spans).toHaveLength(1);
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    // compaction.id dropped due to negative invariant.
+    expect(attrs["compaction.id"]).toBeUndefined();
+    // Span survives with signal.kind + compaction.released.
+    expect(attrs["signal.kind"]).toBe("compaction-release");
+    expect(attrs["compaction.released"]).toBe(1);
+    expect(attrs["compaction.id"]).toBeUndefined();
+    // Log callback received warning.
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toContain("invalid compaction.id");
+    expect(logged[0]).toContain("-1");
+  });
+
+  it("compactionId omitted (undefined) silently omits attr without logging", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    const logged: string[] = [];
+    emitContinuationCompactionReleasedSpan({
+      releasedCount: 1,
+      log: (m) => logged.push(m),
+    });
+    expect(spans).toHaveLength(1);
+    const attrs = spans[0].options?.attributes as ContinuationSpanAttrs;
+    expect(attrs["compaction.id"]).toBeUndefined();
+    expect(attrs["signal.kind"]).toBe("compaction-release");
+    // No log emitted — undefined is a valid "not provided" sentinel.
+    expect(logged).toHaveLength(0);
+  });
+
+  // Producer-side invariant pin: incrementRunCompactionCount (session-run-accounting.ts)
+  // returns `number | undefined`. When defined, the value is computed as
+  // `Math.max(0, entry.compactionCount ?? 0) + Math.max(0, amount)` where amount >= 1
+  // at the agent-runner callsite (amount: autoCompactionCount, guarded by `> 0`).
+  // This means defined-return is always integer >= 1.
+  //
+  // The test below pins the helper's acceptance of the producer range, so if the
+  // producer contract ever drifts (e.g. returning 0 from a different path), the
+  // validate-and-drop boundary tests above catch the mismatch.
+  it("producer-side pin: compactionId values in producer range [1..N] are all accepted", () => {
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+    for (const id of [1, 2, 10, 100]) {
+      emitContinuationCompactionReleasedSpan({ releasedCount: 1, compactionId: id });
+    }
+    expect(spans).toHaveLength(4);
+    for (const span of spans) {
+      const attrs = span.options?.attributes as ContinuationSpanAttrs;
+      expect(typeof attrs["compaction.id"]).toBe("number");
+      expect(Number.isInteger(attrs["compaction.id"])).toBe(true);
+      expect(attrs["compaction.id"]).toBeGreaterThanOrEqual(1);
+    }
   });
 });

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -33,6 +33,35 @@ export type SpanAttributeValue =
 export type SpanAttributes = Readonly<Record<string, SpanAttributeValue>>;
 
 /**
+ * Canonical enumeration of all `signal.kind` attribute values emitted by continuation spans.
+ *
+ * SSOT for the value-space. Helper signatures, disabled-helper narrowing, and tests all
+ * derive from this; do not re-enumerate inline.
+ *
+ * @see ContinuationSignalKind — derived union type
+ * @see ContinuationDisabledSignalKind — Extract<>-narrowed subset for `continuation.disabled`
+ */
+export const CONTINUATION_SIGNAL_KINDS = [
+  "work",
+  "bracket-work",
+  "bracket-delegate",
+  "tool-delegate",
+  "compaction-release",
+] as const;
+
+/** Union type derived from {@link CONTINUATION_SIGNAL_KINDS}. */
+export type ContinuationSignalKind = (typeof CONTINUATION_SIGNAL_KINDS)[number];
+
+/**
+ * Subset of {@link ContinuationSignalKind} that may appear on `continuation.disabled` spans.
+ * Excludes `"work"` and `"compaction-release"` per memo §A asymmetry-only-in-disabled-reason rule.
+ */
+export type ContinuationDisabledSignalKind = Extract<
+  ContinuationSignalKind,
+  "bracket-work" | "bracket-delegate" | "tool-delegate"
+>;
+
+/**
  * Normative attribute-key set for continuation spans.
  *
  * **Pinning these names at the shim type — NOT at the adapter — is the
@@ -98,15 +127,14 @@ export type ContinuationSpanAttrs = {
    */
   readonly "disabled.reason"?: string;
   /**
-   * Signal-family classifier. Pinned set:
-   *   - `"bracket-work"` — bracket CONTINUE_WORK signal at the bracket gate
-   *   - `"bracket-delegate"` — bracket CONTINUE_DELEGATE signal at the bracket gate
-   *   - `"tool-delegate"` — `continue_delegate` tool signal at the tool gate
-   *   - `"compaction-release"` — post-compaction delegates released for dispatch (#334 chunk 6b)
+   * Signal-family classifier. Values are pinned by {@link CONTINUATION_SIGNAL_KINDS} (SSOT).
    * On `continuation.disabled` spans, identifies the rejected signal shape.
    * On `continuation.compaction.released` spans, classifies the release event.
+   *
+   * @see CONTINUATION_SIGNAL_KINDS — canonical value list
+   * @see ContinuationDisabledSignalKind — narrowed subset for disabled spans
    */
-  readonly "signal.kind"?: string;
+  readonly "signal.kind"?: ContinuationSignalKind;
   /**
    * #334 chunk 5b — only set on `continuation.delegate.fire` spans.
    * Wall-clock ms between `setTimeout` arming (immediately before the
@@ -156,6 +184,15 @@ export type ContinuationSpanAttrs = {
    * state); the span is still emitted to mark the compaction event itself.
    */
   readonly "compaction.released"?: number;
+  /**
+   * Session-local monotone compaction counter. Join key is `(session.id, compaction.id)`.
+   *
+   * Currently emitted on `continuation.compaction.released` spans. Future post-compaction-mode
+   * `continuation.delegate.fire` spans will join via this attr (chunk 6c memo §B).
+   *
+   * Invariant: integer ≥ 0, monotone-by-construction at producer (incrementRunCompactionCount).
+   */
+  readonly "compaction.id"?: number;
 };
 
 /**
@@ -443,8 +480,8 @@ export function emitContinuationDelegateSpan(args: {
  *    in chunk 5b. Family semantics (🌻, 2026-04-27): "anything that
  *    prevented follow-through," not "cap axes only" — the family is
  *    grammar-defined (verb-on-gate), not enum-cardinality-defined.
- *  - `signal.kind` (`"bracket-work" | "bracket-delegate" |
- *    "tool-delegate"`): the kind of signal that was rejected.
+ *  - `signal.kind` ({@link ContinuationDisabledSignalKind}): the kind of
+ *    signal that was rejected. Values derived from {@link CONTINUATION_SIGNAL_KINDS} SSOT.
  *  - `delegate.delivery` / `delegate.mode`: only set when the rejected
  *    signal was a delegate (bracket-delegate or tool-delegate). Work
  *    signals omit both — they're self-elected single-session and don't
@@ -466,7 +503,7 @@ export function emitContinuationDisabledSpan(args: {
   chainId: string | undefined;
   chainStepRemaining: number;
   disabledReason: "cap.chain" | "cap.cost" | "cap.delegates_per_turn" | "reservation.missing";
-  signalKind: "bracket-work" | "bracket-delegate" | "tool-delegate";
+  signalKind: ContinuationDisabledSignalKind;
   delegateDelivery?: "immediate" | "timer" | undefined;
   delegateMode?: string | undefined;
   reason?: string | undefined;
@@ -751,6 +788,7 @@ export function emitContinuationQueueDrainSpan(args: {
  */
 export function emitContinuationCompactionReleasedSpan(args: {
   releasedCount: number;
+  compactionId?: number;
   log?: (message: string) => void;
 }): void {
   try {
@@ -759,6 +797,20 @@ export function emitContinuationCompactionReleasedSpan(args: {
       "signal.kind": "compaction-release",
       "compaction.released": releasedCount,
     };
+
+    // §B validate-and-drop-with-log: attach compaction.id only when the
+    // producer-side invariant (integer ≥ 0) holds. No clamp, no throw —
+    // the invariant is producer-side; helper is defensive only in the sense
+    // of **not emitting a lie**.
+    const compactionId = args.compactionId;
+    if (typeof compactionId === "number" && Number.isInteger(compactionId) && compactionId >= 0) {
+      (attrs as Record<string, SpanAttributeValue>)["compaction.id"] = compactionId;
+    } else if (compactionId !== undefined) {
+      args.log?.(
+        `emitContinuationCompactionReleasedSpan: invalid compaction.id (${compactionId}); dropping attr`,
+      );
+    }
+
     const span = activeTracer.startSpan("continuation.compaction.released", {
       attributes: attrs,
     });


### PR DESCRIPTION
## Summary

Implements chunk 6c wire from design memo PR #398 (commit `ecb434977c8`), with doc-only follow-up #399.

**Cohort byte-walk: 3/3 on all 10 Q's.**

### §A — signal.kind SSOT pin

- New `CONTINUATION_SIGNAL_KINDS` const array as single source of truth for the 5-member `signal.kind` value-space: `work`, `bracket-work`, `bracket-delegate`, `tool-delegate`, `compaction-release`
- Derived `ContinuationSignalKind` union type (from SSOT array)
- Derived `ContinuationDisabledSignalKind` via `Extract<>` (narrows to 3 disabled-span kinds, excluding `work` and `compaction-release` per memo §A asymmetry rule)
- `ContinuationSpanAttrs["signal.kind"]` type narrowed from `string` to `ContinuationSignalKind`
- `emitContinuationDisabledSpan` `signalKind` param uses `ContinuationDisabledSignalKind`
- Inline JSDoc lists consolidated to `@see CONTINUATION_SIGNAL_KINDS` reference-by-name
- Existing test pins updated to derive from SSOT (no inline re-enumeration)

### §B — compaction.id cross-cutting attr (release-side wire)

- New `"compaction.id"?: number` attr on `ContinuationSpanAttrs` with full JSDoc (join-key contract: `(session.id, compaction.id)`)
- `emitContinuationCompactionReleasedSpan` extended with `compactionId?: number` — **validate-and-drop-with-log** pattern: emits attr when `Number.isInteger(v) && v >= 0`, drops + logs on invariant violation. NO clamp, NO Math.floor, NO throw — helper is defensive only (does not emit a lie)
- Callsite in `agent-runner.ts` updated to pass `compactionId: count` from `incrementRunCompactionCount`

### Test additions (70/70 green)

- **5 new `compaction.id` boundary tests:** happy (id=7), lower-bound (id=1), ordinal-valid zero (id=0), non-integer drop (7.9), negative drop (-1)
- **1 SSOT pin test:** asserts `CONTINUATION_SIGNAL_KINDS` length=5 + `ContinuationDisabledSignalKind` narrows to 3
- **1 producer-side pin:** validates helper accepts all values in producer range [1..N]
- **Existing 6b tests migrated** to pass `compactionId`

### Deferred follow-ups

1. `[6c-followup]` PR: persistence wiring (compaction.id in delegate state for post-compaction-mode `delegate.fire` join-target)
2. Future post-compaction-mode `continuation.delegate.fire` spans will join via `compaction.id` attr

## Test plan

- [x] `pnpm vitest run src/infra/continuation-tracer.test.ts` — 70/70 green
- [x] `pnpm lint:core` — 0 warnings, 0 errors
- [ ] CI on `cael/325-canonical2` base

🤖 Generated with [Claude Code](https://claude.com/claude-code)