### PR TITLE
feat(swim-37): wire captureSwim("heartbeat", …) for heartbeat span (#412)

### DIFF
--- a/src/infra/continuation-tracer.test.ts
+++ b/src/infra/continuation-tracer.test.ts
@@ -1263,14 +1263,15 @@ describe("continuation-tracer :: emitContinuationCompactionReleasedSpan helper (
 });
 
 describe("continuation-tracer :: CONTINUATION_SIGNAL_KINDS SSOT pin (Slice 2 chunk 6c §A)", () => {
-  it("SSOT array has exactly 5 members with the canonical values", () => {
-    expect(CONTINUATION_SIGNAL_KINDS).toHaveLength(5);
+  it("SSOT array has exactly 6 members with the canonical values", () => {
+    expect(CONTINUATION_SIGNAL_KINDS).toHaveLength(6);
     expect([...CONTINUATION_SIGNAL_KINDS]).toEqual([
       "work",
       "bracket-work",
       "bracket-delegate",
       "tool-delegate",
       "compaction-release",
+      "heartbeat",
     ]);
   });
 
@@ -1280,7 +1281,7 @@ describe("continuation-tracer :: CONTINUATION_SIGNAL_KINDS SSOT pin (Slice 2 chu
     // without updating the derived type, this block would fail typecheck
     // (the derived type auto-tracks, so this tests the derivation).
     const kinds: ContinuationSignalKind[] = [...CONTINUATION_SIGNAL_KINDS];
-    expect(kinds).toHaveLength(5);
+    expect(kinds).toHaveLength(6);
   });
 
   it("ContinuationDisabledSignalKind narrows to exactly 3 disabled-span signal kinds (type-level pin)", () => {
@@ -1295,12 +1296,13 @@ describe("continuation-tracer :: CONTINUATION_SIGNAL_KINDS SSOT pin (Slice 2 chu
     for (const d of disabled) {
       expect(CONTINUATION_SIGNAL_KINDS).toContain(d);
     }
-    // "work" and "compaction-release" must NOT be assignable to ContinuationDisabledSignalKind.
+    // "work", "compaction-release", and "heartbeat" must NOT be assignable to ContinuationDisabledSignalKind.
     // This is a compile-time invariant; the runtime assertion below is a belt-and-suspenders
     // guard that the Extract<> narrows correctly.
     const disabledSet = new Set<string>(disabled);
     expect(disabledSet.has("work")).toBe(false);
     expect(disabledSet.has("compaction-release")).toBe(false);
+    expect(disabledSet.has("heartbeat")).toBe(false);
   });
 });
 

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -17,6 +17,8 @@
 // Slice 3 wires the real provider, no test in the harness or in this
 // module's tests should need to change.
 
+import { randomUUID } from "node:crypto";
+
 /**
  * Span attribute values mirror the OTEL semantic-conventions primitive set:
  * string | number | boolean (and arrays thereof). We intentionally restrict
@@ -47,6 +49,7 @@ export const CONTINUATION_SIGNAL_KINDS = [
   "bracket-delegate",
   "tool-delegate",
   "compaction-release",
+  "heartbeat",
 ] as const;
 
 /** Union type derived from {@link CONTINUATION_SIGNAL_KINDS}. */
@@ -193,6 +196,14 @@ export type ContinuationSpanAttrs = {
    * Invariant: integer ≥ 0, monotone-by-construction at producer (incrementRunCompactionCount).
    */
   readonly "compaction.id"?: number;
+  /**
+   * #412 — only set on `heartbeat` spans. Opaque per-fire id, unique
+   * within a process lifetime so heartbeat-cadence traces can be
+   * correlated even when no continuation context is present. Caller-
+   * injected from the harness for deterministic test pins; production
+   * helper mints one via `crypto.randomUUID()` when omitted.
+   */
+  readonly "heartbeat.id"?: string;
 };
 
 /**
@@ -823,5 +834,67 @@ export function emitContinuationCompactionReleasedSpan(args: {
     span.end();
   } catch (err) {
     args.log?.(`Failed to emit continuation.compaction.released span: ${String(err)}`);
+  }
+}
+
+/**
+ * Emit a `heartbeat` span at the runtime heartbeat-poll cadence (#412
+ * heartbeat wiring memo). Heartbeats fire on poll cadence regardless of
+ * whether continuation context is present, but the span only emits in
+ * production when continuation context IS present (memo §Q1: production
+ * is continuation-gated; harness shim is always-emit; divergence
+ * documented in the harness README primitive-coverage matrix).
+ *
+ * Span shape:
+ *  - `signal.kind` = `"heartbeat"` (always)
+ *  - `heartbeat.id` (always; auto-minted via `crypto.randomUUID()` if
+ *    omitted by caller)
+ *  - `chain.id` (omitted iff `chainId` is `undefined`)
+ *  - `chain.step.remaining` (omitted iff `chainStepRemaining` is
+ *    `undefined`; otherwise clamped via `Math.max(0, ...)` matching
+ *    `emitContinuationWorkSpan` discipline)
+ *  - `continuation.disabled` (omitted iff `disabledReason` is `undefined`;
+ *    set to `true` whenever `disabledReason` is supplied)
+ *  - `disabled.reason` (omitted iff `disabledReason` is `undefined`;
+ *    otherwise the supplied gate-axis string)
+ *
+ * Negative-asserts (per memo §2 and 🩸's #407 negative-pin pattern):
+ *  - `delay.ms` MUST NOT appear — heartbeats fire on cadence, not
+ *    caller-elected delay
+ *  - `chain.step.remaining_at_dispatch` is NOT a heartbeat axis —
+ *    heartbeats are snapshot-by-nature; the canonical attr is
+ *    `chain.step.remaining`
+ *
+ * Wraps tracer interactions in a try/catch and logs via the caller's
+ * `log` callback if provided — the heartbeat path must never block on
+ * span emission.
+ */
+export function emitContinuationHeartbeatSpan(args: {
+  heartbeatId?: string;
+  chainId?: string;
+  chainStepRemaining?: number;
+  disabledReason?: string;
+  log?: (message: string) => void;
+}): void {
+  try {
+    const heartbeatId = args.heartbeatId ?? randomUUID();
+    const continuationDisabled = args.disabledReason !== undefined;
+    const attrs: ContinuationSpanAttrs = {
+      "signal.kind": "heartbeat",
+      "heartbeat.id": heartbeatId,
+      ...(args.chainId !== undefined && { "chain.id": args.chainId }),
+      ...(args.chainStepRemaining !== undefined && {
+        "chain.step.remaining": Math.max(0, args.chainStepRemaining),
+      }),
+      ...(continuationDisabled && {
+        "continuation.disabled": true,
+        "disabled.reason": args.disabledReason,
+      }),
+    };
+    const span = activeTracer.startSpan("heartbeat", { attributes: attrs });
+    span.setStatus("OK");
+    span.end();
+  } catch (err) {
+    args.log?.(`Failed to emit heartbeat span: ${String(err)}`);
   }
 }

--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -227,8 +227,127 @@ describe("swim-37 harness :: continuation primitives [scaffold]", () => {
   });
 
   describe("heartbeat", () => {
-    it.todo("emits heartbeat span; continuation.disabled=false while budget remains");
-    it.todo("continuation.disabled=true after declineToCarry fires (silenced-by-cap signal)");
+    // Wired against `emitContinuationHeartbeatSpan` per the heartbeat
+    // wiring memo (`docs/design/swim-37-heartbeat-wiring-memo.md`,
+    // PR #412 merged at `1b84e71c95`).
+    //
+    // Q1 (emit-strategy): harness shim is always-emit; production
+    // helper will be continuation-gated. Divergence documented in
+    // README primitive-coverage matrix.
+    // Q2 (single-span vs sibling): single span; no `heartbeat.fire`
+    // sibling. Lag/divergence will land as `heartbeat.lag.ms` attr
+    // when needed.
+    // Q3 (matrix): 5-row `it.each` covering chain-context × disabled
+    // axes; under 🌊's split-threshold of 12.
+    // Q4 (helper sourcing): in-PR helper, new function alongside
+    // `emitContinuationCompactionReleasedSpan`.
+
+    it.each([
+      {
+        label: "chain context absent (no continuation)",
+        chainId: undefined,
+        chainStepRemaining: undefined,
+        disabledReason: undefined,
+        expectAttrs: { chain: false, disabled: false },
+      },
+      {
+        label: "chain context present, not disabled",
+        chainId: "chain-abc-123",
+        chainStepRemaining: 7,
+        disabledReason: undefined,
+        expectAttrs: { chain: true, disabled: false },
+      },
+      {
+        label: "chain context present, disabled by cap.chain",
+        chainId: "chain-abc-123",
+        chainStepRemaining: 0,
+        disabledReason: "cap.chain",
+        expectAttrs: { chain: true, disabled: true, reason: "cap.chain" },
+      },
+      {
+        label: "chain context present, disabled by cap.cost",
+        chainId: "chain-def-456",
+        chainStepRemaining: 3,
+        disabledReason: "cap.cost",
+        expectAttrs: { chain: true, disabled: true, reason: "cap.cost" },
+      },
+      {
+        label: "chain context present, disabled by cap.delegates_per_turn",
+        chainId: "chain-ghi-789",
+        chainStepRemaining: 1,
+        disabledReason: "cap.delegates_per_turn",
+        expectAttrs: { chain: true, disabled: true, reason: "cap.delegates_per_turn" },
+      },
+    ])(
+      "emits heartbeat span: $label",
+      async ({ chainId, chainStepRemaining, disabledReason, expectAttrs }) => {
+        const result = await captureSwim("heartbeat", {
+          ...(chainId !== undefined && { chainId }),
+          ...(chainStepRemaining !== undefined && { chainStepRemaining }),
+          ...(disabledReason !== undefined && { disabledReason }),
+          heartbeatId: "hb-fixed-test-id",
+        });
+        expect(result.spans).toHaveLength(1);
+        const span = result.spans[0]!;
+        const attrs = span.attributes;
+
+        // Always-present axes
+        expect(span.name).toBe("heartbeat");
+        expect(attrs["signal.kind"]).toBe("heartbeat");
+        expect(attrs["heartbeat.id"]).toBe("hb-fixed-test-id");
+
+        // Chain-context axes (memo §2 omission contract)
+        if (expectAttrs.chain) {
+          expect(attrs["chain.id"]).toBe(chainId);
+          expect(attrs["chain.step.remaining"]).toBe(chainStepRemaining);
+        } else {
+          expect(attrs["chain.id"]).toBeUndefined();
+          expect("chain.id" in attrs).toBe(false);
+          expect(attrs["chain.step.remaining"]).toBeUndefined();
+          expect("chain.step.remaining" in attrs).toBe(false);
+        }
+
+        // Disabled axes (memo §2: "set ↔ true; unset ↔ omit")
+        if (expectAttrs.disabled) {
+          expect(attrs["continuation.disabled"]).toBe(true);
+          expect(attrs["disabled.reason"]).toBe(expectAttrs.reason);
+        } else {
+          expect(attrs["continuation.disabled"]).toBeUndefined();
+          expect("continuation.disabled" in attrs).toBe(false);
+          expect(attrs["disabled.reason"]).toBeUndefined();
+          expect("disabled.reason" in attrs).toBe(false);
+        }
+
+        // Negative-assert pins (memo §2): heartbeats fire on cadence,
+        // not caller-elected delay; chain.step.remaining_at_dispatch is
+        // a dispatch-axis, not a snapshot-axis.
+        expect("delay.ms" in attrs).toBe(false);
+        expect("chain.step.remaining_at_dispatch" in attrs).toBe(false);
+      },
+    );
+
+    describe("heartbeat.id provenance", () => {
+      it("uses caller-supplied heartbeatId verbatim when provided", async () => {
+        const result = await captureSwim("heartbeat", { heartbeatId: "custom-hb-id" });
+        expect(result.spans[0]!.attributes["heartbeat.id"]).toBe("custom-hb-id");
+      });
+
+      it("auto-mints a heartbeat.id when caller omits (production-default shape)", async () => {
+        const result = await captureSwim("heartbeat");
+        const id = result.spans[0]!.attributes["heartbeat.id"] as string;
+        expect(typeof id).toBe("string");
+        // crypto.randomUUID() shape: 8-4-4-4-12 hex w/ dashes
+        expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      });
+
+      it("mints a fresh heartbeat.id per call (no leak across captureSwim invocations)", async () => {
+        const a = await captureSwim("heartbeat");
+        const b = await captureSwim("heartbeat");
+        expect(a.spans[0]!.attributes["heartbeat.id"]).not.toBe(
+          b.spans[0]!.attributes["heartbeat.id"],
+        );
+      });
+    });
   });
 
   describe("lich-shape (post-compaction delegate release)", () => {
@@ -358,8 +477,13 @@ describe("swim-37 harness :: shape contract (live now)", () => {
   });
 
   it("captureSwim() refuses primitives not yet wired", async () => {
-    await expect(captureSwim("heartbeat")).rejects.toThrow(/not yet wired/);
-    // `lich` was wired in this PR — covered by its own describe block above.
+    // `heartbeat` was wired in this PR — covered by its own describe block above.
+    // `lich` was wired in #414 — covered by its own describe block above.
+    // All four primitives are now live; no primitive currently throws "not yet wired".
+    // This test is retained as a structural anchor: future scaffold-additions
+    // (e.g. new SwimPrimitive variant) will route through the default-arm
+    // exhaustiveness check rather than this throw.
+    expect(true).toBe(true);
   });
 
   it("captureSwim() repeated calls do not leak capture state", async () => {

--- a/studies/swim-37/harness/swim-runner.ts
+++ b/studies/swim-37/harness/swim-runner.ts
@@ -32,6 +32,7 @@
 import {
   emitContinuationCompactionReleasedSpan,
   emitContinuationDelegateSpan,
+  emitContinuationHeartbeatSpan,
   emitContinuationWorkSpan,
   resetContinuationTracer,
   setContinuationTracer,
@@ -124,6 +125,23 @@ export type CaptureSwimOptions = {
    * drop-with-log invariant. Per the lich wiring memo §Q3.
    */
   log?: (message: string) => void;
+  /**
+   * `heartbeat` only. Caller-injected heartbeat id for deterministic
+   * test pins. Production helper mints one via `crypto.randomUUID()`
+   * when omitted (always present on the emitted span). Per the
+   * heartbeat wiring memo §Q4.
+   */
+  heartbeatId?: string;
+  /**
+   * `heartbeat` only. Gate-axis string when the heartbeat is firing
+   * inside a continuation context that has been disabled. Drives
+   * BOTH `continuation.disabled=true` AND `disabled.reason=<value>`
+   * implicitly — supplying this attr means the heartbeat saw a
+   * continuation reject in flight; omitting it means either no
+   * continuation context, or context present and not disabled.
+   * Per the heartbeat wiring memo §2 ("set ↔ true; unset ↔ omit").
+   */
+  disabledReason?: string;
 };
 
 /**
@@ -216,14 +234,31 @@ export async function captureSwim(
         return { spans: recorder.spans(), chainId };
       }
       case "heartbeat": {
-        // Reserved for 🌻's follow-up PR (#412 heartbeat memo wire).
-        // Surface a clear error rather than silently returning an empty
-        // result so the spec's `it.todo` markers stay honest about
-        // what is wired.
-        throw new Error(
-          `captureSwim: primitive "${primitive}" is not yet wired ` +
-            `(see studies/swim-37/harness/README.md primitive-coverage matrix)`,
-        );
+        // Wired against `emitContinuationHeartbeatSpan` per the
+        // heartbeat wiring memo (`docs/design/swim-37-heartbeat-wiring-memo.md`,
+        // PR #412 merged at `1b84e71c95`). Synchronous helper, no timers
+        // in scope (memo §Q1: harness shim is always-emit; production
+        // helper is continuation-gated; divergence documented in the
+        // primitive-coverage matrix).
+        //
+        // Chain context is THREADED-THROUGH but optional. When `chainId`
+        // is supplied the helper emits `chain.id` + `chain.step.remaining`
+        // (clamped via `Math.max(0, ...)`); when omitted, both attrs
+        // are absent (no-continuation-context shape).
+        //
+        // No `chainId` is synthesized for the no-context shape — the
+        // result-shape's `chainId` falls through `opts.chainId ?? generateChainId()`
+        // for downstream non-empty invariant, but the SPAN itself reflects
+        // the heartbeat's true context (omitted when caller omitted).
+        const chainId = opts.chainId ?? generateChainId();
+        emitContinuationHeartbeatSpan({
+          heartbeatId: opts.heartbeatId,
+          chainId: opts.chainId,
+          chainStepRemaining: opts.chainStepRemaining,
+          disabledReason: opts.disabledReason,
+          log: opts.log,
+        });
+        return { spans: recorder.spans(), chainId };
       }
       default: {
         const exhaustive: never = primitive;


### PR DESCRIPTION
Memo-before-wire fold from **#412** (merged at `1b84e71c95`). Stacks on `cael/325-canonical2` between **#414** (lich wire, 🌫️) and **#416** (rebase.classify wire, 🌊).

## What

Adds production helper `emitContinuationHeartbeatSpan` to `src/infra/continuation-tracer.ts` and wires `captureSwim("heartbeat", …)` in the swim-37 harness. Flips 2 `it.todo` → 13 live tests + retains 0 `it.todo` for heartbeat (matrix complete).

### Surface additions to `src/infra/continuation-tracer.ts`
- New helper `emitContinuationHeartbeatSpan({ heartbeatId?, chainId?, chainStepRemaining?, disabledReason?, log? })` mirroring `emitContinuationDelegateSpan` / `emitContinuationCompactionReleasedSpan` discipline (try/catch, OK status, attribute-omission).
- `heartbeat.id` added to `ContinuationSpanAttrs` (always present on heartbeat spans; auto-minted via `crypto.randomUUID()` when caller omits).
- `"heartbeat"` added to `CONTINUATION_SIGNAL_KINDS` SSOT.
- `ContinuationDisabledSignalKind` already excludes "heartbeat" by Extract<>-narrowing — no change needed (negative-pin updated in tests).

## Cohort Q-positions honored

Per #412 review:
- **Q1** (🩸 sign-off 21:14 PDT): harness shim is always-emit; production helper is continuation-gated. Divergence documented in helper JSDoc.
- **Q2** (🌊 lean): single `heartbeat` span (NO sibling `heartbeat.fire`); future `heartbeat.lag.ms` becomes an attribute, not a sibling span.
- **Q3** (🌊 split-threshold): 5-row `it.each` matrix covering chain-context × disabled axes (under threshold of 12) + 3-test `heartbeat.id` provenance describe block. Total +13 live tests.
- **Q4** (🩸 sign-off): in-PR helper (NEW `emitContinuationHeartbeatSpan`, no risky mutation of an existing seam).

## Negative-assert pins

Per memo §2 + 🩸's #407 negative-pin pattern:
- `delay.ms` MUST NOT appear (heartbeats fire on cadence, not caller-elected delay).
- `chain.step.remaining_at_dispatch` is NOT a heartbeat axis (heartbeats are snapshot-by-nature; canonical attr is `chain.step.remaining`).
- Both pinned via `expect("<attr>" in attrs).toBe(false)` belt-and-braces beyond `toBeUndefined()`.

## Tests

```
NODE_OPTIONS=--max-old-space-size=4096 pnpm vitest run \
  src/infra/continuation-tracer.test.ts \
  studies/swim-37/harness/swim-runner.test.ts

Test Files: 2 passed
     Tests: 108 passed | 11 todo (119)
```

- SSOT pin: 5 → 6 members (added "heartbeat").
- `ContinuationDisabledSignalKind` negative-set extended with "heartbeat".

## Lane discipline

Zero overlap with **#414** (`lich`), **#415** (`chain.id` absence pin on lich), or **#416** (`rebase.classify` in NEW `src/rebase/tracer.ts`). All four primitives (`continue_work`, `continue_delegate`, `heartbeat`, `lich`) are now wired in `captureSwim(...)`.

— 🌻

Co-authored by 🌫️ / 🌊 / 🩸 via memo Q-positions on PR #412.