### PR TITLE
test(session-transcript-repair): restore 2 canonical2 sibling tests

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -76,6 +76,68 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out[3]?.role).toBe("user");
   });
 
+  it("uses custom text for synthesized missing tool results", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+      { role: "user", content: "user message that should come after tool use" },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      missingToolResultText: "aborted",
+    });
+
+    expect(result.added).toHaveLength(1);
+    expect(result.messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "user"]);
+    expect(result.added[0]?.content).toEqual([{ type: "text", text: "aborted" }]);
+  });
+
+  it("keeps matched parallel tool results and synthesizes only missing siblings", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "checking" },
+          { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+          { type: "toolCall", id: "call_2", name: "exec", arguments: {} },
+          { type: "toolCall", id: "call_3", name: "write", arguments: {} },
+        ],
+      },
+      { role: "user", content: "user message that should come after tool use" },
+      {
+        role: "toolResult",
+        toolCallId: "call_2",
+        toolName: "exec",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      missingToolResultText: "aborted",
+    });
+
+    expect(result.added.map((message) => message.toolCallId)).toEqual(["call_1", "call_3"]);
+    expect(result.messages.map((m) => m.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "toolResult",
+      "toolResult",
+      "user",
+    ]);
+    expect(getAssistantToolCallBlocks(result.messages)).toMatchObject([
+      { id: "call_1", name: "read" },
+      { id: "call_2", name: "exec" },
+      { id: "call_3", name: "write" },
+    ]);
+    expect((result.messages[1] as { toolCallId?: string }).toolCallId).toBe("call_1");
+    expect((result.messages[2] as { toolCallId?: string }).toolCallId).toBe("call_2");
+    expect((result.messages[3] as { toolCallId?: string }).toolCallId).toBe("call_3");
+    expect(JSON.stringify(result.added)).not.toContain("missing tool result");
+  });
+
   it("repairs blank tool result names from matching tool calls", () => {
     const input = castAgentMessages([
       {


### PR DESCRIPTION
Restores `session-transcript-repair.test.ts` to canonical2 shape (byte-identical to `cf7830ffb3702bf7d826d70838893e2e41709f12`).

**Closes #459** (Pattern G — frond-scribe runbook PR #815).

## Diff
- +62/-0 vs `6c16442812ded9fc7318b4f4fb5696986239ffb2`
- Restores 2 deleted sibling tests (`missingToolResultText` + parallel-tool-results pairing)
- Assertion flipped to canonical2 expectation (`length=1` + `role="user"`)

## Gates
- `pnpm vitest run src/agents/session-transcript-repair.test.ts` → 33/33 ✅ (was 31/31; +2 restored)
- byte-identical to canonical2 (`diff` = 0)

## Topology
- canonical2 baseline: `cf7830ffb3702bf7d826d70838893e2e41709f12`
- pre-fold squash tip: `c22c71e2cf467b6ff68711f78871a3ff6ae161c5`
- repair tip: `c18d57c3c605dfda89d6bdaebb741e5917b944e2`

## Collision note
Supersedes 🌻's `elliott/433-restore-canonical2-sibling-tests @ 49dde4ecfb6` (byte-identical on the test file; branch deleted by 🌻 at supersession per discord msg `1499270745367249017`).

## Refs
- Parent: #433
- Sibling Pattern G: #458 (ext-provider seam-restore)

Per 🩸's lane assignment (msg `1499265289848885401`).
