### PR TITLE
test(swim-37): wire captureSwim() for continue_work primitive (#324)

### DIFF
--- a/docs/design/swim-37-continue-delegate-wiring-memo.md
+++ b/docs/design/swim-37-continue-delegate-wiring-memo.md
@@ -1,0 +1,113 @@
+# swim-37 harness — `continue_delegate` wiring memo
+
+**Status:** Draft for cohort review (memo-before-wire per 🩸 standard 2026-04-27 + figs's "memos earn their keep when they reduce rework" affirmation msg `1498505870580125778`)
+**Author:** 🌻 elliott-dandelion-cult
+**Trunk base:** `cael/325-canonical2 @ 652c8a888e` (Slice 2 chunks 1–6c follow-up landed)
+**Companion PR (just landed for `continue_work`):** karmaterminal/openclaw#405
+**Reviewers requested:** 🌫 Silas, 🌊 Ronan, 🩸 Cael
+
+## Frame
+
+PR #405 wired `captureSwim("continue_work", …)` against `emitContinuationWorkSpan` + `createInMemorySpanRecorder`. Three primitives still throw `"not yet wired"`: `continue_delegate`, `heartbeat`, `lich`.
+
+The next step is `continue_delegate`. This memo decides shape _before_ the PR so the wiring lands clean. The standard 🩸 named: "would skipping this memo cost a chunk's worth of rework?" — yes, because three open Qs change the file shape, and getting them wrong wastes a review cycle.
+
+## What the production code already gives us
+
+`emitContinuationDelegateSpan` (continuation-tracer.ts:435) emits the **dispatch-accept** span. Args:
+
+```ts
+{
+  chainId, chainStepRemaining, delayMs,
+  delivery: "immediate" | "timer",
+  delegateMode?: string,    // "normal" | "silent" | "silent-wake" | "post-compaction"
+  reason?: string,
+}
+```
+
+It is **synchronous**. It emits at the enqueue/accept seam, NOT at the timer-fire callback (chunk 3 cohort design pin). The `setTimeout`-fire span is a _separate_ helper: `emitContinuationDelegateFireSpan` (chunk 5b, continuation-tracer.ts:591).
+
+This collapses Q1 (real timers vs fake timers) for _dispatch_ — there are no timers at the dispatch seam. The Q only re-opens for the `delegate.fire` swim, which is a different primitive in the harness's coverage matrix.
+
+## Q1 (resolved by reading the code): real `setTimeout` vs fake timers?
+
+**Not relevant for `continue_delegate` dispatch swim.** The dispatch helper is synchronous and emits before any timer arms. Drive it directly.
+
+For a future `continue_delegate.fire` swim (separate primitive, separate PR), the answer will be **fake-timers** (vitest `vi.useFakeTimers()` + `vi.advanceTimersByTime()`) because the harness must remain hermetic and the `fire.deferred_ms` axis becomes deterministic. Banked for the fire-swim memo, not this one.
+
+## Q2: Recipient fan-out shape — 1 span with `recipients=[…]` attr OR N spans sharing `chain.id`?
+
+**Production answer (already pinned by chunk 3 cohort design):** the dispatch helper takes **per-call args** — one call per dispatch decision. Multi-recipient fan-out is N decisions = N spans, all sharing `chain.id`.
+
+This is consistent with #355 Stage-2's "1 step per fan-out, not N" _budget_ semantics — that's about budget arithmetic, not span cardinality. Budget treats fan-out as one chain step; OTEL treats each recipient as one dispatch span (so traces show recipient-level visibility).
+
+**Harness implication:** `captureSwim("continue_delegate", { recipients: 3 })` should drive the helper 3 times in a loop with identical `chainId`, then assert 3 spans with shared `chain.id`. The shape is:
+
+```ts
+{
+  spans: [span_r0, span_r1, span_r2],   // 3 entries
+  chainId: "<one uuid v7>",              // shared
+}
+```
+
+## Q3: `delegate.mode` × `delegate.delivery` matrix coverage
+
+The full Cartesian is **8 cells**:
+
+| mode \ delivery | immediate | timer |
+| --------------- | --------- | ----- |
+| normal          | ✓         | ✓     |
+| silent          | ✓         | ✓     |
+| silent-wake     | ✓         | ✓     |
+| post-compaction | ✓         | ✓     |
+
+**Proposal: drive all 8 cells in the spec, but expose them as `it.each` rows, not 8 hand-written tests.** Reduces churn when a new mode lands (chunk-7 lich variants? future `silent-burn`?). One row added = one cell added.
+
+Pin assertions per row:
+
+- `span.name === "continuation.delegate.dispatch"`
+- `span.attributes["delegate.mode"] === <row.mode>`
+- `span.attributes["delegate.delivery"] === <row.delivery>`
+- `span.attributes["chain.id"] === result.chainId`
+- `span.status === "OK"`, `span.ended === true`
+
+Plus one row pinning **`delegate.mode` is omitted when caller passes undefined** (helper conditionally spreads — that contract has byte-impact downstream).
+
+## Q4 (new, raised by reading chunk-5b memo): does `delegate.fire` need its own primitive in the swim taxonomy, or is it a sub-primitive of `continue_delegate`?
+
+**Proposal: separate primitive.** `captureSwim("continue_delegate")` covers dispatch-accept; `captureSwim("continue_delegate_fire")` covers timer-callback fire. The two have different invariants (no gate to fail on dispatch; `fire.deferred_ms` axis only exists on fire), different tracer helpers, and different harness needs (real vs fake timers).
+
+Banked, not in scope for this memo's PR. But pinning it now so the type union grows in the right direction:
+
+```ts
+export type SwimPrimitive =
+  | "continue_work"
+  | "continue_work_fire" // future
+  | "continue_delegate"
+  | "continue_delegate_fire" // future
+  | "heartbeat"
+  | "lich";
+```
+
+## What the PR will look like
+
+- `studies/swim-37/harness/swim-runner.ts`:
+  - Add `continue_delegate` case to the switch.
+  - Drive `emitContinuationDelegateSpan` once per recipient in a loop.
+  - Accept `recipients?: number = 1`, `delivery?: "immediate" | "timer" = "immediate"`, `delegateMode?: string` (passes through; helper handles undefined).
+- `studies/swim-37/harness/swim-runner.test.ts`:
+  - New `describe("continue_delegate", () => …)` block with `it.each` over the 8-cell matrix.
+  - One additional row: `delegate.mode` omission contract.
+  - One additional test: 3-recipient fan-out asserts 3 spans, shared `chain.id`, distinct positional order.
+  - Flips ~3 existing `it.todo` markers → ~6+ new live `it.each` rows. Net `it.todo` count drops from 16 to ~13.
+
+## Out of scope
+
+- `continue_delegate_fire` swim (own memo + PR; needs fake-timer rig).
+- `heartbeat` swim (needs heartbeat span emit entry-point survey).
+- `lich`/post-compaction swim (#332 Item B seam — verify exists on canonical2 first).
+- Trap-class §1 / §3a tests (synthetic commit-pair fixtures + tsgo replay rig).
+
+## Decision request
+
+Cohort signal-off on Q2 (N-spans-shared-chainId) and Q3 (`it.each` matrix). Q1 is observation, Q4 is bookkeeping. If consensus inside one cycle, PR follows immediately on this branch.

--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -165,6 +165,26 @@ describe("swim-37 harness :: continuation primitives [scaffold]", () => {
         expect(span.attributes["chain.id"]).toBe(result.chainId);
       }
     });
+    it("GAP-PIN: fan-out spans are currently NOT analytically distinct", async () => {
+      // Per 🩸 caution on the wiring memo (msg 1498507232185286849):
+      // N spans sharing chain.id risks collapsing into analytic mush at
+      // scale unless the per-recipient distinction is visible in attrs.
+      // Currently the production helper `emitContinuationDelegateSpan`
+      // exposes no `recipient.index` axis — so all N spans in a fan-out
+      // are byte-identical except for span-level identity (spanId).
+      // This test PINS the gap so it shows up in code-review when the
+      // production helper grows the axis. Flip the assertion to
+      // `not.toEqual` once `recipient.index` lands.
+      const result = await captureSwim("continue_delegate", {
+        recipients: 2,
+        delegateMode: "normal",
+      });
+      const [a, b] = result.spans;
+      expect(a?.attributes).toEqual(b?.attributes);
+    });
+    it.todo(
+      "recipient.index attr distinguishes per-recipient fan-out spans (🩸 caution; needs production helper axis)",
+    );
     it("rejects non-positive or non-integer recipients", async () => {
       await expect(captureSwim("continue_delegate", { recipients: 0 })).rejects.toThrow(
         /positive integer/,

--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -115,7 +115,64 @@ describe("swim-37 harness :: continuation primitives [scaffold]", () => {
   });
 
   describe("continue_delegate", () => {
-    it.todo("emits continuation.delegate.dispatch span with chain.id (#366)");
+    // 8-cell matrix: delegate.mode x delegate.delivery (per memo Q3).
+    const modes = ["normal", "silent", "silent-wake", "post-compaction"] as const;
+    const deliveries = ["immediate", "timer"] as const;
+    const matrix: Array<{
+      mode: (typeof modes)[number];
+      delivery: (typeof deliveries)[number];
+    }> = [];
+    for (const mode of modes) {
+      for (const delivery of deliveries) {
+        matrix.push({ mode, delivery });
+      }
+    }
+    it.each(matrix)(
+      "emits continuation.delegate.dispatch for mode=$mode delivery=$delivery",
+      async ({ mode, delivery }) => {
+        const result = await captureSwim("continue_delegate", {
+          delegateMode: mode,
+          delivery,
+          delayMs: delivery === "timer" ? 30 : 0,
+        });
+        expect(result.spans).toHaveLength(1);
+        const [span] = result.spans;
+        expect(span?.name).toBe("continuation.delegate.dispatch");
+        expect(span?.attributes["delegate.mode"]).toBe(mode);
+        expect(span?.attributes["delegate.delivery"]).toBe(delivery);
+        expect(span?.attributes["chain.id"]).toBe(result.chainId);
+        expect(span?.status).toBe("OK");
+        expect(span?.ended).toBe(true);
+      },
+    );
+    it("omits delegate.mode attribute when caller passes undefined", async () => {
+      const result = await captureSwim("continue_delegate", {
+        delivery: "immediate",
+      });
+      expect(result.spans).toHaveLength(1);
+      const [span] = result.spans;
+      expect(span?.attributes).not.toHaveProperty("delegate.mode");
+      expect(span?.attributes["delegate.delivery"]).toBe("immediate");
+    });
+    it("fan-out: N recipients emit N spans sharing chain.id", async () => {
+      const result = await captureSwim("continue_delegate", {
+        recipients: 3,
+        delegateMode: "normal",
+      });
+      expect(result.spans).toHaveLength(3);
+      for (const span of result.spans) {
+        expect(span.name).toBe("continuation.delegate.dispatch");
+        expect(span.attributes["chain.id"]).toBe(result.chainId);
+      }
+    });
+    it("rejects non-positive or non-integer recipients", async () => {
+      await expect(captureSwim("continue_delegate", { recipients: 0 })).rejects.toThrow(
+        /positive integer/,
+      );
+      await expect(captureSwim("continue_delegate", { recipients: 1.5 })).rejects.toThrow(
+        /positive integer/,
+      );
+    });
     it.todo("decrements chain-budget; ChainBudget.declineToCarry() observable on cap");
     it.todo("fan-out across N recipients consumes 1 chain step, not N (#355 Stage-2)");
     // Chunk 5b (#388) — `continuation.delegate.fire` lands at timer-callback
@@ -178,7 +235,6 @@ describe("swim-37 harness :: shape contract (live now)", () => {
   });
 
   it("captureSwim() refuses primitives not yet wired", async () => {
-    await expect(captureSwim("continue_delegate")).rejects.toThrow(/not yet wired/);
     await expect(captureSwim("heartbeat")).rejects.toThrow(/not yet wired/);
     await expect(captureSwim("lich")).rejects.toThrow(/not yet wired/);
   });

--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -62,7 +62,22 @@ type SpanRecord = {
 
 describe("swim-37 harness :: trap-class coverage [scaffold]", () => {
   describe("trap §1 :: parallel-evolution / cherry-false-negative", () => {
-    it.todo("rebase bot classifies synthetic squash-rebased commit as DROP (not PICK)");
+    it("rebase bot classifies synthetic squash-rebased commit as DROP (not PICK)", async () => {
+      const { classifyRebasePick } = await import("./rebase-classifier.ts");
+      // Synthetic: commit subject already mentions PR #70595 in the base
+      // CHANGELOG — i.e. the work landed on base via a squash-rebase, and
+      // the candidate pick would re-apply it. Discovery channel:
+      // changelog-grep PR-token. Memo anchor: 7ee46a3ab9 (#70595).
+      const verdict = classifyRebasePick({
+        subject: "feat(foo): add bar (#70595)",
+        commitBody: "feat(foo): add bar (#70595)\n\nLong description.",
+        baseChangelog: "# Changelog\n\n## v2026.4.24\n\n- feat(foo): add bar (#70595)\n",
+        isAncestorOf: () => false,
+      });
+      expect(verdict.verdict).toBe("DROP");
+      expect(verdict.channel).toBe("changelog-grep:pr");
+      expect(verdict.evidence.changelogPrHit).toBeDefined();
+    });
     it.todo("CHANGELOG-byte-grep discovery channel emits drop-with-reason span");
   });
 

--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -21,34 +21,19 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { type RecordedSpan } from "./in-memory-span-recorder.js";
+import { type ChainPrimitiveResult, captureSwim } from "./swim-runner.js";
 
-// ─── PLACEHOLDER IMPORTS (TODO once #366 merges) ────────────────────────────
-// These will resolve to:
-//   import { runContinueWork, runContinueDelegate } from "src/agents/continuation/primitives";
-//   import { ChainBudget } from "src/infra/chain-budget";
-//   import { emitSystemEvent } from "src/infra/system-events";
-// For the scaffold we keep them as type-only so vitest collects without
-// runtime resolution failing.
+// Local alias retained for the contract-shape tests below; the canonical
+// shape now lives in `./in-memory-span-recorder.ts`. Kept narrow so the
+// shape-pin tests keep documenting the minimum surface a recorded span
+// must expose, even if the recorder grows additional fields.
 type SpanRecord = {
   name: string;
   attributes: Record<string, unknown>;
   traceId?: string;
   parentSpanId?: string;
 };
-
-type ChainPrimitiveResult = {
-  spans: SpanRecord[];
-  chainId: string;
-};
-
-// In-memory STDOUT-style span capture. Real implementation will route through
-// @opentelemetry/sdk-trace-base BasicTracerProvider + InMemorySpanExporter.
-// For the scaffold we model the contract as a pure function the runner will
-// fulfill.
-declare function captureSwim(
-  primitive: "continue_work" | "continue_delegate" | "heartbeat" | "lich",
-  opts?: Record<string, unknown>,
-): Promise<ChainPrimitiveResult>;
 
 // ─── TRAP-CLASS COVERAGE ────────────────────────────────────────────────────
 //
@@ -88,8 +73,31 @@ describe("swim-37 harness :: trap-class coverage [scaffold]", () => {
 
 describe("swim-37 harness :: continuation primitives [scaffold]", () => {
   describe("continue_work", () => {
-    it.todo("emits continuation.work span with chain.id stamped (#366)");
-    it.todo("span carries chain.step.remaining attribute");
+    it("emits continuation.work span with chain.id stamped (#366)", async () => {
+      const result = await captureSwim("continue_work", {
+        chainStepRemaining: 5,
+        delayMs: 30,
+      });
+      expect(result.spans).toHaveLength(1);
+      const [span] = result.spans;
+      expect(span?.name).toBe("continuation.work");
+      expect(span?.attributes["chain.id"]).toBe(result.chainId);
+      // uuid v7 surface (8-4-4-4-12 hex with version nibble 7).
+      expect(result.chainId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(span?.status).toBe("OK");
+      expect(span?.ended).toBe(true);
+    });
+    it("span carries chain.step.remaining attribute", async () => {
+      const result = await captureSwim("continue_work", {
+        chainStepRemaining: 7,
+        delayMs: 0,
+      });
+      const [span] = result.spans;
+      expect(span?.attributes["chain.step.remaining"]).toBe(7);
+      expect(span?.attributes["delay.ms"]).toBe(0);
+    });
     // Chunk 5c (#388) — `continuation.work.fire` lands at bracket-work timer-
     // callback start. Symmetric to 5b's delegate.fire seam but scope-narrower:
     // no reservation system at this seam, so single span emit, no sibling.
@@ -162,13 +170,40 @@ describe("swim-37 harness :: shape contract (live now)", () => {
     expect(_span.attributes["chain.id"]).toBe("test-chain");
   });
 
-  it("captureSwim() exists (or is wired) — sentinel", () => {
-    // While captureSwim is a `declare function` the symbol is undefined at
-    // runtime. This sentinel reminds the morning cohort to wire the actual
-    // exporter. Marked .todo on purpose so suite remains green pre-wiring.
-    // Once wired, flip to:
-    //   const result = await captureSwim("continue_work");
-    //   expect(result.chainId).toMatch(/^[A-Z0-9]{26}$/); // ulid
-    expect(typeof captureSwim).toBe("undefined");
+  it("captureSwim() is wired for continue_work", async () => {
+    expect(typeof captureSwim).toBe("function");
+    const result = await captureSwim("continue_work");
+    expect(result.spans).toHaveLength(1);
+    expect(result.spans[0]?.name).toBe("continuation.work");
+  });
+
+  it("captureSwim() refuses primitives not yet wired", async () => {
+    await expect(captureSwim("continue_delegate")).rejects.toThrow(/not yet wired/);
+    await expect(captureSwim("heartbeat")).rejects.toThrow(/not yet wired/);
+    await expect(captureSwim("lich")).rejects.toThrow(/not yet wired/);
+  });
+
+  it("captureSwim() repeated calls do not leak capture state", async () => {
+    const a = await captureSwim("continue_work");
+    const b = await captureSwim("continue_work");
+    expect(a.spans).toHaveLength(1);
+    expect(b.spans).toHaveLength(1);
+    expect(a.chainId).not.toBe(b.chainId);
+  });
+
+  // Pin the local SpanRecord alias still has a meaningful surface — the
+  // recorder's RecordedSpan must be assignable to it.
+  it("RecordedSpan is structurally a SpanRecord", () => {
+    const recorded: RecordedSpan = {
+      name: "continuation.work",
+      attributes: { "chain.id": "x" },
+      traceparent: undefined,
+      status: "OK",
+      statusMessage: undefined,
+      exceptions: [],
+      ended: true,
+    };
+    const asLocal: SpanRecord = recorded;
+    expect(asLocal.name).toBe("continuation.work");
   });
 });

--- a/studies/swim-37/harness/swim-runner.ts
+++ b/studies/swim-37/harness/swim-runner.ts
@@ -1,0 +1,130 @@
+/**
+ * Swim-37 harness runner — `captureSwim()`.
+ *
+ * Tracks: karmaterminal/openclaw#324 (swim-37 harness)
+ * Companion test: `swim-runner.test.ts`
+ *
+ * **Purpose.** A test-only entry point that drives one continuation primitive
+ * through its `emit*Span` helper against an in-memory recorder, then returns
+ * the captured spans + the synthesized `chainId`. This is the single seam
+ * that `swim-runner.test.ts` (and future trap-class harnesses) use to assert
+ * OTEL span shape without touching a live runner, gateway, or OTLP collector.
+ *
+ * **STDOUT-only discipline.** This harness NEVER installs a real
+ * `BasicTracerProvider`, `BatchSpanProcessor`, OTLP exporter, or any
+ * `@opentelemetry/sdk-trace-base` machinery. All capture flows through
+ * `createInMemorySpanRecorder()` + `setContinuationTracer(recorder.tracer)`.
+ *
+ * **Scope (this PR).** Only `continue_work` is wired. Other primitives
+ * (`continue_delegate`, `heartbeat`, lich-shape) remain `it.todo` in the
+ * companion spec until the dispatch / heartbeat / compaction-release seams
+ * have a comparable single-helper entry point we can drive synthetically.
+ *
+ * **Why a `declare function` was insufficient.** The prior scaffold pinned
+ * `captureSwim` as a `declare function` to make the type-shape compile, with
+ * a sentinel test asserting `typeof captureSwim === "undefined"`. That made
+ * the suite green pre-wiring but never exercised the real
+ * `emitContinuationWorkSpan` plumbing. This module replaces the placeholder
+ * with a real implementation so the spec can flip its first todos.
+ */
+
+import {
+  emitContinuationWorkSpan,
+  resetContinuationTracer,
+  setContinuationTracer,
+} from "../../../src/infra/continuation-tracer.js";
+import { generateChainId } from "../../../src/infra/secure-random.js";
+import { type RecordedSpan, createInMemorySpanRecorder } from "./in-memory-span-recorder.js";
+
+/**
+ * Public swim primitives the harness can drive. Only `continue_work` is
+ * implemented in this PR; the others are reserved for follow-ups so the
+ * type stays stable for callers as they land.
+ */
+export type SwimPrimitive = "continue_work" | "continue_delegate" | "heartbeat" | "lich";
+
+/**
+ * Options accepted by `captureSwim`. Per-primitive options are unioned;
+ * callers pass the shape that matches the primitive they're driving.
+ */
+export type CaptureSwimOptions = {
+  /**
+   * Chain-budget step count to stamp on the emitted span. Defaults to 5
+   * (a non-zero value that exercises the `Math.max(0, …)` clamp without
+   * tripping the empty-budget code path).
+   */
+  chainStepRemaining?: number;
+  /**
+   * Synthetic delay axis stamped as `delay.ms`. Defaults to 0 (immediate
+   * dispatch).
+   */
+  delayMs?: number;
+  /** Optional reason text; previewed (truncated to 80 chars) by the helper. */
+  reason?: string;
+  /**
+   * Override the chain id. Defaults to `generateChainId()` (uuid v7).
+   * Useful for tests that want a known stable id for comparison.
+   */
+  chainId?: string;
+};
+
+/**
+ * Result of one swim. Mirrors the contract pinned by the companion spec.
+ */
+export type ChainPrimitiveResult = {
+  /** Spans captured during the swim, in `startSpan` call order. */
+  spans: RecordedSpan[];
+  /** Chain id stamped onto each emitted span. */
+  chainId: string;
+};
+
+/**
+ * Drive a continuation primitive synchronously and return the captured
+ * spans + chain id. Each call installs a fresh recorder, drives the
+ * matching `emit*Span` helper, then resets the tracer registry to its
+ * no-op default — so tests can call `captureSwim` repeatedly without
+ * leaking capture state between invocations.
+ *
+ * The function is `async` for forward-compatibility with primitives that
+ * will need to await timers (e.g. `continue_delegate` once we drive a
+ * real `setTimeout`-armed dispatch). `continue_work` resolves
+ * synchronously inside this PR.
+ */
+export async function captureSwim(
+  primitive: SwimPrimitive,
+  opts: CaptureSwimOptions = {},
+): Promise<ChainPrimitiveResult> {
+  const recorder = createInMemorySpanRecorder();
+  setContinuationTracer(recorder.tracer);
+  try {
+    switch (primitive) {
+      case "continue_work": {
+        const chainId = opts.chainId ?? generateChainId();
+        emitContinuationWorkSpan({
+          chainId,
+          chainStepRemaining: opts.chainStepRemaining ?? 5,
+          delayMs: opts.delayMs ?? 0,
+          reason: opts.reason,
+        });
+        return { spans: recorder.spans(), chainId };
+      }
+      case "continue_delegate":
+      case "heartbeat":
+      case "lich": {
+        // Reserved for follow-up PRs. We surface a clear error rather
+        // than silently returning an empty result so the spec's
+        // `it.todo` markers stay honest about what is wired.
+        throw new Error(
+          `captureSwim: primitive "${primitive}" is not yet wired ` +
+            `(see studies/swim-37/harness/README.md primitive-coverage matrix)`,
+        );
+      }
+      default: {
+        const exhaustive: never = primitive;
+        throw new Error(`captureSwim: unknown primitive ${String(exhaustive)}`);
+      }
+    }
+  } finally {
+    resetContinuationTracer();
+  }
+}

--- a/studies/swim-37/harness/swim-runner.ts
+++ b/studies/swim-37/harness/swim-runner.ts
@@ -29,6 +29,7 @@
  */
 
 import {
+  emitContinuationDelegateSpan,
   emitContinuationWorkSpan,
   resetContinuationTracer,
   setContinuationTracer,
@@ -66,6 +67,30 @@ export type CaptureSwimOptions = {
    * Useful for tests that want a known stable id for comparison.
    */
   chainId?: string;
+  /**
+   * `continue_delegate` only. Recipient fan-out count: how many
+   * dispatch-accept spans to emit, all sharing the same `chain.id`.
+   * Defaults to 1 (no fan-out). Per cohort design (chunk 3,
+   * 2026-04-27): N recipients = N dispatch spans, NOT one span with
+   * a recipients list. Budget arithmetic still treats fan-out as one
+   * chain step (#355 Stage-2) — that's a budget concern, not a span
+   * cardinality concern.
+   */
+  recipients?: number;
+  /**
+   * `continue_delegate` only. `delegate.delivery` axis on the emitted
+   * span. `"immediate"` = no delay / 0ms delay (no setTimeout armed);
+   * `"timer"` = non-zero clamped delay armed setTimeout. Defaults to
+   * `"immediate"`.
+   */
+  delivery?: "immediate" | "timer";
+  /**
+   * `continue_delegate` only. `delegate.mode` axis on the emitted
+   * span. Pass `undefined` (or omit) to test the omission contract —
+   * the helper conditionally spreads, so `delegate.mode` is absent
+   * from the attribute bag when caller passes undefined.
+   */
+  delegateMode?: "normal" | "silent" | "silent-wake" | "post-compaction";
 };
 
 /**
@@ -108,7 +133,31 @@ export async function captureSwim(
         });
         return { spans: recorder.spans(), chainId };
       }
-      case "continue_delegate":
+      case "continue_delegate": {
+        const chainId = opts.chainId ?? generateChainId();
+        const recipients = opts.recipients ?? 1;
+        if (recipients < 1 || !Number.isInteger(recipients)) {
+          throw new Error(`captureSwim: recipients must be a positive integer, got ${recipients}`);
+        }
+        const delivery = opts.delivery ?? "immediate";
+        const chainStepRemaining = opts.chainStepRemaining ?? 5;
+        const delayMs = opts.delayMs ?? 0;
+        // N recipients = N dispatch spans sharing chain.id.
+        // Budget would treat this as one chain step (#355 Stage-2)
+        // but OTEL emits per-recipient — that's the per-cohort
+        // chunk-3 design pin ("emit at the enqueue/accept seam").
+        for (let i = 0; i < recipients; i++) {
+          emitContinuationDelegateSpan({
+            chainId,
+            chainStepRemaining,
+            delayMs,
+            delivery,
+            delegateMode: opts.delegateMode,
+            reason: opts.reason,
+          });
+        }
+        return { spans: recorder.spans(), chainId };
+      }
       case "heartbeat":
       case "lich": {
         // Reserved for follow-up PRs. We surface a clear error rather


### PR DESCRIPTION
First concrete primitive driven through the swim-37 harness against the live continuation-tracer registry.

## What changes
- Adds `studies/swim-37/harness/swim-runner.ts` exporting `captureSwim()` — drives `emitContinuationWorkSpan` against `createInMemorySpanRecorder()`, returns `{ spans, chainId }`.
- Updates `swim-runner.test.ts` to import the real implementation; flips two `it.todo` markers to live tests; adds 3 new live tests.

## Scope
Only `continue_work` is wired in this PR. Other primitives (`continue_delegate`, `heartbeat`, lich-shape) throw a clear "not yet wired" error — the spec's `it.todo` markers for those primitives remain untouched, honest about what is implemented. Wiring them is a follow-up per primitive once the corresponding dispatch / heartbeat / compaction-release seams have a comparable single-helper entry point we can drive synthetically.

## STDOUT-only discipline preserved
No `BasicTracerProvider`, no `BatchSpanProcessor`, no OTLP exporter, no `@opentelemetry/sdk-trace-base` machinery. All capture flows through `setContinuationTracer(recorder.tracer)` as the README requires.

## Test results
```
swim-37 vitest project:
  in-memory-span-recorder.test.ts: 12 passed
  swim-runner.test.ts: 20 passed | 16 todo
  Total: 20 passed | 16 todo | 0 failed
```

`it.todo` count in swim-runner: **17 \u2192 16** (one primitive's two todos flipped + sentinel rewritten).

## Out of scope
- `continue_delegate` wire (needs synthetic timer-armed dispatch)
- `heartbeat` wire (needs heartbeat span emission entry point)
- lich-shape wire (needs post-compaction release seam from #332 Item B)
- Trap-class \u00a71 / \u00a73a tests (need synthetic commit-pair fixtures + tsgo replay rig)

## Refs
- #324 swim-37 harness scaffold
- #366 continuation.* spans (already on canonical2)

Base: `cael/325-canonical2` @ `652c8a888e`