### PR TITLE
feat(swim-37): wire `captureClassify(...)` for `rebase.classify` span (#413)

### DIFF
--- a/src/rebase/tracer.ts
+++ b/src/rebase/tracer.ts
@@ -1,0 +1,161 @@
+// Rebase-bot tracer shim — span emission for the §1 trap-class classifier.
+//
+// Per `docs/design/swim-37-classifier-span-memo.md` (cohort sign-off
+// 2026-04-27, Q1=Option B, Q2/Q2.5=in-PR helper at `src/rebase/tracer.ts`,
+// Q4=emit PICK normally with no special handling): this module is a peer
+// of `src/infra/continuation-tracer.ts`, NOT a member of it. The two
+// domains share the underlying `Tracer` shim type from `src/infra/`, but
+// their span vocabularies are structurally distinct:
+//
+//   - `src/infra/continuation-tracer.ts` emits `continuation.*` and
+//     `heartbeat` spans whose canonical attribute set is dominated by
+//     `chain.id`, `chain.step.remaining`, `compaction.id`, etc.
+//
+//   - This module emits `rebase.classify` spans whose canonical attribute
+//     set is dominated by `verdict`, `discovery.channel`, `pick.sha`, and
+//     channel-specific `evidence.*` attrs.
+//
+// The negative-assert pins (`chain.id`, `chain.step.remaining`,
+// `disabled.reason` MUST be absent on `rebase.classify` spans) defend
+// against future drift toward conflating rebase-bot lifecycle with
+// continuation lifecycle. Same family-resemblance discipline as
+// #410/#411/#412/#414/#415.
+//
+// The harness in `studies/swim-37/harness/swim-runner.test.ts` pins
+// against THIS module via a separate `captureClassify()` entry point
+// (Option B), which makes the negative-asserts structurally enforceable
+// at the type-system level — `CaptureClassifyOptions` literally cannot
+// accept `chainId`/`compactionId` because the params don't exist.
+
+import { getContinuationTracer, type SpanAttributes } from "../infra/continuation-tracer.ts";
+
+/**
+ * Canonical enumeration of `verdict` attribute values emitted by
+ * `rebase.classify` spans. Mirrors `RebaseVerdict` in
+ * `studies/swim-37/harness/rebase-classifier.ts:45` — runtime SSOT.
+ */
+export const REBASE_VERDICTS = ["DROP", "PICK", "REVIEW"] as const;
+export type RebaseVerdict = (typeof REBASE_VERDICTS)[number];
+
+/**
+ * Canonical enumeration of `discovery.channel` attribute values.
+ * Mirrors `RebaseDiscoveryChannel` in
+ * `studies/swim-37/harness/rebase-classifier.ts:46-51` — runtime SSOT.
+ */
+export const REBASE_DISCOVERY_CHANNELS = [
+  "changelog-grep:pr",
+  "changelog-grep:subject",
+  "cherry-pick-provenance",
+  "conflict-content",
+  "none",
+] as const;
+export type RebaseDiscoveryChannel = (typeof REBASE_DISCOVERY_CHANNELS)[number];
+
+/**
+ * Canonical enumeration of `evidence.conflict.bin` attribute values.
+ * Mirrors the conflict-content rubric bin set from
+ * `studies/swim-37/harness/conflict-content-rubric.ts`.
+ */
+export const REBASE_CONFLICT_BINS = [
+  "test-harness",
+  "naming-label",
+  "release-plumbing",
+  "feature-runtime",
+  "none",
+] as const;
+export type RebaseConflictBin = (typeof REBASE_CONFLICT_BINS)[number];
+
+/**
+ * Channel-specific evidence inputs. Per memo §2 conditional-attributes
+ * table: each evidence sub-object MUST be present iff its channel
+ * matches; unrelated channels' evidence MUST be omitted.
+ *
+ * The helper does NOT cross-validate channel vs evidence — that's the
+ * caller's contract. The helper attaches whatever evidence sub-objects
+ * are supplied as the corresponding `evidence.*` attributes; if the
+ * caller passes inconsistent evidence (e.g. `cherryPickSourceSha` on a
+ * `changelog-grep:pr` channel), the resulting span will be honest about
+ * what the caller did wrong.
+ */
+export interface RebaseClassifyEvidence {
+  /** present iff `channel === "changelog-grep:pr"`; the matched PR-token (e.g. `"#70595"`) */
+  readonly changelogPrToken?: string;
+  /** present iff `channel === "changelog-grep:subject"`; count of subject-line hits */
+  readonly changelogSubjectMatchCount?: number;
+  /** present iff `channel === "cherry-pick-provenance"`; source SHA from footer (truncated to 12 chars by the helper) */
+  readonly cherryPickSourceSha?: string;
+  /** present iff `channel === "conflict-content"` OR (`channel === "none"` AND callback ran AND returned REVIEW) */
+  readonly conflictBin?: RebaseConflictBin;
+  /** present iff `verdict === "REVIEW" && channel === "none"` AND the `conflictContent` callback was NOT supplied */
+  readonly needsConflictContentInspection?: boolean;
+}
+
+export interface EmitRebaseClassifySpanArgs {
+  readonly verdict: RebaseVerdict;
+  readonly channel: RebaseDiscoveryChannel;
+  /** Commit SHA being classified. The helper truncates to 12 chars before emit. */
+  readonly pickSha: string;
+  readonly evidence?: RebaseClassifyEvidence;
+  readonly log?: (message: string) => void;
+}
+
+/**
+ * Truncate a SHA-like string to the canonical 12-char prefix. Matches
+ * the `git rev-parse --short=12` shape the rebase-bot uses elsewhere.
+ * Strings shorter than 12 chars are returned unchanged (the helper does
+ * NOT pad — short input is honest about being short).
+ */
+function truncateSha(sha: string): string {
+  return sha.length > 12 ? sha.slice(0, 12) : sha;
+}
+
+/**
+ * Emit a `rebase.classify` span describing a single classifier verdict.
+ *
+ * Per memo §0–§4 cohort sign-off (2026-04-27):
+ *   - PICK emits normally (no throw, no special handling) — the helper
+ *     is a transparent record of classifier output (Q4 lean A)
+ *   - Negative-assert pins: this helper MUST NOT attach `chain.id`,
+ *     `chain.step.remaining`, or `disabled.reason` (rebase-bot domain
+ *     ≠ continuation domain). The signature has no params for those
+ *     so the assertion is structurally enforced at type-system level
+ *   - try/catch wrap mirrors `emitContinuationCompactionReleasedSpan`
+ *     and `emitContinuationWorkSpan` so producer-side construction
+ *     errors don't propagate through to the rebase-bot caller
+ */
+export function emitRebaseClassifySpan(args: EmitRebaseClassifySpanArgs): void {
+  try {
+    const truncatedSha = truncateSha(args.pickSha);
+
+    // §B conditional-spread: each evidence attr is attached iff the
+    // caller supplied it. The helper performs no cross-channel
+    // validation — see RebaseClassifyEvidence docstring for why.
+    const ev = args.evidence;
+    const attrs: SpanAttributes = {
+      "signal.kind": "rebase.classify",
+      verdict: args.verdict,
+      "discovery.channel": args.channel,
+      "pick.sha": truncatedSha,
+      ...(ev?.changelogPrToken !== undefined
+        ? { "evidence.changelog.pr_token": ev.changelogPrToken }
+        : {}),
+      ...(ev?.changelogSubjectMatchCount !== undefined
+        ? { "evidence.changelog.subject_match_count": ev.changelogSubjectMatchCount }
+        : {}),
+      ...(ev?.cherryPickSourceSha !== undefined
+        ? { "evidence.cherry_pick.source_sha": truncateSha(ev.cherryPickSourceSha) }
+        : {}),
+      ...(ev?.conflictBin !== undefined ? { "evidence.conflict.bin": ev.conflictBin } : {}),
+      ...(ev?.needsConflictContentInspection === true
+        ? { "needs.conflict_content_inspection": true }
+        : {}),
+    };
+
+    const tracer = getContinuationTracer();
+    const span = tracer.startSpan("rebase.classify", { attributes: attrs });
+    span.setStatus("OK");
+    span.end();
+  } catch (err) {
+    args.log?.(`Failed to emit rebase.classify span: ${String(err)}`);
+  }
+}

--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -22,7 +22,7 @@
 
 import { describe, expect, it } from "vitest";
 import { type RecordedSpan } from "./in-memory-span-recorder.js";
-import { type ChainPrimitiveResult, captureSwim } from "./swim-runner.js";
+import { type ChainPrimitiveResult, captureClassify, captureSwim } from "./swim-runner.js";
 
 // Local alias retained for the contract-shape tests below; the canonical
 // shape now lives in `./in-memory-span-recorder.ts`. Kept narrow so the
@@ -394,5 +394,243 @@ describe("swim-37 harness :: shape contract (live now)", () => {
     };
     const asLocal: SpanRecord = recorded;
     expect(asLocal.name).toBe("continuation.work");
+  });
+});
+
+describe("swim-37 harness :: rebase.classify primitive (live now)", () => {
+  // Wired against `emitRebaseClassifySpan` per the rebase.classify
+  // span-emission memo (`docs/design/swim-37-classifier-span-memo.md`).
+  // Cohort sign-off 2026-04-27: Q1=Option B (separate `captureClassify`
+  // entry point), Q2/Q2.5=in-PR helper at `src/rebase/tracer.ts`,
+  // Q3=6-row matrix + truncation + validation describes, Q4=emit PICK
+  // normally (matrix PICK row stays `it.todo` until a PICK-producing
+  // channel lands).
+  //
+  // STDOUT-only discipline preserved: in-memory recorder, try/finally
+  // tracer reset, no real BasicTracerProvider/OTLP machinery.
+
+  describe("per-channel verdict matrix (memo §Q3)", () => {
+    it("channel='changelog-grep:pr' → DROP with evidence.changelog.pr_token", async () => {
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "changelog-grep:pr",
+        pickSha: "abc123def456789",
+        evidence: { changelogPrToken: "#70595" },
+      });
+      expect(result.spans).toHaveLength(1);
+      const span = result.spans[0]!;
+      expect(span.name).toBe("rebase.classify");
+      expect(span.attributes["signal.kind"]).toBe("rebase.classify");
+      expect(span.attributes["verdict"]).toBe("DROP");
+      expect(span.attributes["discovery.channel"]).toBe("changelog-grep:pr");
+      expect(span.attributes["pick.sha"]).toBe("abc123def456");
+      expect(span.attributes["evidence.changelog.pr_token"]).toBe("#70595");
+      // Other channels' evidence absent (per-channel-isolation discipline).
+      expect(span.attributes["evidence.changelog.subject_match_count"]).toBeUndefined();
+      expect(span.attributes["evidence.cherry_pick.source_sha"]).toBeUndefined();
+      expect(span.attributes["evidence.conflict.bin"]).toBeUndefined();
+      expect(span.attributes["needs.conflict_content_inspection"]).toBeUndefined();
+    });
+
+    it("channel='changelog-grep:subject' → DROP with evidence.changelog.subject_match_count", async () => {
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "changelog-grep:subject",
+        pickSha: "feedface1234abcd",
+        evidence: { changelogSubjectMatchCount: 3 },
+      });
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["verdict"]).toBe("DROP");
+      expect(attrs["discovery.channel"]).toBe("changelog-grep:subject");
+      expect(attrs["evidence.changelog.subject_match_count"]).toBe(3);
+      expect(attrs["evidence.changelog.pr_token"]).toBeUndefined();
+      expect(attrs["evidence.cherry_pick.source_sha"]).toBeUndefined();
+      expect(attrs["evidence.conflict.bin"]).toBeUndefined();
+    });
+
+    it("channel='cherry-pick-provenance' → DROP with evidence.cherry_pick.source_sha (helper truncates)", async () => {
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "cherry-pick-provenance",
+        pickSha: "deadbeefcafebabe9999",
+        evidence: { cherryPickSourceSha: "01234567890abcdef0123" },
+      });
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["verdict"]).toBe("DROP");
+      expect(attrs["discovery.channel"]).toBe("cherry-pick-provenance");
+      expect(attrs["pick.sha"]).toBe("deadbeefcafe");
+      expect(attrs["evidence.cherry_pick.source_sha"]).toBe("01234567890a");
+      expect(attrs["evidence.changelog.pr_token"]).toBeUndefined();
+      expect(attrs["evidence.changelog.subject_match_count"]).toBeUndefined();
+      expect(attrs["evidence.conflict.bin"]).toBeUndefined();
+    });
+
+    it("channel='conflict-content' (DROP, callback invoked) → evidence.conflict.bin present", async () => {
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "conflict-content",
+        pickSha: "112233445566",
+        evidence: { conflictBin: "test-harness" },
+      });
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["verdict"]).toBe("DROP");
+      expect(attrs["discovery.channel"]).toBe("conflict-content");
+      expect(attrs["evidence.conflict.bin"]).toBe("test-harness");
+      expect(attrs["evidence.changelog.pr_token"]).toBeUndefined();
+      expect(attrs["evidence.changelog.subject_match_count"]).toBeUndefined();
+      expect(attrs["evidence.cherry_pick.source_sha"]).toBeUndefined();
+    });
+
+    it("channel='none' (REVIEW, no callback) → needs.conflict_content_inspection=true", async () => {
+      // Back-compat path from #408 — caller didn't supply `conflictContent`
+      // callback so the rubric never ran. Memo §2: the only path where
+      // `needs.conflict_content_inspection` is present.
+      const result = await captureClassify({
+        verdict: "REVIEW",
+        channel: "none",
+        pickSha: "aaaaaaaaaaaa",
+        evidence: { needsConflictContentInspection: true },
+      });
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["verdict"]).toBe("REVIEW");
+      expect(attrs["discovery.channel"]).toBe("none");
+      expect(attrs["needs.conflict_content_inspection"]).toBe(true);
+      expect(attrs["evidence.conflict.bin"]).toBeUndefined();
+    });
+
+    it("channel='none' (REVIEW, callback invoked, returned bin='none') → evidence.conflict.bin='none' present", async () => {
+      // Per 🌫's #413 review nit folded into memo §2: bin='none' is a
+      // real value (rubric ran but found no signal), distinct from
+      // attr-absent (rubric never ran). This row is the load-bearing
+      // proof.
+      const result = await captureClassify({
+        verdict: "REVIEW",
+        channel: "none",
+        pickSha: "bbbbbbbbbbbb",
+        evidence: { conflictBin: "none" },
+      });
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["verdict"]).toBe("REVIEW");
+      expect(attrs["discovery.channel"]).toBe("none");
+      expect(attrs["evidence.conflict.bin"]).toBe("none");
+      // bin='none' ≠ attr-absent — the `in` check is the load-bearing pin.
+      expect("evidence.conflict.bin" in attrs).toBe(true);
+      expect(attrs["needs.conflict_content_inspection"]).toBeUndefined();
+    });
+
+    it.todo(
+      "channel=<future> → PICK with evidence (memo §Q4: emits normally; un-producible by §1 substrate today)",
+    );
+  });
+
+  describe("pick.sha truncation invariant", () => {
+    // Pinning the 12-char truncation explicitly per memo §Q3 (separate
+    // describe because it's about a derived attribute, not an input axis).
+
+    it("truncates 40-char full SHA to 12-char prefix", async () => {
+      const fullSha = "a".repeat(40);
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "changelog-grep:pr",
+        pickSha: fullSha,
+        evidence: { changelogPrToken: "#1" },
+      });
+      expect(result.spans[0]!.attributes["pick.sha"]).toBe("a".repeat(12));
+    });
+
+    it("passes 12-char SHA through unchanged", async () => {
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "changelog-grep:pr",
+        pickSha: "123456789abc",
+        evidence: { changelogPrToken: "#1" },
+      });
+      expect(result.spans[0]!.attributes["pick.sha"]).toBe("123456789abc");
+    });
+
+    it("passes short (<12) SHA through unchanged (helper does not pad)", async () => {
+      // Honest about being short rather than pretending. Same discipline
+      // as how `emitContinuationCompactionReleasedSpan` doesn't fabricate
+      // missing compaction.id.
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "changelog-grep:pr",
+        pickSha: "abc123",
+        evidence: { changelogPrToken: "#1" },
+      });
+      expect(result.spans[0]!.attributes["pick.sha"]).toBe("abc123");
+    });
+  });
+
+  describe("negative-assert pins (memo §2)", () => {
+    // These attributes MUST NOT appear on rebase.classify spans. Same
+    // family-resemblance discipline as #410/#411/#412/#414/#415: defends
+    // future drift toward conflating rebase-bot lifecycle with
+    // continuation lifecycle. The `captureClassify` Options shape
+    // already enforces this at the type system level (no `chainId`,
+    // `compactionId`, etc. params), but runtime pinning is
+    // belt-and-braces — if a future maintainer adds those params back
+    // to the Options or helper, this test fails before the contract
+    // drifts.
+
+    it("chain.id MUST be absent on rebase.classify spans", async () => {
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "changelog-grep:pr",
+        pickSha: "abc123",
+        evidence: { changelogPrToken: "#1" },
+      });
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["chain.id"]).toBeUndefined();
+      expect("chain.id" in attrs).toBe(false);
+    });
+
+    it("chain.step.remaining MUST be absent on rebase.classify spans", async () => {
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "changelog-grep:pr",
+        pickSha: "abc123",
+        evidence: { changelogPrToken: "#1" },
+      });
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["chain.step.remaining"]).toBeUndefined();
+      expect("chain.step.remaining" in attrs).toBe(false);
+    });
+
+    it("disabled.reason MUST be absent on rebase.classify spans (DROP ≠ disabled)", async () => {
+      // DROP is a verdict, not a continuation-disabled signal. Pinning
+      // absence prevents copy-paste of `continuation.disabled` shape
+      // onto this helper.
+      const result = await captureClassify({
+        verdict: "DROP",
+        channel: "cherry-pick-provenance",
+        pickSha: "abc123",
+        evidence: { cherryPickSourceSha: "def456" },
+      });
+      const attrs = result.spans[0]!.attributes;
+      expect(attrs["disabled.reason"]).toBeUndefined();
+      expect("disabled.reason" in attrs).toBe(false);
+    });
+  });
+
+  describe("isolation contract (mirrors captureSwim() repeated-call discipline)", () => {
+    it("repeated captureClassify() calls do not leak capture state", async () => {
+      const r1 = await captureClassify({
+        verdict: "DROP",
+        channel: "changelog-grep:pr",
+        pickSha: "first1234567",
+        evidence: { changelogPrToken: "#1" },
+      });
+      const r2 = await captureClassify({
+        verdict: "REVIEW",
+        channel: "none",
+        pickSha: "second123456",
+        evidence: { needsConflictContentInspection: true },
+      });
+      expect(r1.spans).toHaveLength(1);
+      expect(r2.spans).toHaveLength(1);
+      expect(r1.spans[0]!.attributes["pick.sha"]).toBe("first1234567");
+      expect(r2.spans[0]!.attributes["pick.sha"]).toBe("second123456");
+    });
   });
 });

