### PR TITLE
fix(continuation): persist child chain state after delegate drain (r3164380565)

### DIFF
--- a/src/agents/subagent-announce.continuation-drain.test.ts
+++ b/src/agents/subagent-announce.continuation-drain.test.ts
@@ -307,4 +307,107 @@ describe("subagent-announce continuation drain (F7)", () => {
     // Dispatch failure must not break the announce path — it is best-effort.
     expect(didAnnounce).toBe(true);
   });
+
+  it("r3164380565: persists advanced child chain state after delegates dispatched", async () => {
+    // Regression for r3164380565. `drainChildContinuationQueue` must consume
+    // the `chainState` returned by `dispatchToolDelegates` (advanced past
+    // the dispatched hops) and write it back to both the in-memory child
+    // entry AND the durable session store. Without this, the next drain
+    // reloads stale counters and `maxChainLength` enforcement breaks.
+    const childEntry = {
+      sessionId: "session-child",
+      updatedAt: Date.now(),
+      continuationChainCount: 1,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: 5_000,
+    };
+    const store: Record<string, Record<string, unknown>> = {
+      "agent:main:subagent:test": childEntry,
+      "agent:main:main": { sessionId: "session-main", updatedAt: Date.now() },
+    };
+    loadSessionStoreMock.mockImplementation(
+      () => store as unknown as Record<string, unknown>,
+    );
+
+    dispatchToolDelegatesMock.mockResolvedValueOnce({
+      dispatched: 2,
+      rejected: 0,
+      chainState: {
+        currentChainCount: 3,
+        chainStartedAt: 1_700_000_000_000,
+        accumulatedChainTokens: 12_500,
+      },
+    });
+
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-persist",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "persist test",
+      timeoutMs: 100,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+    });
+
+    // In-memory child entry must reflect the advanced chain state so any
+    // post-drain readers (e.g. a second drain on the same entry) see fresh
+    // counters rather than the pre-dispatch snapshot.
+    expect(childEntry.continuationChainCount).toBe(3);
+    expect(childEntry.continuationChainStartedAt).toBe(1_700_000_000_000);
+    expect(childEntry.continuationChainTokens).toBe(12_500);
+  });
+
+  it("r3164380565: skips persist when no delegates dispatched", async () => {
+    // Negative case: when `dispatched` is 0, the chain state is unchanged
+    // and we must not re-write the entry (avoid spurious `updatedAt` churn
+    // and unnecessary store I/O).
+    const childEntry = {
+      sessionId: "session-child",
+      updatedAt: Date.now(),
+      continuationChainCount: 1,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: 5_000,
+    };
+    const store: Record<string, Record<string, unknown>> = {
+      "agent:main:subagent:test": childEntry,
+      "agent:main:main": { sessionId: "session-main", updatedAt: Date.now() },
+    };
+    loadSessionStoreMock.mockImplementation(
+      () => store as unknown as Record<string, unknown>,
+    );
+
+    dispatchToolDelegatesMock.mockResolvedValueOnce({
+      dispatched: 0,
+      rejected: 0,
+      chainState: {
+        currentChainCount: 1,
+        chainStartedAt: 1_700_000_000_000,
+        accumulatedChainTokens: 5_000,
+      },
+    });
+
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-no-dispatch",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "no dispatch test",
+      timeoutMs: 100,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+    });
+
+    // Counter unchanged — no advance to persist.
+    expect(childEntry.continuationChainCount).toBe(1);
+    expect(childEntry.continuationChainTokens).toBe(5_000);
+  });
 });

--- a/src/agents/subagent-announce.continuation-drain.test.ts
+++ b/src/agents/subagent-announce.continuation-drain.test.ts
@@ -23,10 +23,22 @@ const isEmbeddedPiRunActiveMock = vi.fn((_sessionId: string) => false);
 const queueEmbeddedPiMessageMock = vi.fn((_sessionId: string, _text: string) => false);
 const waitForEmbeddedPiRunEndMock = vi.fn(async (_sessionId: string, _timeoutMs?: number) => true);
 
