### PR TITLE
test(continuation): trap mode-only PendingContinuationDelegate at compat boundary

### DIFF
--- a/src/auto-reply/continuation/types.mode-shape.test.ts
+++ b/src/auto-reply/continuation/types.mode-shape.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Trap test for karmaterminal/openclaw#438:
+ * Pin mode-only PendingContinuationDelegate at compat boundary.
+ *
+ * Bug-shape / risk:
+ *   The canonical runtime delegate shape is `PendingContinuationDelegate.mode`,
+ *   while booleans are only an on-disk compatibility encoding. A future refactor
+ *   can accidentally reintroduce `silent` / `silentWake` as runtime API fields
+ *   without breaking today's behavior tests immediately.
+ *
+ * What this trap guards (load-bearing assertions):
+ *   1. RUNTIME OBJECTS: `consumePendingDelegates` / `consumeStagedPostCompactionDelegates`
+ *      return objects whose only mode-bearing field is `mode`. They MUST NOT
+ *      expose `silent` / `silentWake` / `postCompaction` boolean runtime flags.
+ *   2. TOOL DESCRIPTOR: the `continue_delegate` parameter schema advertises
+ *      `mode` as an enum (normal | silent | silent-wake | post-compaction)
+ *      and exposes NO `silent` / `silentWake` boolean parameters.
+ *   3. ON-DISK BACK-COMPAT: persisted TaskFlow `stateJson` MAY still contain
+ *      legacy boolean flags (`silent`, `silentWake`, `postCompaction`). This is
+ *      a positive assertion — the disk shape stays back-compat for historical
+ *      rows — and is what justifies the runtime/disk encoding split.
+ *
+ * Provenance:
+ *   - canonical2 file: `src/auto-reply/continuation/types.ts` @ `cf7830ffb3`
+ *   - canonical2 file: `src/auto-reply/continuation/delegate-store.ts` @ `cf7830ffb3`
+ *   - relevant issue: #433 (the broken push that reintroduced double-encoding
+ *     this trap defends against), #227 (mode-only ADR)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the TaskFlow registry before importing the store. Identical fixture
+// shape to delegate-store.test.ts so the runtime path is exercised through
+// real production code, not stubs.
+const mockFlows = new Map<string, Record<string, unknown>>();
+let flowIdCounter = 0;
+
+vi.mock("../../tasks/task-flow-registry.js", () => ({
+  createManagedTaskFlow: vi.fn((params: Record<string, unknown>) => {
+    const flowId = `flow-${++flowIdCounter}`;
+    mockFlows.set(flowId, {
+      flowId,
+      syncMode: "managed",
+      ownerKey: params.ownerKey,
+      controllerId: params.controllerId,
+      status: "queued",
+      stateJson: params.stateJson,
+      goal: params.goal,
+      currentStep: params.currentStep,
+      revision: 0,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    return mockFlows.get(flowId);
+  }),
+  listTaskFlowsForOwnerKey: vi.fn((ownerKey: string) =>
+    [...mockFlows.values()].filter((f) => f.ownerKey === ownerKey),
+  ),
+  finishFlow: vi.fn((params: { flowId: string; expectedRevision: number }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (!flow || flow.revision !== params.expectedRevision) {
+      return { applied: false, reason: flow ? "revision_conflict" : "not_found" };
+    }
+    flow.status = "succeeded";
+    flow.revision = (flow.revision as number) + 1;
+    return { applied: true, flow: { ...flow } };
+  }),
+  failFlow: vi.fn((params: { flowId: string }) => {
+    const flow = mockFlows.get(params.flowId);
+    if (flow) {
+      flow.status = "failed";
+    }
+    return { applied: !!flow };
+  }),
+  deleteTaskFlowRecordById: vi.fn((flowId: string) => {
+    mockFlows.delete(flowId);
+  }),
+}));
+
+import {
+  consumePendingDelegates,
+  consumeStagedPostCompactionDelegates,
+  enqueuePendingDelegate,
+  stagePostCompactionDelegate,
+} from "./delegate-store.js";
+import type { PendingContinuationDelegate } from "./types.js";
+
+const SESSION_KEY = "test-session-438";
+
+const RUNTIME_BOOLEAN_FIELDS = ["silent", "silentWake", "postCompaction"] as const;
+
+beforeEach(() => {
+  mockFlows.clear();
+  flowIdCounter = 0;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("[#438] keeps PendingContinuationDelegate mode-only at runtime boundaries", () => {
+  describe("runtime objects from consumePendingDelegates", () => {
+    it.each([
+      ["normal", { mode: undefined as PendingContinuationDelegate["mode"] }],
+      ["silent", { mode: "silent" as const }],
+      ["silent-wake", { mode: "silent-wake" as const }],
+    ])(
+      "consume pending (%s mode) returns runtime object with no boolean fields",
+      (_label, { mode }) => {
+        enqueuePendingDelegate(SESSION_KEY, {
+          task: "trap test",
+          ...(mode !== undefined ? { mode } : {}),
+        });
+        const consumed = consumePendingDelegates(SESSION_KEY);
+        expect(consumed).toHaveLength(1);
+        const delegate = consumed[0]!;
+        for (const field of RUNTIME_BOOLEAN_FIELDS) {
+          expect(
+            Object.prototype.hasOwnProperty.call(delegate, field),
+            `runtime PendingContinuationDelegate must not expose '${field}' (mode-only encoding)`,
+          ).toBe(false);
+        }
+        if (mode !== undefined) {
+          expect(delegate.mode).toBe(mode);
+        }
+      },
+    );
+
+    it("consume staged post-compaction returns runtime object with mode='post-compaction' and no boolean fields", () => {
+      stagePostCompactionDelegate(SESSION_KEY, {
+        task: "trap test",
+        stagedAt: Date.now(),
+      });
+      const consumed = consumeStagedPostCompactionDelegates(SESSION_KEY);
+      expect(consumed).toHaveLength(1);
+      const delegate = consumed[0]!;
+      expect(delegate.mode).toBe("post-compaction");
+      for (const field of RUNTIME_BOOLEAN_FIELDS) {
+        expect(
+          Object.prototype.hasOwnProperty.call(delegate, field),
+          `post-compaction runtime delegate must not expose '${field}'`,
+        ).toBe(false);
+      }
+    });
+  });
+
+  describe("on-disk TaskFlow stateJson back-compat (positive assertion)", () => {
+    it.each([
+      ["silent", "silent"],
+      ["silent-wake", "silentWake"],
+      ["post-compaction", "postCompaction"],
+    ] as const)(
+      "persisted stateJson for mode='%s' projects to legacy boolean '%s'=true (back-compat preserved)",
+      (mode, expectedBooleanField) => {
+        if (mode === "post-compaction") {
+          stagePostCompactionDelegate(SESSION_KEY, {
+            task: "back-compat",
+            stagedAt: Date.now(),
+          });
+        } else {
+          enqueuePendingDelegate(SESSION_KEY, { task: "back-compat", mode });
+        }
+        const flow = [...mockFlows.values()][0]!;
+        const stateJson = flow.stateJson as Record<string, unknown>;
+        expect(stateJson[expectedBooleanField]).toBe(true);
+      },
+    );
+
+    it("persisted stateJson for normal mode projects no boolean mode flags", () => {
+      enqueuePendingDelegate(SESSION_KEY, { task: "normal" });
+      const flow = [...mockFlows.values()][0]!;
+      const stateJson = flow.stateJson as Record<string, unknown>;
+      for (const field of RUNTIME_BOOLEAN_FIELDS) {
+        expect(stateJson[field]).toBeUndefined();
+      }
+    });
+  });
+});
+
+describe("[#438] continue_delegate tool descriptor exposes mode enum, not boolean flags", () => {
+  it("descriptor advertises mode as enum with the four canonical values and no silent/silentWake parameters", async () => {
+    // Stub config used by createContinueDelegateTool's resolveMaxDelegatesPerTurn.
+    const tool = (
+      await import("../../agents/tools/continue-delegate-tool.js")
+    ).createContinueDelegateTool({ agentSessionKey: SESSION_KEY });
+
+    const params = tool.parameters as {
+      type?: string;
+      properties?: Record<string, unknown>;
+    };
+
+    expect(params.type).toBe("object");
+    const properties = params.properties ?? {};
+
+    // Must expose `mode` as an enum/string-union.
+    expect(properties).toHaveProperty("mode");
+    const modeProp = properties.mode as {
+      anyOf?: Array<{ const?: string; enum?: string[] }>;
+      enum?: string[];
+    };
+    // optionalStringEnum may render as anyOf [ { const: "normal" }, ... ] OR as enum.
+    const enumValues = new Set<string>();
+    if (Array.isArray(modeProp.enum)) {
+      for (const v of modeProp.enum) enumValues.add(v);
+    }
+    if (Array.isArray(modeProp.anyOf)) {
+      for (const branch of modeProp.anyOf) {
+        if (typeof branch.const === "string") enumValues.add(branch.const);
+        if (Array.isArray(branch.enum)) {
+          for (const v of branch.enum) enumValues.add(v);
+        }
+      }
+    }
+    for (const expected of ["normal", "silent", "silent-wake", "post-compaction"]) {
+      expect(
+        enumValues.has(expected),
+        `tool descriptor mode enum must include '${expected}' (got: ${[...enumValues].join(", ")})`,
+      ).toBe(true);
+    }
+
+    // Must NOT expose boolean `silent` / `silentWake` parameters.
+    for (const forbidden of ["silent", "silentWake"]) {
+      expect(
+        Object.prototype.hasOwnProperty.call(properties, forbidden),
+        `continue_delegate tool descriptor must not expose '${forbidden}' parameter (mode-only API surface)`,
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Closes #438.

## What this PR adds

A single structural trap test at `src/auto-reply/continuation/types.mode-shape.test.ts` (228 lines, test-only — no production code changes) that pins three load-bearing invariants:

1. **Runtime objects are mode-only.** `consumePendingDelegates` and `consumeStagedPostCompactionDelegates` return `PendingContinuationDelegate` shapes whose only mode-bearing field is `mode`. They MUST NOT expose `silent` / `silentWake` / `postCompaction` boolean runtime fields. Asserted across `normal` / `silent` / `silent-wake` / `post-compaction` modes (4 cases via `it.each`).

2. **Tool descriptor exposes mode enum, not boolean flags.** `continue_delegate` parameter schema advertises `mode` as an enum over `[normal, silent, silent-wake, post-compaction]` and exposes NO `silent` / `silentWake` boolean parameters. (Schema-rendering robust: parses both `enum` and `anyOf` forms emitted by `optionalStringEnum`.)

3. **On-disk TaskFlow stateJson MAY still contain legacy booleans.** Positive back-compat assertion: persisted `stateJson` projects `mode='silent'` → `silent: true` etc. This is what justifies the runtime/disk encoding split. Asserted across the three non-normal modes + a clean `normal` row.

## Why this is the trap that catches the next #433

#433 broke push because the squash silently reintroduced double-encoding (booleans + mode) at the compat boundary. The behavior tests didn't catch it because they assert *behavior* (does silent-wake wake?), not *shape* (does the runtime object expose only `mode`?). This trap asserts the shape, full stop.

Comments in `types.ts` and `delegate-store.ts` ([`#227` ADR](https://github.com/karmaterminal/openclaw/issues/227)) explicitly call out the encoding split as load-bearing, but until now nothing rejected boolean-shaped runtime delegates structurally. This PR closes that gap.

## Verified load-bearing

Temporarily added `...(state.silent === true ? { silent: true } : {})` to `flowToDelegate` in `delegate-store.ts` — i.e., the exact regression class `#227` warns against. Result: **1 of the 9 trap tests failed** with the canonical `runtime PendingContinuationDelegate must not expose 'silent' (mode-only encoding)` message. Reverted. 9/9 passing on canonical2 `cf7830ffb3702bf7d826d70838893e2e41709f12` baseline.

## Test surfaces

- 7 runtime-object cases (4 mode variants × consumePending + 1 staged-post-compaction + 2 disk-back-compat)
- 1 tool-descriptor case (mode enum present + boolean params absent)
- 1 disk-back-compat negative (normal mode → no boolean flags persisted)

## Receipts

```
Test Files  1 passed (1)
Tests  9 passed (9)
```

## Refs

- #438 — issue (frond-scribe walker, Project 56)
- #433 — broken push that triggered the walker walk
- #227 — mode-only ADR (the canonical seam this trap defends)
- canonical2 base SHA: `cf7830ffb3702bf7d826d70838893e2e41709f12`

🌫️