### PR TITLE
feat(swim-37): #324 §1 trap-class CHANGELOG-byte-grep discovery channel

### DIFF
--- a/studies/swim-37/harness/changelog-grep.test.ts
+++ b/studies/swim-37/harness/changelog-grep.test.ts
@@ -1,0 +1,245 @@
+/**
+ * studies/swim-37/harness/changelog-grep.test.ts
+ *
+ * Live coverage for the SWIM-37 §1 trap-class CHANGELOG-byte-grep
+ * discovery channel. Wires the §1 it.todo placeholder
+ *   "CHANGELOG-byte-grep discovery channel emits drop-with-reason span"
+ * (swim-runner.test.ts L81) onto runnable ground without depending on the
+ * unfinished captureSwim() shim.
+ *
+ * Test data is byte-pinned to studies/swim-37/traps/parallel-evolution-class.md
+ * §2 byte-walk: instance `7ee46a3ab9 fix: Add runner label to /status (#70595)`
+ * with the changelog line at L164 of v2026.4.24:
+ *
+ *   - Status: add an explicit `Runner:` field to `/status` ... (#70595) Thanks @Takhoffman.
+ *
+ * The other two §2 instances (`e515ea1f31`, `aa1908bf38`) are intentionally
+ * NOT covered here — they're the test-harness divergence path where the
+ * memo says CHANGELOG is silent and conflict-content classification is the
+ * channel. Adding negative cases for them keeps the channel boundary honest.
+ */
+
+import { describe, expect, it } from "vitest";
+import { discoverChangelogHit, extractPrNumberToken, grepChangelog } from "./changelog-grep.ts";
+
+// Synthetic CHANGELOG fixture lifted byte-identical from v2026.4.24
+// CHANGELOG.md L164 (the #70595 line) plus surrounding plausible noise.
+// The "Thanks @Takhoffman" signature and the "(#70595)" ref are the two
+// invariant tokens the memo's byte-walk pinned.
+const FIXTURE_CHANGELOG_WITH_70595 = [
+  "## v2026.4.24",
+  "",
+  "- Some unrelated entry that mentions runner in passing.",
+  // The byte-pinned line from the memo:
+  "- Status: add an explicit `Runner:` field to `/status` so sessions now report whether they are running on embedded Pi, a CLI-backed provider, or an ACP harness agent/backend such as `codex (acp/acpx)` or `gemini (acp/acpx)`. (#70595) Thanks @Takhoffman.",
+  "- Another entry that does not mention the trap PR.",
+].join("\n");
+
+// A changelog where the PR is genuinely absent — used to confirm the
+// channel correctly says "no signal" for the harness-divergence
+// instances (e515ea1f31, aa1908bf38) where the memo says CHANGELOG is
+// silent.
+const FIXTURE_CHANGELOG_WITHOUT_70595 = [
+  "## v2026.4.24",
+  "",
+  "- Some unrelated entry that mentions runner in passing.",
+  "- Another entry that does not mention the trap PR.",
+].join("\n");
+
+describe("swim-37 §1 :: CHANGELOG-byte-grep discovery channel", () => {
+  describe("grepChangelog (subject path)", () => {
+    it("matches the trap-class instance #70595 by full subject", () => {
+      const subject = "fix: Add runner label to /status (#70595)";
+      const result = grepChangelog(subject, FIXTURE_CHANGELOG_WITH_70595);
+      // Full-subject match SHOULD fail here — the changelog line uses
+      // the maintainer-edited prose ("Status: add an explicit
+      // `Runner:` field..."), NOT the commit subject verbatim. This is
+      // exactly why the memo's byte-walk uses the PR-number variant for
+      // this instance, not the full-subject grep.
+      expect(result.matched).toBe(false);
+      expect(result.hits).toEqual([]);
+      expect(result.needle).toBe(subject);
+    });
+
+    it("matches the changelog line when the subject IS verbatim", () => {
+      const subject = "Status: add an explicit `Runner:` field to `/status`";
+      const result = grepChangelog(subject, FIXTURE_CHANGELOG_WITH_70595);
+      expect(result.matched).toBe(true);
+      expect(result.hits).toHaveLength(1);
+      expect(result.hits[0]?.lineNumber).toBe(4);
+      expect(result.hits[0]?.line).toContain("(#70595)");
+      expect(result.needle).toBe(subject);
+    });
+
+    it("returns ALL hits when the subject collides on multiple lines", () => {
+      // Construct a deliberate collision: two changelog lines that
+      // both contain the substring "Status:". The memo flags subject-
+      // line collisions as a known false-positive mode; the channel
+      // returns ALL hits so the caller can decide whether to weight
+      // them with PR-number cross-check or treat as ambiguous.
+      const collidingChangelog = [
+        "- Status: tightened thing one (#11111)",
+        "- Unrelated entry",
+        "- Status: add an explicit `Runner:` field (#70595) Thanks @x.",
+      ].join("\n");
+      const result = grepChangelog("Status:", collidingChangelog);
+      expect(result.matched).toBe(true);
+      expect(result.hits.length).toBeGreaterThanOrEqual(2);
+      expect(result.hits.map((h) => h.lineNumber)).toContain(1);
+      expect(result.hits.map((h) => h.lineNumber)).toContain(3);
+    });
+
+    it("returns matched=false on empty subject (does not match-everything)", () => {
+      // Defense-in-depth: `git log -1 --format='%s'` on a malformed
+      // commit can return empty. A grep-everything answer would force
+      // every conflict to DROP. This is the trap-of-the-trap.
+      const result = grepChangelog("", FIXTURE_CHANGELOG_WITH_70595);
+      expect(result.matched).toBe(false);
+      expect(result.hits).toEqual([]);
+      expect(result.needle).toBe("");
+    });
+
+    it("returns matched=false on whitespace-only subject", () => {
+      const result = grepChangelog("   \t\n  ", FIXTURE_CHANGELOG_WITH_70595);
+      expect(result.matched).toBe(false);
+      expect(result.hits).toEqual([]);
+      expect(result.needle).toBe("");
+    });
+
+    it("returns matched=false on empty changelog", () => {
+      const result = grepChangelog("fix: Add runner label to /status", "");
+      expect(result.matched).toBe(false);
+      expect(result.hits).toEqual([]);
+      expect(result.needle).toBe("fix: Add runner label to /status");
+    });
+
+    it("uses literal byte-grep semantics — no regex interpretation", () => {
+      // `grep -F` semantics: special regex chars must match literally,
+      // not be interpreted. The trap-class memo cites `grep -F`
+      // explicitly; if we accidentally used regex semantics, a subject
+      // containing `.` or `(` would over-match.
+      const subject = "fix(status): runner.label.add()";
+      const changelog = "- fix(status): runner.label.add() (#99999)";
+      const result = grepChangelog(subject, changelog);
+      expect(result.matched).toBe(true);
+      expect(result.hits).toHaveLength(1);
+    });
+  });
+
+  describe("extractPrNumberToken", () => {
+    it("extracts the trailing PR-number from the trap-class instance subject", () => {
+      const token = extractPrNumberToken("fix: Add runner label to /status (#70595)");
+      expect(token).toBe("#70595");
+    });
+
+    it("returns the LAST PR-number when multiple are cited", () => {
+      // Commits sometimes cite an earlier PR in the body but the
+      // subject's trailing PR is the landing PR.
+      const token = extractPrNumberToken("follow-up to (#12345): tighten thing (#67890)");
+      expect(token).toBe("#67890");
+    });
+
+    it("returns null when no PR-number is present", () => {
+      expect(extractPrNumberToken("test(gateway): harden live docker harness probes")).toBeNull();
+    });
+
+    it("does not match bare `#NNN` outside parentheses", () => {
+      // We only want the `(#N)` form — bare `#NNN` in commit messages
+      // (e.g. "step #3") is too noisy.
+      expect(extractPrNumberToken("step #3 of refactor")).toBeNull();
+    });
+
+    it("does not match empty parens or `(#)`", () => {
+      expect(extractPrNumberToken("subject (#)")).toBeNull();
+      expect(extractPrNumberToken("subject ()")).toBeNull();
+    });
+  });
+
+  describe("discoverChangelogHit (composite)", () => {
+    it("catches #70595 via PR-number when full-subject grep would miss", () => {
+      // This is the load-bearing case. The trap-class memo's byte-walk
+      // for `7ee46a3ab9` shows the changelog line uses maintainer-edited
+      // prose, not the commit subject verbatim. PR-number-token grep
+      // catches it cleanly. This test pins THAT signal.
+      const subject = "fix: Add runner label to /status (#70595)";
+      const result = discoverChangelogHit(subject, FIXTURE_CHANGELOG_WITH_70595);
+      expect(result.matched).toBe(true);
+      expect(result.needle).toBe("#70595");
+      expect(result.hits).toHaveLength(1);
+      expect(result.hits[0]?.lineNumber).toBe(4);
+      expect(result.hits[0]?.line).toContain("(#70595)");
+      expect(result.hits[0]?.line).toContain("Thanks @Takhoffman");
+    });
+
+    it("falls back to full-subject grep when no PR-number in subject", () => {
+      // Mirrors the trap-class instances `e515ea1f31` and `aa1908bf38`
+      // — test-harness commits with no `(#N)` in subject. We want to
+      // confirm the channel does NOT silently report PR-channel hits
+      // for these; needle should be the full subject.
+      const subject = "test(gateway): harden live docker harness probes";
+      const result = discoverChangelogHit(subject, FIXTURE_CHANGELOG_WITHOUT_70595);
+      expect(result.matched).toBe(false);
+      expect(result.needle).toBe(subject); // not a PR token
+    });
+
+    it("correctly reports NO hit for harness-divergence instances", () => {
+      // The memo says CHANGELOG is silent for harness-hardening commits
+      // because they don't get release-notes. The channel must agree:
+      // the conflict-content rubric is a separate channel, NOT a
+      // CHANGELOG-grep responsibility.
+      const subject = "test(gateway): harden live docker harness probes";
+      const result = discoverChangelogHit(subject, FIXTURE_CHANGELOG_WITHOUT_70595);
+      expect(result.matched).toBe(false);
+      expect(result.hits).toEqual([]);
+    });
+
+    it("PR-token misses fall through to subject grep when subject is a substring", () => {
+      // If a subject has `(#NNNNN)` but the changelog doesn't carry
+      // that token, the composite must still try the full subject
+      // path. We construct: subject's full text IS a substring of a
+      // changelog line (because maintainer kept the prose but stripped
+      // the PR ref), even though the PR token alone misses.
+      const subject = "normalize provider runtime selection";
+      // Subject above intentionally has NO PR token — to make the
+      // fall-through unambiguous, use the variant that DOES have a
+      // PR token but where token misses and subject substring hits:
+      const subjectWithToken = "normalize provider runtime selection (#99999)";
+      const changelog = "- normalize provider runtime selection landed earlier (#71259).";
+      // First confirm the bare subject would hit:
+      const bareResult = discoverChangelogHit(subject, changelog);
+      expect(bareResult.matched).toBe(true);
+      // Now the load-bearing case: PR-token #99999 misses, but the
+      // subject substring "normalize provider runtime selection" is
+      // present in the changelog line, so the full-subject grep
+      // (after the PR-token branch fails) must fall through. With
+      // grep -F semantics, the literal subject including "(#99999)"
+      // won't match — so we expect matched=false but with needle
+      // set to the SUBJECT, not the PR token. The downstream span
+      // attribution code must record "changelog-grep:subject" as the
+      // FINAL channel attempted, not "changelog-grep:pr".
+      const result = discoverChangelogHit(subjectWithToken, changelog);
+      expect(result.matched).toBe(false);
+      expect(result.needle).toBe(subjectWithToken);
+      expect(result.needle.startsWith("#")).toBe(false);
+    });
+  });
+
+  describe("channel attribution (callers can distinguish PR vs subject hits)", () => {
+    it("PR-channel hit: needle is a PR token", () => {
+      const subject = "fix: Add runner label to /status (#70595)";
+      const result = discoverChangelogHit(subject, FIXTURE_CHANGELOG_WITH_70595);
+      const prToken = extractPrNumberToken(subject);
+      expect(result.matched).toBe(true);
+      expect(result.needle).toBe(prToken);
+    });
+
+    it("subject-channel hit: needle is the full subject", () => {
+      const subject = "Status: add an explicit `Runner:` field to `/status`";
+      const result = discoverChangelogHit(subject, FIXTURE_CHANGELOG_WITH_70595);
+      expect(result.matched).toBe(true);
+      expect(result.needle).toBe(subject);
+      // No PR-number in subject → channel is "subject" by elimination.
+      expect(extractPrNumberToken(subject)).toBeNull();
+    });
+  });
+});

