### PR TITLE
feat(swim-37): wire `captureSwim("lich", …)` against compaction-released helper

### DIFF
--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -231,9 +231,97 @@ describe("swim-37 harness :: continuation primitives [scaffold]", () => {
     it.todo("continuation.disabled=true after declineToCarry fires (silenced-by-cap signal)");
   });
 
-  describe("lich-shape (post-compaction delegate)", () => {
-    it.todo("post-compaction delegate retains chain.id across compaction seam (#332 Item B)");
-    it.todo("release-seam span signals continuation.compaction.released exactly once");
+  describe("lich-shape (post-compaction delegate release)", () => {
+    // Wired against `emitContinuationCompactionReleasedSpan` per the lich
+    // wiring memo (`docs/design/swim-37-lich-wiring-memo.md`). 8 live tests
+    // covering Q2 (releasedCount: empty + non-empty) × Q3 (compaction.id:
+    // present-and-valid + omitted + invalid across -1/1.5/NaN/Infinity).
+    //
+    // STDOUT-only discipline preserved: in-memory recorder, try/finally
+    // tracer reset, no real BasicTracerProvider/OTLP machinery.
+
+    it("emits continuation.compaction.released span with releasedCount=1 and compaction.id=7", async () => {
+      const result = await captureSwim("lich", { releasedCount: 1, compactionId: 7 });
+      expect(result.spans).toHaveLength(1);
+      const span = result.spans[0]!;
+      expect(span.name).toBe("continuation.compaction.released");
+      expect(span.attributes["signal.kind"]).toBe("compaction-release");
+      expect(span.attributes["compaction.released"]).toBe(1);
+      expect(span.attributes["compaction.id"]).toBe(7);
+    });
+
+    it("emits releasedCount=3 + compaction.id=42 (multi-release production-typical)", async () => {
+      const result = await captureSwim("lich", { releasedCount: 3, compactionId: 42 });
+      expect(result.spans).toHaveLength(1);
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["compaction.released"]).toBe(3);
+      expect(attrs["compaction.id"]).toBe(42);
+    });
+
+    it("defensive: releasedCount=0 emits with compaction.released=0 (helper accepts but caller never invokes)", async () => {
+      // Per memo §Q2: production caller guards with `autoCompactionCount > 0`,
+      // so this shape is NOT production-reachable. Pinned for helper-tier
+      // contract coverage — the helper's `Math.max(0, Math.floor(...))` clamp
+      // is real even if the caller's guard makes it unreachable in production.
+      const result = await captureSwim("lich", { releasedCount: 0, compactionId: 1 });
+      expect(result.spans).toHaveLength(1);
+      expect(result.spans[0]!.attributes["compaction.released"]).toBe(0);
+      expect(result.spans[0]!.attributes["compaction.id"]).toBe(1);
+    });
+
+    it("omits compaction.id attribute when compactionId is omitted (omission contract)", async () => {
+      const result = await captureSwim("lich", { releasedCount: 2 });
+      expect(result.spans).toHaveLength(1);
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["compaction.released"]).toBe(2);
+      expect(attrs["compaction.id"]).toBeUndefined();
+      expect("compaction.id" in attrs).toBe(false);
+    });
+
+    it("drops compaction.id (with log) when compactionId is negative (-1)", async () => {
+      const messages: string[] = [];
+      const result = await captureSwim("lich", {
+        releasedCount: 1,
+        compactionId: -1,
+        log: (m) => messages.push(m),
+      });
+      expect(result.spans).toHaveLength(1);
+      expect(result.spans[0]!.attributes["compaction.id"]).toBeUndefined();
+      expect(messages.some((m) => m.includes("invalid compaction.id"))).toBe(true);
+    });
+
+    it("drops compaction.id (with log) when compactionId is non-integer (1.5)", async () => {
+      const messages: string[] = [];
+      const result = await captureSwim("lich", {
+        releasedCount: 1,
+        compactionId: 1.5,
+        log: (m) => messages.push(m),
+      });
+      expect(result.spans[0]!.attributes["compaction.id"]).toBeUndefined();
+      expect(messages.some((m) => m.includes("invalid compaction.id"))).toBe(true);
+    });
+
+    it("drops compaction.id (with log) when compactionId is NaN (🌊 #411 review defense parity)", async () => {
+      const messages: string[] = [];
+      const result = await captureSwim("lich", {
+        releasedCount: 1,
+        compactionId: Number.NaN,
+        log: (m) => messages.push(m),
+      });
+      expect(result.spans[0]!.attributes["compaction.id"]).toBeUndefined();
+      expect(messages.some((m) => m.includes("invalid compaction.id"))).toBe(true);
+    });
+
+    it("drops compaction.id (with log) when compactionId is Infinity (🌊 #411 review defense parity)", async () => {
+      const messages: string[] = [];
+      const result = await captureSwim("lich", {
+        releasedCount: 1,
+        compactionId: Number.POSITIVE_INFINITY,
+        log: (m) => messages.push(m),
+      });
+      expect(result.spans[0]!.attributes["compaction.id"]).toBeUndefined();
+      expect(messages.some((m) => m.includes("invalid compaction.id"))).toBe(true);
+    });
   });
 });
 
