### PR TITLE
fix(continuation): durable write-back for tool-delegate chain state (r3164418100)

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2906,14 +2906,19 @@ export async function runReplyAgent(params: {
       sessionKey &&
       activeSessionEntry
     ) {
-      const { loadContinuationChainState, persistContinuationChainState } =
-        await import("../continuation/lazy.runtime.js");
+      // r3164418100 (P1): use the local async `persistContinuationChainState`
+      // (defined ~line 1269) which does the durable triple-write — sessionEntry
+      // + sessionStore + disk via `updateSessionStore`. The lazy.runtime helper
+      // of the same name only mutates the in-memory `sessionEntry`, so a
+      // restart or disk-based reload would revert chain depth/tokens/chain-id
+      // for tool-delegate hops, weakening max-chain and cost-cap enforcement
+      // and making continuation telemetry inconsistent.
+      const { loadContinuationChainState } = await import("../continuation/lazy.runtime.js");
       const turnTokens = (usage?.input ?? 0) + (usage?.output ?? 0);
       const nextState =
         toolDelegateDispatchResult?.chainState ??
         loadContinuationChainState(activeSessionEntry, turnTokens);
-      persistContinuationChainState({
-        sessionEntry: activeSessionEntry,
+      await persistContinuationChainState({
         count: nextState.currentChainCount,
         startedAt: nextState.chainStartedAt,
         tokens: nextState.accumulatedChainTokens,


### PR DESCRIPTION
**Post-merge codex P1 audit on #423** — review thread `r3164418100` (still unresolved + non-outdated on merged head).

## The bug

Tool-delegate chain-state write-back path in `agent-runner.ts` (~line 2909) imported `persistContinuationChainState` from `continuation/lazy.runtime.js`. That helper only mutates in-memory `sessionEntry` and **shadowed the local async durable writer** defined at line ~1269.

The local writer does the **triple-write**: `sessionEntry` + `sessionStore` + disk via `updateSessionStore`. All other call sites in this file (~2249, ~2327, ~2437, ~2676, ~2751) correctly use the local async one.

**Impact:** restart or any disk-based reload reverts to stale chain depth / tokens / chain-id for tool-delegate hops. Weakens `maxChainLength` and cost-cap enforcement; makes continuation telemetry inconsistent across restart.

## Fix

- Drop `persistContinuationChainState` from the lazy.runtime import (keep `loadContinuationChainState`)
- `await` the local async writer
- Drop the now-redundant `sessionEntry` param (the local writer closes over `activeSessionEntry`)

Comment block at the call site explains the reasoning and references `r3164418100`.

## Tests

49/49 green:
- `agent-runner.continuation-work-span.test.ts` (3/3)
- `agent-runner.continuation-delegate-fire-span.test.ts` (3/3)
- `agent-runner-execution.test.ts` (45/45)
- `session-updates.test.ts` (1/1)

`pnpm exec tsc --noEmit` clean.

## Release coordination

Part of post-merge audit lane on #423. Two sibling threads also need fixes:
- `r3164380565` P1 — `subagent-announce.ts` child drain
- `r3164418106` P2 — `followup-runner.ts` dispatched==0

🌊 driving the other two; this is the `agent-runner.ts` byte-walk.

**Hold release tag `v2026.4.25` (PR #425) until all three resolve on `cael/325-canonical2`.**