### PR TITLE
feat(swim-37): #324 §1 trap-class conflict-content rubric (closes #409)

### DIFF
--- a/studies/swim-37/harness/conflict-content-rubric.test.ts
+++ b/studies/swim-37/harness/conflict-content-rubric.test.ts
@@ -1,0 +1,318 @@
+/**
+ * studies/swim-37/harness/conflict-content-rubric.test.ts
+ *
+ * Live tests for the §1 trap-class third discovery channel:
+ * conflict-content classification rubric.
+ *
+ * Pinned to memo §2 byte-walk:
+ *   - Instance 2 (`e515ea1f31`, test-harness divergence) → DROP via
+ *     test-harness bin
+ *   - Instance 1 (`aa1908bf38`, docker live backend) → DROP via
+ *     test-harness bin
+ *
+ * Plus integration with `classifyRebasePick`: the optional
+ * conflict-content callback flips the no-signal REVIEW into a
+ * channel-attributed verdict.
+ *
+ * Issue: karmaterminal/openclaw#409
+ */
+
+import { describe, expect, it } from "vitest";
+import { classifyConflictContent, type ConflictReport } from "./conflict-content-rubric.ts";
+import { classifyRebasePick } from "./rebase-classifier.ts";
+
+describe("swim-37 §1 cross-cut :: conflict-content rubric (#409)", () => {
+  describe("classifyConflictContent (rubric)", () => {
+    it("returns REVIEW + bin='none' on empty report (refuses silent PICK)", () => {
+      const result = classifyConflictContent({ files: [] });
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.bin).toBe("none");
+      expect(result.files).toEqual([]);
+    });
+
+    it("test-harness bin: e515ea1f31 (live.test.ts) → DROP", () => {
+      // Memo §2 Instance 2: gateway live test hardening.
+      // Files conflicted under *.live.test.ts paths.
+      const report: ConflictReport = {
+        files: [
+          {
+            basePath: "src/gateway/__tests__/probe.live.test.ts",
+            pickPath: "src/gateway/__tests__/probe.live.test.ts",
+          },
+          {
+            basePath: "src/gateway/__tests__/retry.live.test.ts",
+            pickPath: "src/gateway/__tests__/retry.live.test.ts",
+          },
+        ],
+      };
+      const result = classifyConflictContent(report);
+      expect(result.verdict).toBe("DROP");
+      expect(result.bin).toBe("test-harness");
+      expect(result.files).toHaveLength(2);
+      expect(result.files.every((f) => f.bin === "test-harness")).toBe(true);
+    });
+
+    it("test-harness bin: aa1908bf38 (e2e/) → DROP", () => {
+      // Memo §2 Instance 1: docker live backend probes.
+      // Files under e2e/.
+      const report: ConflictReport = {
+        files: [{ basePath: "e2e/docker-backend.spec.ts", pickPath: "e2e/docker-backend.spec.ts" }],
+      };
+      const result = classifyConflictContent(report);
+      expect(result.verdict).toBe("DROP");
+      expect(result.bin).toBe("test-harness");
+    });
+
+    it("test-harness bin: scripts/test-* → DROP", () => {
+      const report: ConflictReport = {
+        files: [
+          { basePath: "scripts/test-live-probes.sh", pickPath: "scripts/test-live-probes.sh" },
+        ],
+      };
+      expect(classifyConflictContent(report).verdict).toBe("DROP");
+    });
+
+    it("test-harness bin: __tests__/ → DROP", () => {
+      const report: ConflictReport = {
+        files: [
+          { basePath: "src/foo/__tests__/bar.test.ts", pickPath: "src/foo/__tests__/bar.test.ts" },
+        ],
+      };
+      expect(classifyConflictContent(report).verdict).toBe("DROP");
+    });
+
+    it("release-plumbing bin: package.json → DROP", () => {
+      const report: ConflictReport = {
+        files: [{ basePath: "package.json", pickPath: "package.json" }],
+      };
+      const result = classifyConflictContent(report);
+      expect(result.verdict).toBe("DROP");
+      expect(result.bin).toBe("release-plumbing");
+    });
+
+    it("release-plumbing bin: pnpm-lock.yaml → DROP", () => {
+      const report: ConflictReport = {
+        files: [{ basePath: "pnpm-lock.yaml", pickPath: "pnpm-lock.yaml" }],
+      };
+      expect(classifyConflictContent(report).verdict).toBe("DROP");
+    });
+
+    it("release-plumbing bin: CHANGELOG.md → DROP", () => {
+      const report: ConflictReport = {
+        files: [{ basePath: "CHANGELOG.md", pickPath: "CHANGELOG.md" }],
+      };
+      expect(classifyConflictContent(report).verdict).toBe("DROP");
+    });
+
+    it("release-plumbing bin: __snapshots__/ → DROP", () => {
+      const report: ConflictReport = {
+        files: [
+          {
+            basePath: "src/foo/__snapshots__/bar.test.ts.snap",
+            pickPath: "src/foo/__snapshots__/bar.test.ts.snap",
+          },
+        ],
+      };
+      expect(classifyConflictContent(report).verdict).toBe("DROP");
+    });
+
+    it("naming-label bin: string-literal-only diff → DROP", () => {
+      // Memo §2 Instance 3 (`7ee46a3ab9`): "Runtime:" vs "Execution:"
+      // label substitution. Both adds + dels share residual code
+      // structure once the quoted regions are stripped.
+      const report: ConflictReport = {
+        files: [
+          {
+            basePath: "src/status/format.ts",
+            pickPath: "src/status/format.ts",
+            diffLines: [
+              { kind: "del", content: "return `Runtime: ${runtime}`;" },
+              { kind: "add", content: "return `Execution: ${runtime}`;" },
+            ],
+          },
+        ],
+      };
+      const result = classifyConflictContent(report);
+      expect(result.verdict).toBe("DROP");
+      expect(result.bin).toBe("naming-label");
+    });
+
+    it("feature-runtime bin: ANY file with no safe-bin match → REVIEW", () => {
+      const report: ConflictReport = {
+        files: [{ basePath: "src/gateway/server.ts", pickPath: "src/gateway/server.ts" }],
+      };
+      const result = classifyConflictContent(report);
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.bin).toBe("feature-runtime");
+    });
+
+    it("mixed: feature-runtime present → REVIEW even if other files are safe", () => {
+      const report: ConflictReport = {
+        files: [
+          { basePath: "src/foo/__tests__/bar.test.ts", pickPath: "src/foo/__tests__/bar.test.ts" },
+          { basePath: "src/gateway/server.ts", pickPath: "src/gateway/server.ts" },
+        ],
+      };
+      const result = classifyConflictContent(report);
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.bin).toBe("feature-runtime");
+      // Per-file evidence preserves test-harness bin on the first
+      // file even though summary bin is feature-runtime.
+      expect(result.files[0]?.bin).toBe("test-harness");
+      expect(result.files[1]?.bin).toBe("feature-runtime");
+    });
+
+    it("mixed safe bins: precedence reports highest-precision summary bin", () => {
+      // naming-label > test-harness > release-plumbing
+      const report: ConflictReport = {
+        files: [
+          { basePath: "package.json", pickPath: "package.json" },
+          { basePath: "src/foo/__tests__/bar.test.ts", pickPath: "src/foo/__tests__/bar.test.ts" },
+          {
+            basePath: "src/status/format.ts",
+            pickPath: "src/status/format.ts",
+            diffLines: [
+              { kind: "del", content: 'return "Runtime";' },
+              { kind: "add", content: 'return "Execution";' },
+            ],
+          },
+        ],
+      };
+      const result = classifyConflictContent(report);
+      expect(result.verdict).toBe("DROP");
+      expect(result.bin).toBe("naming-label");
+    });
+
+    it("naming-label is conservative: refuses to fire without diffLines", () => {
+      // Without diff content, label-only cannot be claimed. The
+      // file falls through to feature-runtime.
+      const report: ConflictReport = {
+        files: [{ basePath: "src/status/format.ts", pickPath: "src/status/format.ts" }],
+      };
+      const result = classifyConflictContent(report);
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.bin).toBe("feature-runtime");
+    });
+
+    it("naming-label rejects when residuals diverge (real code change)", () => {
+      const report: ConflictReport = {
+        files: [
+          {
+            basePath: "src/foo.ts",
+            pickPath: "src/foo.ts",
+            diffLines: [
+              { kind: "del", content: 'const limit = "10";' },
+              { kind: "add", content: 'const cap = "20";' },
+            ],
+          },
+        ],
+      };
+      const result = classifyConflictContent(report);
+      // Residuals: 'const limit = Q;' vs 'const cap = Q;' → not equal
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.bin).toBe("feature-runtime");
+    });
+
+    it("rename-into-test-harness still classifies as test-harness", () => {
+      // basePath is production, pickPath is test-harness — caller
+      // relocated the file. Either side matching wins the bin.
+      const report: ConflictReport = {
+        files: [{ basePath: "src/foo/probe.ts", pickPath: "e2e/probe.spec.ts" }],
+      };
+      const result = classifyConflictContent(report);
+      expect(result.verdict).toBe("DROP");
+      expect(result.bin).toBe("test-harness");
+    });
+  });
+
+  describe("classifyRebasePick :: conflict-content callback integration", () => {
+    it("when changelog/provenance miss AND callback supplied → callback's verdict drives", () => {
+      // Memo §2 Instance 2 shape: CHANGELOG silent, no cherry-pick
+      // footer, conflict-content rubric should DROP.
+      const result = classifyRebasePick({
+        subject: "test(gateway): harden live docker harness probes",
+        commitBody: "Test hardening for live docker probes.",
+        baseChangelog: "# Changelog\n\nNothing relevant here.\n",
+        isAncestorOf: () => false,
+        conflictContent: () =>
+          classifyConflictContent({
+            files: [
+              {
+                basePath: "src/gateway/__tests__/probe.live.test.ts",
+                pickPath: "src/gateway/__tests__/probe.live.test.ts",
+              },
+            ],
+          }),
+      });
+      expect(result.verdict).toBe("DROP");
+      expect(result.channel).toBe("conflict-content");
+      expect(result.evidence.conflictContent?.bin).toBe("test-harness");
+    });
+
+    it("when changelog/provenance miss AND callback returns REVIEW → REVIEW preserved", () => {
+      const result = classifyRebasePick({
+        subject: "feat(gateway): new continuation primitive",
+        commitBody: "Adds a new continuation primitive.",
+        baseChangelog: "# Changelog\n",
+        isAncestorOf: () => false,
+        conflictContent: () =>
+          classifyConflictContent({
+            files: [{ basePath: "src/gateway/server.ts", pickPath: "src/gateway/server.ts" }],
+          }),
+      });
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.channel).toBe("conflict-content");
+      expect(result.needsConflictContentInspection).toBeUndefined();
+      expect(result.evidence.conflictContent?.bin).toBe("feature-runtime");
+    });
+
+    it("when callback omitted → REVIEW + needsConflictContentInspection (back-compat with #408)", () => {
+      const result = classifyRebasePick({
+        subject: "test(gateway): harden live docker harness probes",
+        commitBody: "Test hardening.",
+        baseChangelog: "# Changelog\n",
+        isAncestorOf: () => false,
+        // no conflictContent callback
+      });
+      expect(result.verdict).toBe("REVIEW");
+      expect(result.channel).toBe("none");
+      expect(result.needsConflictContentInspection).toBe(true);
+    });
+
+    it("channel ordering: positive channel-1 (cherry-pick) wins over conflict-content", () => {
+      const result = classifyRebasePick({
+        subject: "test: probe hardening",
+        commitBody:
+          "Test hardening.\n\n(cherry picked from commit 9dd097a7a5b4c3d2e1f0a9b8c7d6e5f4a3b2c1d0)",
+        baseChangelog: "# Changelog\n",
+        isAncestorOf: () => true,
+        conflictContent: () =>
+          classifyConflictContent({
+            files: [{ basePath: "src/gateway/server.ts", pickPath: "src/gateway/server.ts" }],
+          }),
+      });
+      // Cherry-pick channel fires first (higher precision than
+      // conflict-content). Conflict-content callback should NOT
+      // even be invoked.
+      expect(result.verdict).toBe("DROP");
+      expect(result.channel).toBe("cherry-pick-provenance");
+    });
+
+    it("callback NOT invoked when channel-1 fires (precedence + side-effect-free)", () => {
+      let invocations = 0;
+      const result = classifyRebasePick({
+        subject: "fix(runner): add label (#70595)",
+        commitBody: "Fix.",
+        baseChangelog: "# Changelog\n\n- fix(runner): add label (#70595)\n",
+        isAncestorOf: () => false,
+        conflictContent: () => {
+          invocations++;
+          return classifyConflictContent({ files: [] });
+        },
+      });
+      expect(result.verdict).toBe("DROP");
+      expect(result.channel).toBe("changelog-grep:pr");
+      expect(invocations).toBe(0);
+    });
+  });
+});