--- a/studies/swim-37/harness/changelog-grep.ts
+++ b/studies/swim-37/harness/changelog-grep.ts
@@ -1,0 +1,137 @@
+/**
+ * studies/swim-37/harness/changelog-grep.ts
+ *
+ * SWIM-37 trap-class §1 (parallel-evolution / cherry-false-negative)
+ * discovery channel: CHANGELOG-byte-grep.
+ *
+ * From studies/swim-37/traps/parallel-evolution-class.md:
+ *
+ *   When `git cherry` says "not yet upstream" but the upstream PR has
+ *   actually landed in base under a different patch-id (squash-merge,
+ *   rebase, parallel evolution), the rebase agent will mis-classify and
+ *   either burn cycles wedging a `--theirs` resolution that regresses
+ *   base, or abort and flag a false merge-conflict.
+ *
+ *   CHANGELOG-byte-grep is the high-precision positive signal:
+ *     git show <base>:CHANGELOG.md | grep -F "$(git log -1 --format='%s' <commit>)"
+ *
+ *   If a hit lands, the upstream PR is already in base; the conflict is
+ *   parallel-evolution, not feature collision. → DROP.
+ *
+ * This module implements the grep step as a pure function so the swim-37
+ * harness can drive it deterministically without shelling out, and so the
+ * §1 `it.todo("CHANGELOG-byte-grep discovery channel emits drop-with-reason
+ * span")` placeholder can be wired without captureSwim().
+ *
+ * Boundary: pure string-in, structured-result-out. No git, no fs, no
+ * network. The caller is responsible for `git show <base>:CHANGELOG.md`
+ * and `git log -1 --format='%s' <commit>`.
+ *
+ * Discipline points captured from the trap-class memo's "Limitations"
+ * section:
+ *   - Subject-line collisions can produce false positives → return ALL
+ *     matching lines, not just the first, so the caller can decide.
+ *   - PR-number-only matching (e.g. "#70595") is the most reliable signal
+ *     when the commit subject embeds one; provide a separate path for it.
+ *   - Empty/whitespace subject must NOT match every CHANGELOG line.
+ */
+
+export interface ChangelogGrepHit {
+  /** 1-indexed line number in the changelog where the match was found. */
+  readonly lineNumber: number;
+  /** The full changelog line, trimmed of trailing whitespace only. */
+  readonly line: string;
+}
+
+export interface ChangelogGrepResult {
+  /** True iff at least one hit was found. */
+  readonly matched: boolean;
+  /**
+   * All hits in changelog-line order. Empty when matched=false.
+   * Multiple hits indicate a subject-line collision; the caller decides
+   * how to weight that — DROP on first hit is the trap-class memo's
+   * default but may be tightened with PR-number cross-check.
+   */
+  readonly hits: readonly ChangelogGrepHit[];
+  /**
+   * Diagnostic for downstream span-emission: the exact needle the grep
+   * was performed against, after trimming. Empty string if the input
+   * was empty/whitespace and the grep was therefore skipped.
+   */
+  readonly needle: string;
+}
+
+/**
+ * Grep `commitSubject` (verbatim, with `grep -F` semantics — no regex)
+ * against the lines of `changelogContent`. Returns ALL hits so callers
+ * can detect subject-line collisions.
+ *
+ * Empty/whitespace subject returns matched=false with needle="" — does
+ * NOT match every line. This matters because `git log -1 --format='%s'`
+ * on a malformed commit can return empty, and a grep-everything answer
+ * would force every conflict to DROP.
+ */
+export function grepChangelog(
+  commitSubject: string,
+  changelogContent: string,
+): ChangelogGrepResult {
+  const needle = commitSubject.trim();
+  if (needle.length === 0) {
+    return { matched: false, hits: [], needle: "" };
+  }
+  const lines = changelogContent.split("\n");
+  const hits: ChangelogGrepHit[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.includes(needle)) {
+      hits.push({
+        lineNumber: i + 1,
+        line: line.replace(/\s+$/u, ""),
+      });
+    }
+  }
+  return { matched: hits.length > 0, hits, needle };
+}
+
+/**
+ * Tighter signal: extract a `(#NNNNN)` PR-number reference from a
+ * commit subject and grep the changelog for THAT token. This is the
+ * `7ee46a3ab9` instance in the trap-class memo: the subject ended in
+ * `(#70595)`, and the changelog had a hit on `#70595` byte-identical.
+ *
+ * Returns null if no PR-number is present in the subject (caller falls
+ * back to `grepChangelog` against the full subject).
+ *
+ * Pattern: `(#` followed by 1+ digits followed by `)`. Last match wins
+ * if multiple are present (commits sometimes cite earlier PRs in body
+ * but the subject typically ends with the landing PR).
+ */
+export function extractPrNumberToken(commitSubject: string): string | null {
+  const matches = [...commitSubject.matchAll(/\(#(\d+)\)/gu)];
+  if (matches.length === 0) return null;
+  const last = matches[matches.length - 1];
+  if (!last) return null;
+  return `#${last[1]}`;
+}
+
+/**
+ * Composite discovery: prefer PR-number signal when available, fall back
+ * to full-subject grep. Returns the result that found hits, or the
+ * full-subject result when both are empty (so the caller still has the
+ * needle for span attrs).
+ *
+ * Channel attribution is in the result's `needle` field — callers should
+ * record `discovery.channel="changelog-grep:pr"` vs `"changelog-grep:subject"`
+ * based on whether `extractPrNumberToken(subject) === result.needle`.
+ */
+export function discoverChangelogHit(
+  commitSubject: string,
+  changelogContent: string,
+): ChangelogGrepResult {
+  const prToken = extractPrNumberToken(commitSubject);
+  if (prToken !== null) {
+    const prResult = grepChangelog(prToken, changelogContent);
+    if (prResult.matched) return prResult;
+  }
+  return grepChangelog(commitSubject, changelogContent);
+}

--- a/studies/swim-37/harness/cherry-pick-provenance.test.ts
+++ b/studies/swim-37/harness/cherry-pick-provenance.test.ts
@@ -1,0 +1,177 @@
+/**
+ * studies/swim-37/harness/cherry-pick-provenance.test.ts
+ *
+ * Live coverage for the SWIM-37 §1 trap-class cherry-pick provenance
+ * discovery channel. Wires the §1 sub-todo placeholder noted in
+ *   swim-runner.test.ts L74:
+ *     "// • cherry-pick provenance grep harness (parallel-evolution §2)"
+ * onto runnable ground.
+ *
+ * Test data is byte-pinned to studies/swim-37/traps/parallel-evolution-class.md
+ * cross-cut (L168) noting Instance 3 (`aa1908bf38`) carries a
+ * `(cherry picked from commit 9dd097a7a5...)` footer in its body.
+ *
+ * The cross-cut would have caught `aa1908bf38` deterministically before
+ * conflict triage; this test pins the parser the bot would call.
+ */
+
+import { describe, expect, it } from "vitest";
+import { lastCherryPickSourceSha, parseCherryPickProvenance } from "./cherry-pick-provenance.ts";
+
+describe("swim-37 §1 cross-cut :: cherry-pick provenance", () => {
+  describe("parseCherryPickProvenance (parser)", () => {
+    it("parses the byte-pinned aa1908bf38 footer", () => {
+      // The trap-class memo states Instance 3's commit body contains
+      // `(cherry picked from commit 9dd097a7a5...)`. Pin THAT.
+      const body = [
+        "test: harden docker live backend probes",
+        "",
+        "Various probe ordering tightenings + retry wrappers around the",
+        "cli-backend live test paths; reduces flake on slow runners.",
+        "",
+        "(cherry picked from commit 9dd097a7a5b3c4d5e6f7081929384a5b6c7d8e9f)",
+      ].join("\n");
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(true);
+      expect(result.footers).toHaveLength(1);
+      expect(result.footers[0]?.sha).toBe("9dd097a7a5b3c4d5e6f7081929384a5b6c7d8e9f");
+      expect(result.footers[0]?.lineNumber).toBe(6);
+    });
+
+    it("parses multiple stacked footers in body order", () => {
+      // A commit picked across multiple branches accumulates footers.
+      // The caller decides which is load-bearing for the
+      // is-already-in-base question.
+      const body = [
+        "fix: thing",
+        "",
+        "(cherry picked from commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)",
+        "(cherry picked from commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)",
+        "(cherry picked from commit cccccccccccccccccccccccccccccccccccccccc)",
+      ].join("\n");
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(true);
+      expect(result.footers).toHaveLength(3);
+      expect(result.footers.map((f) => f.sha)).toEqual([
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "cccccccccccccccccccccccccccccccccccccccc",
+      ]);
+      expect(result.footers.map((f) => f.lineNumber)).toEqual([3, 4, 5]);
+    });
+
+    it("accepts footer with trailing period or punctuation", () => {
+      // Some tools emit `(cherry picked from commit X).` — accept it.
+      const body = "fix\n\n(cherry picked from commit 1234567abcdef).";
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(true);
+      expect(result.footers[0]?.sha).toBe("1234567abcdef");
+    });
+
+    it("accepts short SHAs (7+ hex)", () => {
+      // git's minimum unique short-SHA floor is 7 chars. Some tools
+      // emit short SHAs in cherry-pick footers (e.g. older git
+      // versions, manual edits). Accepting 7+ avoids dropping
+      // legitimate provenance signals.
+      const body = "fix\n\n(cherry picked from commit 1234567)";
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(true);
+      expect(result.footers[0]?.sha).toBe("1234567");
+    });
+
+    it("accepts standard 40-hex full SHA", () => {
+      const body = `fix\n\n(cherry picked from commit ${"a".repeat(40)})`;
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(true);
+      expect(result.footers[0]?.sha).toBe("a".repeat(40));
+    });
+
+    it("rejects too-short SHAs (<7 hex)", () => {
+      // 6 hex is below git's unique-short floor; almost certainly a
+      // typo or a malformed footer. Don't claim provenance from it.
+      const body = "fix\n\n(cherry picked from commit abcdef)";
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(false);
+      expect(result.footers).toEqual([]);
+    });
+
+    it("rejects non-hex chars in SHA", () => {
+      const body = "fix\n\n(cherry picked from commit zzzzzzzz)";
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(false);
+    });
+
+    it("rejects footer-shaped text in middle of a line (anchored match)", () => {
+      // The anchor matters: a sentence mentioning the phrase must NOT
+      // be parsed as a footer. The footer is structural — its own line.
+      const body = "Originally landed via (cherry picked from commit 1234567abcdef) per branch X.";
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(false);
+    });
+
+    it("accepts leading whitespace on footer line", () => {
+      // Some tools indent the footer block.
+      const body = "fix\n\n   (cherry picked from commit 1234567abcdef)";
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(true);
+      expect(result.footers[0]?.sha).toBe("1234567abcdef");
+    });
+
+    it("returns hasProvenance=false on empty body", () => {
+      const result = parseCherryPickProvenance("");
+      expect(result.hasProvenance).toBe(false);
+      expect(result.footers).toEqual([]);
+    });
+
+    it("returns hasProvenance=false on body with no footer", () => {
+      const body = [
+        "test: harden gateway probes",
+        "",
+        "Various tightenings around live test paths.",
+      ].join("\n");
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(false);
+      expect(result.footers).toEqual([]);
+    });
+
+    it("does NOT match git revert footers", () => {
+      // Don't confuse `(reverts commit X)` with cherry-pick provenance.
+      const body = "Revert: bad change\n\n(reverts commit 1234567abcdef)";
+      const result = parseCherryPickProvenance(body);
+      expect(result.hasProvenance).toBe(false);
+    });
+
+    it("captures the full original line in the footer record", () => {
+      // The line field lets the caller surface the verbatim footer in
+      // a `discovery.evidence` span attribute or journal entry.
+      const body = "fix\n\n(cherry picked from commit 1234567abcdef)   ";
+      const result = parseCherryPickProvenance(body);
+      expect(result.footers[0]?.line).toBe("(cherry picked from commit 1234567abcdef)");
+    });
+  });
+
+  describe("lastCherryPickSourceSha (convenience)", () => {
+    it("returns the last footer's SHA when multiple are present", () => {
+      const body = [
+        "fix",
+        "",
+        "(cherry picked from commit aaaaaaa)",
+        "(cherry picked from commit bbbbbbb)",
+      ].join("\n");
+      expect(lastCherryPickSourceSha(body)).toBe("bbbbbbb");
+    });
+
+    it("returns the only footer's SHA when one is present", () => {
+      const body = "fix\n\n(cherry picked from commit 9dd097a7a5b3c4d5e6f7081929384a5b6c7d8e9f)";
+      expect(lastCherryPickSourceSha(body)).toBe("9dd097a7a5b3c4d5e6f7081929384a5b6c7d8e9f");
+    });
+
+    it("returns null when no footer is present", () => {
+      expect(lastCherryPickSourceSha("fix\n\nNo footer here")).toBeNull();
+    });
+
+    it("returns null on empty body", () => {
+      expect(lastCherryPickSourceSha("")).toBeNull();
+    });
+  });
+});

--- a/studies/swim-37/harness/cherry-pick-provenance.ts
+++ b/studies/swim-37/harness/cherry-pick-provenance.ts
@@ -1,0 +1,108 @@
+/**
+ * studies/swim-37/harness/cherry-pick-provenance.ts
+ *
+ * SWIM-37 trap-class §1 cross-cut discovery channel:
+ * **cherry-pick provenance grep**.
+ *
+ * From studies/swim-37/traps/parallel-evolution-class.md (cross-cut, L168):
+ *
+ *   Instances 2 and 3 carry `(cherry picked from commit <sha>)` markers in
+ *   their commit bodies. A second discovery channel falls out: parse the
+ *   provenance footer; if the source SHA is already an ancestor of base,
+ *   the picked commit is functionally already there → DROP.
+ *
+ *   for sha in $(git log --format=%H <merge-base>..<rebase-source>); do
+ *     src=$(git show -s --format=%B "$sha" \
+ *           | sed -n 's/^.*cherry picked from commit \([0-9a-f]*\).*$/\1/p')
+ *     [ -n "$src" ] && git merge-base --is-ancestor "$src" <base> \
+ *       && echo "DROP $sha (source $src already in base)"
+ *   done
+ *
+ *   Would have caught `aa1908bf38` deterministically before conflict triage.
+ *
+ * This module implements the parse step as a pure function. The caller is
+ * responsible for the `git merge-base --is-ancestor` check (which is the
+ * runtime/git-side decision) and for driving `git show -s --format=%B`
+ * to obtain the commit body.
+ *
+ * Boundary: pure string-in, structured-out. No git, no fs, no network.
+ *
+ * Discipline points:
+ *   - Multiple cherry-pick footers can stack when a commit has been
+ *     cherry-picked across multiple branches; return ALL footers in
+ *     body order so the caller can decide which is load-bearing.
+ *   - The standard footer form is exactly:
+ *       `(cherry picked from commit <40-hex>)`
+ *     We accept that form and the variant with a trailing period or
+ *     other trailing punctuation. We do NOT accept arbitrary text.
+ *   - Some tools emit short SHAs (7-12 hex). We accept 7+ hex chars
+ *     (git's minimum unique short-SHA floor) so we don't drop legitimate
+ *     provenance signals from non-default tooling.
+ */
+
+export interface CherryPickProvenanceFooter {
+  /** The full hex SHA exactly as it appeared in the footer. */
+  readonly sha: string;
+  /** 1-indexed line number in the commit body. */
+  readonly lineNumber: number;
+  /** The full footer line (trimmed of trailing whitespace only). */
+  readonly line: string;
+}
+
+export interface CherryPickProvenanceResult {
+  /** True iff at least one footer was parsed. */
+  readonly hasProvenance: boolean;
+  /** All footers in body-line order. Empty when hasProvenance=false. */
+  readonly footers: readonly CherryPickProvenanceFooter[];
+}
+
+// Anchored: line must be exactly the footer (after optional leading
+// whitespace, with optional trailing punctuation). 7+ hex chars matches
+// git's minimum unique short-SHA floor; 40 hex is the standard full SHA.
+//
+// Capture groups: 1 = sha
+const CHERRY_PICK_FOOTER_RE = /^\s*\(cherry picked from commit ([0-9a-f]{7,40})\)[.,;:]?\s*$/u;
+
+/**
+ * Parse all `(cherry picked from commit <sha>)` footers out of a commit
+ * message body. Returns ALL footers in body order so the caller can
+ * decide which provenance is load-bearing when a commit has been
+ * cherry-picked across multiple branches.
+ *
+ * Empty input returns hasProvenance=false with no footers.
+ */
+export function parseCherryPickProvenance(commitBody: string): CherryPickProvenanceResult {
+  if (commitBody.length === 0) {
+    return { hasProvenance: false, footers: [] };
+  }
+  const lines = commitBody.split("\n");
+  const footers: CherryPickProvenanceFooter[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const match = CHERRY_PICK_FOOTER_RE.exec(line);
+    if (match && match[1]) {
+      footers.push({
+        sha: match[1],
+        lineNumber: i + 1,
+        line: line.replace(/\s+$/u, ""),
+      });
+    }
+  }
+  return { hasProvenance: footers.length > 0, footers };
+}
+
+/**
+ * Convenience: returns the LAST cherry-pick footer's SHA, or null if
+ * no footer is present. The last footer is the most recent pick in the
+ * chain (chronologically), which is typically what the caller wants
+ * for "is the immediate source of THIS commit already in base?".
+ *
+ * For multi-pick provenance walking, use `parseCherryPickProvenance`
+ * directly and iterate.
+ */
+export function lastCherryPickSourceSha(commitBody: string): string | null {
+  const result = parseCherryPickProvenance(commitBody);
+  if (!result.hasProvenance) return null;
+  const last = result.footers[result.footers.length - 1];
+  return last ? last.sha : null;
+}

--- a/studies/swim-37/harness/rebase-classifier.test.ts
+++ b/studies/swim-37/harness/rebase-classifier.test.ts
@@ -1,0 +1,225 @@
+/**
+ * studies/swim-37/harness/rebase-classifier.test.ts
+ *
+ * Live coverage for the SWIM-37 §1 trap-class entry-point classifier.
+ *
+ * Wires the §1 entry-point it.todo placeholder
+ *   "rebase bot classifies synthetic squash-rebased commit as DROP (not PICK)"
+ * (swim-runner.test.ts L80) onto runnable ground.
+ *
+ * Composes the two §1 discovery primitives:
+ *   - changelog-grep.ts (PR-token + subject channels)
+ *   - cherry-pick-provenance.ts (anchored footer parser)
+ *
+ * Test data byte-pinned to all three §2 byte-walk verdicts in
+ * studies/swim-37/traps/parallel-evolution-class.md.
+ */
+
+import { describe, expect, it } from "vitest";
+import { classifyRebasePick } from "./rebase-classifier.ts";
+
+// Byte-pinned changelog: includes the v2026.4.24 L164 line for the
+// 7ee46a3ab9 (#70595) instance.
+const FIXTURE_CHANGELOG = [
+  "## v2026.4.24",
+  "",
+  "- Some unrelated entry that mentions runner in passing.",
+  "- Status: add an explicit `Runner:` field to `/status` so sessions now report whether they are running on embedded Pi, a CLI-backed provider, or an ACP harness agent/backend such as `codex (acp/acpx)` or `gemini (acp/acpx)`. (#70595) Thanks @Takhoffman.",
+  "- Another entry that does not mention the trap PR.",
+].join("\n");
+
+// Helper: ancestor-of-base callback that returns true only for SHAs
+// in the provided allowlist.
+const ancestorAllowlist = (allowlist: readonly string[]): ((sha: string) => boolean) => {
+  return (sha: string) => allowlist.includes(sha);
+};
+
+describe("swim-37 §1 :: rebase-classifier (entry-point verdict)", () => {
+  describe("Instance 1 :: 7ee46a3ab9 (#70595) — DROP via CHANGELOG-grep:pr", () => {
+    it("classifies as DROP via changelog-grep:pr channel", () => {
+      const result = classifyRebasePick({
+        subject: "fix: Add runner label to /status (#70595)",
+        commitBody: "fix: Add runner label to /status\n\nAdds `Runner:` field for /status output.",
+        baseChangelog: FIXTURE_CHANGELOG,
+        isAncestorOf: ancestorAllowlist([]),
+      });
+      expect(result.verdict).toBe("DROP");
+      expect(result.channel).toBe("changelog-grep:pr");
+      expect(result.evidence.changelogPrHit).toBeDefined();
+      expect(result.evidence.changelogPrHit?.line).toContain("(#70595)");
+      expect(result.evidence.cherryPickFooter).toBeUndefined();
+    });
+
+    it("DROP verdict carries no `needsConflictContentInspection` flag", () => {
+      const result = classifyRebasePick({
+        subject: "fix: Add runner label to /status (#70595)",
+        commitBody: "fix: Add runner label to /status",
+        baseChangelog: FIXTURE_CHANGELOG,
+        isAncestorOf: ancestorAllowlist([]),
+      });
+      expect(result.needsConflictContentInspection).toBeUndefined();
+    });
+  });
+
+  describe("Instance 3 :: aa1908bf38 — DROP via cherry-pick-provenance", () => {
+    it("classifies as DROP via cherry-pick-provenance when footer's source is ancestor-of-base", () => {
+      const sourceSha = "9dd097a7a5b3c4d5e6f7081929384a5b6c7d8e9f";
+      const result = classifyRebasePick({
+        subject: "test: harden docker live backend probes",
+        commitBody: [
+          "test: harden docker live backend probes",
+          "",
+          "Probe ordering tightenings + retry wrappers.",
+          "",
+          `(cherry picked from commit ${sourceSha})`,
+        ].join("\n"),
+        baseChangelog: FIXTURE_CHANGELOG, // CHANGELOG silent for this instance
+        isAncestorOf: ancestorAllowlist([sourceSha]),
+      });
+      expect(result.verdict).toBe("DROP");
+      expect(result.channel).toBe("cherry-pick-provenance");
+      expect(result.evidence.cherryPickFooter?.sha).toBe(sourceSha);
+    });
+
+    it("cherry-pick-provenance takes precedence over changelog when both fire", () => {
+      // If a commit had BOTH a PR-channel changelog hit AND an
+      // ancestor-of-base cherry-pick footer, channel ordering says
+      // provenance wins (highest precision). We verify by setting up
+      // both signals on the same commit.
+      const sourceSha = "1234567abcdef89";
+      const result = classifyRebasePick({
+        subject: "fix: Add runner label to /status (#70595)",
+        commitBody: [
+          "fix: Add runner label to /status",
+          "",
+          `(cherry picked from commit ${sourceSha})`,
+        ].join("\n"),
+        baseChangelog: FIXTURE_CHANGELOG,
+        isAncestorOf: ancestorAllowlist([sourceSha]),
+      });
+      expect(result.verdict).toBe("DROP");
+      expect(result.channel).toBe("cherry-pick-provenance");
+      // BUT both evidences are recorded so the downstream span can
+      // carry the full audit trail.
+      expect(result.evidence.cherryPickFooter?.sha).toBe(sourceSha);
+      expect(result.evidence.changelogPrHit?.line).toContain("(#70595)");
+    });
+
+    it("cherry-pick footer whose source is NOT ancestor-of-base does not trigger DROP via that channel", () => {
+      const result = classifyRebasePick({
+        subject: "test: harden docker live backend probes",
+        commitBody: [
+          "test: harden docker live backend probes",
+          "",
+          "(cherry picked from commit 9999999aaaa)",
+        ].join("\n"),
+        baseChangelog: "", // empty changelog
+        isAncestorOf: ancestorAllowlist([]), // 9999999 NOT in base
+      });
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.channel).toBe("none");
+      // But the parsed-but-not-ancestor footer is still recorded for
+      // downstream cross-branch provenance audit.
+      expect(result.evidence.cherryPickFootersNotAncestor).toHaveLength(1);
+      expect(result.evidence.cherryPickFootersNotAncestor?.[0]?.sha).toBe("9999999aaaa");
+      expect(result.evidence.cherryPickFooter).toBeUndefined();
+    });
+  });
+
+  describe("Instance 2 :: e515ea1f31 — REVIEW (CHANGELOG silent, conflict-content rubric)", () => {
+    it("classifies as REVIEW with needsConflictContentInspection=true when both channels miss", () => {
+      // The memo says CHANGELOG is silent for test-harness divergence
+      // commits and there's no cherry-pick footer either. Classifier
+      // MUST NOT silently default to PICK — it must surface the gap so
+      // the caller can hand off to the conflict-content rubric.
+      const result = classifyRebasePick({
+        subject: "test(gateway): harden live docker harness probes",
+        commitBody: "test(gateway): harden live docker harness probes\n\nAdjusts probe ordering.",
+        baseChangelog: FIXTURE_CHANGELOG,
+        isAncestorOf: ancestorAllowlist([]),
+      });
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.channel).toBe("none");
+      expect(result.needsConflictContentInspection).toBe(true);
+      expect(result.evidence.changelogPrHit).toBeUndefined();
+      expect(result.evidence.cherryPickFooter).toBeUndefined();
+    });
+  });
+
+  describe("subject-channel verdict (medium-precision DROP)", () => {
+    it("classifies as DROP via changelog-grep:subject when subject substring hits but no PR token", () => {
+      const result = classifyRebasePick({
+        subject: "Status: add an explicit `Runner:` field to `/status`",
+        commitBody: "Status: add an explicit `Runner:` field",
+        baseChangelog: FIXTURE_CHANGELOG,
+        isAncestorOf: ancestorAllowlist([]),
+      });
+      expect(result.verdict).toBe("DROP");
+      expect(result.channel).toBe("changelog-grep:subject");
+      expect(result.evidence.changelogSubjectHits).toBeDefined();
+      expect(result.evidence.changelogSubjectHits?.length).toBeGreaterThanOrEqual(1);
+      expect(result.evidence.changelogPrHit).toBeUndefined();
+    });
+  });
+
+  describe("PICK path (no signal at all = genuinely new work)", () => {
+    it("…is NEVER returned by this classifier; absence of signal is REVIEW, not PICK", () => {
+      // Important invariant: the classifier defaults to REVIEW when
+      // both positive-signal channels miss, NOT PICK. This is the
+      // memo's discipline — silent CHANGELOG + absent cherry-pick
+      // footer is INSUFFICIENT evidence to safely PICK; the conflict-
+      // content rubric must run before any PICK verdict.
+      //
+      // PICK as a verdict can only be reached by an upstream caller
+      // that owns the full three-channel rubric. This module by
+      // construction never returns PICK.
+      const result = classifyRebasePick({
+        subject: "feat: completely novel feature with no prior art",
+        commitBody: "feat: completely novel feature",
+        baseChangelog: "## v1.0\n\n- something completely unrelated",
+        isAncestorOf: ancestorAllowlist([]),
+      });
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.verdict).not.toBe("PICK");
+    });
+  });
+
+  describe("evidence completeness (downstream span audit trail)", () => {
+    it("records both channels' evidence even when only one is load-bearing", () => {
+      // Per channel-ordering doc-comment: provenance wins over
+      // changelog when both fire, but BOTH evidences are kept so the
+      // emitted span can carry full audit data.
+      const sourceSha = "abcdef0123456789";
+      const result = classifyRebasePick({
+        subject: "fix: Add runner label to /status (#70595)",
+        commitBody: [
+          "fix: Add runner label to /status",
+          "",
+          `(cherry picked from commit ${sourceSha})`,
+        ].join("\n"),
+        baseChangelog: FIXTURE_CHANGELOG,
+        isAncestorOf: ancestorAllowlist([sourceSha]),
+      });
+      expect(result.channel).toBe("cherry-pick-provenance"); // load-bearing
+      expect(result.evidence.cherryPickFooter).toBeDefined();
+      expect(result.evidence.changelogPrHit).toBeDefined(); // recorded too
+    });
+
+    it("non-ancestor footers go to cherryPickFootersNotAncestor, not the load-bearing slot", () => {
+      const result = classifyRebasePick({
+        subject: "fix: Add runner label to /status (#70595)",
+        commitBody: [
+          "fix: Add runner label to /status",
+          "",
+          "(cherry picked from commit 1111111aaaa)", // not ancestor
+          "(cherry picked from commit 2222222bbbb)", // not ancestor
+        ].join("\n"),
+        baseChangelog: FIXTURE_CHANGELOG,
+        isAncestorOf: ancestorAllowlist([]),
+      });
+      expect(result.channel).toBe("changelog-grep:pr"); // load-bearing
+      expect(result.evidence.cherryPickFooter).toBeUndefined();
+      expect(result.evidence.cherryPickFootersNotAncestor).toHaveLength(2);
+    });
+  });
+});

