### PR TITLE
test(swim-37): S4 followup-runner disk callsite trap (#442)

### DIFF
--- a/studies/swim-37/harness/durability/s4-followup-runner-disk-callsite.test.ts
+++ b/studies/swim-37/harness/durability/s4-followup-runner-disk-callsite.test.ts
@@ -1,0 +1,108 @@
+/**
+ * S4 — Followup-runner disk-callsite trap (#442).
+ *
+ * **Boundary under test:** the *production callsite* in
+ * `src/auto-reply/reply/followup-runner.ts` that wires the disk-persist block
+ * onto the followup turn. S2/S3 already cover the *semantic* regressions
+ * (token chain advances, count advances, survives restart) at the primitive
+ * level by exercising `persistContinuationChainState` + `updateSessionStore`
+ * directly. What S2/S3 cannot catch: somebody deleting or gutting the wiring
+ * inside `followup-runner.ts` itself. The primitives still pass. The
+ * production path silently stops persisting.
+ *
+ * **Why source-regex instead of full mock-and-call:** honest invocation of
+ * `createFollowupRunner` requires mocking ~15 deep imports
+ * (`runEmbeddedPiAgent`, `runWithModelFallback`, `agent-runner-memory`,
+ * `route-reply`, `typing`, `session-run-accounting`, `followup-delivery`,
+ * `queue`, `reply-run-registry`, `origin-routing`, plus
+ * `task-flow-registry` + `spawnSubagentDirect`). That mock scaffold runs
+ * past the 350-LOC test cap and any single-mock 50-LOC cap. Per cohort
+ * adjudication (🩸 PR-comment 4352857578 + 🌫 msg 1499402113518665859)
+ * the freeze window forbids production-extraction to a helper file, which
+ * would let us call the persist block in isolation. So this test trades
+ * dynamic invocation for static structural assertion: the *bytes* of the
+ * wiring must be present in `followup-runner.ts`. Sabotage-verified by
+ * commenting any single asserted pattern → test fails.
+ *
+ * Cohort: see #442 + PR #466 thread.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const FOLLOWUP_RUNNER_PATH = path.resolve(
+  __dirname,
+  "../../../../src/auto-reply/reply/followup-runner.ts",
+);
+
+const SOURCE = fs.readFileSync(FOLLOWUP_RUNNER_PATH, "utf8");
+
+describe("S4: followup-runner disk-callsite wiring (#442)", () => {
+  it("imports persistContinuationChainState from continuation/state", () => {
+    // Sentinel 1: the in-memory persist primitive must be imported.
+    // If this is gone, no advancement happens at all.
+    expect(SOURCE).toMatch(
+      /\{\s*loadContinuationChainState\s*,\s*persistContinuationChainState\s*\}/,
+    );
+    expect(SOURCE).toMatch(/import\(\s*["']\.\.\/continuation\/state\.js["']\s*\)/);
+  });
+
+  it("imports updateSessionStore + resolveSessionStoreEntry from sessions/store", () => {
+    // Sentinel 2: the disk writer + legacy-key resolver must be imported.
+    // Without these the in-memory mutation is orphaned for disk (#431).
+    expect(SOURCE).toMatch(/\{\s*updateSessionStore\s*,\s*resolveSessionStoreEntry\s*\}/);
+    expect(SOURCE).toMatch(/import\(\s*["']\.\.\/\.\.\/config\/sessions\/store\.js["']\s*\)/);
+  });
+
+  it("retains the `if (dispatchResult && tailEntry)` guard block", () => {
+    // Sentinel 3: the outer guard from r3164418106 — persist even when
+    // dispatched===0, but only when chainState round-tripped through
+    // dispatchToolDelegates and we have a tailEntry to write into.
+    expect(SOURCE).toMatch(/if\s*\(\s*dispatchResult\s*&&\s*tailEntry\s*\)\s*\{/);
+  });
+
+  it("calls persistContinuationChainState({ sessionEntry: tailEntry, ... }) inside the guard", () => {
+    // Sentinel 4a: in-memory mutation. Asserting the {sessionEntry: tailEntry}
+    // shape pins the call to the audit-fix wiring, not some stray helper.
+    expect(SOURCE).toMatch(/persistContinuationChainState\(\s*\{\s*sessionEntry:\s*tailEntry\s*,/);
+  });
+
+  it("calls await updateSessionStore(storePath, ...) inside the guard", () => {
+    // Sentinel 4b: durable disk write (#431). Without this the in-memory
+    // mutation never reaches disk; cost-cap and maxChainLength readers see
+    // stale values across cache eviction or gateway restart.
+    expect(SOURCE).toMatch(/await\s+updateSessionStore\(\s*storePath\s*,/);
+  });
+
+  it("calls resolveSessionStoreEntry({ store, sessionKey }) inside the disk-write callback", () => {
+    // Sentinel 4c: legacy-key cleanup. Mirrors agent-runner.ts post-r3164418100.
+    // Without this, chain fields can land on a stale legacy key while readers
+    // load the canonical key — silent drift.
+    expect(SOURCE).toMatch(/resolveSessionStoreEntry\(\s*\{\s*store\s*,\s*sessionKey\s*\}\s*\)/);
+  });
+
+  it("wraps the disk-write call in a try/catch with defensive defaultRuntime.error", () => {
+    // Sentinel 4d: persistence failure must not break the followup reply
+    // itself (mirrors agent-runner.ts defensive log shape).
+    expect(SOURCE).toMatch(
+      /defaultRuntime\.error\?\.\(\s*[\s\S]{0,160}?\[followup-runner\][\s\S]{0,200}?failed to persist continuation chain state/,
+    );
+  });
+
+  it("sets the three continuationChain* fields inside the disk-write callback", () => {
+    // Sentinel 4e: the actual fields written. If the callback is gutted to
+    // an empty closure (or the field assignments are removed), this fails.
+    expect(SOURCE).toMatch(
+      /continuationChainCount:\s*dispatchResult\.chainState\.currentChainCount/,
+    );
+    expect(SOURCE).toMatch(
+      /continuationChainStartedAt:\s*dispatchResult\.chainState\.chainStartedAt/,
+    );
+    expect(SOURCE).toMatch(
+      /continuationChainTokens:\s*dispatchResult\.chainState\.accumulatedChainTokens/,
+    );
+  });
+});


### PR DESCRIPTION
**Test-only PR.** Production-extraction reverted per cohort adjudication:

- 🩸 https://github.com/karmaterminal/openclaw/pull/466#issuecomment-4352857578
- 🌫 https://discord.com/channels/1485437814265217236/1494867057627168821/1499402113518665859

Original production-touch (helper-file extraction for clean semantic test) deferred to #467, blocked on `cfa27eee834` greenlight (post-#433 freeze release).

## What this PR does

Adds `studies/swim-37/harness/durability/s4-followup-runner-disk-callsite.test.ts` — a source-regex test pinning the disk-persist wiring inside `src/auto-reply/reply/followup-runner.ts` (lines ~487–533, the audit fix from #431/#432).

S2/S3 already cover the *semantic* regressions at the primitive level (`persistContinuationChainState` + `updateSessionStore` directly). S4 closes the gap S2/S3 cannot see: somebody deleting or gutting the wiring inside `followup-runner.ts` itself. The primitives still pass; the production path silently stops persisting. S4 fails fast in that scenario.

## Why source-regex instead of full mock-and-call

Honest invocation of `createFollowupRunner` requires mocking ~15 deep imports (`runEmbeddedPiAgent`, `runWithModelFallback`, `agent-runner-memory`, `route-reply`, `typing`, `session-run-accounting`, `followup-delivery`, `queue`, `reply-run-registry`, `origin-routing`, plus `task-flow-registry` + `spawnSubagentDirect`). The B2 mock scaffold blew the 350-LOC test cap and the 50-LOC per-mock cap. Helper-file extraction (B-prime) would isolate the persist block but is forbidden in the freeze window per the adjudications above.

So this is a structural trap, not a semantic one. Trade documented in the file's docstring.

## Sentinels (8)

1. `persistContinuationChainState` import from `../continuation/state.js` (dynamic)
2. `updateSessionStore` + `resolveSessionStoreEntry` import from `../../config/sessions/store.js` (dynamic)
3. `if (dispatchResult && tailEntry)` outer guard
4. `persistContinuationChainState({ sessionEntry: tailEntry, ... })` call inside guard
5. `await updateSessionStore(storePath, ...)` call inside guard
6. `resolveSessionStoreEntry({ store, sessionKey })` call inside disk-write callback
7. Defensive `defaultRuntime.error?.('[followup-runner] failed to persist continuation chain state...')` catch
8. Three field assignments: `continuationChainCount`, `continuationChainStartedAt`, `continuationChainTokens`

## Sabotage receipt

Replaced `await updateSessionStore` with `await /*SABOTAGE*/null/*updateSessionStore*/` in `followup-runner.ts`:

```
FAIL  studies/swim-37/harness/durability/s4-followup-runner-disk-callsite.test.ts
  > S4: followup-runner disk-callsite wiring (#442)
  > calls await updateSessionStore(storePath, ...) inside the guard
    expect(SOURCE).toMatch(/await\s+updateSessionStore\(\s*storePath\s*,/)
```

Restored → 16/16 green (8 tests × 2 vitest projects: `continuation-durability` + `swim-37`).

## Diff scope

- 1 file changed, +108 / −0
- `studies/swim-37/harness/durability/s4-followup-runner-disk-callsite.test.ts` (new)
- Production-clean proof against live canonical baseline:

```
$ git fetch origin cael/325-canonical2
$ git diff origin/cael/325-canonical2 -- src/auto-reply/
$  # (empty)
```

## Refs

- Tracking: #442
- Audit fix this traps: #431 / #432 (commit `cf7830ffb37`)
- Deferred refactor: #467
- Canonical baseline: `origin/cael/325-canonical2` (currently `cf7830ffb37`)