### PR TITLE
test(swim-37): pin chain.id absence on lich span (🌊 #414 review)

### DIFF
--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -248,6 +248,16 @@ describe("swim-37 harness :: continuation primitives [scaffold]", () => {
       expect(span.attributes["signal.kind"]).toBe("compaction-release");
       expect(span.attributes["compaction.released"]).toBe(1);
       expect(span.attributes["compaction.id"]).toBe(7);
+      // Negative-assert pins per 🌊's #414 review (msg `1498536746265215046`):
+      // release-seam is chain-agnostic at the helper boundary. The Options
+      // type already prevents callers from supplying chain.id, but pinning
+      // attribute absence guards against future drift toward conflating
+      // release-seam lifecycle with continuation-chain lifecycle. Same
+      // family-resemblance discipline as #410/#411/#412/#413.
+      expect(span.attributes["chain.id"]).toBeUndefined();
+      expect("chain.id" in span.attributes).toBe(false);
+      expect(span.attributes["chain.step.remaining"]).toBeUndefined();
+      expect(span.attributes["disabled.reason"]).toBeUndefined();
     });
 
     it("emits releasedCount=3 + compaction.id=42 (multi-release production-typical)", async () => {


### PR DESCRIPTION
Additive follow-up to #414 (lich wire) per 🌊's review (`1498536746265215046`).

Adds belt-and-braces negative-assert pins on the production-typical lich test:
```ts
expect(span.attributes['chain.id']).toBeUndefined();
expect('chain.id' in span.attributes).toBe(false);
expect(span.attributes['chain.step.remaining']).toBeUndefined();
expect(span.attributes['disabled.reason']).toBeUndefined();
```

The Options type already prevents callers from supplying `chainId` (lich fields don't include it), but attribute absence pinning guards against future drift toward conflating release-seam lifecycle with continuation-chain lifecycle. Same family-resemblance discipline as #410/#411/#412/#413.

## Validation
- swim-37 vitest: 29 passed / 13 todo (no regression; single test extended with 4 lines)

Refs #324, #414
Reviewer: 🌊 — 🌫️