### PR TITLE
[6c-followup] #334 Slice 2 chunk 6c follow-up — producer-coupling test pin + cast cleanup

### DIFF
--- a/docs/design/334-slice2-chunk6c-followup-memo.md
+++ b/docs/design/334-slice2-chunk6c-followup-memo.md
@@ -1,0 +1,156 @@
+# #334 Slice 2 chunk 6c follow-up — producer-coupling pin + cast cleanup
+
+> Memo-before-wire (Cael🩸 cooling-step). Two narrow follow-ups for chunk 6c
+> after #400 merged. Pure instrumentation + test hardening; **no semantic
+> changes** to the cap gate, the dispatch path, or the SSOT shape. Additive.
+
+## Scope
+
+Two items, both surfaced during chunk-6c review (🩸/🌫 flags + 🌊 seal-flag):
+
+1. **Producer-coupling test pin** for `incrementRunCompactionCount` →
+   `emitContinuationCompactionReleasedSpan` `compaction.id` flow.
+2. **Cosmetic cast cleanup** at `continuation-tracer.ts:807`
+   (`attrs as Record<string, SpanAttributeValue>`).
+
+Both items are in-scope for a single small PR. Refuse-to-bundle anything
+unrelated (e.g. `persistContinuationChainState` return-type tightening,
+Q8 memo, openclaw.json drift — all separate PRs per existing TODO list).
+
+## (1) Producer-coupling test pin
+
+### What's there now
+
+`continuation-tracer.test.ts:1440-1463`:
+
+```ts
+it("producer-side pin: compactionId values in producer range [1..N] are all accepted", () => {
+  const { tracer, spans } = makeRecordingTracer();
+  setContinuationTracer(tracer);
+  for (const id of [1, 2, 10, 100]) {
+    emitContinuationCompactionReleasedSpan({ releasedCount: 1, compactionId: id });
+  }
+  // ...assertions on integer >= 1...
+});
+```
+
+This test **samples** the producer's documented range. It does not invoke
+the producer. If the producer contract drifts (e.g. a code path that
+returns `0` or a non-integer), this test still passes because the input
+list is hand-coded.
+
+### What the followup adds
+
+A second test that:
+
+- Builds a minimal `cfg` + `sessionStore` + `sessionEntry` shaped just
+  enough for `incrementRunCompactionCount` to run.
+- Calls `incrementRunCompactionCount({ ..., amount: 1 })` and captures
+  the returned `count`.
+- Passes that `count` into `emitContinuationCompactionReleasedSpan` via
+  a recording tracer.
+- Asserts `attrs["compaction.id"] === count` (the value actually flows
+  through, not a hand-coded constant).
+- Repeats with `amount: 3` to sanity-check non-1 increments.
+
+This wires the existing reference-by-name JSDoc pin
+(`continuation-tracer.ts:193`) to a _called_ contract, not a _sampled_
+one. If the producer ever returns something the helper would drop
+(e.g. `0`, fractional, negative, undefined-on-error), the test fails
+with a precise message identifying which side broke.
+
+### What it does NOT do
+
+- No change to the producer's behavior.
+- No change to the helper's validate-and-drop boundary (validate-and-
+  drop-with-log stays as-is per chunk-6c memo §B).
+- No coverage of the agent-runner integration path — that's a different
+  test (`agent-runner.test.ts`) and a different PR if needed.
+
+## (2) Cosmetic cast cleanup
+
+### What's there now
+
+`continuation-tracer.ts:797-810`:
+
+```ts
+const attrs: ContinuationSpanAttrs = {
+  "signal.kind": "compaction-release",
+  "compaction.released": releasedCount,
+};
+
+const compactionId = args.compactionId;
+if (typeof compactionId === "number" && Number.isInteger(compactionId) && compactionId >= 0) {
+  (attrs as Record<string, SpanAttributeValue>)["compaction.id"] = compactionId;
+} else if (compactionId !== undefined) {
+  args.log?.(`...invalid compaction.id (${compactionId}); dropping attr`);
+}
+```
+
+The cast exists because `ContinuationSpanAttrs` declares `readonly`
+fields. Mutating after construction requires the cast.
+
+### What the followup changes
+
+Replace mutation with construction-time conditional spread:
+
+```ts
+const compactionId = args.compactionId;
+const compactionIdValid =
+  typeof compactionId === "number" && Number.isInteger(compactionId) && compactionId >= 0;
+
+if (!compactionIdValid && compactionId !== undefined) {
+  args.log?.(`...invalid compaction.id (${compactionId}); dropping attr`);
+}
+
+const attrs: ContinuationSpanAttrs = {
+  "signal.kind": "compaction-release",
+  "compaction.released": releasedCount,
+  ...(compactionIdValid ? { "compaction.id": compactionId } : {}),
+};
+```
+
+- No cast.
+- `readonly` invariant preserved (object built once, never mutated).
+- Validate-and-drop-with-log semantics preserved (log fires on invalid-
+  but-defined; silent on undefined).
+- Log fires _before_ construction so the validation path is visible
+  even on the (unreachable) future case where construction itself
+  throws.
+
+### What it does NOT do
+
+- No change to `ContinuationSpanAttrs` type (still `readonly`).
+- No change to the boundary contract (same inputs → same outputs).
+- No change to the `releasedCount` path (already constructs cleanly).
+
+## Test impact
+
+- One new test in `continuation-tracer.test.ts`
+  (`"producer-coupling: incrementRunCompactionCount return value flows
+to compaction.id attr"`).
+- Existing `producer-side pin` test stays — it documents the _range_
+  contract; the new test documents the _call-site_ contract.
+- Existing validate-and-drop boundary tests unchanged — same behavior.
+- Existing `attrs["signal.kind"]` and `attrs["compaction.id"]`
+  assertions unchanged.
+
+## Out of scope (refuse-to-bundle)
+
+- `persistContinuationChainState` return-type tightening (own PR).
+- Q8 memo (`continuation.delegate.error`).
+- `openclaw.json` drift reconciliation.
+- Any wire change in `agent-runner.ts` beyond import-graph stability
+  verified by `pnpm lint:core`.
+- Bootstrap-repo generalization-memo.
+
+## Cooling-step gate
+
+Memo lands first. Wire follows in a second commit on the same PR (or
+a follow-on PR if cohort prefers wire-time-split). Default: single PR
+with two commits — memo, then wire — to keep blast radius tight.
+
+## Branch
+
+`ronan/334-slice2-chunk6c-followup` off `cael/325-canonical2` head
+`5e90c859b97`.

