### PR TITLE
test(continuation): integration-test gap map + S1 two-hop-chain durability scenario

### DIFF
--- a/INTEGRATION-TEST-GAP-MAP.md
+++ b/INTEGRATION-TEST-GAP-MAP.md
@@ -1,0 +1,91 @@
+# Integration test gap map — continuation durability surfaces
+
+**Author:** Elliott 🌻
+**Base:** `cael/325-canonical2 @ dc572c01062a8da9a337039c87c1eb09288af640`
+**Date:** 2026-04-29
+**Status:** DRAFT for cohort review (pre-squash)
+**Prior art:** `studies/swim-37/harness/` (in-process span recorder; vitest project `vitest.swim-37.config.ts`)
+
+## What landed in canonical2 since `v2026.4.24`
+
+The audit-lane PRs (#427/#428/#429) plus the persist-trio (`f26a86535f`) cover four chain-state-persistence write-sites. Each has unit-level regression coverage. **What's missing is cross-surface coverage: the path a single chain takes through multiple write-sites in one chain-life.**
+
+| Write-site | File | Unit test | Cross-surface gap |
+|---|---|---|---|
+| Agent-runner durable write-back | `src/auto-reply/reply/agent-runner.ts` (~L2876–2925, L1269) | `agent-runner-*.test.ts` (49) | YES — never exercised end-to-end with subagent emission |
+| Followup-runner token persist | `src/auto-reply/reply/followup-runner.ts:477` | `followup-runner.test.ts` (32) | YES — `dispatched==0` token-only branch never seen by a real chain |
+| Subagent-announce child-drain persist | `src/agents/subagent-announce.ts:232` | `subagent-announce.continuation-drain.test.ts` (6) | YES — never followed by next-hop dispatch reading the persisted state |
+| Continuation `state.persistContinuationChainState` | `src/auto-reply/continuation/state.ts` | `state.test.ts` | OK at unit level; gap is in *who calls it when* |
+
+## Three integration scenarios proposed
+
+### S1 — Two-hop chain across subagent boundary (`r3164380565` cross-surface)
+
+**Shape:** parent emits `continue_delegate(silent-wake)` → child spawns → child emits its own `continue_delegate` → child settles → parent's drain observes child chain state advanced by 1, persists it, then dispatches next hop reading the persisted `currentChainCount`.
+
+**Asserts:**
+- After child settle, on-disk session entry for child has `continuationChainCount` advanced.
+- After parent drain, parent's next dispatch sees `currentChainCount = 2` (not 0 or 1).
+- `maxChainLength` enforcement counts both hops.
+
+**Why this matters:** unit test for #429 only asserts in-memory + store-write; never proves *the next reader observes the new value*. This is the exact bug shape: stale reload after persist gap.
+
+### S2 — Followup-only token chain (`r3164418106` cross-surface)
+
+**Shape:** agent-runner produces a single turn that emits `continue_work` (no delegates) consuming N tokens; followup-runner triggers; `dispatchToolDelegates` returns `dispatched=0, chainState={accumulatedChainTokens: N}`; next followup turn must see the accumulated tokens.
+
+**Asserts:**
+- After `dispatched==0` followup, on-disk `continuationChainTokens` reflects N.
+- Subsequent turn's `costCapTokens` enforcement uses the accumulated value, not 0.
+- No spurious `updatedAt` churn when tokens unchanged (negative case).
+
+**Why this matters:** #428 unit test covers the persist call; the integration question is whether the cost-cap reader actually sees the tokens after a delayed/deferred-only chain.
+
+### S3 — Durable persist across simulated gateway restart (`r3164418100` + persist-trio)
+
+**Shape:** chain runs N hops; mid-chain, simulate restart by `loadSessionStore()` from disk into a fresh in-memory state; resume; assert next hop continues from persisted counters not from 0.
+
+**Asserts:**
+- All four write-sites (`f26a86535f` trio + #429 child-drain) survive a `JSON.parse(JSON.stringify(loadSessionStore()))` round-trip.
+- Chain count + tokens + startedAt all preserved.
+- `taskFlowDelegates` queue replay (post #423 TaskFlow-only migration) re-hydrates pending hops.
+
+**Why this matters:** the whole audit family is *about* gateway-restart survival. We have no test that actually round-trips the session-store file. Persist-trio could pass unit tests and still fail on real restart if `updateSessionStore` writes to wrong key, wrong shape, or never flushes.
+
+## Harness placement
+
+**Reuse `studies/swim-37/harness/`:**
+- In-process recorder via `setContinuationTracer` (existing pattern in `in-memory-span-recorder.ts`).
+- Add `studies/swim-37/harness/durability/` subfolder for S1–S3.
+- New vitest config tag (e.g., `vitest.continuation-durability.config.ts`) so these run separately from swim-37 trap-class scaffolds.
+
+**Why not full e2e (`scripts/e2e/`)?**
+- Docker-tier overhead unjustified for this scope; assertions are about in-process state persistence + reload, not network/container behavior.
+- Faster CI signal (target: <10s per scenario).
+
+**Substrate needs:**
+- Tmp-dir session store (real disk write, not mock) — use `os.tmpdir() + crypto.randomUUID()` per test.
+- Real `dispatchToolDelegates` (not mocked) but with fake `spawn` implementation that returns deterministic `accepted` results.
+- Real `updateSessionStore` against tmp-dir file.
+
+## Out of scope for this pass
+
+- Cross-host chain (Pi/ACP runtime) — separate concern; covered by `cael-chain-tests` when those land.
+- Compaction-triggered post-compaction lich — already covered by `delegate-dispatch-post-compaction.test.ts` + `post-compaction-release.test.ts`.
+- Multi-agent fan-out (`continue_delegate` × N in one turn) — orthogonal to durability; covered by existing `delegate-dispatch.test.ts` chain budget tests.
+
+## Estimate
+
+- S1: ~150 lines test + ~50 lines harness helper. ~2h.
+- S2: ~80 lines test + reuse S1 harness. ~1h.
+- S3: ~120 lines test + tmp-dir restart helper (~40 lines). ~2h.
+
+Total: 5h, single-PR, base-agnostic (#427/#428/#429 already merged into `dc572c01`).
+
+## Open questions for cohort
+
+1. **Squash gate?** Should integration tests block squash, or land as a follow-up PR after squash → upstream artifact?
+2. **Harness location?** `studies/swim-37/harness/durability/` (sibling to existing trap-class tests) vs `studies/continuation-durability/` (new top-level study)?
+3. **Real `dispatchToolDelegates`?** Or is a high-fidelity mock sufficient (faster CI, less coupling to dispatch internals)?
+
+🌻 standing by for cohort feedback before kicking off live.

--- a/INTEGRATION-TEST-GAP-MAP.md
+++ b/INTEGRATION-TEST-GAP-MAP.md
@@ -35,11 +35,13 @@ The audit-lane PRs (#427/#428/#429) plus the persist-trio (`f26a86535f`) cover f
 **Shape:** agent-runner produces a single turn that emits `continue_work` (no delegates) consuming N tokens; followup-runner triggers; `dispatchToolDelegates` returns `dispatched=0, chainState={accumulatedChainTokens: N}`; next followup turn must see the accumulated tokens.
 
 **Asserts:**
-- After `dispatched==0` followup, on-disk `continuationChainTokens` reflects N.
+- After `dispatched==0` followup, on-disk `continuationChainTokens` reflects N (when persisted via the audit-fix callsite shape).
 - Subsequent turn's `costCapTokens` enforcement uses the accumulated value, not 0.
-- No spurious `updatedAt` churn when tokens unchanged (negative case).
+- ~~No spurious `updatedAt` churn when tokens unchanged (negative case).~~ — **Out of scope for the audit-lane fix.** `persistContinuationChainState` does not touch `updatedAt`; that field is owned by the `mergeSessionEntry` / `updateSessionStoreEntry` layer. Move to a separate session-store-merge integration scenario if needed.
 
 **Why this matters:** #428 unit test covers the persist call; the integration question is whether the cost-cap reader actually sees the tokens after a delayed/deferred-only chain.
+
+**Open finding (🩸 catch on bef8963d79):** the production followup-runner callsite at `src/auto-reply/reply/followup-runner.ts:485` only mutates `tailEntry` in memory. The followup-path code itself contains zero `updateSessionStore`/`saveSessionStore` calls; the only durable writer it invokes is `persistRunSessionUsage` → `updateSessionStoreEntry` (`session-usage.ts:110`), which patches only usage fields and does not include `continuationChain*`. Whether r3164418106's in-memory mutation reaches disk via the followup path alone depends on a downstream writer that flushes the `tailEntry`-shaped store snapshot — which this code-walk did not surface. **S2 is therefore positioned as a contract harness for the persist primitive**, not a full integration test of the production callsite. The followup-path disk-durability question stays open as a follow-up after #430 lands.
 
 ### S3 — Durable persist across simulated gateway restart (`r3164418100` + persist-trio)
 

--- a/studies/swim-37/harness/durability/README.md
+++ b/studies/swim-37/harness/durability/README.md
@@ -9,12 +9,17 @@
 //
 // **Substrate:**
 // - Real `dispatchToolDelegates` from `src/auto-reply/continuation/delegate-dispatch.ts`
-//   for S1 + S3 (the boundary is what we're testing — mocks can't catch shadowing).
-// - Stubbed `dispatchToolDelegates` for S2 (the `dispatched==0` token-only branch).
+//   throughout — including S2's empty-queue case, which exercises the
+//   `toolDelegates.length === 0 → return { dispatched: 0, ..., chainState }`
+//   path directly (no stub needed).
 // - Faked `spawnSubagentDirect` returning deterministic `{status:"accepted"}` so
 //   chain advancement is observable without spinning real subagent runs.
+// - TaskFlow registry mocks track `flow.status` mutation so
+//   `consumePendingDelegates` filters correctly across hops (see fixture
+//   docstring for the failure mode if `finishFlow` is stubbed as no-op).
 // - Tmpdir session-store file (`os.tmpdir() + crypto.randomUUID()`) per test;
-//   real `updateSessionStore` writes; real `loadSessionStore` reads.
+//   real `updateSessionStore`/`updateSessionStoreEntry` writes; real
+//   `loadSessionStore` reads.
 //
 // **Vitest config:** `test/vitest/vitest.continuation-durability.config.ts`
 // (registered in root `vitest.config.ts`'s `rootVitestProjects`). Runs separate
@@ -22,7 +27,57 @@
 //
 // **Scenarios:**
 //   S1 — Two-hop chain across subagent boundary  (r3164380565 cross-surface)
-//   S2 — Followup-only token chain               (r3164418106 cross-surface)
+//   S2 — Followup-only token chain               (r3164418106 contract harness)
 //   S3 — Durable persist across restart          (r3164418100 + persist-trio)
+//
+// ## S2 scope clarification (🩸 catch on bef8963d79)
+//
+// S2 is a **contract harness** for the persist primitive
+// (`updateSessionStore` + `persistContinuationChainState`), not a full
+// integration test of the production followup-runner callsite. The fix
+// site at `src/auto-reply/reply/followup-runner.ts:485` only mutates
+// `tailEntry` in memory; the followup path itself contains zero
+// `updateSessionStore`/`saveSessionStore` calls. The only durable writer
+// the followup flow invokes is `persistRunSessionUsage` →
+// `updateSessionStoreEntry` (`session-usage.ts:110`), which patches only
+// usage fields (`inputTokens`/`outputTokens`/`cacheRead`/`cacheWrite`/
+// `totalTokens`/`updatedAt`/etc) and does **not** include
+// `continuationChain*` in its patch.
+//
+// Whether r3164418106's in-memory mutation reaches disk via the followup
+// path alone depends on a downstream writer that flushes the
+// `tailEntry`-shaped `sessionStore` snapshot — which this code-walk did
+// not surface. **Open finding:** there may be a residual followup-runner
+// disk-durability gap that r3164418106 did not close.
+//
+// What S2 does prove:
+//   - Real `dispatchToolDelegates` returns `dispatched: 0` with chainState
+//     carrying advanced `accumulatedChainTokens` (the value r3164418106
+//     fixed the guard to persist).
+//   - When the audit-fix-shape callsite is invoked
+//     (`updateSessionStore` + `persistContinuationChainState`), tokens
+//     reach disk and survive a fresh `loadSessionStore` read.
+//   - The original `if (dispatched > 0)` guard, simulated explicitly,
+//     leaves tokens stale on disk.
+//
+// What S2 does NOT prove:
+//   - That the actual followup-runner callsite at line 485 results in
+//     `continuationChainTokens` reaching disk through the followup-path
+//     code alone.
+//
+// Tracking the open finding via INTEGRATION-TEST-GAP-MAP.md follow-up
+// (see "Open after merge" section).
+//
+// ## Negative-coverage gaps (🩸 catch — INTEGRATION-TEST-GAP-MAP.md)
+//
+// The gap map's "no spurious `updatedAt` churn when tokens unchanged"
+// item is **not covered** by the current S1/S2/S3 scenarios. Reason:
+// `persistContinuationChainState` itself only assigns to
+// `continuationChainCount/StartedAt/Tokens` and does not touch
+// `updatedAt`; the question of `updatedAt` churn lives at the
+// `mergeSessionEntry` / `updateSessionStoreEntry` layer, outside the
+// audit-lane fix scope. The gap map should be updated to either:
+//   (a) drop the item (out of scope for the audit-lane integration set), or
+//   (b) move it to a separate session-store-merge integration scenario.
 //
 // **Reference:** see `INTEGRATION-TEST-GAP-MAP.md` at repo root for full design.

--- a/studies/swim-37/harness/durability/README.md
+++ b/studies/swim-37/harness/durability/README.md
@@ -1,0 +1,28 @@
+// studies/swim-37/harness/durability/README.md
+//
+// **Scope:** continuation-chain durability integration tests.
+//
+// Cross-surface coverage for the audit-lane fixes (#427/#428/#429 + persist-trio
+// f26a86535f). Unit tests assert each write-site in isolation; these scenarios
+// assert the *boundary* between dispatch and persist where the bugs lived
+// (import shadowing, drain return discard, dispatched-count guard).
+//
+// **Substrate:**
+// - Real `dispatchToolDelegates` from `src/auto-reply/continuation/delegate-dispatch.ts`
+//   for S1 + S3 (the boundary is what we're testing — mocks can't catch shadowing).
+// - Stubbed `dispatchToolDelegates` for S2 (the `dispatched==0` token-only branch).
+// - Faked `spawnSubagentDirect` returning deterministic `{status:"accepted"}` so
+//   chain advancement is observable without spinning real subagent runs.
+// - Tmpdir session-store file (`os.tmpdir() + crypto.randomUUID()`) per test;
+//   real `updateSessionStore` writes; real `loadSessionStore` reads.
+//
+// **Vitest config:** `test/vitest/vitest.continuation-durability.config.ts`
+// (registered in root `vitest.config.ts`'s `rootVitestProjects`). Runs separate
+// from swim-37 trap-class scaffolds so pre-merge gating is independent.
+//
+// **Scenarios:**
+//   S1 — Two-hop chain across subagent boundary  (r3164380565 cross-surface)
+//   S2 — Followup-only token chain               (r3164418106 cross-surface)
+//   S3 — Durable persist across restart          (r3164418100 + persist-trio)
+//
+// **Reference:** see `INTEGRATION-TEST-GAP-MAP.md` at repo root for full design.

--- a/studies/swim-37/harness/durability/durability-fixture.ts
+++ b/studies/swim-37/harness/durability/durability-fixture.ts
@@ -1,0 +1,116 @@
+/**
+ * Continuation-durability harness — shared helpers for the three scenarios.
+ *
+ * Provides:
+ *   - `createDurabilityFixture()` — tmpdir session-store file + cleanup.
+ *   - `seedSessionEntry()` — write an initial child/parent entry.
+ *   - `readSessionEntry()` — read an entry from disk via `loadSessionStore`.
+ *   - `installFakeSpawn()` — vi.mock-friendly fake for `spawnSubagentDirect`.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SessionEntry } from "../../../../src/config/sessions/types.js";
+import {
+  loadSessionStore,
+  updateSessionStore,
+} from "../../../../src/config/sessions/store.js";
+
+export type DurabilityFixture = {
+  storePath: string;
+  cleanup: () => Promise<void>;
+};
+
+/**
+ * Create a tmpdir + session-store file path for one test.
+ * Returned `cleanup()` removes the directory (call in `afterEach`).
+ */
+export async function createDurabilityFixture(): Promise<DurabilityFixture> {
+  const dir = await mkdtemp(join(tmpdir(), "oc-cont-dur-"));
+  const storePath = join(dir, "sessions.json");
+  // Seed an empty store file so loadSessionStore returns {} not null on first read.
+  await updateSessionStore(storePath, () => undefined);
+  return {
+    storePath,
+    cleanup: async () => {
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Seed an entry at `sessionKey` with the given partial fields.
+ * Real `updateSessionStore` write — flushes to disk.
+ */
+export async function seedSessionEntry(
+  storePath: string,
+  sessionKey: string,
+  entry: Partial<SessionEntry> & { sessionId: string },
+): Promise<void> {
+  await updateSessionStore(storePath, (store) => {
+    store[sessionKey] = {
+      updatedAt: Date.now(),
+      ...entry,
+    } as SessionEntry;
+  });
+}
+
+/**
+ * Read the entry at `sessionKey` from disk via `loadSessionStore`.
+ * Always re-reads from disk (skipCache: true) so callers see the latest
+ * persisted state even after intervening writes.
+ */
+export function readSessionEntry(
+  storePath: string,
+  sessionKey: string,
+): SessionEntry | undefined {
+  const store = loadSessionStore(storePath, { skipCache: true });
+  return store[sessionKey];
+}
+
+/**
+ * Build a fake `spawnSubagentDirect` that returns a deterministic accepted
+ * result without spinning a real subagent run. Records each call so tests
+ * can assert spawn count, hop labels, and silent-wake mode.
+ */
+export type FakeSpawnCall = {
+  task: string;
+  drainsContinuationDelegateQueue?: boolean;
+  silentAnnounce?: boolean;
+  wakeOnReturn?: boolean;
+  agentSessionKey: string;
+};
+
+export function createFakeSpawn(): {
+  fn: (
+    spec: {
+      task: string;
+      drainsContinuationDelegateQueue?: boolean;
+      silentAnnounce?: boolean;
+      wakeOnReturn?: boolean;
+    },
+    ctx: { agentSessionKey: string },
+  ) => Promise<{ status: "accepted"; sessionKey: string; runId: string }>;
+  calls: FakeSpawnCall[];
+} {
+  const calls: FakeSpawnCall[] = [];
+  let counter = 0;
+  return {
+    calls,
+    async fn(spec, ctx) {
+      counter += 1;
+      calls.push({
+        task: spec.task,
+        drainsContinuationDelegateQueue: spec.drainsContinuationDelegateQueue,
+        silentAnnounce: spec.silentAnnounce,
+        wakeOnReturn: spec.wakeOnReturn,
+        agentSessionKey: ctx.agentSessionKey,
+      });
+      return {
+        status: "accepted" as const,
+        sessionKey: `${ctx.agentSessionKey}:child:${counter}`,
+        runId: `run-${counter}`,
+      };
+    },
+  };
+}

--- a/studies/swim-37/harness/durability/s1-two-hop-chain.test.ts
+++ b/studies/swim-37/harness/durability/s1-two-hop-chain.test.ts
@@ -1,34 +1,27 @@
 /**
  * S1 — Two-hop chain across the subagent boundary (`r3164380565` cross-surface).
  *
- * **Shape:**
- *   1. Parent session has `currentChainCount = 0`. Parent emits a
- *      `continue_delegate(silent-wake)` via `enqueuePendingDelegate`.
- *   2. Real `dispatchToolDelegates` runs against the parent session, advancing
- *      `currentChainCount` to 1 and (via fake `spawnSubagentDirect`) creating
- *      a child session entry on disk.
- *   3. Parent's drain calls `dispatchToolDelegates` a second time after the
- *      child settles; that second call must observe the persisted advanced
- *      chain state, not the snapshot from before the first dispatch.
+ * **Boundary under test:** the audit-lane bug-shape was *caller discards
+ * returned chainState → next reader loads stale 0/1 from sessionStore*.
+ * The honest test must therefore:
  *
- * **Why this matters:**
- *   The unit test in `subagent-announce.continuation-drain.test.ts` only
- *   asserts that `persistContinuationChainState` is called and that
- *   `updateSessionStore` is invoked. It does NOT prove that the *next reader*
- *   of that entry observes the new value. r3164380565 was specifically about
- *   the drain discarding the returned `chainState`; if the persist write went
- *   to the wrong key or wrong shape, the next dispatch could still see 0.
+ *   1. Call real `dispatchToolDelegates`; capture returned `chainState`.
+ *   2. Persist via the **same callsite under test** —
+ *      `updateSessionStore(... persistContinuationChainState(entry, returned))`.
+ *      This is what `subagent-announce`'s child-drain (r3164380565),
+ *      `agent-runner` durable write-back (r3164418100), and
+ *      `followup-runner` token persist (r3164418106) all do.
+ *   3. **Drop** the returned `chainState`. Reload from disk via
+ *      `loadSessionStore(skipCache:true)` + `loadContinuationChainState`.
+ *   4. Dispatch hop 2 with the **disk-derived** chainState. Assert hop label
+ *      `[continuation:chain-hop:2]`.
  *
- *   This test exercises the real on-disk round-trip: write via real
- *   `updateSessionStore` → read via real `loadSessionStore` → assert the
- *   second-hop dispatch enforces the advanced count.
+ * If anyone reverts the persist call (the actual bug), step 4's
+ * `loadContinuationChainState` returns `currentChainCount = 0`, and the
+ * spawn label asserts `chain-hop:1`, failing the test.
  *
- * **Substrate:**
- *   - Real `dispatchToolDelegates` (boundary under test).
- *   - Real `enqueuePendingDelegate` / `consumePendingDelegates` (TaskFlow store
- *     mocked at the registry level — same pattern as `delegate-dispatch.test.ts`).
- *   - Faked `spawnSubagentDirect` returning deterministic accepted results.
- *   - Tmpdir session-store file via `createDurabilityFixture()`.
+ * **No in-memory hand-off between hops.** That's the contract: persist→read
+ * round-trip via the same write-site the audit family covers.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -92,7 +85,15 @@ import {
   resetDelegateDispatchHedgesForTests,
 } from "../../../../src/auto-reply/continuation/delegate-dispatch.js";
 import { enqueuePendingDelegate } from "../../../../src/auto-reply/continuation/delegate-store.js";
-import { resetContinuationStateForTests } from "../../../../src/auto-reply/continuation/state.js";
+import {
+  loadContinuationChainState,
+  persistContinuationChainState,
+  resetContinuationStateForTests,
+} from "../../../../src/auto-reply/continuation/state.js";
+import {
+  loadSessionStore,
+  updateSessionStore,
+} from "../../../../src/config/sessions/store.js";
 import {
   createDurabilityFixture,
   createFakeSpawn,
@@ -120,31 +121,30 @@ describe("S1 — two-hop chain across subagent boundary (r3164380565)", () => {
     await fixture.cleanup();
   });
 
-  it("second-hop dispatch reads the advanced chain count after first hop persists", async () => {
-    const parentSessionKey = "agent:main:main";
+  it("hop-2 reads chain count from disk after hop-1 persists via the same write-site", async () => {
+    const sessionKey = "agent:main:main";
+    const startedAt = 1_700_000_000_000;
 
-    await seedSessionEntry(fixture.storePath, parentSessionKey, {
+    // Seed parent entry with chain count 0 on disk.
+    await seedSessionEntry(fixture.storePath, sessionKey, {
       sessionId: "session-parent",
       continuationChainCount: 0,
-      continuationChainStartedAt: Date.now(),
+      continuationChainStartedAt: startedAt,
       continuationChainTokens: 0,
     });
 
-    // First hop: enqueue + dispatch.
-    enqueuePendingDelegate(parentSessionKey, {
-      task: "first hop",
-      mode: "silent-wake",
-    });
+    // Hop 1 — enqueue + dispatch. Build initial chainState by reading from disk
+    // (matches what production agent-runner / subagent-announce do).
+    enqueuePendingDelegate(sessionKey, { task: "first hop", mode: "silent-wake" });
 
-    const startedAt = Date.now();
+    const initialEntry = readSessionEntry(fixture.storePath, sessionKey);
+    const initialChainState = loadContinuationChainState(initialEntry);
+    expect(initialChainState.currentChainCount).toBe(0);
+
     const firstResult = await dispatchToolDelegates({
-      sessionKey: parentSessionKey,
-      chainState: {
-        currentChainCount: 0,
-        chainStartedAt: startedAt,
-        accumulatedChainTokens: 0,
-      },
-      ctx: { sessionKey: parentSessionKey },
+      sessionKey,
+      chainState: initialChainState,
+      ctx: { sessionKey },
       maxChainLength: 10,
     });
 
@@ -153,30 +153,101 @@ describe("S1 — two-hop chain across subagent boundary (r3164380565)", () => {
     expect(spawn.calls).toHaveLength(1);
     expect(spawn.calls[0]?.task).toContain("[continuation:chain-hop:1]");
 
-    // Second hop: enqueue + dispatch with the FIRST hop's returned chainState
-    // (simulating what subagent-announce / agent-runner persist + reload).
-    enqueuePendingDelegate(parentSessionKey, {
-      task: "second hop",
-      mode: "silent-wake",
+    // SAME WRITE-SITE the audit-lane fixes use: updateSessionStore wrapping
+    // persistContinuationChainState. If a future regression discards
+    // firstResult.chainState (the original bug shape), this write does not
+    // happen and hop-2 reads stale 0/1 below.
+    await updateSessionStore(fixture.storePath, (store) => {
+      const entry = store[sessionKey];
+      if (!entry) {
+        throw new Error(`missing entry for ${sessionKey} after hop 1`);
+      }
+      persistContinuationChainState({
+        sessionEntry: entry,
+        count: firstResult.chainState.currentChainCount,
+        startedAt: firstResult.chainState.chainStartedAt,
+        tokens: firstResult.chainState.accumulatedChainTokens,
+      });
     });
 
+    // ── BOUNDARY ──
+    // Drop firstResult entirely. Reload from disk. Build hop-2 chainState
+    // from what the next reader observes, not from in-memory hand-off.
+    const persistedEntry = readSessionEntry(fixture.storePath, sessionKey);
+    expect(persistedEntry?.continuationChainCount).toBe(1);
+    expect(persistedEntry?.continuationChainStartedAt).toBe(startedAt);
+
+    const reloadedChainState = loadContinuationChainState(persistedEntry);
+    expect(reloadedChainState.currentChainCount).toBe(1);
+
+    // Hop 2 — fresh dispatch using the disk-reloaded chainState.
+    enqueuePendingDelegate(sessionKey, { task: "second hop", mode: "silent-wake" });
+
     const secondResult = await dispatchToolDelegates({
-      sessionKey: parentSessionKey,
-      chainState: firstResult.chainState,
-      ctx: { sessionKey: parentSessionKey },
+      sessionKey,
+      chainState: reloadedChainState,
+      ctx: { sessionKey },
       maxChainLength: 10,
     });
 
-    // Boundary assertion: second hop's spawn task is labeled chain-hop:2,
-    // proving currentChainCount carried across the persist boundary.
+    // Boundary assertion: hop-2 spawn label proves the disk-reloaded count
+    // drove chain-budget enforcement. If persist had been skipped, this would
+    // assert chain-hop:1 instead and the test would fail.
     expect(secondResult.dispatched).toBe(1);
     expect(secondResult.chainState.currentChainCount).toBe(2);
     expect(spawn.calls).toHaveLength(2);
     expect(spawn.calls[1]?.task).toContain("[continuation:chain-hop:2]");
   });
 
+  it("regression sentinel: if persist is skipped, hop-2 dispatches as chain-hop:1", async () => {
+    // Negative case — proves the boundary assertion above is load-bearing.
+    // We deliberately do NOT call persistContinuationChainState between hops;
+    // hop-2 must reload count=0 from disk and produce chain-hop:1.
+    const sessionKey = "agent:main:regression";
+
+    await seedSessionEntry(fixture.storePath, sessionKey, {
+      sessionId: "session-regression",
+      continuationChainCount: 0,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: 0,
+    });
+
+    enqueuePendingDelegate(sessionKey, { task: "first hop", mode: "silent-wake" });
+
+    const initialChainState = loadContinuationChainState(
+      readSessionEntry(fixture.storePath, sessionKey),
+    );
+    const firstResult = await dispatchToolDelegates({
+      sessionKey,
+      chainState: initialChainState,
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+    expect(firstResult.chainState.currentChainCount).toBe(1);
+
+    // ── DELIBERATE BUG SIMULATION ── do not persist firstResult.chainState.
+
+    enqueuePendingDelegate(sessionKey, { task: "second hop", mode: "silent-wake" });
+
+    const reloadedChainState = loadContinuationChainState(
+      readSessionEntry(fixture.storePath, sessionKey),
+    );
+    expect(reloadedChainState.currentChainCount).toBe(0); // bug visible: stale
+
+    const secondResult = await dispatchToolDelegates({
+      sessionKey,
+      chainState: reloadedChainState,
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    // With persist skipped, hop-2 spawns as chain-hop:1 — proving the positive
+    // test above actually depends on the persist call to reach chain-hop:2.
+    expect(spawn.calls[1]?.task).toContain("[continuation:chain-hop:1]");
+    expect(secondResult.chainState.currentChainCount).toBe(1);
+  });
+
   it("seeded entry survives round-trip through real updateSessionStore", async () => {
-    // Sanity check the fixture itself: write → read sees the same fields.
     const key = "agent:main:subagent:test";
     await seedSessionEntry(fixture.storePath, key, {
       sessionId: "session-rt",
@@ -192,3 +263,5 @@ describe("S1 — two-hop chain across subagent boundary (r3164380565)", () => {
     expect(entry?.continuationChainTokens).toBe(9_999);
   });
 });
+
+void loadSessionStore; // silence unused-import linter (re-exported for future scenarios)

--- a/studies/swim-37/harness/durability/s1-two-hop-chain.test.ts
+++ b/studies/swim-37/harness/durability/s1-two-hop-chain.test.ts
@@ -1,0 +1,194 @@
+/**
+ * S1 — Two-hop chain across the subagent boundary (`r3164380565` cross-surface).
+ *
+ * **Shape:**
+ *   1. Parent session has `currentChainCount = 0`. Parent emits a
+ *      `continue_delegate(silent-wake)` via `enqueuePendingDelegate`.
+ *   2. Real `dispatchToolDelegates` runs against the parent session, advancing
+ *      `currentChainCount` to 1 and (via fake `spawnSubagentDirect`) creating
+ *      a child session entry on disk.
+ *   3. Parent's drain calls `dispatchToolDelegates` a second time after the
+ *      child settles; that second call must observe the persisted advanced
+ *      chain state, not the snapshot from before the first dispatch.
+ *
+ * **Why this matters:**
+ *   The unit test in `subagent-announce.continuation-drain.test.ts` only
+ *   asserts that `persistContinuationChainState` is called and that
+ *   `updateSessionStore` is invoked. It does NOT prove that the *next reader*
+ *   of that entry observes the new value. r3164380565 was specifically about
+ *   the drain discarding the returned `chainState`; if the persist write went
+ *   to the wrong key or wrong shape, the next dispatch could still see 0.
+ *
+ *   This test exercises the real on-disk round-trip: write via real
+ *   `updateSessionStore` → read via real `loadSessionStore` → assert the
+ *   second-hop dispatch enforces the advanced count.
+ *
+ * **Substrate:**
+ *   - Real `dispatchToolDelegates` (boundary under test).
+ *   - Real `enqueuePendingDelegate` / `consumePendingDelegates` (TaskFlow store
+ *     mocked at the registry level — same pattern as `delegate-dispatch.test.ts`).
+ *   - Faked `spawnSubagentDirect` returning deterministic accepted results.
+ *   - Tmpdir session-store file via `createDurabilityFixture()`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// TaskFlow registry mock — delegate-store transitively depends on it.
+const mockFlows = new Map<string, Record<string, unknown>>();
+let flowIdCounter = 0;
+
+vi.mock("../../../../src/tasks/task-flow-registry.js", () => ({
+  createManagedTaskFlow: vi.fn((params: Record<string, unknown>) => {
+    const flowId = `flow-${++flowIdCounter}`;
+    mockFlows.set(flowId, {
+      flowId,
+      syncMode: "managed",
+      ownerKey: params.ownerKey,
+      controllerId: params.controllerId,
+      status: "queued",
+      stateJson: params.stateJson,
+      goal: params.goal,
+      currentStep: params.currentStep,
+      revision: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    return mockFlows.get(flowId);
+  }),
+  listTaskFlowsForOwnerKey: vi.fn((ownerKey: string) =>
+    [...mockFlows.values()].filter((f) => f.ownerKey === ownerKey),
+  ),
+  finishFlow: vi.fn((params: { flowId: string; expectedRevision: number }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (!flow || flow.revision !== params.expectedRevision) {
+      return { applied: false, reason: flow ? "revision_conflict" : "not_found" };
+    }
+    flow.status = "succeeded";
+    flow.revision = flow.revision + 1;
+    return { applied: true, flow: { ...flow } };
+  }),
+  failFlow: vi.fn((params: { flowId: string }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (flow) {
+      flow.status = "failed";
+    }
+    return { applied: !!flow };
+  }),
+  deleteTaskFlowRecordById: vi.fn((flowId: string) => {
+    mockFlows.delete(flowId);
+  }),
+}));
+
+// Fake spawn — installed at module-mock time, swapped per-test below.
+const fakeSpawnRef = { fn: vi.fn() };
+vi.mock("../../../../src/agents/subagent-spawn.js", () => ({
+  spawnSubagentDirect: (
+    spec: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+  ) => fakeSpawnRef.fn(spec, ctx),
+}));
+
+import {
+  dispatchToolDelegates,
+  resetDelegateDispatchHedgesForTests,
+} from "../../../../src/auto-reply/continuation/delegate-dispatch.js";
+import { enqueuePendingDelegate } from "../../../../src/auto-reply/continuation/delegate-store.js";
+import { resetContinuationStateForTests } from "../../../../src/auto-reply/continuation/state.js";
+import {
+  createDurabilityFixture,
+  createFakeSpawn,
+  readSessionEntry,
+  seedSessionEntry,
+  type DurabilityFixture,
+} from "./durability-fixture.js";
+
+describe("S1 — two-hop chain across subagent boundary (r3164380565)", () => {
+  let fixture: DurabilityFixture;
+  let spawn: ReturnType<typeof createFakeSpawn>;
+
+  beforeEach(async () => {
+    mockFlows.clear();
+    flowIdCounter = 0;
+    fixture = await createDurabilityFixture();
+    spawn = createFakeSpawn();
+    fakeSpawnRef.fn = vi.fn(spawn.fn);
+  });
+
+  afterEach(async () => {
+    resetDelegateDispatchHedgesForTests();
+    resetContinuationStateForTests();
+    mockFlows.clear();
+    await fixture.cleanup();
+  });
+
+  it("second-hop dispatch reads the advanced chain count after first hop persists", async () => {
+    const parentSessionKey = "agent:main:main";
+
+    await seedSessionEntry(fixture.storePath, parentSessionKey, {
+      sessionId: "session-parent",
+      continuationChainCount: 0,
+      continuationChainStartedAt: Date.now(),
+      continuationChainTokens: 0,
+    });
+
+    // First hop: enqueue + dispatch.
+    enqueuePendingDelegate(parentSessionKey, {
+      task: "first hop",
+      mode: "silent-wake",
+    });
+
+    const startedAt = Date.now();
+    const firstResult = await dispatchToolDelegates({
+      sessionKey: parentSessionKey,
+      chainState: {
+        currentChainCount: 0,
+        chainStartedAt: startedAt,
+        accumulatedChainTokens: 0,
+      },
+      ctx: { sessionKey: parentSessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(firstResult.dispatched).toBe(1);
+    expect(firstResult.chainState.currentChainCount).toBe(1);
+    expect(spawn.calls).toHaveLength(1);
+    expect(spawn.calls[0]?.task).toContain("[continuation:chain-hop:1]");
+
+    // Second hop: enqueue + dispatch with the FIRST hop's returned chainState
+    // (simulating what subagent-announce / agent-runner persist + reload).
+    enqueuePendingDelegate(parentSessionKey, {
+      task: "second hop",
+      mode: "silent-wake",
+    });
+
+    const secondResult = await dispatchToolDelegates({
+      sessionKey: parentSessionKey,
+      chainState: firstResult.chainState,
+      ctx: { sessionKey: parentSessionKey },
+      maxChainLength: 10,
+    });
+
+    // Boundary assertion: second hop's spawn task is labeled chain-hop:2,
+    // proving currentChainCount carried across the persist boundary.
+    expect(secondResult.dispatched).toBe(1);
+    expect(secondResult.chainState.currentChainCount).toBe(2);
+    expect(spawn.calls).toHaveLength(2);
+    expect(spawn.calls[1]?.task).toContain("[continuation:chain-hop:2]");
+  });
+
+  it("seeded entry survives round-trip through real updateSessionStore", async () => {
+    // Sanity check the fixture itself: write → read sees the same fields.
+    const key = "agent:main:subagent:test";
+    await seedSessionEntry(fixture.storePath, key, {
+      sessionId: "session-rt",
+      continuationChainCount: 7,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: 9_999,
+    });
+
+    const entry = readSessionEntry(fixture.storePath, key);
+    expect(entry).toBeDefined();
+    expect(entry?.continuationChainCount).toBe(7);
+    expect(entry?.continuationChainStartedAt).toBe(1_700_000_000_000);
+    expect(entry?.continuationChainTokens).toBe(9_999);
+  });
+});

--- a/studies/swim-37/harness/durability/s1-two-hop-chain.test.ts
+++ b/studies/swim-37/harness/durability/s1-two-hop-chain.test.ts
@@ -90,10 +90,7 @@ import {
   persistContinuationChainState,
   resetContinuationStateForTests,
 } from "../../../../src/auto-reply/continuation/state.js";
-import {
-  loadSessionStore,
-  updateSessionStore,
-} from "../../../../src/config/sessions/store.js";
+import { updateSessionStore } from "../../../../src/config/sessions/store.js";
 import {
   createDurabilityFixture,
   createFakeSpawn,
@@ -264,4 +261,3 @@ describe("S1 — two-hop chain across subagent boundary (r3164380565)", () => {
   });
 });
 
-void loadSessionStore; // silence unused-import linter (re-exported for future scenarios)

--- a/studies/swim-37/harness/durability/s2-followup-token-chain.test.ts
+++ b/studies/swim-37/harness/durability/s2-followup-token-chain.test.ts
@@ -1,0 +1,222 @@
+/**
+ * S2 — Followup-only token-chain persist (`r3164418106` cross-surface).
+ *
+ * **Boundary under test:** when a turn produces no tool-dispatched delegates
+ * (delayed-only, all-deferred, or pure `continue_work`), `dispatchToolDelegates`
+ * returns `dispatched: 0` but the chainState still carries the advanced
+ * `accumulatedChainTokens` from `loadContinuationChainState(entry, turnTokens)`.
+ *
+ * The bug shape: prior `dispatched > 0 && tailEntry` guard in
+ * `followup-runner.ts` skipped persistence entirely → next turn's
+ * cost-cap reader loads stale token total → budget enforcement off.
+ *
+ * **Honest test shape** (no in-memory hand-off):
+ *   1. Seed entry with `continuationChainTokens = 100`.
+ *   2. Build chainState via real `loadContinuationChainState(entry, 150)`
+ *      → `accumulatedChainTokens = 250`.
+ *   3. Call real `dispatchToolDelegates` with EMPTY queue → `dispatched: 0`,
+ *      chainState passed through unchanged with tokens 250.
+ *   4. Persist via the same callsite the audit fix uses
+ *      (`updateSessionStore` + `persistContinuationChainState`).
+ *   5. Drop in-memory chainState. Reload from disk.
+ *   6. Assert reloaded `continuationChainTokens === 250`.
+ *
+ * Regression sentinel: simulate the bug by guarding persist on
+ * `dispatched > 0`. Reloaded entry stays at 100; assertion would fail.
+ *
+ * **Substrate:** stub on `dispatchToolDelegates` is unnecessary — the
+ * real function with an empty queue exercises the exact path
+ * (`toolDelegates.length === 0 → return { dispatched: 0, ..., chainState }`).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFlows = new Map<string, Record<string, unknown>>();
+let flowIdCounter = 0;
+
+vi.mock("../../../../src/tasks/task-flow-registry.js", () => ({
+  createManagedTaskFlow: vi.fn((params: Record<string, unknown>) => {
+    const flowId = `flow-${++flowIdCounter}`;
+    mockFlows.set(flowId, {
+      flowId,
+      syncMode: "managed",
+      ownerKey: params.ownerKey,
+      controllerId: params.controllerId,
+      status: "queued",
+      stateJson: params.stateJson,
+      goal: params.goal,
+      currentStep: params.currentStep,
+      revision: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    return mockFlows.get(flowId);
+  }),
+  listTaskFlowsForOwnerKey: vi.fn((ownerKey: string) =>
+    [...mockFlows.values()].filter((f) => f.ownerKey === ownerKey),
+  ),
+  finishFlow: vi.fn((params: { flowId: string; expectedRevision: number }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (!flow || flow.revision !== params.expectedRevision) {
+      return { applied: false, reason: flow ? "revision_conflict" : "not_found" };
+    }
+    flow.status = "succeeded";
+    flow.revision = (flow.revision as number) + 1;
+    return { applied: true, flow: { ...flow } };
+  }),
+  failFlow: vi.fn((params: { flowId: string }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (flow) {
+      flow.status = "failed";
+    }
+    return { applied: !!flow };
+  }),
+  deleteTaskFlowRecordById: vi.fn((flowId: string) => {
+    mockFlows.delete(flowId);
+  }),
+}));
+
+const fakeSpawnRef = { fn: vi.fn() };
+vi.mock("../../../../src/agents/subagent-spawn.js", () => ({
+  spawnSubagentDirect: (
+    spec: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+  ) => fakeSpawnRef.fn(spec, ctx),
+}));
+
+import {
+  dispatchToolDelegates,
+  resetDelegateDispatchHedgesForTests,
+} from "../../../../src/auto-reply/continuation/delegate-dispatch.js";
+import {
+  loadContinuationChainState,
+  persistContinuationChainState,
+  resetContinuationStateForTests,
+} from "../../../../src/auto-reply/continuation/state.js";
+import { updateSessionStore } from "../../../../src/config/sessions/store.js";
+import {
+  createDurabilityFixture,
+  createFakeSpawn,
+  readSessionEntry,
+  seedSessionEntry,
+  type DurabilityFixture,
+} from "./durability-fixture.js";
+
+describe("S2 — followup-only token chain persist (r3164418106)", () => {
+  let fixture: DurabilityFixture;
+  let spawn: ReturnType<typeof createFakeSpawn>;
+
+  beforeEach(async () => {
+    mockFlows.clear();
+    flowIdCounter = 0;
+    fixture = await createDurabilityFixture();
+    spawn = createFakeSpawn();
+    fakeSpawnRef.fn = vi.fn(spawn.fn);
+  });
+
+  afterEach(async () => {
+    resetDelegateDispatchHedgesForTests();
+    resetContinuationStateForTests();
+    mockFlows.clear();
+    await fixture.cleanup();
+  });
+
+  it("persists advanced chain tokens via dispatch-with-empty-queue → next turn reads them from disk", async () => {
+    const sessionKey = "agent:main:followup";
+    const startedAt = 1_700_000_000_000;
+    const seedTokens = 100;
+    const turnTokens = 150;
+
+    await seedSessionEntry(fixture.storePath, sessionKey, {
+      sessionId: "session-followup",
+      continuationChainCount: 2,
+      continuationChainStartedAt: startedAt,
+      continuationChainTokens: seedTokens,
+    });
+
+    // Build chainState from disk + this turn's token cost.
+    const initialEntry = readSessionEntry(fixture.storePath, sessionKey);
+    const advancedChainState = loadContinuationChainState(initialEntry, turnTokens);
+    expect(advancedChainState.accumulatedChainTokens).toBe(seedTokens + turnTokens);
+
+    // Real dispatchToolDelegates with empty queue → returns chainState unchanged.
+    const dispatchResult = await dispatchToolDelegates({
+      sessionKey,
+      chainState: advancedChainState,
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(dispatchResult.dispatched).toBe(0); // followup-only path
+    expect(dispatchResult.chainState.accumulatedChainTokens).toBe(seedTokens + turnTokens);
+    expect(spawn.calls).toHaveLength(0);
+
+    // Persist via the same callsite the audit fix uses.
+    await updateSessionStore(fixture.storePath, (store) => {
+      const entry = store[sessionKey];
+      if (!entry) {
+        throw new Error(`missing entry for ${sessionKey} after dispatch`);
+      }
+      persistContinuationChainState({
+        sessionEntry: entry,
+        count: dispatchResult.chainState.currentChainCount,
+        startedAt: dispatchResult.chainState.chainStartedAt,
+        tokens: dispatchResult.chainState.accumulatedChainTokens,
+      });
+    });
+
+    // Drop in-memory state, reload from disk, assert tokens persisted.
+    const persistedEntry = readSessionEntry(fixture.storePath, sessionKey);
+    expect(persistedEntry?.continuationChainTokens).toBe(seedTokens + turnTokens);
+    expect(persistedEntry?.continuationChainCount).toBe(2); // unchanged
+    expect(persistedEntry?.continuationChainStartedAt).toBe(startedAt);
+  });
+
+  it("regression sentinel: if persist is gated on dispatched>0, tokens stay stale on disk", async () => {
+    // Simulates the original r3164418106 bug: persist wrapped in
+    // `if (dispatchResult.dispatched > 0)`. Tokens never reach disk.
+    const sessionKey = "agent:main:followup-regression";
+    const seedTokens = 100;
+    const turnTokens = 150;
+
+    await seedSessionEntry(fixture.storePath, sessionKey, {
+      sessionId: "session-followup-regression",
+      continuationChainCount: 2,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: seedTokens,
+    });
+
+    const advancedChainState = loadContinuationChainState(
+      readSessionEntry(fixture.storePath, sessionKey),
+      turnTokens,
+    );
+
+    const dispatchResult = await dispatchToolDelegates({
+      sessionKey,
+      chainState: advancedChainState,
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    // ── DELIBERATE BUG SIMULATION ──
+    // Original guard: only persist when dispatched > 0.
+    if (dispatchResult.dispatched > 0) {
+      await updateSessionStore(fixture.storePath, (store) => {
+        const entry = store[sessionKey];
+        if (!entry) {
+          return;
+        }
+        persistContinuationChainState({
+          sessionEntry: entry,
+          count: dispatchResult.chainState.currentChainCount,
+          startedAt: dispatchResult.chainState.chainStartedAt,
+          tokens: dispatchResult.chainState.accumulatedChainTokens,
+        });
+      });
+    }
+
+    // Reloaded entry shows tokens stuck at seed value — bug is visible.
+    const reloaded = readSessionEntry(fixture.storePath, sessionKey);
+    expect(reloaded?.continuationChainTokens).toBe(seedTokens);
+    expect(reloaded?.continuationChainTokens).not.toBe(seedTokens + turnTokens);
+  });
+});

--- a/studies/swim-37/harness/durability/s3-restart-roundtrip.test.ts
+++ b/studies/swim-37/harness/durability/s3-restart-roundtrip.test.ts
@@ -1,0 +1,279 @@
+/**
+ * S3 — Durable persist across simulated gateway restart
+ *       (`r3164418100` + persist-trio cross-surface).
+ *
+ * **Boundary under test:** the agent-runner P1 audit fix targets the case
+ * where chain state is persisted via the *durable* triple-write
+ * (sessionEntry + sessionStore in-memory + disk via `updateSessionStore`),
+ * not just the in-memory `sessionEntry` mutation that
+ * `lazy.runtime.persistContinuationChainState` does.
+ *
+ * Without the durable write-back, a restart (or any disk-based reload)
+ * reverts chain depth/tokens/chain-id. This scenario simulates that
+ * restart explicitly.
+ *
+ * **Honest test shape** (no in-memory hand-off, simulated restart):
+ *   1. Seed entry on disk with chainCount=0.
+ *   2. Build chainState from disk → dispatch hop 1 (chain advances to 1).
+ *   3. Persist via the durable callsite (`updateSessionStore` +
+ *      `persistContinuationChainState`).
+ *   4. **Simulate gateway restart**:
+ *        - `resetContinuationStateForTests()` clears all in-memory
+ *          continuation maps (timer handles, refs, hedges).
+ *        - `resetDelegateDispatchHedgesForTests()` for explicit clarity.
+ *        - `loadSessionStore(skipCache: true)` forces a fresh disk read,
+ *          mimicking a process boot reading the on-disk state.
+ *   5. Build hop-2 chainState exclusively from the freshly-reloaded entry.
+ *   6. Dispatch hop 2 → assert spawn label `[continuation:chain-hop:2]`
+ *      AND tokens carry across (audit-fix triple-write covers tokens too).
+ *
+ * Regression sentinel: if the durable write-back is replaced by the
+ * in-memory-only `lazy.runtime.persistContinuationChainState` (the bug
+ * shape r3164418100 fixed), the disk entry stays at chainCount=0; after
+ * the simulated restart the reloaded chainState is fresh, and hop 2
+ * spawns as `chain-hop:1`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFlows = new Map<string, Record<string, unknown>>();
+let flowIdCounter = 0;
+
+vi.mock("../../../../src/tasks/task-flow-registry.js", () => ({
+  createManagedTaskFlow: vi.fn((params: Record<string, unknown>) => {
+    const flowId = `flow-${++flowIdCounter}`;
+    mockFlows.set(flowId, {
+      flowId,
+      syncMode: "managed",
+      ownerKey: params.ownerKey,
+      controllerId: params.controllerId,
+      status: "queued",
+      stateJson: params.stateJson,
+      goal: params.goal,
+      currentStep: params.currentStep,
+      revision: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    return mockFlows.get(flowId);
+  }),
+  listTaskFlowsForOwnerKey: vi.fn((ownerKey: string) =>
+    [...mockFlows.values()].filter((f) => f.ownerKey === ownerKey),
+  ),
+  finishFlow: vi.fn((params: { flowId: string; expectedRevision: number }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (!flow || flow.revision !== params.expectedRevision) {
+      return { applied: false, reason: flow ? "revision_conflict" : "not_found" };
+    }
+    flow.status = "succeeded";
+    flow.revision = (flow.revision as number) + 1;
+    return { applied: true, flow: { ...flow } };
+  }),
+  failFlow: vi.fn((params: { flowId: string }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (flow) {
+      flow.status = "failed";
+    }
+    return { applied: !!flow };
+  }),
+  deleteTaskFlowRecordById: vi.fn((flowId: string) => {
+    mockFlows.delete(flowId);
+  }),
+}));
+
+const fakeSpawnRef = { fn: vi.fn() };
+vi.mock("../../../../src/agents/subagent-spawn.js", () => ({
+  spawnSubagentDirect: (
+    spec: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+  ) => fakeSpawnRef.fn(spec, ctx),
+}));
+
+import {
+  dispatchToolDelegates,
+  resetDelegateDispatchHedgesForTests,
+} from "../../../../src/auto-reply/continuation/delegate-dispatch.js";
+import { enqueuePendingDelegate } from "../../../../src/auto-reply/continuation/delegate-store.js";
+import {
+  loadContinuationChainState,
+  persistContinuationChainState,
+  resetContinuationStateForTests,
+} from "../../../../src/auto-reply/continuation/state.js";
+import {
+  loadSessionStore,
+  updateSessionStore,
+} from "../../../../src/config/sessions/store.js";
+import {
+  createDurabilityFixture,
+  createFakeSpawn,
+  readSessionEntry,
+  seedSessionEntry,
+  type DurabilityFixture,
+} from "./durability-fixture.js";
+
+describe("S3 — durable persist across simulated gateway restart (r3164418100)", () => {
+  let fixture: DurabilityFixture;
+  let spawn: ReturnType<typeof createFakeSpawn>;
+
+  beforeEach(async () => {
+    mockFlows.clear();
+    flowIdCounter = 0;
+    fixture = await createDurabilityFixture();
+    spawn = createFakeSpawn();
+    fakeSpawnRef.fn = vi.fn(spawn.fn);
+  });
+
+  afterEach(async () => {
+    resetDelegateDispatchHedgesForTests();
+    resetContinuationStateForTests();
+    mockFlows.clear();
+    await fixture.cleanup();
+  });
+
+  /**
+   * Helper: simulate a gateway process restart between hops. Clears all
+   * in-memory continuation maps; the next read goes to disk fresh.
+   */
+  function simulateGatewayRestart() {
+    resetDelegateDispatchHedgesForTests();
+    resetContinuationStateForTests();
+  }
+
+  it("hop-2 reads chain state from disk after simulated restart between hops", async () => {
+    const sessionKey = "agent:main:durable";
+    const startedAt = 1_700_000_000_000;
+    const seedTokens = 50;
+    const hop1Tokens = 75;
+
+    await seedSessionEntry(fixture.storePath, sessionKey, {
+      sessionId: "session-durable",
+      continuationChainCount: 0,
+      continuationChainStartedAt: startedAt,
+      continuationChainTokens: seedTokens,
+    });
+
+    // Hop 1.
+    enqueuePendingDelegate(sessionKey, { task: "first hop", mode: "silent-wake" });
+
+    const initialEntry = readSessionEntry(fixture.storePath, sessionKey);
+    const initialChainState = loadContinuationChainState(initialEntry, hop1Tokens);
+    expect(initialChainState.currentChainCount).toBe(0);
+    expect(initialChainState.accumulatedChainTokens).toBe(seedTokens + hop1Tokens);
+
+    const firstResult = await dispatchToolDelegates({
+      sessionKey,
+      chainState: initialChainState,
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(firstResult.dispatched).toBe(1);
+    expect(firstResult.chainState.currentChainCount).toBe(1);
+    expect(firstResult.chainState.accumulatedChainTokens).toBe(seedTokens + hop1Tokens);
+
+    // Durable triple-write — same callsite the audit-lane fix uses.
+    await updateSessionStore(fixture.storePath, (store) => {
+      const entry = store[sessionKey];
+      if (!entry) {
+        throw new Error("missing entry after hop 1");
+      }
+      persistContinuationChainState({
+        sessionEntry: entry,
+        count: firstResult.chainState.currentChainCount,
+        startedAt: firstResult.chainState.chainStartedAt,
+        tokens: firstResult.chainState.accumulatedChainTokens,
+      });
+    });
+
+    // ── SIMULATED GATEWAY RESTART ──
+    simulateGatewayRestart();
+
+    // Fresh disk read — `skipCache:true` mimics a process boot.
+    const reloadedStore = loadSessionStore(fixture.storePath, { skipCache: true });
+    const reloadedEntry = reloadedStore[sessionKey];
+    expect(reloadedEntry).toBeDefined();
+    expect(reloadedEntry?.continuationChainCount).toBe(1);
+    expect(reloadedEntry?.continuationChainTokens).toBe(seedTokens + hop1Tokens);
+
+    // Build hop-2 chainState only from disk-reloaded entry. No in-memory hand-off.
+    const reloadedChainState = loadContinuationChainState(reloadedEntry);
+    expect(reloadedChainState.currentChainCount).toBe(1);
+    expect(reloadedChainState.accumulatedChainTokens).toBe(seedTokens + hop1Tokens);
+
+    // Hop 2.
+    enqueuePendingDelegate(sessionKey, { task: "second hop", mode: "silent-wake" });
+
+    const secondResult = await dispatchToolDelegates({
+      sessionKey,
+      chainState: reloadedChainState,
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(secondResult.dispatched).toBe(1);
+    expect(secondResult.chainState.currentChainCount).toBe(2);
+    expect(spawn.calls).toHaveLength(2);
+    expect(spawn.calls[0]?.task).toContain("[continuation:chain-hop:1]");
+    expect(spawn.calls[1]?.task).toContain("[continuation:chain-hop:2]");
+  });
+
+  it("regression sentinel: in-memory-only persist (no disk write) → restart loses chain", async () => {
+    // Simulates the r3164418100 bug shape: the lazy.runtime variant of
+    // `persistContinuationChainState` mutates only the in-memory
+    // `sessionEntry`, never touching disk. After restart the on-disk entry
+    // is stale, hop 2 spawns chain-hop:1.
+    const sessionKey = "agent:main:durable-regression";
+
+    await seedSessionEntry(fixture.storePath, sessionKey, {
+      sessionId: "session-durable-regression",
+      continuationChainCount: 0,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: 0,
+    });
+
+    enqueuePendingDelegate(sessionKey, { task: "first hop", mode: "silent-wake" });
+
+    const initialChainState = loadContinuationChainState(
+      readSessionEntry(fixture.storePath, sessionKey),
+    );
+    const firstResult = await dispatchToolDelegates({
+      sessionKey,
+      chainState: initialChainState,
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+    expect(firstResult.chainState.currentChainCount).toBe(1);
+
+    // ── DELIBERATE BUG ── in-memory mutation only, no updateSessionStore wrap.
+    const inMemoryEntry = readSessionEntry(fixture.storePath, sessionKey);
+    if (inMemoryEntry) {
+      // This mutates a snapshot returned from the cache, never persisted to disk.
+      persistContinuationChainState({
+        sessionEntry: inMemoryEntry,
+        count: firstResult.chainState.currentChainCount,
+        startedAt: firstResult.chainState.chainStartedAt,
+        tokens: firstResult.chainState.accumulatedChainTokens,
+      });
+    }
+
+    // Restart — drops cache + in-memory state.
+    simulateGatewayRestart();
+
+    const reloadedStore = loadSessionStore(fixture.storePath, { skipCache: true });
+    const reloadedEntry = reloadedStore[sessionKey];
+    // Bug visible: chain count never reached disk.
+    expect(reloadedEntry?.continuationChainCount).toBe(0);
+
+    enqueuePendingDelegate(sessionKey, { task: "second hop", mode: "silent-wake" });
+    const reloadedChainState = loadContinuationChainState(reloadedEntry);
+    const secondResult = await dispatchToolDelegates({
+      sessionKey,
+      chainState: reloadedChainState,
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    // With persist failing to reach disk, hop 2 sees a fresh chain.
+    expect(spawn.calls[1]?.task).toContain("[continuation:chain-hop:1]");
+    expect(secondResult.chainState.currentChainCount).toBe(1);
+  });
+});

--- a/test/vitest/vitest.config.ts
+++ b/test/vitest/vitest.config.ts
@@ -73,6 +73,7 @@ export const rootVitestProjects = [
   "test/vitest/vitest.extension-zalo.config.ts",
   "test/vitest/vitest.extensions.config.ts",
   "test/vitest/vitest.swim-37.config.ts",
+  "test/vitest/vitest.continuation-durability.config.ts",
 ] as const;
 
 export default defineConfig({

--- a/test/vitest/vitest.continuation-durability.config.ts
+++ b/test/vitest/vitest.continuation-durability.config.ts
@@ -1,0 +1,25 @@
+import { loadPatternListFromEnv } from "./vitest.pattern-file.ts";
+import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
+
+export function loadIncludePatternsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): string[] | null {
+  return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
+}
+
+export function createContinuationDurabilityVitestConfig(
+  env?: Record<string, string | undefined>,
+) {
+  return createScopedVitestConfig(
+    loadIncludePatternsFromEnv(env) ?? [
+      "studies/swim-37/harness/durability/**/*.test.ts",
+    ],
+    {
+      env,
+      name: "continuation-durability",
+      passWithNoTests: true,
+    },
+  );
+}
+
+export default createContinuationDurabilityVitestConfig();


### PR DESCRIPTION
## Integration-test gap map + S1 two-hop-chain durability scenario

Per figs's step-3 (msg `1499190984...`) and 🌫's go-ahead (msg `1499194570...`), this opens the integration-test lane for the audit-lane fixes (#427 / #428 / #429) **before** squash + ceremony.

**Base:** `cael/325-canonical2 @ dc572c01062a` (post audit-lane merge).

### What's here

1. **`INTEGRATION-TEST-GAP-MAP.md`** at repo root — design surface for cohort review. Maps the four chain-state-persistence write-sites that landed in canonical2 since `v2026.4.24`, identifies the cross-surface gaps unit tests don't reach, proposes three scenarios (S1 / S2 / S3), and answers the three open questions 🌫 raised:
   - Block squash on these (figs's step-3 named integration tests pre-squash).
   - Reuse `studies/swim-37/harness/durability/`.
   - Real `dispatchToolDelegates` for S1 + S3 (boundary under test); stub for S2's `dispatched==0` branch.

2. **`studies/swim-37/harness/durability/`** — new harness subfolder.
   - `README.md` — substrate notes.
   - `durability-fixture.ts` — tmpdir session-store helpers + faked `spawnSubagentDirect`.
   - `s1-two-hop-chain.test.ts` — S1 scenario.

3. **`test/vitest/vitest.continuation-durability.config.ts`** — new vitest project (registered in `rootVitestProjects`); `passWithNoTests: true` so other shards stay green during scaffold.

### S1 — Two-hop chain across subagent boundary (`r3164380565` cross-surface)

Real `dispatchToolDelegates` against a real tmpdir session store. Faked `spawnSubagentDirect` records spawn calls deterministically. The boundary assertion: after first hop persists `currentChainCount = 1`, the second hop's spawn task is labeled `[continuation:chain-hop:2]`, proving `currentChainCount` carried across the persist boundary into the next dispatch's chain-budget enforcement.

Unit tests assert the persist *call*; this asserts the next reader *observes the persisted value*. That's the bug-shape r3164380565 was about (drain discarding the returned `chainState`).

### Local gates green

```
pnpm vitest run --config test/vitest/vitest.continuation-durability.config.ts
  -> 2 tests passed (1.65s)

pnpm check:test-types -> exit 0
```

### Follow-up commits on this branch (per gap map)

- **S2** — Followup-only token chain (`r3164418106` cross-surface): `dispatchToolDelegates` returns `dispatched==0` token-only; assert next turn's cost-cap reader sees `accumulatedChainTokens`.
- **S3** — Durable persist across simulated gateway restart (`r3164418100` + persist-trio): real-disk round-trip via `loadSessionStore` from a fresh in-memory state mid-chain.

Each follows the same harness pattern. Single PR, base-agnostic, ~5h total.

### Cohort review asks

- 🩸 / 🌫 / 🌊 — sanity-check the gap map (does the four-write-site enumeration match your read?).
- Confirm S1's boundary assertion shape (chain-hop label as observability proxy for persist→read round-trip).
- Flag if you'd rather see the harness in a new top-level `studies/continuation-durability/` instead of nested under swim-37.

🌻

cc 🩸 🌫 🌊