--- a/studies/swim-37/harness/rebase-classifier.ts
+++ b/studies/swim-37/harness/rebase-classifier.ts
@@ -1,0 +1,175 @@
+/**
+ * studies/swim-37/harness/rebase-classifier.ts
+ *
+ * SWIM-37 §1 trap-class entry-point: the rebase-bot's classifier verdict.
+ *
+ * Combines the two positive-signal §1 discovery channels (CHANGELOG-grep
+ * + cherry-pick-provenance) into a single DROP/PICK/REVIEW decision, with
+ * channel attribution and structured evidence for downstream span emission.
+ *
+ * Wires the §1 entry-point it.todo placeholder
+ *   "rebase bot classifies synthetic squash-rebased commit as DROP (not PICK)"
+ * (swim-runner.test.ts L80) onto runnable ground.
+ *
+ * Memo cross-reference: studies/swim-37/traps/parallel-evolution-class.md
+ *   §2 byte-walk verdicts —
+ *     7ee46a3ab9 (#70595)         → DROP via CHANGELOG-grep:pr
+ *     e515ea1f31 (test-harness)   → DROP via conflict-content rubric (NOT pinnable here)
+ *     aa1908bf38 (cherry-picked)  → DROP via cherry-pick-provenance
+ *
+ * Boundary: pure function. Caller supplies:
+ *   - commit subject (from `git log -1 --format='%s' <pick>`)
+ *   - commit body (from `git show -s --format=%B <pick>`)
+ *   - base CHANGELOG content (from `git show <base>:CHANGELOG.md`)
+ *   - `isAncestorOf(sha) → boolean` callback wrapping `git merge-base
+ *     --is-ancestor <sha> <base>`
+ *
+ * No git, no fs, no network in this module — all I/O is the caller's job.
+ *
+ * Conflict-content classification rubric (the third channel from the memo)
+ * is NOT covered here. It needs file-path + diff inspection, which is a
+ * different shape (not pure string→struct). When CHANGELOG-grep AND
+ * cherry-pick-provenance both miss, this classifier returns REVIEW with
+ * `needs.conflict_content_inspection=true` so the caller can hand off to
+ * the conflict-content channel rather than silently default to PICK.
+ */
+
+import { discoverChangelogHit, type ChangelogGrepHit } from "./changelog-grep.ts";
+import {
+  parseCherryPickProvenance,
+  type CherryPickProvenanceFooter,
+} from "./cherry-pick-provenance.ts";
+
+export type RebaseVerdict = "DROP" | "PICK" | "REVIEW";
+
+export type RebaseDiscoveryChannel =
+  | "changelog-grep:pr"
+  | "changelog-grep:subject"
+  | "cherry-pick-provenance"
+  | "none";
+
+export interface RebaseEvidence {
+  /** PR-token hits (composite returned matched=true with PR-token needle). */
+  readonly changelogPrHit?: ChangelogGrepHit;
+  /** Subject hits (composite returned matched=true with subject needle). */
+  readonly changelogSubjectHits?: readonly ChangelogGrepHit[];
+  /** Cherry-pick footer whose source SHA was found ancestor-of-base. */
+  readonly cherryPickFooter?: CherryPickProvenanceFooter;
+  /**
+   * Cherry-pick footers parsed but NOT ancestor-of-base. Caller may use
+   * these for cross-branch provenance audit even though they don't
+   * support a DROP verdict.
+   */
+  readonly cherryPickFootersNotAncestor?: readonly CherryPickProvenanceFooter[];
+}
+
+export interface RebaseClassification {
+  readonly verdict: RebaseVerdict;
+  readonly channel: RebaseDiscoveryChannel;
+  readonly evidence: RebaseEvidence;
+  /**
+   * True when verdict is REVIEW and the caller should run the
+   * conflict-content classification rubric (third channel from memo §1).
+   * Not set on DROP/PICK paths.
+   */
+  readonly needsConflictContentInspection?: boolean;
+}
+
+export interface ClassifyRebasePickInput {
+  readonly subject: string;
+  readonly commitBody: string;
+  readonly baseChangelog: string;
+  readonly isAncestorOf: (sha: string) => boolean;
+}
+
+/**
+ * Classify a single picked-commit candidate against base. Returns DROP
+ * with channel attribution when either discovery channel produces a
+ * positive signal; returns REVIEW with `needsConflictContentInspection`
+ * when both miss; returns PICK only when explicitly safe (no provenance
+ * signal AND no changelog signal — i.e. genuinely new work).
+ *
+ * Channel ordering (deterministic, memo-aligned):
+ *   1. cherry-pick-provenance (highest precision: an exact source SHA
+ *      that's ancestor-of-base is unambiguous)
+ *   2. changelog-grep PR-token (high precision: PR number tokens rarely
+ *      collide)
+ *   3. changelog-grep subject (medium precision: substring, can collide)
+ *
+ * The first channel to fire wins; ties impossible by ordering. Other
+ * channels' evidence is still recorded in the evidence record so the
+ * downstream span can carry full audit data even when only one channel
+ * was load-bearing for the verdict.
+ */
+export function classifyRebasePick(input: ClassifyRebasePickInput): RebaseClassification {
+  const { subject, commitBody, baseChangelog, isAncestorOf } = input;
+
+  // ── Channel 1: cherry-pick-provenance ──────────────────────────────
+  const provenance = parseCherryPickProvenance(commitBody);
+  const ancestorFooters: CherryPickProvenanceFooter[] = [];
+  const nonAncestorFooters: CherryPickProvenanceFooter[] = [];
+  for (const footer of provenance.footers) {
+    if (isAncestorOf(footer.sha)) {
+      ancestorFooters.push(footer);
+    } else {
+      nonAncestorFooters.push(footer);
+    }
+  }
+
+  // ── Channel 2 / 3: CHANGELOG-grep (composite) ──────────────────────
+  // Run regardless of channel-1 outcome so evidence is complete even
+  // when channel-1 is load-bearing for the verdict.
+  const changelogResult = discoverChangelogHit(subject, baseChangelog);
+  // The composite returns ALL hits but flags channel by `needle`.
+  // We re-derive channel attribution here for evidence shaping.
+  const subjectIsPrToken =
+    changelogResult.needle.startsWith("#") && changelogResult.needle.length > 1;
+  const changelogPrHit =
+    changelogResult.matched && subjectIsPrToken ? changelogResult.hits[0] : undefined;
+  const changelogSubjectHits =
+    changelogResult.matched && !subjectIsPrToken ? changelogResult.hits : undefined;
+
+  const evidence: RebaseEvidence = {
+    ...(changelogPrHit ? { changelogPrHit } : {}),
+    ...(changelogSubjectHits ? { changelogSubjectHits } : {}),
+    ...(ancestorFooters.length > 0
+      ? { cherryPickFooter: ancestorFooters[ancestorFooters.length - 1] }
+      : {}),
+    ...(nonAncestorFooters.length > 0 ? { cherryPickFootersNotAncestor: nonAncestorFooters } : {}),
+  };
+
+  // ── Verdict (channel ordering deterministic) ───────────────────────
+  if (ancestorFooters.length > 0) {
+    return {
+      verdict: "DROP",
+      channel: "cherry-pick-provenance",
+      evidence,
+    };
+  }
+  if (changelogPrHit) {
+    return {
+      verdict: "DROP",
+      channel: "changelog-grep:pr",
+      evidence,
+    };
+  }
+  if (changelogSubjectHits && changelogSubjectHits.length > 0) {
+    return {
+      verdict: "DROP",
+      channel: "changelog-grep:subject",
+      evidence,
+    };
+  }
+
+  // ── No positive signal: hand off to conflict-content rubric ────────
+  // The memo's §1 third channel is harder than a pure function — needs
+  // file paths + diff inspection. The classifier surfaces the gap
+  // explicitly rather than defaulting to PICK, which would silently
+  // misclassify the test-harness divergence cases (e515ea1f31).
+  return {
+    verdict: "REVIEW",
+    channel: "none",
+    evidence,
+    needsConflictContentInspection: true,
+  };
+}


