### PR TITLE
fix(continuation): wrap followup-runner persistContinuationChainState in updateSessionStore (#431)

### DIFF
--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -489,6 +489,46 @@ export function createFollowupRunner(params: {
             startedAt: dispatchResult.chainState.chainStartedAt,
             tokens: dispatchResult.chainState.accumulatedChainTokens,
           });
+          // #431: the in-memory mutation above is orphaned for disk. The
+          // followup path's only durable writer is `persistRunSessionUsage`
+          // → `updateSessionStoreEntry`, which `loadSessionStore(...,
+          // skipCache: true)` and patches usage fields only —
+          // `continuationChain*` is not in that patch shape. Without an
+          // explicit `updateSessionStore` call the followup-only token chain
+          // never reaches disk; cost-cap and `maxChainLength` enforcement
+          // see stale values across cache eviction or gateway restart.
+          //
+          // Mirrors `agent-runner.ts`'s post-r3164418100 shape (~line 1310):
+          // explicit `updateSessionStore` with `resolveSessionStoreEntry`
+          // legacy-key cleanup so the chain fields land alongside the
+          // disk-canonical entry.
+          if (storePath && sessionKey) {
+            try {
+              const { updateSessionStore, resolveSessionStoreEntry } = await import(
+                "../../config/sessions/store.js"
+              );
+              await updateSessionStore(storePath, (store) => {
+                const resolved = resolveSessionStoreEntry({ store, sessionKey });
+                if (resolved.existing) {
+                  store[resolved.normalizedKey] = {
+                    ...resolved.existing,
+                    continuationChainCount: dispatchResult.chainState.currentChainCount,
+                    continuationChainStartedAt: dispatchResult.chainState.chainStartedAt,
+                    continuationChainTokens: dispatchResult.chainState.accumulatedChainTokens,
+                  };
+                  for (const legacyKey of resolved.legacyKeys) {
+                    delete store[legacyKey];
+                  }
+                }
+              });
+            } catch (err) {
+              // Mirror agent-runner.ts's defensive log: persistence failure
+              // must not break the followup reply itself.
+              defaultRuntime.error?.(
+                `[followup-runner] failed to persist continuation chain state for ${sessionKey}: ${String(err)}`,
+              );
+            }
+          }
         }
       }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -448,10 +448,12 @@ export function createFollowupRunner(params: {
           { dispatchToolDelegates },
           { resolveContinuationRuntimeConfig },
           { loadContinuationChainState, persistContinuationChainState },
+          { updateSessionStore, resolveSessionStoreEntry },
         ] = await Promise.all([
           import("../continuation/delegate-dispatch.js"),
           import("../continuation/config.js"),
           import("../continuation/state.js"),
+          import("../../config/sessions/store.js"),
         ]);
         const tailUsage = runResult.meta?.agentMeta?.usage;
         const turnTokens = (tailUsage?.input ?? 0) + (tailUsage?.output ?? 0);
@@ -504,9 +506,6 @@ export function createFollowupRunner(params: {
           // disk-canonical entry.
           if (storePath && sessionKey) {
             try {
-              const { updateSessionStore, resolveSessionStoreEntry } = await import(
-                "../../config/sessions/store.js"
-              );
               await updateSessionStore(storePath, (store) => {
                 const resolved = resolveSessionStoreEntry({ store, sessionKey });
                 if (resolved.existing) {

--- a/studies/swim-37/harness/durability/s2-followup-token-chain.test.ts
+++ b/studies/swim-37/harness/durability/s2-followup-token-chain.test.ts
@@ -219,4 +219,59 @@ describe("S2 — followup-only token chain persist (r3164418106)", () => {
     expect(reloaded?.continuationChainTokens).toBe(seedTokens);
     expect(reloaded?.continuationChainTokens).not.toBe(seedTokens + turnTokens);
   });
+
+  it("#431 sentinel: bare persistContinuationChainState mutation (no updateSessionStore wrap) is orphaned for disk", async () => {
+    // Simulates the #431 bug shape: r3164418106 closed the in-memory
+    // shape but the bare `persistContinuationChainState({ sessionEntry:
+    // tailEntry, ... })` mutation never reached disk via the followup
+    // path. The followup-runner's only durable writer
+    // (`persistRunSessionUsage` → `updateSessionStoreEntry`) does
+    // `loadSessionStore(skipCache:true)` and patches usage fields only.
+    //
+    // Without the `updateSessionStore` wrap (added in the #431 fix at
+    // `followup-runner.ts:485`-area), tokens stay stale on disk even
+    // though the in-memory entry shows the advanced value.
+    const sessionKey = "agent:main:followup-orphan";
+    const seedTokens = 100;
+    const turnTokens = 150;
+
+    await seedSessionEntry(fixture.storePath, sessionKey, {
+      sessionId: "session-followup-orphan",
+      continuationChainCount: 2,
+      continuationChainStartedAt: 1_700_000_000_000,
+      continuationChainTokens: seedTokens,
+    });
+
+    // Load entry from disk into an in-memory "tailEntry"-shaped object.
+    const tailEntry = readSessionEntry(fixture.storePath, sessionKey);
+    expect(tailEntry).toBeDefined();
+
+    const advancedChainState = loadContinuationChainState(tailEntry, turnTokens);
+
+    const dispatchResult = await dispatchToolDelegates({
+      sessionKey,
+      chainState: advancedChainState,
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    // ── DELIBERATE BUG SIMULATION (#431 orphan shape) ──
+    // Bare mutation only — NO `updateSessionStore` wrap. This is what
+    // r3164418106 originally shipped at `followup-runner.ts:485`.
+    persistContinuationChainState({
+      sessionEntry: tailEntry!,
+      count: dispatchResult.chainState.currentChainCount,
+      startedAt: dispatchResult.chainState.chainStartedAt,
+      tokens: dispatchResult.chainState.accumulatedChainTokens,
+    });
+
+    // In-memory tailEntry shows the advanced value (the in-memory shape
+    // r3164418106 fixed correctly).
+    expect(tailEntry!.continuationChainTokens).toBe(seedTokens + turnTokens);
+
+    // But disk still has the stale value — the orphan #431 surfaced.
+    const reloaded = readSessionEntry(fixture.storePath, sessionKey);
+    expect(reloaded?.continuationChainTokens).toBe(seedTokens);
+    expect(reloaded?.continuationChainTokens).not.toBe(seedTokens + turnTokens);
+  });
 });


### PR DESCRIPTION
Closes #431.

## Summary

`r3164418106`/#428 closed the in-memory shape of the followup-only token-chain drift but the durable layer was orphaned. The bare `persistContinuationChainState({ sessionEntry: tailEntry, ... })` mutation at `followup-runner.ts:485` only mutates the in-memory `tailEntry`. Byte-walk receipt:

- The followup path itself contains zero `updateSessionStore` / `saveSessionStore` calls.
- The only durable writer the followup flow invokes is `persistRunSessionUsage` → `updateSessionStoreEntry` (`session-usage.ts:110`).
- `updateSessionStoreEntry` (`store.ts:643-668`) does `loadSessionStore(storePath, { skipCache: true })` — discarding any cached in-memory mutations — then patches usage fields only (`inputTokens`/`outputTokens`/`cacheRead`/`cacheWrite`/`totalTokens`/`updatedAt`/etc).
- `continuationChain*` is not in that patch shape.

Result: `maxChainLength` and `costCapTokens` enforcement on followup-only chains under-report on disk; restart silently resets.

## Fix

Wrap the persist call in `updateSessionStore` mirroring `agent-runner.ts`'s post-`r3164418100` shape (~line 1310): explicit `updateSessionStore` with `resolveSessionStoreEntry` legacy-key cleanup so the chain fields land alongside the disk-canonical entry. Defensive log on persist failure (mirrors agent-runner.ts) so a disk write error never breaks the followup reply itself.

```ts
if (storePath && sessionKey) {
  try {
    const { updateSessionStore, resolveSessionStoreEntry } = await import(
      "../../config/sessions/store.js"
    );
    await updateSessionStore(storePath, (store) => {
      const resolved = resolveSessionStoreEntry({ store, sessionKey });
      if (resolved.existing) {
        store[resolved.normalizedKey] = {
          ...resolved.existing,
          continuationChainCount: dispatchResult.chainState.currentChainCount,
          continuationChainStartedAt: dispatchResult.chainState.chainStartedAt,
          continuationChainTokens: dispatchResult.chainState.accumulatedChainTokens,
        };
        for (const legacyKey of resolved.legacyKeys) {
          delete store[legacyKey];
        }
      }
    });
  } catch (err) {
    defaultRuntime.error?.(...);
  }
}
```

## Test promotion

S2's previous regression sentinel only covered the original `r3164418106` bug (persist guarded on `dispatched > 0`). This PR adds an explicit `#431` sentinel that simulates the bare-mutation orphan and asserts the in-memory entry shows the advanced value while disk stays stale. Without this PR's `updateSessionStore` wrap, the sentinel would flip from 'deliberate bug simulation' to 'live bug detector' against the production callsite.

S2 is now positioned to catch regressions of this gap going forward.

## Surfaced by

- karmaterminal/openclaw#430 integration harness
- Cael's S2 byte-walk on `bef8963d79` (Discord msg `1499204863026790511`)
- Ronan's elevation (msg `1499206790481449040`)
- Silas's independent `store.ts:643-668` byte-receipt (msg `1499207094271349800`)

## Local gates

- continuation-durability harness: 8/8 (S1 3/3, **S2 3/3** with new #431 sentinel, S3 2/2)
- followup-runner unit: 32/32
- `pnpm tsgo:core`, `tsgo:prod`, `tsgo:core:test`, `tsgo:extensions:test`: clean
- `pnpm lint`: 0 warnings 0 errors

🌻