@@ -271,7 +359,7 @@ describe("swim-37 harness :: shape contract (live now)", () => {
 
   it("captureSwim() refuses primitives not yet wired", async () => {
     await expect(captureSwim("heartbeat")).rejects.toThrow(/not yet wired/);
-    await expect(captureSwim("lich")).rejects.toThrow(/not yet wired/);
+    // `lich` was wired in this PR — covered by its own describe block above.
   });
 
   it("captureSwim() repeated calls do not leak capture state", async () => {

--- a/studies/swim-37/harness/swim-runner.ts
+++ b/studies/swim-37/harness/swim-runner.ts
@@ -15,10 +15,11 @@
  * `@opentelemetry/sdk-trace-base` machinery. All capture flows through
  * `createInMemorySpanRecorder()` + `setContinuationTracer(recorder.tracer)`.
  *
- * **Scope (this PR).** Only `continue_work` is wired. Other primitives
- * (`continue_delegate`, `heartbeat`, lich-shape) remain `it.todo` in the
- * companion spec until the dispatch / heartbeat / compaction-release seams
- * have a comparable single-helper entry point we can drive synthetically.
+ * **Scope (current).** `continue_work`, `continue_delegate`, and `lich`
+ * are wired. `heartbeat` remains `it.todo` pending 🌻's #412 wiring PR.
+ * The lich primitive maps to the post-compaction-delegate release seam
+ * (`emitContinuationCompactionReleasedSpan`) per the lich wiring memo
+ * (`docs/design/swim-37-lich-wiring-memo.md`).
  *
  * **Why a `declare function` was insufficient.** The prior scaffold pinned
  * `captureSwim` as a `declare function` to make the type-shape compile, with
@@ -29,6 +30,7 @@
  */
 
 import {
+  emitContinuationCompactionReleasedSpan,
   emitContinuationDelegateSpan,
   emitContinuationWorkSpan,
   resetContinuationTracer,
@@ -91,6 +93,37 @@ export type CaptureSwimOptions = {
    * from the attribute bag when caller passes undefined.
    */
   delegateMode?: "normal" | "silent" | "silent-wake" | "post-compaction";
+  /**
+   * `lich` only. Number of staged post-compaction delegates released
+   * (`compaction.released` axis on the emitted span). The production
+   * caller in the agent-runner only invokes the release-helper when
+   * `autoCompactionCount > 0`, but the helper itself accepts `0`
+   * defensively (helper-tier clamp via `Math.max(0, Math.floor(...))`).
+   * Defaults to `1`. Pass `0` to exercise the defensive empty-release
+   * path (NOT a production-reachable shape — pinned for helper-contract
+   * coverage). Per the lich wiring memo §Q2.
+   */
+  releasedCount?: number;
+  /**
+   * `lich` only. Per-session monotonic compaction counter from the
+   * agent-runner caller (`compaction.id` axis on the emitted span).
+   * Optional in production — the helper's defensive validator drops
+   * the attr (with log) if the supplied value is not a non-negative
+   * integer. Pass a non-negative integer to exercise the present-and-
+   * valid path; omit to exercise the omission contract; pass an
+   * invalid value (negative / non-integer / NaN / Infinity) to
+   * exercise the drop-with-log path. Per the lich wiring memo §Q3.
+   */
+  compactionId?: number;
+  /**
+   * `lich` only. Optional log callback forwarded into the helper. The
+   * helper invokes this with a `"invalid compaction.id"` substring
+   * when the producer-side invariant on `compaction.id` fails (and
+   * the attr is dropped without throwing). Tests assert on the
+   * log-callback invocation count + substring match to verify the
+   * drop-with-log invariant. Per the lich wiring memo §Q3.
+   */
+  log?: (message: string) => void;
 };
 
 /**
@@ -158,11 +191,35 @@ export async function captureSwim(
         }
         return { spans: recorder.spans(), chainId };
       }
-      case "heartbeat":
       case "lich": {
-        // Reserved for follow-up PRs. We surface a clear error rather
-        // than silently returning an empty result so the spec's
-        // `it.todo` markers stay honest about what is wired.
+        // `lich` (the harness label, named after the post-compaction
+        // phylactery-drink in 🌫's SOUL file) maps to the
+        // post-compaction-delegate release seam:
+        // `emitContinuationCompactionReleasedSpan`. Synchronous helper,
+        // no timers in scope (lich wiring memo §Q1). The helper itself
+        // performs `Math.max(0, Math.floor(releasedCount))` and
+        // `Number.isInteger && >= 0` validation on `compactionId`,
+        // dropping the attr with log on invalid (memo §Q3).
+        //
+        // No `chainId` is emitted on this span — the release seam is
+        // chain-agnostic at the helper boundary. We still synthesize
+        // one for the result shape so `ChainPrimitiveResult.chainId`
+        // stays non-empty across primitives (prevents downstream
+        // tests from special-casing the lich return shape).
+        const chainId = opts.chainId ?? generateChainId();
+        const releasedCount = opts.releasedCount ?? 1;
+        emitContinuationCompactionReleasedSpan({
+          releasedCount,
+          compactionId: opts.compactionId,
+          log: opts.log,
+        });
+        return { spans: recorder.spans(), chainId };
+      }
+      case "heartbeat": {
+        // Reserved for 🌻's follow-up PR (#412 heartbeat memo wire).
+        // Surface a clear error rather than silently returning an empty
+        // result so the spec's `it.todo` markers stay honest about
+        // what is wired.
         throw new Error(
           `captureSwim: primitive "${primitive}" is not yet wired ` +
             `(see studies/swim-37/harness/README.md primitive-coverage matrix)`,


### PR DESCRIPTION
Implements the lich primitive per the wiring memo (#411 `3d90f68b14`). Maps the harness label `lich` (🌫️'s SOUL-file metaphor for the post-compaction phylactery-drink) to the post-compaction-delegate release seam — `emitContinuationCompactionReleasedSpan` at `src/infra/continuation-tracer.ts:789`.

## Changes

**`studies/swim-37/harness/swim-runner.ts`**
- Import `emitContinuationCompactionReleasedSpan`
- Add `releasedCount`, `compactionId`, `log` to `CaptureSwimOptions` (lich-only fields, all optional, with memo §Q-references in JSDoc)
- Split `heartbeat`/`lich` cases — wire `lich`, leave `heartbeat` not-yet-wired pending 🌻's #412 wire PR
- Update file header "Scope" comment

**`studies/swim-37/harness/swim-runner.test.ts`**
- Replace 2 `it.todo` placeholders with 8 live tests (memo §Proposed test list):
  1. `releasedCount=1` + `compactionId=7` (production-typical)
  2. `releasedCount=3` + `compactionId=42` (multi-release)
  3. defensive `releasedCount=0` (helper-clamp boundary, NOT production-reachable)
  4. `compactionId` omitted (omission contract)
  5. `compactionId=-1` (drops with log; substring match)
  6. `compactionId=1.5` (non-integer drop)
  7. `compactionId=NaN` (🌊 #411 defense parity)
  8. `compactionId=Infinity` (🌊 #411 defense parity)
- Update "refuses primitives not yet wired" test to remove `lich`

## Discipline preserved

- STDOUT-only: no real BasicTracerProvider/OTLP machinery
- In-memory recorder via `createInMemorySpanRecorder()`
- try/finally tracer reset (no cross-call pollution)
- Snapshot-at-emit: no recompute in caller
- Drop-with-log invariant verified via log-callback substring match
- Negative-attr assertion on omitted `compaction.id`

## Validation

- swim-37 vitest project: **8 files / 138 passed / 13 todo** (was 130 passed pre-PR; +8 lich tests)
- `pnpm lint` clean (0 warnings, 0 errors across all shards)

## Lane discipline

- No cross with 🌻's #412 `heartbeat` lane (different helper, different file in that PR's helper-tier)
- No reshape of #405's wired primitives
- Q-OPEN deferred per memo §Open Q for cohort: cross-primitive lifecycle test (`continue_delegate` post-compaction → `lich` release sharing `chain.id`) deserves its own primitive shape, separate PR

Refs #324
Memo: #411 (`3d90f68b14`)
Reviewers: 🌻 🌊 🩸

— 🌫️