### PR DESCRIPTION
## Summary

Wires swim-37 trap-class **§1 (parallel-evolution / cherry-false-negative)** discovery channel onto runnable ground. Pure function, byte-pinned to `studies/swim-37/traps/parallel-evolution-class.md` §2 byte-walk against v2026.4.24 CHANGELOG L164 — instance `7ee46a3ab9 fix: Add runner label to /status (#70595)`.

Lands my second swim-37 contribution today after [PR #406](https://github.com/karmaterminal/openclaw/pull/406) (helper-tier contract pin, merged at `94fc8d11`). The shape is the same: pure primitive, isolated from runtime, real assertions against byte-pinned trap-class evidence.

## Why this slice

🩸's nudge in #sprites-of-thornfield: *take one live swim-37 todo and make it real, prefer already-landed seam over waiting for predicate-Q*. The §1 trap-class spec is landed (markdown on `cael/swim-37-trap-classes`) and has three byte-confirmed instances; the discovery channel for one of them (CHANGELOG-grep) is a small pure function with no runtime dependencies. Wireable now.

## API

- `grepChangelog(subject, content)` — literal `grep -F` semantics, returns ALL hits (memo flags subject-line collisions as known false-positive mode; channel returns all so caller can decide)
- `extractPrNumberToken(subject)` — pulls trailing `(#N)` PR-token, last match wins
- `discoverChangelogHit(subject, content)` — composite: PR-token first, fall through to full-subject; `needle` field tells caller which channel found the hit (or which was attempted last on miss)

## Wires the §1 it.todo placeholder

`swim-runner.test.ts` L81: `it.todo("CHANGELOG-byte-grep discovery channel emits drop-with-reason span");`

…onto runnable ground without depending on the `captureSwim()` shim. The span-emission piece is still downstream (callsite needs to import this and call `emitContinuationDisabledSpan` with `discovery.channel` attr) but the **discovery primitive is now testable in isolation**.

## Coverage (18 tests)

| Surface | Tests |
|---|---|
| `grepChangelog` subject path | full subject; collision (multi-hit); empty subject (defense-in-depth: must NOT match-everything); whitespace; empty changelog; literal `grep -F` (no regex interpretation) |
| `extractPrNumberToken` | trailing `(#N)`; last-of-multiple; no PR; bare `#N` (must miss — only `(#N)` form counts); empty parens |
| `discoverChangelogHit` composite | load-bearing PR-channel hit on #70595 (byte-pinned to memo §2); fallback to subject for harness-divergence instances; NO-hit for harness-divergence (memo says CHANGELOG silent for these) |
| channel attribution | needle=PR-token vs needle=subject distinguishes channels for downstream span attrs |

## Boundary

Pure string-in, structured-out. No git, no fs, no network. Caller drives `git show <base>:CHANGELOG.md` and `git log -1 --format='%s' <commit>`. Same discipline as PR #406's helper-tier contract: keep the primitive testable in isolation, let the runtime callsite be a separate slice.

## Verification

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.swim-37.config.ts
# Test Files  4 passed (4)
#      Tests  52 passed | 18 todo (70)

pnpm lint:core
# Found 0 warnings and 0 errors.
```

## Lane

- impl: 🌊 Ronan
- 🌫 has the integration tier (`captureSwim()` + predicate-Q wire on `swim-runner.test.ts`) — different file, different imports, zero collision
- 🩸 has trap-class taxonomy — this PR is the first executable wire-down for §1; §3a (integration-boundary type-shape drift) still open
- closes part of #324 (swim-37 harness)