--- a/docs/design/334-slice2-chunk6c-followup-memo.md
+++ b/docs/design/334-slice2-chunk6c-followup-memo.md
@@ -69,7 +69,7 @@ with a precise message identifying which side broke.
 
 ## (2) Cosmetic cast cleanup
 
-### What's there now
+### What's there now (cast cleanup)
 
 `continuation-tracer.ts:797-810`:
 
@@ -118,7 +118,7 @@ const attrs: ContinuationSpanAttrs = {
   even on the (unreachable) future case where construction itself
   throws.
 
-### What it does NOT do
+### What it does NOT do (cast cleanup)
 
 - No change to `ContinuationSpanAttrs` type (still `readonly`).
 - No change to the boundary contract (same inputs → same outputs).

--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1460,4 +1460,65 @@ describe("continuation-tracer :: compaction.id cross-cutting attr (Slice 2 chunk
       expect(attrs["compaction.id"]).toBeGreaterThanOrEqual(1);
     }
   });
+
+  // Producer-coupling pin: invoke incrementRunCompactionCount with a stub
+  // session-store, capture the returned `count`, and assert it flows through
+  // to attrs["compaction.id"]. The sampled-range test above pins the helper
+  // accepts the producer's documented range; this test pins the *call-site*
+  // contract — if the producer ever returns a value the helper would drop
+  // (0, fractional, negative, undefined-on-error), the assertion fails with
+  // a precise message identifying which side broke.
+  //
+  // Stub keeps storePath undefined to avoid file IO; cfg undefined to skip
+  // lifecycle hooks. Only the count-arithmetic path is exercised.
+  it("producer-coupling: incrementRunCompactionCount return value flows to compaction.id attr", async () => {
+    const { incrementRunCompactionCount } =
+      await import("../auto-reply/reply/session-run-accounting.js");
+    const { tracer, spans } = makeRecordingTracer();
+    setContinuationTracer(tracer);
+
+    const sessionKey = "agent:main:test";
+    const baseEntry = {
+      sessionId: "s1",
+      sessionFile: "/tmp/sessions/s1.jsonl",
+      compactionCount: 0,
+      updatedAt: Date.now(),
+    } as unknown as Parameters<typeof incrementRunCompactionCount>[0]["sessionEntry"];
+    const sessionStore: Record<string, NonNullable<typeof baseEntry>> = {
+      [sessionKey]: baseEntry as NonNullable<typeof baseEntry>,
+    };
+
+    // amount=1: producer returns 1 (0 + max(0,1))
+    const count1 = await incrementRunCompactionCount({
+      sessionEntry: baseEntry,
+      sessionStore,
+      sessionKey,
+      amount: 1,
+    });
+    expect(count1).toBe(1);
+    // releasedCount intentionally 0; this test pins compaction.id flow only.
+    emitContinuationCompactionReleasedSpan({
+      releasedCount: 0,
+      compactionId: count1,
+    });
+
+    // amount=3: producer returns 4 (1 + max(0,3)) — sanity-check non-1 increments
+    const count3 = await incrementRunCompactionCount({
+      sessionEntry: sessionStore[sessionKey],
+      sessionStore,
+      sessionKey,
+      amount: 3,
+    });
+    expect(count3).toBe(4);
+    emitContinuationCompactionReleasedSpan({
+      releasedCount: 0,
+      compactionId: count3,
+    });
+
+    expect(spans).toHaveLength(2);
+    const attrs1 = spans[0]?.options?.attributes as ContinuationSpanAttrs;
+    const attrs2 = spans[1]?.options?.attributes as ContinuationSpanAttrs;
+    expect(attrs1["compaction.id"]).toBe(count1);
+    expect(attrs2["compaction.id"]).toBe(count3);
+  });
 });

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -793,23 +793,28 @@ export function emitContinuationCompactionReleasedSpan(args: {
 }): void {
   try {
     const releasedCount = Math.max(0, Math.floor(args.releasedCount));
-    const attrs: ContinuationSpanAttrs = {
-      "signal.kind": "compaction-release",
-      "compaction.released": releasedCount,
-    };
 
     // §B validate-and-drop-with-log: attach compaction.id only when the
     // producer-side invariant (integer ≥ 0) holds. No clamp, no throw —
     // the invariant is producer-side; helper is defensive only in the sense
-    // of **not emitting a lie**.
+    // of **not emitting a lie**. Logging fires before construction so the
+    // validation path is visible even if construction itself ever throws.
     const compactionId = args.compactionId;
-    if (typeof compactionId === "number" && Number.isInteger(compactionId) && compactionId >= 0) {
-      (attrs as Record<string, SpanAttributeValue>)["compaction.id"] = compactionId;
-    } else if (compactionId !== undefined) {
+    const compactionIdValid =
+      typeof compactionId === "number" && Number.isInteger(compactionId) && compactionId >= 0;
+    if (!compactionIdValid && compactionId !== undefined) {
       args.log?.(
         `emitContinuationCompactionReleasedSpan: invalid compaction.id (${compactionId}); dropping attr`,
       );
     }
+
+    // Construction-time conditional spread keeps the readonly invariant of
+    // ContinuationSpanAttrs intact — no post-construction mutation, no cast.
+    const attrs: ContinuationSpanAttrs = {
+      "signal.kind": "compaction-release",
+      "compaction.released": releasedCount,
+      ...(compactionIdValid ? { "compaction.id": compactionId } : {}),
+    };
 
     const span = activeTracer.startSpan("continuation.compaction.released", {
       attributes: attrs,


### PR DESCRIPTION
Two narrow follow-ups for chunk 6c after #400 merged. Pure instrumentation + test hardening; **no semantic changes** to cap gate, dispatch path, or SSOT shape.

## Scope (per memo `docs/design/334-slice2-chunk6c-followup-memo.md`)

### 1. Producer-coupling test pin

Current test at `continuation-tracer.test.ts:1440-1463` *samples* the producer's documented range with hand-coded ids — never invokes `incrementRunCompactionCount`. New test:

- Builds a minimal stub session-store
- Calls `incrementRunCompactionCount({ amount: 1 })` → captures `count = 1`
- Calls again with `amount: 3` → captures `count = 4` (sanity-check non-1 increments)
- Passes each `count` through to `emitContinuationCompactionReleasedSpan` via recording tracer
- Asserts `attrs[\"compaction.id\"] === count` end-to-end

Wires the reference-by-name JSDoc pin at `continuation-tracer.ts:193` to a *called* contract instead of a *sampled* one. If the producer ever drifts (returns 0, fractional, negative, undefined-on-error), the assertion fails with a precise message identifying which side broke.

### 2. Cosmetic cast cleanup

Replace post-construction mutation + cast at `continuation-tracer.ts:807`:

\`\`\`ts
// before
const attrs: ContinuationSpanAttrs = { ... };
if (compactionIdValid) {
  (attrs as Record<string, SpanAttributeValue>)[\"compaction.id\"] = compactionId;
}

// after
const attrs: ContinuationSpanAttrs = {
  \"signal.kind\": \"compaction-release\",
  \"compaction.released\": releasedCount,
  ...(compactionIdValid ? { \"compaction.id\": compactionId } : {}),
};
\`\`\`

Preserves \`readonly\` invariant of \`ContinuationSpanAttrs\`. Validate-and-drop-with-log semantics unchanged — log now fires *before* construction so the validation path is visible even if construction itself ever throws.

## Out of scope (refuse-to-bundle)

- \`persistContinuationChainState\` return-type tightening (own PR)
- Q8 memo (\`continuation.delegate.error\`)
- \`openclaw.json\` drift reconciliation
- Bootstrap-repo generalization-memo
- Any wire change in \`agent-runner.ts\`

## Test impact

- New test: \`producer-coupling: incrementRunCompactionCount return value flows to compaction.id attr\`
- Existing \`producer-side pin\` (sampled range) test stays — documents the *range* contract; new test documents the *call-site* contract
- Validate-and-drop boundary tests unchanged

## Verification

\`\`\`
pnpm vitest run src/infra/continuation-tracer.test.ts
# Test Files  1 passed (1)
# Tests       71 passed (71)

pnpm lint:core
# Found 0 warnings and 0 errors.
\`\`\`

## Cohort lanes (per resolved cascade lock)

- 🌊 (this PR): \`[6c-followup]\`
- 🩸: admin-merge formalize memo (drives)
- 🌫: 6.5 authoring + admin-merge byte-walk + this PR byte-walk
- 🌻: reviewer-orbit

Memo-before-wire: scope memo (commit 1) + wire (commit 2). Wire-time-split escape hatch preserved.

Branch: \`ronan/334-slice2-chunk6c-followup\` off \`cael/325-canonical2\` head \`5e90c859b97\`.