-const dispatchToolDelegatesMock = vi.fn(async (_params: unknown) => ({
-  dispatched: 0,
-  rejected: 0,
-}));
+const dispatchToolDelegatesMock = vi.fn(
+  async (
+    _params: unknown,
+  ): Promise<{
+    dispatched: number;
+    rejected: number;
+    chainState?: {
+      currentChainCount: number;
+      chainStartedAt: number;
+      accumulatedChainTokens: number;
+    };
+  }> => ({
+    dispatched: 0,
+    rejected: 0,
+  }),
+);
 const resolveContinuationRuntimeConfigMock = vi.fn((_cfg?: unknown) => ({
   enabled: true,
   defaultDelayMs: 15_000,

--- a/src/agents/subagent-announce.continuation.runtime.ts
+++ b/src/agents/subagent-announce.continuation.runtime.ts
@@ -17,4 +17,9 @@
 // in `tsdown.config.ts`.
 export { dispatchToolDelegates } from "../auto-reply/continuation/delegate-dispatch.js";
 export { resolveContinuationRuntimeConfig } from "../auto-reply/continuation/config.js";
-export { loadContinuationChainState } from "../auto-reply/continuation/state.js";
+export {
+  loadContinuationChainState,
+  persistContinuationChainState,
+} from "../auto-reply/continuation/state.js";
+export { updateSessionStore } from "../config/sessions/store.js";
+export { resolveStorePath, resolveAgentIdFromSessionKey } from "../config/sessions.js";

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -155,7 +155,11 @@ type ContinuationDispatchModule = {
     chainState: ContinuationChainState;
     ctx: ContinuationDispatchContext;
     maxChainLength: number;
-  }) => Promise<{ dispatched: number; rejected: number }>;
+  }) => Promise<{
+    dispatched: number;
+    rejected: number;
+    chainState: ContinuationChainState;
+  }>;
 };
 
 type ContinuationConfigModule = {
@@ -173,6 +177,23 @@ type ContinuationStateModule = {
     source: ContinuationChainSource | undefined,
     turnTokens?: number,
   ) => ContinuationChainState;
+  persistContinuationChainState: (params: {
+    sessionEntry?: ContinuationChainSource;
+    count: number;
+    startedAt: number;
+    tokens: number;
+  }) => void;
+};
+
+type SessionStoreUpdateModule = {
+  updateSessionStore: <T>(
+    storePath: string,
+    mutator: (
+      store: Record<string, ContinuationChainSource & Record<string, unknown>>,
+    ) => Promise<T> | T,
+  ) => Promise<T>;
+  resolveStorePath: (store: unknown, options: { agentId: string }) => string;
+  resolveAgentIdFromSessionKey: (sessionKey: string) => string;
 };
 
 /**
@@ -208,7 +229,7 @@ async function drainChildContinuationQueue(params: {
     // with a literal path would pull `subagent-spawn.js` into a cycle via
     // `delegate-dispatch.js → subagent-spawn.js → subagent-registry.js →
     // subagent-announce.ts`.
-    const [dispatchModule, configModule, stateModule] = await Promise.all([
+    const [dispatchModule, configModule, stateModule, sessionStoreModule] = await Promise.all([
       importRuntimeModule<ContinuationDispatchModule>(import.meta.url, [
         "./subagent-announce.continuation.runtime",
         ".js",
@@ -221,15 +242,21 @@ async function drainChildContinuationQueue(params: {
         "./subagent-announce.continuation.runtime",
         ".js",
       ]),
+      importRuntimeModule<SessionStoreUpdateModule>(import.meta.url, [
+        "./subagent-announce.continuation.runtime",
+        ".js",
+      ]),
     ]);
     const { dispatchToolDelegates } = dispatchModule;
     const { resolveContinuationRuntimeConfig } = configModule;
-    const { loadContinuationChainState } = stateModule;
+    const { loadContinuationChainState, persistContinuationChainState } = stateModule;
+    const { updateSessionStore, resolveStorePath, resolveAgentIdFromSessionKey } =
+      sessionStoreModule;
     const childEntry = loadSessionEntryByKey(params.childSessionKey) as
       | ContinuationChainSource
       | undefined;
     const dispatchConfig = resolveContinuationRuntimeConfig(cfg);
-    await dispatchToolDelegates({
+    const dispatchResult = await dispatchToolDelegates({
       sessionKey: params.childSessionKey,
       chainState: loadContinuationChainState(childEntry),
       ctx: {
@@ -241,6 +268,49 @@ async function drainChildContinuationQueue(params: {
       },
       maxChainLength: dispatchConfig.maxChainLength,
     });
+
+    // r3164380565: persist the advanced child chain state after delegate
+    // drain. Without this, child `continuationChainCount/StartedAt/Tokens`
+    // never advances after accepted spawns; later drains reload stale
+    // counters and under-enforce `maxChainLength`. Mirror the agent-runner
+    // and followup-runner persist patterns from `f26a86535f`.
+    if (dispatchResult && dispatchResult.dispatched > 0) {
+      const advanced = dispatchResult.chainState;
+      const childEntryForWrite = childEntry as
+        | (ContinuationChainSource & Record<string, unknown>)
+        | undefined;
+      // In-memory mirror so any post-drain reads of the same entry see the
+      // advanced state immediately.
+      persistContinuationChainState({
+        sessionEntry: childEntryForWrite,
+        count: advanced.currentChainCount,
+        startedAt: advanced.chainStartedAt,
+        tokens: advanced.accumulatedChainTokens,
+      });
+      // Durable write through the session store so the advanced state
+      // survives gateway restart and is observable by other readers of
+      // the on-disk session entry.
+      try {
+        const agentId = resolveAgentIdFromSessionKey(params.childSessionKey);
+        const storePath = resolveStorePath(cfg.session?.store, { agentId });
+        await updateSessionStore(storePath, (store) => {
+          const existing = store[params.childSessionKey];
+          if (!existing) {
+            return;
+          }
+          store[params.childSessionKey] = {
+            ...existing,
+            continuationChainCount: advanced.currentChainCount,
+            continuationChainStartedAt: advanced.chainStartedAt,
+            continuationChainTokens: advanced.accumulatedChainTokens,
+          };
+        });
+      } catch (writeErr) {
+        defaultRuntime.error?.(
+          `[continuation:drain-persist-failed] child=${params.childSessionKey} error=${writeErr instanceof Error ? writeErr.message : String(writeErr)}`,
+        );
+      }
+    }
   } catch (err) {
     defaultRuntime.error?.(
       `Subagent continuation delegate drain failed for ${params.childSessionKey}: ${String(err)}`,


### PR DESCRIPTION
Resolves codex P1 thread `r3164380565` on merged PR #423 head `c8f85f525466dbadc70791759c4c7db32318978a`.

## Problem

`drainChildContinuationQueue` in `src/agents/subagent-announce.ts` awaited `dispatchToolDelegates` but discarded the returned `chainState`. The child session's `continuationChainCount`, `continuationChainStartedAt`, and `continuationChainTokens` never advanced after accepted delegate spawns. In subagent chains where a child emits `continue_delegate` across multiple settle cycles, later drains reloaded stale counters and under-enforced `maxChainLength`, producing incorrect continuation telemetry.

This was the **child-drain** path missed in the persist-trio fix (`f26a86535f`) which covered the agent-runner and followup-runner paths only.

## Fix

Mirror the persist pattern from `f26a86535f`. When `dispatchResult.dispatched > 0`:

1. **In-memory mirror** via `persistContinuationChainState({ sessionEntry, count, startedAt, tokens })` so any post-drain readers see fresh counters.
2. **Durable write** through `updateSessionStore(storePath, mutator)` so the advanced state survives gateway restart and is observable by other readers of the on-disk session entry.

Best-effort: persist failures log via `defaultRuntime.error?.()` with `[continuation:drain-persist-failed]` tag and do not break the announce path. Mirrors the existing `[continuation:drain-config-load-failed]` pattern in the same function.

## Runtime module

`subagent-announce.continuation.runtime.ts` re-exports widened to include `persistContinuationChainState`, `updateSessionStore`, `resolveStorePath`, `resolveAgentIdFromSessionKey`. Same `importRuntimeModule` cycle-avoidance as the existing dispatch/config/state imports.

## Tests

`src/agents/subagent-announce.continuation-drain.test.ts` extends with two regression tests:

- `r3164380565: persists advanced child chain state after delegates dispatched` — asserts in-memory `continuationChainCount/StartedAt/Tokens` advance to the values returned in `dispatchResult.chainState`.
- `r3164380565: skips persist when no delegates dispatched` — negative case: `dispatched == 0` leaves counters unchanged (avoid spurious churn).

```
$ pnpm exec tsgo --noEmit
EXIT 0

$ vitest run src/agents/subagent-announce.continuation-drain.test.ts
Test Files  1 passed (1)
     Tests  6 passed (6)
EXIT 0
```

## Lane coordination

This is the child-drain lane. Sister lanes:
- `r3164418100` agent-runner durable write-back — Silas's PR #427 (`silas/427-agent-runner-durable-writeback`)
- `r3164418106` followup-runner `dispatched == 0` token persistence — Cael's respawned fixer

Release `2026.4.X` tag/npm/deploy held until all three merge to `cael/325-canonical2` and figs picks the version string on #425.

---

**Author:** Elliott 🌻
**Branch:** `elliott/427-child-drain-persist` off `c8f85f5254`
**Commit:** `86d836571d`