--- a/studies/swim-37/harness/swim-runner.ts
+++ b/studies/swim-37/harness/swim-runner.ts
@@ -37,6 +37,13 @@ import {
   setContinuationTracer,
 } from "../../../src/infra/continuation-tracer.js";
 import { generateChainId } from "../../../src/infra/secure-random.js";
+import {
+  emitRebaseClassifySpan,
+  type EmitRebaseClassifySpanArgs,
+  type RebaseClassifyEvidence,
+  type RebaseDiscoveryChannel,
+  type RebaseVerdict,
+} from "../../../src/rebase/tracer.ts";
 import { type RecordedSpan, createInMemorySpanRecorder } from "./in-memory-span-recorder.js";
 
 /**
@@ -230,6 +237,66 @@ export async function captureSwim(
         throw new Error(`captureSwim: unknown primitive ${String(exhaustive)}`);
       }
     }
+  } finally {
+    resetContinuationTracer();
+  }
+}
+
+/**
+ * Options accepted by `captureClassify`. Per memo Q1 cohort sign-off
+ * (Option B, 2026-04-27), this is structurally distinct from
+ * `CaptureSwimOptions` — the rebase-bot domain doesn't share lifecycle
+ * axes with continuation primitives, so the negative-assert pins
+ * (`chain.id`, `chain.step.remaining`, `disabled.reason` MUST be absent
+ * on emitted spans) are enforced at the type system level: this Options
+ * shape literally cannot accept those params.
+ */
+export type CaptureClassifyOptions = {
+  readonly verdict: RebaseVerdict;
+  readonly channel: RebaseDiscoveryChannel;
+  /** Commit SHA being classified. Helper truncates to 12 chars at emit time. */
+  readonly pickSha: string;
+  readonly evidence?: RebaseClassifyEvidence;
+  /** Optional log callback forwarded into the helper for emit-failure diagnostics. */
+  readonly log?: (message: string) => void;
+};
+
+export type ClassifyCaptureResult = {
+  readonly spans: ReadonlyArray<{
+    readonly name: string;
+    readonly attributes: Readonly<Record<string, unknown>>;
+    readonly status: string;
+  }>;
+};
+
+/**
+ * Drive `emitRebaseClassifySpan` against an in-memory tracer recorder
+ * and return captured spans for assertion.
+ *
+ * Mirrors the `captureSwim()` discipline: fresh recorder per call,
+ * tracer reset in `finally`, no leaked state between invocations.
+ * STDOUT-only — no real BasicTracerProvider, no live OTLP, no
+ * @opentelemetry/sdk-trace-base machinery.
+ *
+ * Per memo Q4: PICK verdicts emit normally with no special handling.
+ * The matrix marks PICK as `it.todo` because PICK is not currently
+ * producible by the §1 substrate, but the helper accepts it.
+ */
+export async function captureClassify(
+  opts: CaptureClassifyOptions,
+): Promise<ClassifyCaptureResult> {
+  const recorder = createInMemorySpanRecorder();
+  setContinuationTracer(recorder.tracer);
+  try {
+    const args: EmitRebaseClassifySpanArgs = {
+      verdict: opts.verdict,
+      channel: opts.channel,
+      pickSha: opts.pickSha,
+      ...(opts.evidence !== undefined ? { evidence: opts.evidence } : {}),
+      ...(opts.log !== undefined ? { log: opts.log } : {}),
+    };
+    emitRebaseClassifySpan(args);
+    return { spans: recorder.spans() };
   } finally {
     resetContinuationTracer();
   }


### PR DESCRIPTION
Wires the contract pinned in #413 (`docs/design/swim-37-classifier-span-memo.md`, merged `fff243c781`).

Memo-before-wire cycle: #413 memo → this wire. Cohort sign-off was 2026-04-27 with these locked positions, all honored:

- **Q1 (Option A vs B)**: ✅ Option B — separate `captureClassify()` entry point. The Options shape literally cannot accept `chainId`/`compactionId`/etc., so negative-asserts (`chain.id`, `chain.step.remaining`, `disabled.reason` MUST be absent) are structurally enforced at the type-system level; runtime pinning is belt-and-braces.
- **Q2/Q2.5 (location)**: ✅ in-PR helper at NEW `src/rebase/tracer.ts`. Mirrors `src/infra/continuation-tracer.ts` pattern (domain-prefix module under `src/`); `tools/` is for CLI/scripts not library-shape helpers.
- **Q3 (test matrix)**: ✅ 6-row per-channel matrix (5 live + 1 `it.todo` for the future PICK-producing channel) + separate `describe` blocks for truncation invariant + negative-assert pins.
- **Q4 (PICK emit)**: ✅ emit normally with no special handling. Throwing would couple tracer to classifier capability surface.

## Files

- **NEW** `src/rebase/tracer.ts` (164 lines) — peer of `src/infra/continuation-tracer.ts`. Exports `emitRebaseClassifySpan(args)` + runtime-SSOT enums (`REBASE_VERDICTS`, `REBASE_DISCOVERY_CHANNELS`, `REBASE_CONFLICT_BINS`). try/catch wrap mirrors `emitContinuationCompactionReleasedSpan`. Truncates `pickSha` to 12 chars; helper does NOT pad short input (honest about being short).
- `studies/swim-37/harness/swim-runner.ts` (+58/-1) — adds `captureClassify` + `CaptureClassifyOptions` + `ClassifyCaptureResult`. Mirrors `captureSwim` discipline.
- `studies/swim-37/harness/swim-runner.test.ts` (+218/-1) — NEW `describe("swim-37 harness :: rebase.classify primitive (live now)")` block:
  - 6-row matrix describe (channel × verdict × evidence presence)
  - 3-test truncation describe (40→12, 12 unchanged, <12 unchanged-no-pad)
  - 3-test negative-assert describe (`chain.id`, `chain.step.remaining`, `disabled.reason` all pinned absent + `in` checks)
  - 1-test isolation contract

## Test results

`pnpm vitest run -c test/vitest/vitest.swim-37.config.ts` → **8 files / 151 passed / 14 todo** (was 138/13 from `bcccac2e91` baseline; +13 live tests + 1 todo for the future PICK row).

## Lane discipline (memo §5)

NEW module (`src/rebase/tracer.ts`) + NEW entry point (`captureClassify`) + new `describe` block = zero overlap with:
- #414's `captureSwim("lich")` lane (merged `e4d49fc02b`)
- #415's `chain.id` absence pin (merged `bcccac2e91`)
- 🌻's incoming heartbeat-wire lane (`captureSwim("heartbeat")`)

Stack on `cael/325-canonical2` after this lands: #406 → #407 → #408 → #405 → #410 → #411 → #412 → #413 → #414 → #415 → **this** (eleventh swim-37 PR; third memo-before-wire cycle landed).

— 🌊