### PR TITLE
DRAFT chore(release): prepare 2026.4.25 (frond-release-mechanism artifact, awaiting figs version-bit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.4.24",
+  "version": "2026.4.25",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",


### PR DESCRIPTION
# DRAFT — release-prep artifact for figs to pick

**Status:** byte-pinned demonstration. Do NOT merge, tag, or dispatch the npm-release workflow from this commit without explicit version-naming bit from figs.

## What this is

The single-commit version-bump `package.json: 2026.4.24 → 2026.4.25` on `cael/325-canonical2`. The commit that anchors a frond-release of `karmaterminal/openclaw` on **our** fork lineage.

## What this is NOT

- Not a lift onto upstream `openclaw/openclaw v2026.4.26` (separate axis, figs explicitly retired ~75min pre-PR-open: *"Do NOT split work onto another basis of upstream until you have finished this one, you will DEFINATELY fuck up"*)
- Not a `canonical2 → main` promotion (#424 is that artifact, separate axis, awaiting 🩸 disposition)
- Not a `canonical2 → flesh_beast_figs/20260414-claude` parent umbrella (🩸 owns that, holds open until 🌻+figs convergence on 126-commit topology)

## Why this exists

Cohort spent ~90min cycling on "lift to v2026.4.26" framing in 6 different word-shapes. The byte-pin every iteration:

```
$ readlink -f $(which openclaw)
/home/figs/flesh_beast_tmp/openclaw/openclaw.mjs            ← FORK CHECKOUT SYMLINK

$ npm view openclaw repository.url
'git+https://github.com/openclaw/openclaw.git'              ← npm package = UPSTREAM

$ npm view openclaw version
'2026.4.26'                                                  ← upstream tag, no fork work
```

`npm i -g openclaw@2026.4.26` on any prince = replace fork-checkout symlink with upstream tarball = drop all 96 commits of our continuation/swim/auto-reply work from the gateway runtime path.

The frond-release-mechanism for `karmaterminal/openclaw`, byte-walked from the fork's own `.github/workflows/`:

```
1. chore(release): prepare 2026.4.X    ← THIS COMMIT
2. git tag v2026.4.X                   ← annotated tag on OUR fork lineage
3. gh workflow run openclaw-npm-release.yml \
     -f tag=v2026.4.X \
     -f npm_dist_tag=beta
4. deploy-gateway.yml refreshes fork-build symlink on each prince
```

Existing fork tag cadence: `v2026.4.24-beta.{1..6}` → `v2026.4.24`. Next number on **our** line: `2026.4.25` (chosen here as default; figs's bit decides the actual string).

## Cohort context

- Fleet deployed homogeneous on `cael/325-canonical2 @ 29e556eb11` at deploy-time
- canonical2 has since advanced to `42f1bb9c14b` (#422 Slice-3 OTel adapter merged 12:53Z)
- Same fork. Same npm package name. Same symlink path on each prince. Our 96 commits intact.

## Bit owed from figs

- **Version string:** `2026.4.25`? `2026.4.25-beta.1`? `2026.4.26` (jump to match upstream cadence)? Pick one — this commit is trivially amendable.
- **Sequencing:** does this PR merge before or after the canonical2-promotion topology question (parent umbrella vs main-direct vs neither) settles?
- **Dispatch:** when bit lands, who fires `gh workflow run openclaw-npm-release.yml`? (Cael as canonical2-owner is the natural trigger.)

## Lane assignments standing

- 🌊 (Ronan) — `src/auto-reply/*` conflict resolution if any surfaces in promotion topology
- 🌫️ (Silas) — `src/agents/*` continuation surface
- 🩸 (Cael) — umbrella PR ownership + merge substrate + final synthesis
- 🌻 (Elliott) — topology second-eyes, post-deploy 4-prince homogeneity walk after release lands

## Standing rule (fleet-scope, in force)

**No `openclaw update` on any prince.** Substrate-orphan path. Holds until figs disambiguates.

---

**Author:** Ronan 🌊
**Cohort discussion:** sprites-of-thornfield 2026-04-29 13:00 UTC
