### PR TITLE
test/docs(swim-37): heartbeat harness-shape nits (🌫 + 🩸 #417 review)

### DIFF
--- a/studies/swim-37/harness/swim-runner.test.ts
+++ b/studies/swim-37/harness/swim-runner.test.ts
@@ -343,9 +343,16 @@ describe("swim-37 harness :: continuation primitives [scaffold]", () => {
       it("mints a fresh heartbeat.id per call (no leak across captureSwim invocations)", async () => {
         const a = await captureSwim("heartbeat");
         const b = await captureSwim("heartbeat");
-        expect(a.spans[0]!.attributes["heartbeat.id"]).not.toBe(
-          b.spans[0]!.attributes["heartbeat.id"],
-        );
+        const idA = a.spans[0]!.attributes["heartbeat.id"] as string;
+        const idB = b.spans[0]!.attributes["heartbeat.id"] as string;
+        // Stricter-defense per 🌫's #417 review: each fresh mint must
+        // ALSO conform to crypto.randomUUID() shape, not just differ.
+        // (Catches a hypothetical regression where the auto-mint seam
+        // degrades to a counter or timestamp under one branch.)
+        const uuidShape = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+        expect(idA).toMatch(uuidShape);
+        expect(idB).toMatch(uuidShape);
+        expect(idA).not.toBe(idB);
       });
     });
   });

--- a/studies/swim-37/harness/swim-runner.ts
+++ b/studies/swim-37/harness/swim-runner.ts
@@ -259,6 +259,13 @@ export async function captureSwim(
         // result-shape's `chainId` falls through `opts.chainId ?? generateChainId()`
         // for downstream non-empty invariant, but the SPAN itself reflects
         // the heartbeat's true context (omitted when caller omitted).
+        //
+        // CONTRACT (per 🩸's #417 review): the SPAN is the truth. The
+        // result-field `chainId` is harness plumbing for assertion symmetry
+        // with the other primitives — it does NOT round-trip through the
+        // emitted span when `opts.chainId` is undefined. Tests asserting
+        // chain-context absence MUST inspect `result.spans[0]!.attributes`,
+        // not `result.chainId`.
         const chainId = opts.chainId ?? generateChainId();
         emitContinuationHeartbeatSpan({
           heartbeatId: opts.heartbeatId,


### PR DESCRIPTION
Two non-blocker nits from #417 review folded in additively, mirroring the approve→merge→fold-as-additive precedent (#414→#415, #416→#418).

## Folded nits

1. **🌫 #417 review** — `UUID-shape regex pin on auto-mint per-call freshness test`. Existing 'mints a fresh heartbeat.id per call' test asserted `.not.toBe(...)` only, which catches leaks but not regressions where the auto-mint seam degrades to a counter/timestamp on one branch. Strengthened to ALSO match `crypto.randomUUID()` shape on each fresh mint.

2. **🩸 #417 review** — `chainId synthesis-vs-span asymmetry JSDoc clarification`. The 'heartbeat' case in `captureSwim` synthesizes a result-field `chainId` for harness plumbing symmetry, but the EMITTED span correctly omits `chain.id` when caller omitted `opts.chainId`. Comment now explicitly names this asymmetry and directs assertion-writers to inspect `result.spans[0]!.attributes` instead of `result.chainId` for chain-context absence.

## Scope

Both nits are harness-shape, NOT wire-correctness:
- No production code touched
- SSOT (`CONTINUATION_SIGNAL_KINDS`) unchanged
- Helper signatures (`emitContinuationHeartbeatSpan`) unchanged
- Span attribute contracts unchanged
- Negative-pins (`delay.ms`, `chain.step.remaining_at_dispatch`) unchanged

## Tests

```
pnpm vitest run studies/swim-37/harness/swim-runner.test.ts
Test Files: 1 passed
     Tests: 54 passed | 12 todo (66)
```

No regressions; same row count (UUID pin folded INTO existing freshness test rather than added as new row).

## Lane discipline

Zero overlap with #418 (`captureClassify` validation backfill, merged at `148792a0b7`). Stacks cleanly on `cael/325-canonical2`.

— 🌻