### PR TITLE
fix(continuation): persist followup chain tokens when dispatched===0 (r3164418106)

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1672,6 +1672,73 @@ describe("createFollowupRunner continuation delegate dispatch", () => {
 
     expect(dispatchToolDelegatesMock).not.toHaveBeenCalled();
   });
+
+  it("persists chain tokens even when dispatchResult.dispatched === 0 (r3164418106)", async () => {
+    // Repro: prior guard `dispatched > 0 && tailEntry` dropped chain-token
+    // persistence on followup-only chains (delayed-only delegates, all
+    // deferred, or pure continue_work turns). The chainState carries fresh
+    // accumulatedChainTokens from loadContinuationChainState(tailEntry,
+    // turnTokens) regardless of dispatched count, so we must persist it
+    // unconditionally to keep the token-budget counter advancing across hops.
+    const storePath = path.join(
+      await fs.mkdtemp(path.join(tmpdir(), "openclaw-followup-r3164418106-")),
+      "sessions.json",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 2,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: 100,
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      main: sessionEntry,
+    };
+    registerFollowupTestSessionStore(storePath, sessionStore);
+
+    // dispatched === 0 (no delegates spawned this turn) but chainState
+    // returned with the advanced token total.
+    dispatchToolDelegatesMock.mockResolvedValueOnce({
+      dispatched: 0,
+      rejected: 0,
+      chainState: {
+        currentChainCount: 2,
+        chainStartedAt: 1_700_000_000_000,
+        accumulatedChainTokens: 250,
+      },
+    });
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello" }],
+      meta: { agentMeta: { usage: { input: 100, output: 50 } } },
+    });
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "openai/gpt-5.4",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+    });
+    const queued = createQueuedRun({
+      run: {
+        sessionKey: "main",
+        config: {
+          agents: { defaults: { continuation: { enabled: true } } },
+        } as OpenClawConfig,
+      },
+    });
+
+    await runner(queued);
+
+    expect(dispatchToolDelegatesMock).toHaveBeenCalledTimes(1);
+    // The fix: chain tokens must advance from 100 → 250 even when
+    // dispatched === 0. Pre-fix: this stayed at 100 and the budget drifted.
+    expect(sessionStore.main.continuationChainTokens).toBe(250);
+    expect(sessionStore.main.continuationChainCount).toBe(2);
+  });
 });
 
 describe("createFollowupRunner agentDir forwarding", () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -474,7 +474,15 @@ export function createFollowupRunner(params: {
         // r3163899586: persist the advanced chain state back to the session
         // entry after dispatch. Without this the followup-path counter never
         // advances and `maxChainLength` enforcement breaks across hops.
-        if (dispatchResult && dispatchResult.dispatched > 0 && tailEntry) {
+        //
+        // r3164418106: persist even when `dispatched === 0`. The chainState
+        // returned from `dispatchToolDelegates` carries the fresh
+        // `accumulatedChainTokens` from `loadContinuationChainState(tailEntry,
+        // turnTokens)` regardless of whether any delegate spawned. Guarding on
+        // `dispatched > 0` drops the token total on followup-only chains
+        // (delayed-only delegates, all-deferred dispatches, or pure
+        // continue_work turns), causing token-budget drift across hops.
+        if (dispatchResult && tailEntry) {
           persistContinuationChainState({
             sessionEntry: tailEntry,
             count: dispatchResult.chainState.currentChainCount,


### PR DESCRIPTION
Codex review **r3164418106** on merged PR #423.

## Bug

`followup-runner.ts:477` guards chain-state persistence on `dispatchResult.dispatched > 0`:

```ts
if (dispatchResult && dispatchResult.dispatched > 0 && tailEntry) {
  persistContinuationChainState({ ...accumulatedChainTokens });
}
```

This drops chain-token persistence on **followup-only chains**:
- delayed-only delegates (all scheduled with `delaySeconds > 0`)
- all-deferred dispatches (rejected/blocked, not spawned)
- pure `continue_work` turns (no `continue_delegate` calls)

`dispatchToolDelegates` returns `chainState` with fresh `accumulatedChainTokens` from `loadContinuationChainState(tailEntry, turnTokens)` regardless of dispatched count. The token total carries the current turn's tokens unconditionally — but the guard discards them. Result: per-session token-budget counter stops advancing on followup-only chains, breaking `maxChainLength`/budget enforcement across hops.

## Fix

Drop the `dispatched > 0` clause; persist whenever a dispatch result is returned.

```diff
-if (dispatchResult && dispatchResult.dispatched > 0 && tailEntry) {
+if (dispatchResult && tailEntry) {
   persistContinuationChainState({ ... });
 }
```

## Test

`persists chain tokens even when dispatchResult.dispatched === 0 (r3164418106)` in `followup-runner.test.ts`:
- Seeds `sessionEntry.continuationChainTokens = 100`
- Mocks `dispatchToolDelegates` returning `{ dispatched: 0, chainState: { accumulatedChainTokens: 250 } }`
- Asserts `sessionStore.main.continuationChainTokens === 250` after run
- Pre-fix: stays at 100 (drift). Post-fix: advances to 250.

## Receipts

- branch: `ronan/427-followup-runner-token-persist`
- head: `fa62f1bb`
- base: `cael/325-canonical2 @ c8f85f5254`
- diff: 1 file, +9 -1 in `src/auto-reply/reply/followup-runner.ts`; +67 -0 test
- vitest `followup-runner.test.ts`: **32/32 green** (31 prior + 1 new regression)

## Sibling lanes (#423 post-merge audit)

- #427 `silas/427-agent-runner-durable-writeback` — r3164418100 P1 (agent-runner durable write-back)
- `elliott/427-child-drain-persist` — r3164380565 P1 (subagent-announce child drain), in flight

Release lane (`v2026.4.24` artifact prep) holds until all three audit fixes land.