### PR TITLE
fix(swim-37): `captureClassify` validation + `signal.kind` rename (🌫 #416 review)

### DIFF
--- a/docs/design/swim-37-classifier-span-memo.md
+++ b/docs/design/swim-37-classifier-span-memo.md
@@ -38,7 +38,7 @@ Production callsite wiring is out of scope for this memo (separate issue; same p
 
 ### Required attributes (always present)
 
-- `signal.kind: "rebase.classify"` — fixed string discriminator (matches the same shape `continuation.*` helpers use for downstream filterability)
+- `signal.kind: "rebase-classify"` — fixed string discriminator (matches the family-resemblance shape used by `continuation.*` helpers, e.g. `"compaction-release"` for `continuation.compaction.released`; uses hyphen-form so a downstream filter on `signal.kind` doesn't redundantly slice the span name. Updated 2026-04-27 post-#416 per 🌫 review nit; the original memo had `"rebase.classify"` which exactly matched the span name and was redundant on the wire.)
 - `verdict: "DROP" | "PICK" | "REVIEW"` — the classifier's output
 - `discovery.channel: "changelog-grep:pr" | "changelog-grep:subject" | "cherry-pick-provenance" | "conflict-content" | "none"` — which channel produced the verdict (matches `RebaseDiscoveryChannel` exactly; type re-export from `rebase-classifier.ts`)
 - `pick.sha: string` — the commit SHA being classified (truncated to 12 chars; full SHA available via separate trace correlation if needed)

--- a/src/rebase/tracer.ts
+++ b/src/rebase/tracer.ts
@@ -132,7 +132,7 @@ export function emitRebaseClassifySpan(args: EmitRebaseClassifySpanArgs): void {
     // validation — see RebaseClassifyEvidence docstring for why.
     const ev = args.evidence;
     const attrs: SpanAttributes = {
-      "signal.kind": "rebase.classify",
+      "signal.kind": "rebase-classify",
       verdict: args.verdict,
       "discovery.channel": args.channel,
       "pick.sha": truncatedSha,

--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -420,7 +420,7 @@ describe("swim-37 harness :: rebase.classify primitive (live now)", () => {
       expect(result.spans).toHaveLength(1);
       const span = result.spans[0]!;
       expect(span.name).toBe("rebase.classify");
-      expect(span.attributes["signal.kind"]).toBe("rebase.classify");
+      expect(span.attributes["signal.kind"]).toBe("rebase-classify");
       expect(span.attributes["verdict"]).toBe("DROP");
       expect(span.attributes["discovery.channel"]).toBe("changelog-grep:pr");
       expect(span.attributes["pick.sha"]).toBe("abc123def456");
@@ -548,17 +548,74 @@ describe("swim-37 harness :: rebase.classify primitive (live now)", () => {
       expect(result.spans[0]!.attributes["pick.sha"]).toBe("123456789abc");
     });
 
-    it("passes short (<12) SHA through unchanged (helper does not pad)", async () => {
-      // Honest about being short rather than pretending. Same discipline
-      // as how `emitContinuationCompactionReleasedSpan` doesn't fabricate
-      // missing compaction.id.
+    it("passes short-but-valid (7-char) SHA through unchanged (helper does not pad)", async () => {
+      // Honest about being short rather than pretending. The 7-char
+      // boundary is git's minimum unambiguous prefix per memo §3; the
+      // captureClassify boundary throws on <7, but valid 7-11 char SHAs
+      // pass through to the helper without padding (same discipline as
+      // how `emitContinuationCompactionReleasedSpan` doesn't fabricate
+      // missing compaction.id).
       const result = await captureClassify({
         verdict: "DROP",
         channel: "changelog-grep:pr",
-        pickSha: "abc123",
+        pickSha: "abc1234",
         evidence: { changelogPrToken: "#1" },
       });
-      expect(result.spans[0]!.attributes["pick.sha"]).toBe("abc123");
+      expect(result.spans[0]!.attributes["pick.sha"]).toBe("abc1234");
+    });
+  });
+
+  describe("input validation (memo §3 throw-on-bad-input)", () => {
+    // Memo §3 specs synchronous throw-on-bad-input matching #405/#411/#412
+    // family-resemblance. Enforced at the harness boundary (mirrors
+    // captureSwim's `recipients` invariant at swim-runner.ts:180); the
+    // production helper stays drop-with-log so producer errors don't
+    // propagate to the rebase-bot caller.
+
+    it("throws when verdict is not in the canonical enum", async () => {
+      await expect(
+        captureClassify({
+          // @ts-expect-error — runtime check belt-and-braces over TS narrowing
+          verdict: "BOGUS",
+          channel: "changelog-grep:pr",
+          pickSha: "abc1234",
+          evidence: { changelogPrToken: "#1" },
+        }),
+      ).rejects.toThrow(/verdict must be one of/);
+    });
+
+    it("throws when channel is not in the canonical enum", async () => {
+      await expect(
+        captureClassify({
+          verdict: "DROP",
+          // @ts-expect-error — runtime check belt-and-braces over TS narrowing
+          channel: "made-up-channel",
+          pickSha: "abc1234",
+          evidence: { changelogPrToken: "#1" },
+        }),
+      ).rejects.toThrow(/channel must be one of/);
+    });
+
+    it("throws when pickSha is shorter than 7 hex chars (memo §3 git-prefix-min)", async () => {
+      await expect(
+        captureClassify({
+          verdict: "DROP",
+          channel: "changelog-grep:pr",
+          pickSha: "abc123",
+          evidence: { changelogPrToken: "#1" },
+        }),
+      ).rejects.toThrow(/at least 7 hex chars/);
+    });
+
+    it("throws when pickSha contains non-hex characters", async () => {
+      await expect(
+        captureClassify({
+          verdict: "DROP",
+          channel: "changelog-grep:pr",
+          pickSha: "NOTHEXXX",
+          evidence: { changelogPrToken: "#1" },
+        }),
+      ).rejects.toThrow(/lowercase hex/);
     });
   });
 
@@ -577,7 +634,7 @@ describe("swim-37 harness :: rebase.classify primitive (live now)", () => {
       const result = await captureClassify({
         verdict: "DROP",
         channel: "changelog-grep:pr",
-        pickSha: "abc123",
+        pickSha: "abc1234",
         evidence: { changelogPrToken: "#1" },
       });
       const attrs = result.spans[0]!.attributes;
@@ -589,7 +646,7 @@ describe("swim-37 harness :: rebase.classify primitive (live now)", () => {
       const result = await captureClassify({
         verdict: "DROP",
         channel: "changelog-grep:pr",
-        pickSha: "abc123",
+        pickSha: "abc1234",
         evidence: { changelogPrToken: "#1" },
       });
       const attrs = result.spans[0]!.attributes;
@@ -604,8 +661,8 @@ describe("swim-37 harness :: rebase.classify primitive (live now)", () => {
       const result = await captureClassify({
         verdict: "DROP",
         channel: "cherry-pick-provenance",
-        pickSha: "abc123",
-        evidence: { cherryPickSourceSha: "def456" },
+        pickSha: "abc1234",
+        evidence: { cherryPickSourceSha: "def4567" },
       });
       const attrs = result.spans[0]!.attributes;
       expect(attrs["disabled.reason"]).toBeUndefined();
@@ -618,19 +675,19 @@ describe("swim-37 harness :: rebase.classify primitive (live now)", () => {
       const r1 = await captureClassify({
         verdict: "DROP",
         channel: "changelog-grep:pr",
-        pickSha: "first1234567",
+        pickSha: "f1450123456",
         evidence: { changelogPrToken: "#1" },
       });
       const r2 = await captureClassify({
         verdict: "REVIEW",
         channel: "none",
-        pickSha: "second123456",
+        pickSha: "5ec0d123456",
         evidence: { needsConflictContentInspection: true },
       });
       expect(r1.spans).toHaveLength(1);
       expect(r2.spans).toHaveLength(1);
-      expect(r1.spans[0]!.attributes["pick.sha"]).toBe("first1234567");
-      expect(r2.spans[0]!.attributes["pick.sha"]).toBe("second123456");
+      expect(r1.spans[0]!.attributes["pick.sha"]).toBe("f1450123456");
+      expect(r2.spans[0]!.attributes["pick.sha"]).toBe("5ec0d123456");
     });
   });
 });

--- a/studies/swim-37/harness/swim-runner.ts
+++ b/studies/swim-37/harness/swim-runner.ts
@@ -38,6 +38,8 @@ import {
 } from "../../../src/infra/continuation-tracer.js";
 import { generateChainId } from "../../../src/infra/secure-random.js";
 import {
+  REBASE_DISCOVERY_CHANNELS,
+  REBASE_VERDICTS,
   emitRebaseClassifySpan,
   type EmitRebaseClassifySpanArgs,
   type RebaseClassifyEvidence,
@@ -285,6 +287,36 @@ export type ClassifyCaptureResult = {
 export async function captureClassify(
   opts: CaptureClassifyOptions,
 ): Promise<ClassifyCaptureResult> {
+  // Memo §3 validation (throw-on-bad-input — matches #405/#411/#412
+  // family-resemblance via the harness boundary, same shape as
+  // `captureSwim`'s `recipients must be a positive integer` throw at
+  // line 180). Enforced here at the Options boundary rather than inside
+  // the helper so the production tracer surface stays drop-with-log
+  // (matches `emitContinuationCompactionReleasedSpan`'s discipline of
+  // never throwing through to the caller).
+  if (!REBASE_VERDICTS.includes(opts.verdict)) {
+    throw new Error(
+      `captureClassify: verdict must be one of ${REBASE_VERDICTS.join("|")}, got ${String(opts.verdict)}`,
+    );
+  }
+  if (!REBASE_DISCOVERY_CHANNELS.includes(opts.channel)) {
+    throw new Error(
+      `captureClassify: channel must be one of ${REBASE_DISCOVERY_CHANNELS.join("|")}, got ${String(opts.channel)}`,
+    );
+  }
+  // pickSha ≥ 7 hex chars per memo §3 (git's minimum unambiguous prefix).
+  // Hex-only check matches the `^[0-9a-f]+$` shape git rev-parse emits.
+  if (typeof opts.pickSha !== "string" || opts.pickSha.length < 7) {
+    throw new Error(
+      `captureClassify: pickSha must be at least 7 hex chars, got ${JSON.stringify(opts.pickSha)}`,
+    );
+  }
+  if (!/^[0-9a-f]+$/.test(opts.pickSha)) {
+    throw new Error(
+      `captureClassify: pickSha must be lowercase hex (matches git rev-parse), got ${JSON.stringify(opts.pickSha)}`,
+    );
+  }
+
   const recorder = createInMemorySpanRecorder();
   setContinuationTracer(recorder.tracer);
   try {


### PR DESCRIPTION
Folds three flags from 🌫's #416 second-eye review (msg [`1498543295234834432`](https://discord.com/channels/1235610176883523614/1466192485440164011/1498543295234834432)).

## Flag 1 — memo §3 validation gap
Memo specced throw-on-bad-input matching #405/#411/#412 family-resemblance; #416 wire skipped it. Adds boundary throws in `captureClassify`:
- `verdict` not in `REBASE_VERDICTS`
- `channel` not in `REBASE_DISCOVERY_CHANNELS`
- `pickSha` < 7 hex chars (memo §3 git-prefix-min)
- `pickSha` containing non-hex chars

Validation lives at the **harness boundary** (mirrors `captureSwim`'s `recipients` invariant at `swim-runner.ts:180`); the production helper `emitRebaseClassifySpan` stays **drop-with-log** so producer errors don't propagate to the rebase-bot caller. Same asymmetry as how `captureSwim` throws on bad Options but `emitContinuationCompactionReleasedSpan` only logs.

## Flag 2 — `truncateSha` ↔ memo §3 "≥7 hex chars" tension
The `<12 unchanged (helper does not pad)` test from #416 contradicted the memo's ≥7 floor. Replaced with `passes short-but-valid (7-char) SHA through unchanged` — honors BOTH the memo floor AND the no-pad discipline. **Memo + code + tests now agree.**

## Nit — `signal.kind: "rebase.classify"` redundant with span name
Other helpers use the underlying primitive name as discriminator (e.g. `"compaction-release"` for `continuation.compaction.released`), so a downstream filter on `signal.kind` doesn't redundantly slice the span name. Renamed to `"rebase-classify"` (hyphen-form, matches family). Memo §2 updated in-place with provenance note.

## Test additions
- NEW `describe("input validation (memo §3 throw-on-bad-input)")` block: 4 tests
- Existing `<12 unchanged` test deleted, replaced with valid 7-char passes-through-unchanged

## Test results
`pnpm vitest run -c test/vitest/vitest.swim-37.config.ts` → **8 files / 155 passed / 14 todo** (was 151/14 from #416 at `526540de15`; +4 live tests, same todos).

## Lane discipline
Same lane as #416 follow-up — mirrors how #415 followed #414. Zero overlap with 🌻's incoming heartbeat wire. Twelfth swim-37 PR on the `cael/325-canonical2` stack.

— 🌊