### PR TITLE
fix(copilot): isolate bearer cache per auth profile

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1625,8 +1625,14 @@ export const registerTelegramHandlers = ({
             try {
               await updateSessionStore(storePath, (store) => {
                 const sessionKey = sessionState.sessionKey;
-                const entry = store[sessionKey] ?? {};
-                store[sessionKey] = entry;
+                const resolved = resolveSessionStoreEntry({ store, sessionKey });
+                const entry =
+                  resolved.existing ??
+                  ({} as Parameters<typeof applyModelOverrideToSessionEntry>[0]["entry"]);
+                store[resolved.normalizedKey] = entry;
+                for (const legacyKey of resolved.legacyKeys) {
+                  delete store[legacyKey];
+                }
                 applyModelOverrideToSessionEntry({
                   entry,
                   selection: {

--- a/extensions/whatsapp/src/auto-reply/heartbeat-runner.runtime.ts
+++ b/extensions/whatsapp/src/auto-reply/heartbeat-runner.runtime.ts
@@ -4,6 +4,7 @@ export {
   loadConfig,
   loadSessionStore,
   resolveSessionKey,
+  resolveSessionStoreEntry,
   resolveStorePath,
   updateSessionStore,
 } from "openclaw/plugin-sdk/config-runtime";

--- a/extensions/whatsapp/src/auto-reply/heartbeat-runner.ts
+++ b/extensions/whatsapp/src/auto-reply/heartbeat-runner.ts
@@ -20,6 +20,7 @@ import {
   resolveIndicatorType,
   resolveSendableOutboundReplyParts,
   resolveSessionKey,
+  resolveSessionStoreEntry,
   resolveStorePath,
   resolveWhatsAppHeartbeatRecipients,
   sendMessageWhatsApp,
@@ -97,19 +98,27 @@ export async function runWebHeartbeatOnce(opts: {
   if (sessionId) {
     const storePath = resolveStorePath(cfg.session?.store);
     const store = loadSessionStore(storePath);
-    const current = store[sessionKey] ?? {};
-    store[sessionKey] = {
+    const memResolved = resolveSessionStoreEntry({ store, sessionKey });
+    const current = memResolved.existing ?? {};
+    store[memResolved.normalizedKey] = {
       ...current,
       sessionId,
       updatedAt: Date.now(),
     };
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete store[legacyKey];
+    }
     await updateSessionStore(storePath, (nextStore) => {
-      const nextCurrent = nextStore[sessionKey] ?? current;
-      nextStore[sessionKey] = {
+      const resolved = resolveSessionStoreEntry({ store: nextStore, sessionKey });
+      const nextCurrent = resolved.existing ?? current;
+      nextStore[resolved.normalizedKey] = {
         ...nextCurrent,
         sessionId,
         updatedAt: Date.now(),
       };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete nextStore[legacyKey];
+      }
     });
   }
   const sessionSnapshot = getSessionSnapshot(cfg, to, true, { sessionKey });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -37,12 +37,19 @@ export async function clearSessionAuthProfileOverride(params: {
   delete sessionEntry.authProfileOverrideSource;
   delete sessionEntry.authProfileOverrideCompactionCount;
   sessionEntry.updatedAt = Date.now();
-  sessionStore[sessionKey] = sessionEntry;
+  const runtime = await loadSessionStoreRuntime();
+  const memResolved = runtime.resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+  sessionStore[memResolved.normalizedKey] = sessionEntry;
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
   if (storePath) {
-    await (
-      await loadSessionStoreRuntime()
-    ).updateSessionStore(storePath, (store) => {
-      store[sessionKey] = sessionEntry;
+    await runtime.updateSessionStore(storePath, (store) => {
+      const resolved = runtime.resolveSessionStoreEntry({ store, sessionKey });
+      store[resolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     });
   }
 }
@@ -159,12 +166,19 @@ export async function resolveSessionAuthProfileOverride(params: {
     sessionEntry.authProfileOverrideSource = "auto";
     sessionEntry.authProfileOverrideCompactionCount = compactionCount;
     sessionEntry.updatedAt = Date.now();
-    sessionStore[sessionKey] = sessionEntry;
+    const runtime = await loadSessionStoreRuntime();
+    const memResolved = runtime.resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+    sessionStore[memResolved.normalizedKey] = sessionEntry;
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
     if (storePath) {
-      await (
-        await loadSessionStoreRuntime()
-      ).updateSessionStore(storePath, (store) => {
-        store[sessionKey] = sessionEntry;
+      await runtime.updateSessionStore(storePath, (store) => {
+        const resolved = runtime.resolveSessionStoreEntry({ store, sessionKey });
+        store[resolved.normalizedKey] = sessionEntry;
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
       });
     }
   }

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -1,5 +1,6 @@
 import {
   mergeSessionEntry,
+  resolveSessionStoreEntry,
   setSessionRuntimeModel,
   type SessionEntry,
   updateSessionStore,
@@ -71,7 +72,8 @@ export async function updateSessionStoreAfterAgentRun(params: {
       allowAsyncLoad: false,
     }) ?? DEFAULT_CONTEXT_TOKENS;
 
-  const entry = sessionStore[sessionKey] ?? {
+  const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+  const entry = memResolved.existing ?? {
     sessionId,
     updatedAt: Date.now(),
   };
@@ -139,9 +141,16 @@ export async function updateSessionStoreAfterAgentRun(params: {
     next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;
   }
   const persisted = await updateSessionStore(storePath, (store) => {
-    const merged = mergeSessionEntry(store[sessionKey], next);
-    store[sessionKey] = merged;
+    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    const merged = mergeSessionEntry(resolved.existing, next);
+    store[resolved.normalizedKey] = merged;
+    for (const legacyKey of resolved.legacyKeys) {
+      delete store[legacyKey];
+    }
     return merged;
   });
-  sessionStore[sessionKey] = persisted;
+  sessionStore[memResolved.normalizedKey] = persisted;
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
 }

--- a/src/agents/github-copilot-token.test.ts
+++ b/src/agents/github-copilot-token.test.ts
@@ -47,6 +47,45 @@ describe("resolveCopilotApiToken", () => {
     expect(result.expiresAt).toBe(12_345_678_901_000);
   });
 
+  it("keys cache paths by auth profile so named profiles do not collapse", async () => {
+    const loadJsonFileImpl = vi.fn<(path: string) => unknown>(() => undefined);
+    const saveJsonFileImpl = vi.fn<(path: string, value: unknown) => void>(() => undefined);
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        token: "copilot-token",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    }));
+    const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" } as NodeJS.ProcessEnv;
+
+    await resolveCopilotApiToken({
+      githubToken: "github-token-a",
+      profileId: "github-copilot:github",
+      env,
+      loadJsonFileImpl,
+      saveJsonFileImpl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await resolveCopilotApiToken({
+      githubToken: "github-token-b",
+      profileId: "github-copilot:pool-1",
+      env,
+      loadJsonFileImpl,
+      saveJsonFileImpl,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(loadJsonFileImpl.mock.calls.map(([cachePath]) => cachePath)).toEqual([
+      "/tmp/openclaw-state/credentials/github-copilot.github-copilot-github.token.json",
+      "/tmp/openclaw-state/credentials/github-copilot.github-copilot-pool-1.token.json",
+    ]);
+    expect(saveJsonFileImpl.mock.calls.map(([cachePath]) => cachePath)).toEqual([
+      "/tmp/openclaw-state/credentials/github-copilot.github-copilot-github.token.json",
+      "/tmp/openclaw-state/credentials/github-copilot.github-copilot-pool-1.token.json",
+    ]);
+  });
+
   it("sends IDE headers when exchanging the GitHub token", async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: true,

--- a/src/agents/github-copilot-token.ts
+++ b/src/agents/github-copilot-token.ts
@@ -15,8 +15,18 @@ export type CachedCopilotToken = {
   updatedAt: number;
 };
 
-function resolveCopilotTokenCachePath(env: NodeJS.ProcessEnv = process.env) {
-  return path.join(resolveStateDir(env), "credentials", "github-copilot.token.json");
+function normalizeCopilotProfileCacheKey(profileId: string | undefined): string {
+  return normalizeLowercaseStringOrEmpty(profileId)
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function resolveCopilotTokenCachePath(env: NodeJS.ProcessEnv = process.env, profileId?: string) {
+  const profileKey = normalizeCopilotProfileCacheKey(profileId);
+  const filename = profileKey
+    ? `github-copilot.${profileKey}.token.json`
+    : "github-copilot.token.json";
+  return path.join(resolveStateDir(env), "credentials", filename);
 }
 
 function isTokenUsable(cache: CachedCopilotToken, now = Date.now()): boolean {
@@ -104,6 +114,7 @@ export function deriveCopilotApiBaseUrlFromToken(token: string): string | null {
 
 export async function resolveCopilotApiToken(params: {
   githubToken: string;
+  profileId?: string;
   env?: NodeJS.ProcessEnv;
   fetchImpl?: typeof fetch;
   cachePath?: string;
@@ -116,7 +127,7 @@ export async function resolveCopilotApiToken(params: {
   baseUrl: string;
 }> {
   const env = params.env ?? process.env;
-  const cachePath = params.cachePath?.trim() || resolveCopilotTokenCachePath(env);
+  const cachePath = params.cachePath?.trim() || resolveCopilotTokenCachePath(env, params.profileId);
   const loadJsonFileFn = params.loadJsonFileImpl ?? loadJsonFile;
   const saveJsonFileFn = params.saveJsonFileImpl ?? saveJsonFile;
   const cached = loadJsonFileFn(cachePath) as CachedCopilotToken | undefined;

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -53,6 +53,15 @@ vi.mock("./model-selection.js", () => ({
 vi.mock("../config/sessions/store.js", () => ({
   loadSessionStore: (...args: unknown[]) => state.loadSessionStoreMock(...args),
   updateSessionStore: (...args: unknown[]) => state.updateSessionStoreMock(...args),
+  // Stubbed for swim-35/A1: identity-style resolver. The real impl applies
+  // session-key normalization; tests don't exercise the legacy-key cleanup paths.
+  resolveSessionStoreEntry: ({
+    store,
+    sessionKey,
+  }: {
+    store: Record<string, unknown>;
+    sessionKey: string;
+  }) => ({ normalizedKey: sessionKey, existing: store[sessionKey], legacyKeys: [] }),
 }));
 
 vi.mock("../config/sessions/paths.js", () => ({
@@ -63,6 +72,14 @@ vi.mock("../config/sessions.js", () => ({
   loadSessionStore: (...args: unknown[]) => state.loadSessionStoreMock(...args),
   resolveStorePath: (...args: unknown[]) => state.resolveStorePathMock(...args),
   updateSessionStore: (...args: unknown[]) => state.updateSessionStoreMock(...args),
+  // Stubbed for swim-35/A1: identity-style resolver. See store.js mock above.
+  resolveSessionStoreEntry: ({
+    store,
+    sessionKey,
+  }: {
+    store: Record<string, unknown>;
+    sessionKey: string;
+  }) => ({ normalizedKey: sessionKey, existing: store[sessionKey], legacyKeys: [] }),
 }));
 
 async function loadModule() {

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -1,5 +1,9 @@
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { loadSessionStore, updateSessionStore } from "../config/sessions/store.js";
+import {
+  loadSessionStore,
+  resolveSessionStoreEntry,
+  updateSessionStore,
+} from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
@@ -218,9 +222,14 @@ export async function clearLiveModelSwitchPending(params: {
     return;
   }
   await updateSessionStore(storePath, (store) => {
-    const entry = store[sessionKey];
+    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    const entry = resolved.existing;
     if (entry) {
       delete entry.liveModelSwitchPending;
+      store[resolved.normalizedKey] = entry;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     }
   });
 }

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -28,6 +28,7 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
+import { buildCopilotIdeHeaders } from "../copilot-dynamic-headers.js";
 import { isTimeoutError } from "../failover-error.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -233,7 +234,11 @@ async function resolveModelAuth(
       reason: `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
     };
   }
-  return { ok: true, apiKey: requestAuth.apiKey, headers: requestAuth.headers };
+  const headers =
+    model.provider === "github-copilot"
+      ? { ...buildCopilotIdeHeaders(), ...requestAuth.headers }
+      : requestAuth.headers;
+  return { ok: true, apiKey: requestAuth.apiKey, headers };
 }
 
 function clampNonNegativeInt(value: unknown, fallback: number): number {

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -101,11 +101,13 @@ async function setRuntimeApiKeyForCompletion(params: {
   authStorage: SimpleCompletionAuthStorage;
   model: Model<Api>;
   apiKey: string;
+  profileId?: string;
 }): Promise<CompletionRuntimeCredential> {
   if (params.model.provider === "github-copilot") {
     const { resolveCopilotApiToken } = await import("./github-copilot-token.js");
     const copilotToken = await resolveCopilotApiToken({
       githubToken: params.apiKey,
+      profileId: params.profileId,
     });
     params.authStorage.setRuntimeApiKey(params.model.provider, copilotToken.token);
     return {
@@ -177,6 +179,7 @@ export async function prepareSimpleCompletionModel(params: {
       authStorage: resolved.authStorage,
       model: resolved.model,
       apiKey: rawApiKey,
+      profileId: auth.profileId ?? params.profileId,
     });
     resolvedApiKey = runtimeCredential.apiKey;
     const runtimeBaseUrl = runtimeCredential.baseUrl?.trim();

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -4,13 +4,13 @@ import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
   resolveAgentIdFromSessionKey,
+  resolveSessionStoreEntry,
   resolveStorePath,
   updateSessionStore,
   type SessionEntry,
 } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { defaultRuntime } from "../runtime.js";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { type SubagentRunOutcome } from "./subagent-announce-output.js";
 import { SUBAGENT_ENDED_REASON_ERROR } from "./subagent-lifecycle-events.js";
 import { runOutcomesEqual } from "./subagent-registry-completion.js";
@@ -74,17 +74,8 @@ export function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit
 }
 
 function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
-  const direct = store[sessionKey];
-  if (direct) {
-    return direct;
-  }
-  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
-  for (const [key, entry] of Object.entries(store)) {
-    if (normalizeLowercaseStringOrEmpty(key) === normalized) {
-      return entry;
-    }
-  }
-  return undefined;
+  const resolved = resolveSessionStoreEntry({ store, sessionKey });
+  return resolved.existing;
 }
 
 export async function persistSubagentSessionTiming(entry: SubagentRunRecord) {
@@ -106,7 +97,8 @@ export async function persistSubagentSessionTiming(entry: SubagentRunRecord) {
   const status = resolveSubagentSessionStatus(entry);
 
   await updateSessionStore(storePath, (store) => {
-    const sessionEntry = findSessionEntryByKey(store, childSessionKey);
+    const resolved = resolveSessionStoreEntry({ store, sessionKey: childSessionKey });
+    const sessionEntry = resolved.existing;
     if (!sessionEntry) {
       return;
     }
@@ -133,6 +125,13 @@ export async function persistSubagentSessionTiming(entry: SubagentRunRecord) {
       sessionEntry.status = status;
     } else {
       delete sessionEntry.status;
+    }
+
+    // Re-anchor under normalizedKey and clean up any legacy duplicates so
+    // that future reads don't pick the wrong copy.
+    store[resolved.normalizedKey] = sessionEntry;
+    for (const legacyKey of resolved.legacyKeys) {
+      delete store[legacyKey];
     }
   });
 }

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -57,6 +57,16 @@ vi.mock("../config/sessions.js", () => ({
   resolveAgentIdFromSessionKey: mocks.resolveAgentIdFromSessionKey,
   resolveStorePath: mocks.resolveStorePath,
   updateSessionStore: mocks.updateSessionStore,
+  // Stubbed for swim-35/A1: identity-style resolver returns normalizedKey=sessionKey,
+  // existing=store[sessionKey], no legacyKeys. The real impl applies session-key
+  // normalization; this test's session-key fixtures are already in canonical form.
+  resolveSessionStoreEntry: ({
+    store,
+    sessionKey,
+  }: {
+    store: Record<string, unknown>;
+    sessionKey: string;
+  }) => ({ normalizedKey: sessionKey, existing: store[sessionKey], legacyKeys: [] }),
 }));
 
 vi.mock("../sessions/session-lifecycle-events.js", () => ({

--- a/src/auto-reply/reply/abort-cutoff.runtime.ts
+++ b/src/auto-reply/reply/abort-cutoff.runtime.ts
@@ -1,4 +1,4 @@
-import { updateSessionStore } from "../../config/sessions/store.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { applyAbortCutoffToSessionEntry, hasAbortCutoff } from "./abort-cutoff.js";
 
@@ -15,17 +15,27 @@ export async function clearAbortCutoffInSessionRuntime(params: {
 
   applyAbortCutoffToSessionEntry(sessionEntry, undefined);
   sessionEntry.updatedAt = Date.now();
-  sessionStore[sessionKey] = sessionEntry;
+  {
+    const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+    sessionStore[memResolved.normalizedKey] = sessionEntry;
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
+  }
 
   if (storePath) {
     await updateSessionStore(storePath, (store) => {
-      const existing = store[sessionKey] ?? sessionEntry;
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      const existing = resolved.existing ?? sessionEntry;
       if (!existing) {
         return;
       }
       applyAbortCutoffToSessionEntry(existing, undefined);
       existing.updatedAt = Date.now();
-      store[sessionKey] = existing;
+      store[resolved.normalizedKey] = existing;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     });
   }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -29,6 +29,7 @@ import { isLikelyExecutionAckPrompt } from "../../agents/pi-embedded-runner/run/
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import {
   resolveGroupSessionKey,
+  resolveSessionStoreEntry,
   resolveSessionTranscriptPath,
   type SessionEntry,
   updateSessionStore,
@@ -1418,11 +1419,24 @@ export async function runAgentTurnWithFallback(params: {
           }
 
           // Keep the in-memory snapshot consistent with the on-disk store reset.
-          delete params.activeSessionStore[sessionKey];
+          {
+            const memResolved = resolveSessionStoreEntry({
+              store: params.activeSessionStore,
+              sessionKey,
+            });
+            delete params.activeSessionStore[memResolved.normalizedKey];
+            for (const legacyKey of memResolved.legacyKeys) {
+              delete params.activeSessionStore[legacyKey];
+            }
+          }
 
           // Remove session entry from store using a fresh, locked snapshot.
           await updateSessionStore(params.storePath, (store) => {
-            delete store[sessionKey];
+            const resolved = resolveSessionStoreEntry({ store, sessionKey });
+            delete store[resolved.normalizedKey];
+            for (const legacyKey of resolved.legacyKeys) {
+              delete store[legacyKey];
+            }
           });
         } catch (cleanupErr) {
           defaultRuntime.error(

--- a/src/auto-reply/reply/body.ts
+++ b/src/auto-reply/reply/body.ts
@@ -28,20 +28,31 @@ export async function applySessionHints(params: {
     if (params.sessionEntry && params.sessionStore && params.sessionKey) {
       params.sessionEntry.abortedLastRun = false;
       params.sessionEntry.updatedAt = Date.now();
-      params.sessionStore[params.sessionKey] = params.sessionEntry;
+      const sessionKey = params.sessionKey;
+      const runtime = await loadSessionStoreRuntime();
+      const memResolved = runtime.resolveSessionStoreEntry({
+        store: params.sessionStore,
+        sessionKey,
+      });
+      params.sessionStore[memResolved.normalizedKey] = params.sessionEntry;
+      for (const legacyKey of memResolved.legacyKeys) {
+        delete params.sessionStore[legacyKey];
+      }
       if (params.storePath) {
-        const sessionKey = params.sessionKey;
-        const { updateSessionStore } = await loadSessionStoreRuntime();
-        await updateSessionStore(params.storePath, (store) => {
-          const entry = store[sessionKey] ?? params.sessionEntry;
+        await runtime.updateSessionStore(params.storePath, (store) => {
+          const resolved = runtime.resolveSessionStoreEntry({ store, sessionKey });
+          const entry = resolved.existing ?? params.sessionEntry;
           if (!entry) {
             return;
           }
-          store[sessionKey] = {
+          store[resolved.normalizedKey] = {
             ...entry,
             abortedLastRun: false,
             updatedAt: Date.now(),
           };
+          for (const legacyKey of resolved.legacyKeys) {
+            delete store[legacyKey];
+          }
         });
       }
     } else if (params.abortKey) {

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -3,7 +3,7 @@ import { renderExecTargetLabel } from "../../agents/bash-tools.exec-runtime.js";
 import { resolveExecDefaults } from "../../agents/exec-defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
-import { updateSessionStore } from "../../config/sessions.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyTraceOverride, applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
@@ -414,10 +414,20 @@ export async function handleDirectiveOnly(
       }
     }
     sessionEntry.updatedAt = Date.now();
-    sessionStore[sessionKey] = sessionEntry;
+    {
+      const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+      sessionStore[memResolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of memResolved.legacyKeys) {
+        delete sessionStore[legacyKey];
+      }
+    }
     if (storePath) {
       await updateSessionStore(storePath, (store) => {
-        store[sessionKey] = sessionEntry;
+        const resolved = resolveSessionStoreEntry({ store, sessionKey });
+        store[resolved.normalizedKey] = sessionEntry;
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
       });
     }
     if (modelSelection && modelSelectionUpdated && sessionKey) {

--- a/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
+++ b/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
@@ -18,6 +18,14 @@ vi.mock("../../agents/sandbox.js", () => ({
 
 vi.mock("../../config/sessions/store.js", () => ({
   updateSessionStore: vi.fn(async () => {}),
+  // Stubbed for swim-35/A1: identity-style resolver. See sister test for rationale.
+  resolveSessionStoreEntry: vi.fn(
+    ({ store, sessionKey }: { store: Record<string, unknown>; sessionKey: string }) => ({
+      normalizedKey: sessionKey,
+      existing: store[sessionKey],
+      legacyKeys: [] as string[],
+    }),
+  ),
 }));
 
 vi.mock("../../infra/system-events.js", () => ({

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -70,6 +70,16 @@ vi.mock("../../agents/sandbox.js", () => ({
 
 vi.mock("../../config/sessions.js", () => ({
   updateSessionStore: vi.fn(async () => {}),
+  // Stubbed for swim-35/A1: identity-style resolver returns normalizedKey=sessionKey,
+  // existing=store[sessionKey], no legacyKeys. Real impl applies session-key normalization;
+  // tests don't exercise legacy-key cleanup paths, so this stub is behavior-equivalent here.
+  resolveSessionStoreEntry: vi.fn(
+    ({ store, sessionKey }: { store: Record<string, unknown>; sessionKey: string }) => ({
+      normalizedKey: sessionKey,
+      existing: store[sessionKey],
+      legacyKeys: [] as string[],
+    }),
+  ),
 }));
 
 vi.mock("../../infra/system-events.js", () => ({

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -6,7 +6,7 @@ import {
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
-import { updateSessionStore } from "../../config/sessions/store.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -211,10 +211,18 @@ export async function persistInlineDirectives(params: {
 
     if (updated) {
       sessionEntry.updatedAt = Date.now();
-      sessionStore[sessionKey] = sessionEntry;
+      const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+      sessionStore[memResolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of memResolved.legacyKeys) {
+        delete sessionStore[legacyKey];
+      }
       if (storePath) {
         await updateSessionStore(storePath, (store) => {
-          store[sessionKey] = sessionEntry;
+          const resolved = resolveSessionStoreEntry({ store, sessionKey });
+          store[resolved.normalizedKey] = sessionEntry;
+          for (const legacyKey of resolved.legacyKeys) {
+            delete store[legacyKey];
+          }
         });
       }
       enqueueModeSwitchEvents({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -466,11 +466,19 @@ export async function runPreparedReply(
     if (sessionEntry && sessionStore && sessionKey && sessionEntry.thinkingLevel === "xhigh") {
       sessionEntry.thinkingLevel = "high";
       sessionEntry.updatedAt = Date.now();
-      sessionStore[sessionKey] = sessionEntry;
+      const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+      sessionStore[memResolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of memResolved.legacyKeys) {
+        delete sessionStore[legacyKey];
+      }
       if (storePath) {
         const { updateSessionStore } = await loadSessionStoreRuntime();
         await updateSessionStore(storePath, (store) => {
-          store[sessionKey] = sessionEntry;
+          const resolved = resolveSessionStoreEntry({ store, sessionKey });
+          store[resolved.normalizedKey] = sessionEntry;
+          for (const legacyKey of resolved.legacyKeys) {
+            delete store[legacyKey];
+          }
         });
       }
     }

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -351,12 +351,19 @@ export async function createModelSelectionState(params: {
         selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
       });
       if (updated) {
-        sessionStore[sessionKey] = sessionEntry;
+        const runtime = await loadSessionStoreRuntime();
+        const memResolved = runtime.resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+        sessionStore[memResolved.normalizedKey] = sessionEntry;
+        for (const legacyKey of memResolved.legacyKeys) {
+          delete sessionStore[legacyKey];
+        }
         if (storePath) {
-          await (
-            await loadSessionStoreRuntime()
-          ).updateSessionStore(storePath, (store) => {
-            store[sessionKey] = sessionEntry;
+          await runtime.updateSessionStore(storePath, (store) => {
+            const resolved = runtime.resolveSessionStoreEntry({ store, sessionKey });
+            store[resolved.normalizedKey] = sessionEntry;
+            for (const legacyKey of resolved.legacyKeys) {
+              delete store[legacyKey];
+            }
           });
         }
       }

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -7,7 +7,7 @@ import {
   type ModelAliasIndex,
 } from "../../agents/model-selection.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { updateSessionStore } from "../../config/sessions.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -76,10 +76,18 @@ function applySelectionToSession(params: {
   if (!updated) {
     return;
   }
-  sessionStore[sessionKey] = sessionEntry;
+  const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+  sessionStore[memResolved.normalizedKey] = sessionEntry;
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
   if (storePath) {
     updateSessionStore(storePath, (store) => {
-      store[sessionKey] = sessionEntry;
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      store[resolved.normalizedKey] = sessionEntry;
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     }).catch(() => {
       // Ignore persistence errors; session still proceeds.
     });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -13,6 +13,7 @@ import {
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
+  resolveSessionStoreEntry,
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
@@ -35,15 +36,26 @@ async function persistSessionEntryUpdate(params: {
   if (!params.sessionStore || !params.sessionKey) {
     return;
   }
-  params.sessionStore[params.sessionKey] = {
-    ...params.sessionStore[params.sessionKey],
-    ...params.nextEntry,
-  };
+  const sessionKey = params.sessionKey;
+  {
+    const memResolved = resolveSessionStoreEntry({ store: params.sessionStore, sessionKey });
+    params.sessionStore[memResolved.normalizedKey] = {
+      ...memResolved.existing,
+      ...params.nextEntry,
+    };
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete params.sessionStore[legacyKey];
+    }
+  }
   if (!params.storePath) {
     return;
   }
   await updateSessionStore(params.storePath, (store) => {
-    store[params.sessionKey!] = { ...store[params.sessionKey!], ...params.nextEntry };
+    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    store[resolved.normalizedKey] = { ...resolved.existing, ...params.nextEntry };
+    for (const legacyKey of resolved.legacyKeys) {
+      delete store[legacyKey];
+    }
   });
 }
 
@@ -159,7 +171,7 @@ export async function ensureSkillSnapshot(params: {
 
   if (isFirstTurnInSession && sessionStore && sessionKey) {
     const current = nextEntry ??
-      sessionStore[sessionKey] ?? {
+      resolveSessionStoreEntry({ store: sessionStore, sessionKey }).existing ?? {
         sessionId: sessionId ?? crypto.randomUUID(),
         updatedAt: Date.now(),
       };
@@ -234,7 +246,8 @@ export async function incrementCompactionCount(params: {
   if (!sessionStore || !sessionKey) {
     return undefined;
   }
-  const entry = sessionStore[sessionKey] ?? sessionEntry;
+  const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+  const entry = memResolved.existing ?? sessionEntry;
   if (!entry) {
     return undefined;
   }
@@ -264,16 +277,23 @@ export async function incrementCompactionCount(params: {
     updates.cacheRead = undefined;
     updates.cacheWrite = undefined;
   }
-  sessionStore[sessionKey] = {
+  sessionStore[memResolved.normalizedKey] = {
     ...entry,
     ...updates,
   };
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
   if (storePath) {
     await updateSessionStore(storePath, (store) => {
-      store[sessionKey] = {
-        ...store[sessionKey],
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      store[resolved.normalizedKey] = {
+        ...(resolved.existing ?? entry),
         ...updates,
       };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
     });
   }
   if (newSessionId && newSessionId !== entry.sessionId && cfg) {
@@ -282,7 +302,7 @@ export async function incrementCompactionCount(params: {
       sessionKey,
       storePath,
       previousEntry: entry,
-      nextEntry: sessionStore[sessionKey],
+      nextEntry: sessionStore[memResolved.normalizedKey],
     });
   }
   return nextCount;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -20,7 +20,11 @@ import {
 import { resolveAndPersistSessionFile } from "../../config/sessions/session-file.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
-import { loadSessionStore, updateSessionStore } from "../../config/sessions/store.js";
+import {
+  loadSessionStore,
+  resolveSessionStoreEntry,
+  updateSessionStore,
+} from "../../config/sessions/store.js";
 import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import {
   DEFAULT_RESET_TRIGGERS,
@@ -399,7 +403,7 @@ export async function initSessionState(params: {
   if (retiredLegacyMainDelivery) {
     sessionStore[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
   }
-  const entry = sessionStore[sessionKey];
+  const entry = resolveSessionStoreEntry({ store: sessionStore, sessionKey }).existing;
   const now = Date.now();
   const isThread = resolveThreadFlag({
     sessionKey,
@@ -451,7 +455,7 @@ export async function initSessionState(params: {
     previousSessionId: previousSessionEntry?.sessionId,
   });
 
-  if (!isNewSession && freshEntry) {
+  if (!isNewSession && freshEntry && entry) {
     sessionId = entry.sessionId;
     systemSent = entry.systemSent ?? false;
     abortedLastRun = entry.abortedLastRun ?? false;
@@ -716,12 +720,22 @@ export async function initSessionState(params: {
     sessionEntry.contextTokens = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
-  sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };
+  {
+    const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
+    sessionStore[memResolved.normalizedKey] = { ...memResolved.existing, ...sessionEntry };
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
+  }
   await updateSessionStore(
     storePath,
     (store) => {
       // Preserve per-session overrides while resetting compaction state on /new.
-      store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      store[resolved.normalizedKey] = { ...resolved.existing, ...sessionEntry };
+      for (const legacyKey of resolved.legacyKeys) {
+        delete store[legacyKey];
+      }
       if (retiredLegacyMainDelivery) {
         store[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
       }

--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   formatSessionArchiveTimestamp,
+  isCheckpointSessionTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
+  parseParentSessionIdFromCheckpointFileName,
   parseUsageCountedSessionIdFromFileName,
   parseSessionArchiveTimestamp,
 } from "./artifacts.js";
@@ -50,6 +52,32 @@ describe("session artifact helpers", () => {
     ).toBe("abc");
     expect(parseUsageCountedSessionIdFromFileName("abc.jsonl.bak.2026-01-01T00-00-00.000Z")).toBe(
       null,
+    );
+  });
+
+  it("classifies checkpoint transcript files and extracts parent session id", () => {
+    const parent = "e417ba9b-8043-43db-8d18-d88f1823567d";
+    const ckp = "21901ee7-8f22-4d07-9e39-6eaf7b224630";
+
+    // Positive: well-formed checkpoint sibling.
+    expect(isCheckpointSessionTranscriptFileName(`${parent}.checkpoint.${ckp}.jsonl`)).toBe(true);
+    expect(parseParentSessionIdFromCheckpointFileName(`${parent}.checkpoint.${ckp}.jsonl`)).toBe(
+      parent,
+    );
+
+    // Negative: primary, archive, non-uuid suffix, or substring matches.
+    expect(isCheckpointSessionTranscriptFileName(`${parent}.jsonl`)).toBe(false);
+    expect(
+      isCheckpointSessionTranscriptFileName(`${parent}.jsonl.deleted.2026-01-01T00-00-00.000Z`),
+    ).toBe(false);
+    // Substring contains "checkpoint" but is missing the UUID shape — must not dedup.
+    expect(isCheckpointSessionTranscriptFileName("my-checkpoint-review-session.jsonl")).toBe(false);
+    expect(parseParentSessionIdFromCheckpointFileName("my-checkpoint-review-session.jsonl")).toBe(
+      null,
+    );
+    // Shape looks close but the trailing UUID segment is malformed.
+    expect(isCheckpointSessionTranscriptFileName(`${parent}.checkpoint.not-a-uuid.jsonl`)).toBe(
+      false,
     );
   });
 

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -3,6 +3,13 @@ export type SessionArchiveReason = "bak" | "reset" | "deleted";
 const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
 const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
 
+// Anchored at end of file name: literal `.checkpoint.` + UUID-v4 shape + `.jsonl`.
+// Session IDs that happen to contain the substring "checkpoint" (with any suffix
+// shape) do NOT match because the UUID regex requires the exact `[0-9a-f]{8}-…`
+// shape immediately after `.checkpoint.` and `.jsonl` immediately after that.
+const CHECKPOINT_MARKER_RE =
+  /\.checkpoint\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+
 function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boolean {
   const marker = `.${reason}.`;
   const index = fileName.lastIndexOf(marker);
@@ -39,6 +46,30 @@ export function isUsageCountedSessionTranscriptFileName(fileName: string): boole
     return true;
   }
   return hasArchiveSuffix(fileName, "reset") || hasArchiveSuffix(fileName, "deleted");
+}
+
+/**
+ * Classify pre-compaction checkpoint-twin transcript files, e.g.
+ * `<parentId>.checkpoint.<uuid>.jsonl`. Uses an anchored UUID-shape match so
+ * session IDs that happen to contain the substring "checkpoint" do not
+ * false-positive.
+ */
+export function isCheckpointSessionTranscriptFileName(fileName: string): boolean {
+  return CHECKPOINT_MARKER_RE.test(fileName);
+}
+
+/**
+ * Extract the parent session id from a checkpoint transcript file name. The
+ * parent session id is the part BEFORE `.checkpoint.<uuid>.jsonl`; it matches
+ * what `isPrimarySessionTranscriptFileName` expects when the parent primary
+ * exists as `<parentId>.jsonl`. Returns `null` if the file is not a checkpoint.
+ */
+export function parseParentSessionIdFromCheckpointFileName(fileName: string): string | null {
+  const match = fileName.match(CHECKPOINT_MARKER_RE);
+  if (!match || match.index === undefined) {
+    return null;
+  }
+  return fileName.slice(0, match.index);
 }
 
 export function parseUsageCountedSessionIdFromFileName(fileName: string): string | null {

--- a/src/config/sessions/session-file.ts
+++ b/src/config/sessions/session-file.ts
@@ -1,6 +1,6 @@
 import { resolveSessionFilePath } from "./paths.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
-import { updateSessionStore } from "./store.js";
+import { resolveSessionStoreEntry, updateSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
 
 export async function resolveAndPersistSessionFile(params: {
@@ -16,8 +16,9 @@ export async function resolveAndPersistSessionFile(params: {
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
 }): Promise<{ sessionFile: string; sessionEntry: SessionEntry }> {
   const { sessionId, sessionKey, sessionStore, storePath } = params;
+  const memResolved = resolveSessionStoreEntry({ store: sessionStore, sessionKey });
   const baseEntry = params.sessionEntry ??
-    sessionStore[sessionKey] ?? { sessionId, updatedAt: Date.now() };
+    memResolved.existing ?? { sessionId, updatedAt: Date.now() };
   const fallbackSessionFile = params.fallbackSessionFile?.trim();
   const entryForResolve =
     !baseEntry.sessionFile && fallbackSessionFile
@@ -34,14 +35,21 @@ export async function resolveAndPersistSessionFile(params: {
     sessionFile,
   };
   if (baseEntry.sessionId !== sessionId || baseEntry.sessionFile !== sessionFile) {
-    sessionStore[sessionKey] = persistedEntry;
+    sessionStore[memResolved.normalizedKey] = persistedEntry;
+    for (const legacyKey of memResolved.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
     await updateSessionStore(
       storePath,
       (store) => {
-        store[sessionKey] = {
-          ...store[sessionKey],
+        const resolved = resolveSessionStoreEntry({ store, sessionKey });
+        store[resolved.normalizedKey] = {
+          ...resolved.existing,
           ...persistedEntry,
         };
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
       },
       params.activeSessionKey || params.maintenanceConfig
         ? {
@@ -52,6 +60,9 @@ export async function resolveAndPersistSessionFile(params: {
     );
     return { sessionFile, sessionEntry: persistedEntry };
   }
-  sessionStore[sessionKey] = persistedEntry;
+  sessionStore[memResolved.normalizedKey] = persistedEntry;
+  for (const legacyKey of memResolved.legacyKeys) {
+    delete sessionStore[legacyKey];
+  }
   return { sessionFile, sessionEntry: persistedEntry };
 }

--- a/src/config/sessions/store.runtime.ts
+++ b/src/config/sessions/store.runtime.ts
@@ -1,1 +1,1 @@
-export { updateSessionStore, updateSessionStoreEntry } from "./store.js";
+export { resolveSessionStoreEntry, updateSessionStore, updateSessionStoreEntry } from "./store.js";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -150,6 +150,7 @@ export const AgentDefaultsSchema = z
         postCompactionSections: z.array(z.string()).optional(),
         model: z.string().optional(),
         timeoutSeconds: z.number().int().positive().optional(),
+        truncateAfterCompaction: z.boolean().optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -37,6 +37,7 @@ import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
 import {
   archiveRemovedSessionTranscripts,
+  resolveSessionStoreEntry,
   saveSessionStore,
   updateSessionStore,
 } from "../config/sessions/store.js";
@@ -425,7 +426,8 @@ async function restoreHeartbeatUpdatedAt(params: {
     return;
   }
   const store = loadSessionStore(storePath);
-  const entry = store[sessionKey];
+  const resolvedRead = resolveSessionStoreEntry({ store, sessionKey });
+  const entry = resolvedRead.existing;
   if (!entry) {
     return;
   }
@@ -434,7 +436,8 @@ async function restoreHeartbeatUpdatedAt(params: {
     return;
   }
   await updateSessionStore(storePath, (nextStore) => {
-    const nextEntry = nextStore[sessionKey] ?? entry;
+    const resolved = resolveSessionStoreEntry({ store: nextStore, sessionKey });
+    const nextEntry = resolved.existing ?? entry;
     if (!nextEntry) {
       return;
     }
@@ -442,7 +445,10 @@ async function restoreHeartbeatUpdatedAt(params: {
     if (nextEntry.updatedAt === resolvedUpdatedAt) {
       return;
     }
-    nextStore[sessionKey] = { ...nextEntry, updatedAt: resolvedUpdatedAt };
+    nextStore[resolved.normalizedKey] = { ...nextEntry, updatedAt: resolvedUpdatedAt };
+    for (const legacyKey of resolved.legacyKeys) {
+      delete nextStore[legacyKey];
+    }
   });
 }
 
@@ -911,7 +917,8 @@ export async function runHeartbeatOnce(opts: {
     }
 
     const store = loadSessionStore(storePath);
-    const current = store[sessionKey];
+    const resolved = resolveSessionStoreEntry({ store, sessionKey });
+    const current = resolved.existing;
     // Initialize stub entry on first run when current doesn't exist
     const base = current ?? {
       // Generate valid sessionId - derive from sessionKey without colons
@@ -930,7 +937,10 @@ export async function runHeartbeatOnce(opts: {
       }
     }
 
-    store[sessionKey] = { ...base, heartbeatTaskState: taskState };
+    store[resolved.normalizedKey] = { ...base, heartbeatTaskState: taskState };
+    for (const legacyKey of resolved.legacyKeys) {
+      delete store[legacyKey];
+    }
     await saveSessionStore(storePath, store);
   };
 
@@ -1215,13 +1225,17 @@ export async function runHeartbeatOnce(opts: {
     // Record last delivered heartbeat payload for dedupe.
     if (!shouldSkipMain && normalized.text.trim()) {
       const store = loadSessionStore(storePath);
-      const current = store[sessionKey];
+      const resolved = resolveSessionStoreEntry({ store, sessionKey });
+      const current = resolved.existing;
       if (current) {
-        store[sessionKey] = {
+        store[resolved.normalizedKey] = {
           ...current,
           lastHeartbeatText: normalized.text,
           lastHeartbeatSentAt: startedAt,
         };
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
         await saveSessionStore(storePath, store);
       }
     }

--- a/src/infra/session-cost-usage.discoverAllSessions.test.ts
+++ b/src/infra/session-cost-usage.discoverAllSessions.test.ts
@@ -1,0 +1,153 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { type DiscoveredSession, discoverAllSessions } from "./session-cost-usage.js";
+
+// ---------------------------------------------------------------------------
+// openclaw-bootstrap#475 — checkpoint dedup regression coverage
+//
+// discoverAllSessions must NOT treat `<parentId>.checkpoint.<uuid>.jsonl`
+// files as distinct sessions. They are pre-compaction snapshot siblings of
+// the parent primary and must be grouped under the parent session id. See
+// src/config/sessions/artifacts.ts for the classifier + parent-id parser.
+// ---------------------------------------------------------------------------
+
+const PARENT_UUID = "e417ba9b-8043-43db-8d18-d88f1823567d";
+const OTHER_PARENT_UUID = "71029058-ffdd-4def-9a8c-c84f9e1e3f01";
+const CHECKPOINT_UUIDS = [
+  "21901ee7-8f22-4d07-9e39-6eaf7b224630",
+  "44d92356-464c-4556-9403-77096e791375",
+  "47b9a01e-169a-442c-8e42-52f2188051eb",
+  "7da74434-2bd8-499e-8216-ba3fa0869884",
+  "ac813e2a-ad7b-4a0f-9f7b-26c0fbac2746",
+];
+
+const USER_JSONL_LINE = JSON.stringify({
+  type: "message",
+  message: { role: "user", content: "hello from parent primary" },
+});
+const EMPTY_JSONL = "";
+
+async function makeAgentSessionsDir(root: string, agentId = "main"): Promise<string> {
+  const sessionsDir = path.join(root, "agents", agentId, "sessions");
+  await fs.mkdir(sessionsDir, { recursive: true });
+  return sessionsDir;
+}
+
+async function discoverUnder(stateDir: string): Promise<DiscoveredSession[]> {
+  return await withEnvAsync(
+    { OPENCLAW_STATE_DIR: stateDir },
+    async () => await discoverAllSessions(),
+  );
+}
+
+describe("discoverAllSessions — checkpoint dedup (bootstrap#475)", () => {
+  const suiteRootTracker = createSuiteTempRootTracker({
+    prefix: "openclaw-discover-ckp-",
+  });
+
+  beforeAll(async () => {
+    await suiteRootTracker.setup();
+  });
+
+  afterAll(async () => {
+    await suiteRootTracker.cleanup();
+  });
+
+  it("(a) single primary: surfaces one discovered session", async () => {
+    const root = await suiteRootTracker.make("case-a");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+  });
+
+  it("(b) primary + one checkpoint: one discovered session under parent id", async () => {
+    const root = await suiteRootTracker.make("case-b");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+    await fs.writeFile(
+      path.join(sessionsDir, `${PARENT_UUID}.checkpoint.${CHECKPOINT_UUIDS[0]}.jsonl`),
+      EMPTY_JSONL,
+    );
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+    // Primary's sessionFile wins over checkpoint's sessionFile.
+    expect(discovered[0]?.sessionFile.endsWith(`${PARENT_UUID}.jsonl`)).toBe(true);
+  });
+
+  it("(c) five checkpoints only, parent primary missing: one discovered entry under parent id", async () => {
+    const root = await suiteRootTracker.make("case-c");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    for (const ckpUuid of CHECKPOINT_UUIDS) {
+      await fs.writeFile(
+        path.join(sessionsDir, `${PARENT_UUID}.checkpoint.${ckpUuid}.jsonl`),
+        EMPTY_JSONL,
+      );
+    }
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+  });
+
+  it("(d) primary + five checkpoints (Elliott shape): one discovered session", async () => {
+    const root = await suiteRootTracker.make("case-d");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+    for (const ckpUuid of CHECKPOINT_UUIDS) {
+      await fs.writeFile(
+        path.join(sessionsDir, `${PARENT_UUID}.checkpoint.${ckpUuid}.jsonl`),
+        EMPTY_JSONL,
+      );
+    }
+    // Also include an unrelated session to be sure discover returns 2 total, not 6.
+    await fs.writeFile(path.join(sessionsDir, `${OTHER_PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+
+    const discovered = await discoverUnder(root);
+    const ids = discovered.map((d) => d.sessionId).toSorted();
+    expect(ids).toEqual([OTHER_PARENT_UUID, PARENT_UUID].toSorted());
+  });
+
+  it("(e) .reset./.deleted. archives: still counted as their own entries (usage-count preserved)", async () => {
+    const root = await suiteRootTracker.make("case-e");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    // Primary present, plus one reset archive and one deleted archive for the same id.
+    await fs.writeFile(path.join(sessionsDir, `${PARENT_UUID}.jsonl`), USER_JSONL_LINE);
+    await fs.writeFile(
+      path.join(sessionsDir, `${PARENT_UUID}.jsonl.reset.2026-01-01T00-00-00.000Z`),
+      EMPTY_JSONL,
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, `${PARENT_UUID}.jsonl.deleted.2026-02-02T00-00-00.000Z`),
+      EMPTY_JSONL,
+    );
+
+    const discovered = await discoverUnder(root);
+    // The archives share the same session id and dedup with the primary in the
+    // discover map, so final count is 1 — the primary wins sessionFile.
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(PARENT_UUID);
+    expect(discovered[0]?.sessionFile.endsWith(`${PARENT_UUID}.jsonl`)).toBe(true);
+  });
+
+  it("(f) primary with 'checkpoint' substring in session id: NOT dedup (regex anchored)", async () => {
+    const root = await suiteRootTracker.make("case-f");
+    const sessionsDir = await makeAgentSessionsDir(root);
+    // This file name contains "checkpoint" in the session id portion, but
+    // does NOT match the UUID-anchored checkpoint regex. Must be treated as
+    // a distinct primary session.
+    const trickyId = "my-checkpoint-review-session";
+    await fs.writeFile(path.join(sessionsDir, `${trickyId}.jsonl`), USER_JSONL_LINE);
+
+    const discovered = await discoverUnder(root);
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.sessionId).toBe(trickyId);
+  });
+});

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -5,9 +5,11 @@ import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import {
+  isCheckpointSessionTranscriptFileName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
+  parseParentSessionIdFromCheckpointFileName,
   parseSessionArchiveTimestamp,
   parseUsageCountedSessionIdFromFileName,
 } from "../config/sessions/artifacts.js";
@@ -470,6 +472,48 @@ export async function discoverAllSessions(params?: {
       continue;
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
+
+    // Checkpoint-twin dedup (issue #475): `<parentId>.checkpoint.<uuid>.jsonl`
+    // files are pre-compaction snapshot siblings of the parent primary
+    // session. They must NOT surface as distinct discovered sessions — that
+    // lopsides the discover map (one lopsided prince session can present as
+    // 6 separate sessions) and, worse, opens each file for first-user-message
+    // extraction, which is the dominant read cost on a prince with deep
+    // checkpoint history. Group them under the parent session id, do not
+    // re-read for label (the parent primary already carries it), and advance
+    // the parent's mtime if this checkpoint is newer.
+    if (isCheckpointSessionTranscriptFileName(entry.name)) {
+      const parentId = parseParentSessionIdFromCheckpointFileName(entry.name);
+      if (!parentId) {
+        continue;
+      }
+      const existing = discovered.get(parentId);
+      if (!existing) {
+        // Parent primary may not have been scanned yet (or may be absent
+        // entirely, which is the parent-missing recovery case). Record the
+        // checkpoint's mtime under the parent id without a sessionFile
+        // commitment; the parent primary will replace this entry when we
+        // encounter it via the primary branch below.
+        discovered.set(parentId, {
+          sessionId: parentId,
+          sessionFile: filePath,
+          mtime: stats.mtimeMs,
+          firstUserMessage: undefined,
+        });
+      } else if (stats.mtimeMs > existing.mtime) {
+        // Advance the parent's mtime if this checkpoint is newer; do NOT
+        // overwrite sessionFile when existing points at a primary transcript.
+        const existingIsPrimary = isPrimarySessionTranscriptFileName(
+          path.basename(existing.sessionFile),
+        );
+        discovered.set(parentId, {
+          ...existing,
+          sessionFile: existingIsPrimary ? existing.sessionFile : filePath,
+          mtime: stats.mtimeMs,
+        });
+      }
+      continue;
+    }
 
     const sessionId = parseUsageCountedSessionIdFromFileName(entry.name);
     if (!sessionId) {


### PR DESCRIPTION
## Summary
- key GitHub Copilot bearer cache files by auth profile instead of one global cache path
- thread `profileId` through the simple-completion runtime so named profiles refresh into distinct cache files
- add regression coverage proving `github-copilot:github` and `github-copilot:pool-1` do not collapse onto one cache path

Closes #148.

## Verification
- `pnpm exec vitest run src/agents/simple-completion-runtime.test.ts src/agents/simple-completion-runtime.selection.test.ts src/agents/github-copilot-token.test.ts`
