### PR TITLE
fix(agent-runner): surface terminal blocked livenessState as channel-visible marker (#475)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -511,6 +511,101 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("prefixes outbound error payloads with a blocked-session marker when livenessState is blocked (#475)", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [
+        {
+          text: "Context overflow: prompt too large for the model. Try /reset (or /new) to start a fresh session, or use a larger-context model.",
+          isError: true,
+        },
+      ],
+      meta: {
+        livenessState: "blocked",
+        error: {
+          kind: "compaction_failure",
+          message: "compaction failed: too many attempts",
+        },
+      },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([
+        {
+          text: "⛔ Session blocked: Context overflow: prompt too large for the model. Try /reset (or /new) to start a fresh session, or use a larger-context model.",
+          isError: true,
+        },
+      ]);
+    }
+  });
+
+  it("does not double-prefix the blocked-session marker on subsequent passes (#475)", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [
+        {
+          text: "⛔ Session blocked: already-prefixed payload",
+          isError: true,
+        },
+      ],
+      meta: {
+        livenessState: "blocked",
+      },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([
+        {
+          text: "⛔ Session blocked: already-prefixed payload",
+          isError: true,
+        },
+      ]);
+    }
+  });
+
+  it("leaves non-error payloads unchanged when livenessState is blocked (#475)", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "normal assistant text" }, { text: "some error", isError: true }],
+      meta: {
+        livenessState: "blocked",
+      },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([
+        { text: "normal assistant text" },
+        { text: "⛔ Session blocked: some error", isError: true },
+      ]);
+    }
+  });
+
+  it("does not prefix payloads when livenessState is working (#475)", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "a normal error", isError: true }],
+      meta: {
+        livenessState: "working",
+      },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([{ text: "a normal error", isError: true }]);
+    }
+  });
+
   it("surfaces model capacity errors from pre-reply CLI failures", async () => {
     state.runWithModelFallbackMock.mockRejectedValueOnce(
       new Error("Selected model is at capacity. Please try a different model."),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1823,10 +1823,16 @@ export async function runAgentTurnWithFallback(params: {
   ) {
     const blockedMarker = "⛔ Session blocked: ";
     runResult.payloads = runResult.payloads.map((payload) => {
-      if (!payload.isError) return payload;
+      if (!payload.isError) {
+        return payload;
+      }
       const text = normalizeOptionalString(payload.text);
-      if (!text) return payload;
-      if (text.startsWith(blockedMarker)) return payload;
+      if (!text) {
+        return payload;
+      }
+      if (text.startsWith(blockedMarker)) {
+        return payload;
+      }
       return { ...payload, text: `${blockedMarker}${text}` };
     });
   }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1804,6 +1804,33 @@ export async function runAgentTurnWithFallback(params: {
     }
   }
 
+  // #475: surface terminal blocked livenessState as a channel-visible marker.
+  // The embedded runner sets `meta.livenessState = "blocked"` on terminal
+  // give-up paths (compaction-failure cap, strict-agentic blocked, role-ordering
+  // give-up, etc.) but channel consumers never read this metadata. Operators
+  // could not distinguish a normal error reply from a session that gave up
+  // after exhausting compaction retries. Inject a one-line marker prefix on the
+  // outbound error payload(s) when liveness is blocked AND the payload hasn't
+  // already been auto-recovered or replaced by a more specific marker.
+  // (B-shape cascade-phase observability is tracked separately as a follow-up
+  // PR — it requires a new typing/status protocol surface.)
+  const finalLivenessState = runResult?.meta?.livenessState;
+  if (
+    runResult &&
+    finalLivenessState === "blocked" &&
+    Array.isArray(runResult.payloads) &&
+    runResult.payloads.length > 0
+  ) {
+    const blockedMarker = "⛔ Session blocked: ";
+    runResult.payloads = runResult.payloads.map((payload) => {
+      if (!payload.isError) return payload;
+      const text = normalizeOptionalString(payload.text);
+      if (!text) return payload;
+      if (text.startsWith(blockedMarker)) return payload;
+      return { ...payload, text: `${blockedMarker}${text}` };
+    });
+  }
+
   // Surface rate limit and overload errors that occur mid-turn (after tool
   // calls) instead of silently returning an empty response. See #36142.
   // Only applies when the assistant produced no valid (non-error) reply text,


### PR DESCRIPTION
Closes #475 (shape A: terminal-state surfacing). Sibling follow-up PR for cascade-phase observability (shape B) to come separately — that requires a new typing/status protocol surface and deserves its own review cycle.

## Mechanism receipt (pre-fix byte-walk)

**Producers** — set `meta.livenessState = "blocked"` on terminal give-up paths:
- `src/agents/pi-embedded-runner/run.ts` lines `788`, `1414`, `1440`, `1470`, `1496`, `1510`, `1536`, `2055`
- Covers compaction-failure cap (`MAX_OVERFLOW_COMPACTION_ATTEMPTS`), strict-agentic blocked text, role-ordering give-up, and other terminal lifecycle exits

**Forwarder** — `src/agents/pi-embedded-subscribe.handlers.lifecycle.ts:62-63` derives `livenessState` and includes it in lifecycle event payload at `:121/131/142/151` (`...(livenessState ? { livenessState } : {})`)

**Drop point (pre-fix)** — `src/auto-reply/reply/agent-runner-execution.ts` `onAgentEvent` reads `evt.data.phase` only; `evt.data.livenessState` silently dropped. Consumer-grep confirms ZERO readers of `livenessState` outside the pi-embedded producer/forwarder surface before this patch.

## Fix shape (A — minimal)

After the existing context-overflow recovery branch in `runAgentTurnWithFallback`, when `runResult.meta.livenessState === "blocked"`:

- Prefix any `isError` payload with `⛔ Session blocked: `
- Idempotent — does not double-prefix payloads that already start with the marker
- Leaves non-error payloads unchanged (so a successful turn that briefly reported blocked state during compaction does not get marked)
- Single file, ~25 LOC

## Cohort tiebreak

🌻 voted (A) for this PR + (B) as immediate follow-up. 🩸 concurred. Reasoning: figs's freeze directive (`fixes done + tested + reviewed + merged FIRST, then SWIM-39 deploy`) → land-fast > land-perfect-once. (A) closes the give-up-moment surfacing gap mergeable today; (B) closes the cascade-phase pain (figs's 85% / "text would change but turn repeating" symptom) on its own design cycle.

## Tests

4 new regression tests in `src/auto-reply/reply/agent-runner-execution.test.ts`:
- `prefixes outbound error payloads with a blocked-session marker when livenessState is blocked (#475)`
- `does not double-prefix the blocked-session marker on subsequent passes (#475)`
- `leaves non-error payloads unchanged when livenessState is blocked (#475)`
- `does not prefix payloads when livenessState is working (#475)`

All 4 pass; existing 45 tests in file unaffected (`vitest run -t "475"` → 4 passed | 45 skipped).

`tsc --noEmit` clean.

## Base

`cael/325-canonical2` per cohort lane-call (B: direct rebase onto canonical2 over c5-repair stack-merge — c5-repair gated behind frozen `#469`).

🌫