--- a/studies/swim-37/harness/conflict-content-rubric.ts
+++ b/studies/swim-37/harness/conflict-content-rubric.ts
@@ -1,0 +1,309 @@
+/**
+ * studies/swim-37/harness/conflict-content-rubric.ts
+ *
+ * SWIM-37 §1 trap-class third discovery channel: **conflict-content
+ * classification rubric**.
+ *
+ * Closes the gap left explicitly uncovered by PR #408 (where
+ * `classifyRebasePick` returns
+ * `REVIEW + needsConflictContentInspection=true` when the two pure
+ * positive-signal channels — `changelog-grep` and
+ * `cherry-pick-provenance` — both miss).
+ *
+ * Memo cross-reference: studies/swim-37/traps/parallel-evolution-class.md
+ *   §"Conflict-content classification rubric" (four bins):
+ *     - feature/runtime  → REVIEW (STOP, prince inspection)
+ *     - test-harness     → DROP   (paths: *.live.test.*, scripts/test-*, e2e/)
+ *     - naming/label     → DROP   (string-literal substitutions only)
+ *     - release-plumbing → DROP   (version bumps, generated baselines)
+ *
+ * The pure-function shape from #408 is preserved: the module takes a
+ * `ConflictReport` struct produced by the rebase driver (caller's
+ * responsibility) and returns a structured verdict. NO git, NO fs, NO
+ * network in this module.
+ *
+ * Pinned to memo §2 byte-walk Instance 2 (`e515ea1f31`,
+ * test-harness divergence) — the representative case where CHANGELOG
+ * is silent, no cherry-pick footer, but ground-truth verdict is DROP.
+ *
+ * Issue: karmaterminal/openclaw#409
+ * Parent: karmaterminal/openclaw#324
+ */
+
+export type ConflictRubricVerdict = "DROP" | "PICK" | "REVIEW";
+
+/**
+ * Classifies which of the four rubric bins fired (or "none" when
+ * insufficient evidence). Mirrors the memo's §"Conflict-content
+ * classification rubric" enumeration.
+ */
+export type ConflictRubricBin =
+  | "test-harness"
+  | "naming-label"
+  | "release-plumbing"
+  | "feature-runtime"
+  | "none";
+
+/**
+ * Per-file diff descriptor supplied by the rebase driver. The
+ * `pathA`/`pathB` distinction lets the caller represent renames
+ * (path differs across the conflict) without dragging the rubric
+ * into rename-detection. For non-renamed conflicts, pass the same
+ * path on both sides.
+ */
+export interface ConflictReportFile {
+  /** Path on the base side of the conflict (the upstream tree). */
+  readonly basePath: string;
+  /** Path on the pick side of the conflict (the rebase-source tree). */
+  readonly pickPath: string;
+  /**
+   * Optional: lines changed by the picked commit, NOT counting
+   * conflict markers. When supplied, used by the naming-label bin
+   * to detect "string-literal-only" diffs. When omitted, the
+   * naming-label bin is conservative and won't fire (sources
+   * cannot be classified as label-only without diff content).
+   */
+  readonly diffLines?: readonly ConflictDiffLine[];
+}
+
+/**
+ * Single diff line as the rubric needs it. `kind` matches
+ * unified-diff prefixes; `content` is the line body (no leading +/-).
+ */
+export interface ConflictDiffLine {
+  readonly kind: "add" | "del" | "context";
+  readonly content: string;
+}
+
+/**
+ * Input contract for `classifyConflictContent`. Caller's job:
+ * collect the conflicted files + diff content from the rebase
+ * driver and hand them in. The rubric does the classification
+ * and nothing else.
+ */
+export interface ConflictReport {
+  readonly files: readonly ConflictReportFile[];
+}
+
+/**
+ * Per-file evidence produced by the rubric. Preserves which bin
+ * matched the file so the caller can attribute classification
+ * granularly even when multiple files conflicted.
+ */
+export interface ConflictRubricFileEvidence {
+  readonly basePath: string;
+  readonly pickPath: string;
+  readonly bin: ConflictRubricBin;
+  /**
+   * Brief human-readable reason for the bin assignment (e.g.
+   * "matches *.live.test.ts pattern"). Useful for span emission
+   * and prince journal entries.
+   */
+  readonly reason: string;
+}
+
+export interface ConflictRubricClassification {
+  readonly verdict: ConflictRubricVerdict;
+  /**
+   * Bin that drove the verdict. When all files match safe-DROP
+   * bins (test-harness, naming-label, release-plumbing) the
+   * verdict is DROP and `bin` reports the highest-precision bin
+   * observed. When ANY file matches feature-runtime the verdict
+   * is REVIEW and `bin` is `feature-runtime`. When the report has
+   * no files, the verdict is REVIEW with `bin: "none"` (rubric
+   * cannot speak without input).
+   */
+  readonly bin: ConflictRubricBin;
+  readonly files: readonly ConflictRubricFileEvidence[];
+}
+
+// ─── Path heuristics (test-harness bin) ────────────────────────────
+
+/**
+ * Pre-compiled patterns for the test-harness bin. Memo-aligned:
+ *   *.live.test.ts / *.live.test.js
+ *   scripts/test-*
+ *   e2e/* (any depth)
+ *   __tests__/* (any depth)  — common JS-ecosystem convention
+ *
+ * The patterns are INTENTIONALLY conservative. The rubric prefers
+ * REVIEW over a wrongful DROP; broadening the test-harness bin
+ * risks misclassifying production code that happens to live near
+ * a test file.
+ */
+const TEST_HARNESS_PATTERNS: readonly RegExp[] = [
+  /\.live\.test\.(ts|tsx|js|jsx|mjs|cjs)$/,
+  /(^|\/)scripts\/test-[^/]+$/,
+  /(^|\/)e2e\//,
+  /(^|\/)__tests__\//,
+];
+
+function matchesTestHarnessPath(path: string): boolean {
+  return TEST_HARNESS_PATTERNS.some((re) => re.test(path));
+}
+
+// ─── Path heuristics (release-plumbing bin) ────────────────────────
+
+/**
+ * Release-plumbing patterns. Memo: "version bumps, generated
+ * baselines, i18n regen — already explicitly `--theirs` per #325
+ * conflict policy".
+ *
+ * CHANGELOG.md is included because parallel-evolution often
+ * conflicts on duplicate-PR-entry insertions.
+ */
+const RELEASE_PLUMBING_PATTERNS: readonly RegExp[] = [
+  /(^|\/)package\.json$/,
+  /(^|\/)package-lock\.json$/,
+  /(^|\/)pnpm-lock\.yaml$/,
+  /(^|\/)yarn\.lock$/,
+  /(^|\/)CHANGELOG\.md$/,
+  /(^|\/)i18n\/.+\.(json|po|pot|yml|yaml)$/,
+  /\.snap$/,
+  /(^|\/)__snapshots__\//,
+];
+
+function matchesReleasePlumbingPath(path: string): boolean {
+  return RELEASE_PLUMBING_PATTERNS.some((re) => re.test(path));
+}
+
+// ─── Diff-content heuristics (naming-label bin) ────────────────────
+
+/**
+ * The naming-label bin requires diff lines (non-context add/del
+ * pairs) to be byte-equivalent modulo a small set of string-literal
+ * substitutions. This is intentionally narrow:
+ *
+ *   - every non-context line must contain a quoted string literal
+ *   - removing the quoted regions, the residual code must be
+ *     byte-identical between an add line and at least one del line
+ *
+ * If diff content is absent, this bin cannot fire (returns false),
+ * because we refuse to claim "label-only" without observing the
+ * actual diff.
+ */
+function isNamingLabelOnly(diffLines: readonly ConflictDiffLine[] | undefined): boolean {
+  if (!diffLines || diffLines.length === 0) return false;
+  const adds = diffLines.filter((l) => l.kind === "add");
+  const dels = diffLines.filter((l) => l.kind === "del");
+  if (adds.length === 0 || dels.length === 0) return false;
+  // Strip quoted regions (single, double, backtick) from each line.
+  // If the residual is byte-identical between any add/del pair AND
+  // both lines actually contained a quoted region, treat the diff
+  // as label-only.
+  const stripQuoted = (s: string): { residual: string; hadQuote: boolean } => {
+    let hadQuote = false;
+    const residual = s.replace(/(['"`])(?:\\.|(?!\1).)*\1/g, () => {
+      hadQuote = true;
+      return "Q";
+    });
+    return { residual: residual.trim(), hadQuote };
+  };
+  const delResiduals = dels.map((d) => stripQuoted(d.content));
+  for (const add of adds) {
+    const { residual: addRes, hadQuote: addHad } = stripQuoted(add.content);
+    if (!addHad) return false;
+    const matched = delResiduals.find((d) => d.hadQuote && d.residual === addRes);
+    if (!matched) return false;
+  }
+  return true;
+}
+
+// ─── Per-file classification ───────────────────────────────────────
+
+function classifyFile(file: ConflictReportFile): ConflictRubricFileEvidence {
+  // Path-based bins fire before diff-based bins. Both paths are
+  // checked so a rename-into-test-harness still classifies as
+  // test-harness (path on the pick side carries the new location).
+  const isTestHarness =
+    matchesTestHarnessPath(file.basePath) || matchesTestHarnessPath(file.pickPath);
+  if (isTestHarness) {
+    return {
+      basePath: file.basePath,
+      pickPath: file.pickPath,
+      bin: "test-harness",
+      reason: "matches test-harness path pattern",
+    };
+  }
+  const isReleasePlumbing =
+    matchesReleasePlumbingPath(file.basePath) || matchesReleasePlumbingPath(file.pickPath);
+  if (isReleasePlumbing) {
+    return {
+      basePath: file.basePath,
+      pickPath: file.pickPath,
+      bin: "release-plumbing",
+      reason: "matches release-plumbing path pattern",
+    };
+  }
+  if (isNamingLabelOnly(file.diffLines)) {
+    return {
+      basePath: file.basePath,
+      pickPath: file.pickPath,
+      bin: "naming-label",
+      reason: "diff is string-literal-only substitution",
+    };
+  }
+  return {
+    basePath: file.basePath,
+    pickPath: file.pickPath,
+    bin: "feature-runtime",
+    reason: "no safe-DROP bin matched; defaults to feature-runtime (REVIEW)",
+  };
+}
+
+// ─── Rubric entry point ────────────────────────────────────────────
+
+/**
+ * Classify a `ConflictReport` against the four-bin rubric.
+ *
+ * Verdict semantics:
+ *   - ALL files in safe-DROP bins (test-harness | naming-label |
+ *     release-plumbing) → `DROP`. The reported `bin` is the
+ *     highest-precision safe bin observed (see precedence below).
+ *   - ANY file in `feature-runtime` → `REVIEW`. The reported `bin`
+ *     is `feature-runtime`.
+ *   - Empty report (no files) → `REVIEW` with `bin: "none"`. The
+ *     rubric refuses to default to PICK on no input — a silent
+ *     PICK is exactly the failure shape this channel exists to
+ *     prevent.
+ *
+ * Bin precedence for reporting (highest precision first):
+ *   1. naming-label       (diff-content evidence)
+ *   2. test-harness       (path pattern + memo-named bin)
+ *   3. release-plumbing   (path pattern + memo-named bin)
+ *
+ * Precedence affects the SUMMARY `bin` field only; per-file
+ * evidence preserves each file's actual bin.
+ */
+export function classifyConflictContent(report: ConflictReport): ConflictRubricClassification {
+  if (report.files.length === 0) {
+    return {
+      verdict: "REVIEW",
+      bin: "none",
+      files: [],
+    };
+  }
+  const fileEvidence = report.files.map(classifyFile);
+  const hasFeatureRuntime = fileEvidence.some((f) => f.bin === "feature-runtime");
+  if (hasFeatureRuntime) {
+    return {
+      verdict: "REVIEW",
+      bin: "feature-runtime",
+      files: fileEvidence,
+    };
+  }
+  // All files in safe-DROP bins. Report the highest-precision bin
+  // observed in `bin`; per-file evidence carries each file's actual
+  // bin.
+  const observedBins = new Set(fileEvidence.map((f) => f.bin));
+  const summaryBin: ConflictRubricBin = observedBins.has("naming-label")
+    ? "naming-label"
+    : observedBins.has("test-harness")
+      ? "test-harness"
+      : "release-plumbing";
+  return {
+    verdict: "DROP",
+    bin: summaryBin,
+    files: fileEvidence,
+  };
+}

--- a/studies/swim-37/harness/rebase-classifier.ts
+++ b/studies/swim-37/harness/rebase-classifier.ts
@@ -39,6 +39,7 @@ import {
   parseCherryPickProvenance,
   type CherryPickProvenanceFooter,
 } from "./cherry-pick-provenance.ts";
+import type { ConflictRubricClassification } from "./conflict-content-rubric.ts";
 
 export type RebaseVerdict = "DROP" | "PICK" | "REVIEW";
 
@@ -46,6 +47,7 @@ export type RebaseDiscoveryChannel =
   | "changelog-grep:pr"
   | "changelog-grep:subject"
   | "cherry-pick-provenance"
+  | "conflict-content"
   | "none";
 
 export interface RebaseEvidence {
@@ -61,6 +63,13 @@ export interface RebaseEvidence {
    * support a DROP verdict.
    */
   readonly cherryPickFootersNotAncestor?: readonly CherryPickProvenanceFooter[];
+  /**
+   * Conflict-content rubric classification (third channel, #409).
+   * Present only when the conflict-content callback was invoked,
+   * which happens iff both positive-signal channels miss AND the
+   * caller supplied a `conflictContent` callback.
+   */
+  readonly conflictContent?: ConflictRubricClassification;
 }
 
 export interface RebaseClassification {
@@ -80,6 +89,16 @@ export interface ClassifyRebasePickInput {
   readonly commitBody: string;
   readonly baseChangelog: string;
   readonly isAncestorOf: (sha: string) => boolean;
+  /**
+   * Optional third-channel callback (#409). Invoked iff both
+   * positive-signal channels (cherry-pick-provenance, changelog-grep)
+   * miss. Caller is responsible for assembling the `ConflictReport`
+   * input and invoking `classifyConflictContent` (or any equivalent
+   * shape that returns a `ConflictRubricClassification`). When
+   * omitted, the no-signal path returns the back-compatible
+   * `REVIEW + needsConflictContentInspection: true` shape from #408.
+   */
+  readonly conflictContent?: () => ConflictRubricClassification;
 }
 
 /**
@@ -161,7 +180,31 @@ export function classifyRebasePick(input: ClassifyRebasePickInput): RebaseClassi
     };
   }
 
-  // ── No positive signal: hand off to conflict-content rubric ────────
+  // ── Channel 4: conflict-content rubric (#409) ──────────────────────
+  // Invoked only when both positive-signal channels missed AND the
+  // caller supplied a callback. Side-effect-free precedence: callback
+  // is NOT invoked on the channel-1/2/3 paths above.
+  if (input.conflictContent) {
+    const conflictContent = input.conflictContent();
+    const enrichedEvidence: RebaseEvidence = { ...evidence, conflictContent };
+    if (conflictContent.verdict === "DROP") {
+      return {
+        verdict: "DROP",
+        channel: "conflict-content",
+        evidence: enrichedEvidence,
+      };
+    }
+    // PICK or REVIEW from the rubric: surface its verdict with
+    // `channel: "conflict-content"` for attribution. We do NOT set
+    // `needsConflictContentInspection` because the rubric DID run.
+    return {
+      verdict: conflictContent.verdict,
+      channel: "conflict-content",
+      evidence: enrichedEvidence,
+    };
+  }
+
+  // ── No positive signal AND no callback: back-compat with #408 ──────
   // The memo's §1 third channel is harder than a pure function — needs
   // file paths + diff inspection. The classifier surfaces the gap
   // explicitly rather than defaulting to PICK, which would silently


### PR DESCRIPTION
Closes #409 — the third §1 discovery channel left explicitly uncovered by #408.

## Shape

Pure function, no git / fs / network. Caller assembles a `ConflictReport` from rebase-driver output and passes it via `classifyRebasePick`'s new optional `conflictContent` callback.

## Four bins (memo-aligned)

| bin | verdict | trigger |
|---|---|---|
| `test-harness` | DROP | paths: `*.live.test.*`, `scripts/test-*`, `e2e/`, `__tests__/` |
| `release-plumbing` | DROP | `package.json`, lockfiles, `CHANGELOG.md`, `__snapshots__/`, i18n |
| `naming-label` | DROP | diff is string-literal-only substitution with byte-equal residual |
| `feature-runtime` | REVIEW | no safe bin matched — STOP, prince inspection |

Empty report → REVIEW + `bin: 'none'`. The rubric refuses silent-PICK on no input — exactly the failure shape this channel exists to prevent.

## classifyRebasePick integration

- Invoked iff both positive-signal channels (cherry-pick-provenance, changelog-grep) miss AND caller supplied `conflictContent`.
- **Side-effect-free precedence**: callback NOT invoked when channel-1/2/3 fires (test pinned).
- **Back-compat**: when callback omitted, returns the #408 shape (`REVIEW + needsConflictContentInspection: true`).
- New channel attribution: `conflict-content`.

## Pin

Memo §2 byte-walk:
- Instance 2 (`e515ea1f31`, `*.live.test.ts`) → DROP via test-harness
- Instance 1 (`aa1908bf38`, `e2e/`) → DROP via test-harness

## Tests

- 18 live (rubric) + 5 live (integration with classifyRebasePick).
- swim-37 vitest project: **8 files, 130 passed, 15 todo**, lint clean.

## Boundary discipline preserved from #408

Pure function, no I/O in module, caller drives all of it.

— 🌫️