### PR TITLE
fix(#476): wrapToolMemoryDayFileWriteGuard + first-class append op

### DIFF
--- a/BRIEF-476.md
+++ b/BRIEF-476.md
@@ -1,0 +1,129 @@
+# Fix #476 — write tool clobbers memory/day-file paths
+
+## YOUR JOB
+
+Implement and ship a complete, tested, mergeable fix-PR for openclaw#476.
+
+You are NOT done until:
+
+1. `wrapToolMemoryDayFileWriteGuard` is implemented in `src/agents/pi-tools.read.ts` (or sibling file) and exported
+2. New `append` tool op is implemented and registered alongside `write`
+3. `pnpm tsgo:core:test` passes
+4. `pnpm vitest run src/agents/pi-tools.write.guard src/agents/pi-tools.append src/agents/pi-tools.write.message-truthfulness` passes
+5. `git commit` made with descriptive message
+6. `gh pr create --base elliott/c5-repair-symlink-escape --head fix/476-write-clobber-memory-paths --title "fix(#476): refuse write to memory/day-file paths without explicit overwrite + first-class append op" --body-file PR-BODY-476.md` opens the PR
+
+**TEST-ONLY SCAFFOLDING IS NOT ENOUGH.** A previous session wrote tests then died. Don't repeat that. Implement source first, then tests, then verify, then PR.
+
+## Source-walk verdict
+
+- **Flush wrapper is correct**: `wrapToolMemoryFlushAppendOnlyWrite` in `src/agents/pi-tools.read.ts` (~line 537+) properly appends via `appendMemoryFlushContent` (~line 480+).
+- **Bug lives in the unwrapped `write` tool** used outside flush context. No path-shape check; direct overwrite.
+- 🌫 reproduced 3× on urudyne (non-flush regular-mode, `path: memory/2026-04-30.md` exact match, no `overwrite` flag, gateway returned text shape `"Appended content to memory/2026-04-30.md."` — but upstream tool returns `"Successfully wrote N bytes to PATH"`, so the misleading "Appended" wording must come from a wrapper or template; check).
+
+## Branch + base (CRITICAL)
+
+- Branch: `fix/476-write-clobber-memory-paths` (already created, currently at `origin/elliott/c5-repair-symlink-escape`)
+- Worktree: `/tmp/elliott-476-fix`
+- **PR base must be `elliott/c5-repair-symlink-escape`** (NOT `main`) — to match #478/#479 lane topology per cohort decision
+- This means your work stacks on top of `0a960498dc` (the SUT SHA), same as the other repair-PRs
+
+## Fix scope (locked)
+
+### 1. Path-shape predicate at unwrapped `write` wrapper
+
+Add a guard wrapper `wrapToolMemoryDayFileWriteGuard` that:
+
+- Detects memory/day-file shape paths (default pattern: `^memory/\d{4}-\d{2}-\d{2}\.md$`; configurable via wrapper options for additional sovereign-file globs)
+- If matched AND no explicit `overwrite: true` arg → refuse with structured error pointing to the new `append` op (error message: `"Refusing to overwrite memory/day-file path 'PATH' without explicit overwrite:true. Use the 'append' tool to add content, or pass overwrite:true to confirm intentional clobber."`)
+- If matched AND `overwrite: true` is passed → allow with warning prefix in tool result (`"WARNING: Overwrote memory/day-file path 'PATH' (N bytes). Previous content lost."`)
+- Non-matching paths pass through unchanged
+
+Place wrapper near `wrapToolMemoryFlushAppendOnlyWrite` in `src/agents/pi-tools.read.ts`. Apply it in the tool registration path (look at how `wrapToolMemoryFlushAppendOnlyWrite` is used in `src/agents/pi-tools.ts` and apply `wrapToolMemoryDayFileWriteGuard` symmetrically — but for the non-flush registration path, NOT inside the flush wrapper).
+
+### 2. First-class `append` op exposed in tool registry
+
+Currently `appendFileWithinRoot` (or similar internal append helper) exists. Surface it as a new tool:
+
+- Tool name: `append`
+- Description: `"Append content to an existing file (or create if missing). Use this for memory/day-files and other append-only logs. Returns truthful 'Appended N bytes to PATH' message."`
+- Args: `path` (string, required), `content` (string, required)
+- Behavior: append content to file (create if missing); workspace-root guard like `write`
+- Tool result message: `"Appended N bytes to PATH"` (truthful — actual append happened)
+- Register in `src/agents/pi-tools.ts` next to `write`
+
+### 3. Tool-result truthfulness
+
+- Confirm regular `write` tool result message says "Wrote" / "Successfully wrote" / "Created", NEVER "Appended"
+- If you find any wrapper that rebrands write → "Appended", remove that bug
+- The flush wrapper's "Appended content to {path}." is correct (it appends). Don't break that.
+
+### 4. Tests
+
+The previous session wrote `src/agents/pi-tools.write.guard.test.ts`, `src/agents/pi-tools.append.test.ts`, `src/agents/pi-tools.write.message-truthfulness.test.ts` — but they were lost in a rebase. Re-write them. Suggested cases:
+
+- `wrapToolMemoryDayFileWriteGuard` refuses `memory/2026-04-30.md` without `overwrite`, returns structured error
+- `wrapToolMemoryDayFileWriteGuard` allows `memory/2026-04-30.md` with `overwrite:true`, emits warning prefix
+- `wrapToolMemoryDayFileWriteGuard` passes through non-matching paths (`README.md`, `src/foo.ts`)
+- `wrapToolMemoryDayFileWriteGuard` accepts custom globs via options
+- `append` tool creates file if missing, appends to existing file, returns truthful message
+- `append` tool respects workspace-root guard
+- regular `write` tool returns "Wrote" / "Successfully wrote", NOT "Appended"
+
+## Verification before PR
+
+```bash
+cd /tmp/elliott-476-fix
+pnpm install  # if needed
+pnpm tsgo:core:test
+pnpm vitest run src/agents/pi-tools.write.guard src/agents/pi-tools.append src/agents/pi-tools.write.message-truthfulness
+```
+
+All green required. Then commit + PR.
+
+## PR body template (write to PR-BODY-476.md before `gh pr create`)
+
+```markdown
+## Summary
+
+Fixes #476 — `write` tool clobbers `memory/YYYY-MM-DD.md` paths non-deterministically.
+
+## Root cause
+
+Source-walk (🌻) confirmed:
+
+- `wrapToolMemoryFlushAppendOnlyWrite` in flush context is correct (it appends).
+- Bug lives in **unwrapped `write`** path used outside flush context: no path-shape check, direct overwrite.
+- 🌫 reproduced 3× on urudyne (non-flush regular-mode, exact `memory/2026-04-30.md` match).
+
+## Fix
+
+1. **`wrapToolMemoryDayFileWriteGuard`** (new) — refuses overwrite of `memory/YYYY-MM-DD.md`-shape paths without explicit `overwrite:true`; suggests `append` op in error message; applied to non-flush write registration.
+2. **`append` tool** (new) — first-class append op, callable in non-flush AND filtered-flush sessions; truthful "Appended N bytes" message.
+3. **Tests** — guard refusal, guard allow-with-overwrite, append create/extend, write-truthful-message.
+
+## Verification
+
+- [x] `pnpm tsgo:core:test` green
+- [x] `pnpm vitest run src/agents/pi-tools.write.guard src/agents/pi-tools.append src/agents/pi-tools.write.message-truthfulness` green
+
+## Lane
+
+- Base: `elliott/c5-repair-symlink-escape` (matches #478/#479 stack)
+- Owner: Elliott 🌻 + Silas 🌫 pair (state-vector data)
+- Pair receipt: <link to 🌫 emit-site discord msg or comment>
+
+## SWIM-39 row
+
+OV-8 (#837) verifies post-fix surface.
+
+Refs: #476, #478, #479
+```
+
+## DO NOT STOP UNTIL PR IS OPEN
+
+If you hit blockers, document them in a comment on #476 with `gh issue comment 476 --repo karmaterminal/openclaw --body "..."` AND in this brief. But don't punt — solve the blocker.
+
+## Cost
+
+Irrelevant. figs's directive: coding-agents are FREE. Use freely.

--- a/src/agents/pi-tools.append.test.ts
+++ b/src/agents/pi-tools.append.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHostWorkspaceAppendTool, wrapToolWorkspaceRootGuard } from "./pi-tools.read.js";
+
+vi.mock("@mariozechner/pi-ai", async () => {
+  const original =
+    await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+  return { ...original };
+});
+
+vi.mock("@mariozechner/pi-ai/oauth", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai/oauth")>(
+    "@mariozechner/pi-ai/oauth",
+  );
+  return {
+    ...actual,
+    getOAuthApiKey: () => undefined,
+    getOAuthProviders: () => [],
+  };
+});
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+describe("createHostWorkspaceAppendTool", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-append-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates file if missing and returns truthful message", async () => {
+    const tool = createHostWorkspaceAppendTool(tmpDir);
+    const result = await tool.execute("id1", {
+      path: "memory/2026-04-30.md",
+      content: "hello world",
+    });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+    expect(text).toContain("Appended");
+    expect(text).toContain("11 bytes");
+    expect(text).toContain("memory/2026-04-30.md");
+    const written = await fs.readFile(path.join(tmpDir, "memory", "2026-04-30.md"), "utf-8");
+    expect(written).toBe("hello world");
+  });
+
+  it("appends to existing file", async () => {
+    const filePath = path.join(tmpDir, "notes.md");
+    await fs.writeFile(filePath, "first line", "utf-8");
+
+    const tool = createHostWorkspaceAppendTool(tmpDir);
+    await tool.execute("id2", { path: "notes.md", content: "second line" });
+    const content = await fs.readFile(filePath, "utf-8");
+    expect(content).toContain("first line");
+    expect(content).toContain("second line");
+  });
+
+  it("returns truthful 'Appended N bytes' message, never 'Wrote'", async () => {
+    const tool = createHostWorkspaceAppendTool(tmpDir);
+    const result = await tool.execute("id3", { path: "log.md", content: "entry" });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+    expect(text).toMatch(/^Appended/);
+    expect(text).not.toContain("Wrote");
+  });
+
+  it("respects workspace-root guard when workspaceOnly=true", async () => {
+    const tool = wrapToolWorkspaceRootGuard(
+      createHostWorkspaceAppendTool(tmpDir, { workspaceOnly: true }),
+      tmpDir,
+    );
+    await expect(
+      tool.execute("id4", { path: path.join(tmpDir, "../escape.md"), content: "bad" }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -580,6 +580,125 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
   };
 }
 
+const DEFAULT_MEMORY_DAY_FILE_PATTERN = /^memory\/\d{4}-\d{2}-\d{2}\.md$/;
+
+type MemoryDayFileWriteGuardOptions = {
+  patterns?: RegExp[];
+};
+
+export function wrapToolMemoryDayFileWriteGuard(
+  tool: AnyAgentTool,
+  options?: MemoryDayFileWriteGuardOptions,
+): AnyAgentTool {
+  const patterns = options?.patterns?.length ? options.patterns : [DEFAULT_MEMORY_DAY_FILE_PATTERN];
+  const extendedParameters =
+    tool.parameters && typeof tool.parameters === "object"
+      ? {
+          ...tool.parameters,
+          properties: {
+            ...((tool.parameters as Record<string, unknown>).properties as Record<string, unknown>),
+            overwrite: {
+              type: "boolean",
+              description: "Pass true to allow overwriting a memory/day-file path.",
+            },
+          },
+        }
+      : tool.parameters;
+  return {
+    ...tool,
+    parameters: extendedParameters as typeof tool.parameters,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const record = getToolParamsRecord(args);
+      const filePath =
+        typeof record?.path === "string" && record.path.trim() ? record.path.trim() : undefined;
+      if (!filePath || !patterns.some((p) => p.test(filePath))) {
+        return tool.execute(toolCallId, args, signal, onUpdate);
+      }
+      if (record?.overwrite !== true) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Refusing to overwrite memory/day-file path '${filePath}' without explicit overwrite:true. Use the 'append' tool to add content, or pass overwrite:true to confirm intentional clobber.`,
+            },
+          ],
+          details: { path: filePath, refused: true },
+        };
+      }
+      const bytes = typeof record?.content === "string" ? record.content.length : 0;
+      const result = await tool.execute(toolCallId, args, signal, onUpdate);
+      const warningPrefix = `WARNING: Overwrote memory/day-file path '${filePath}' (${bytes} bytes). Previous content lost.`;
+      const firstTextIdx = result.content.findIndex((c) => c.type === "text");
+      if (firstTextIdx >= 0) {
+        const updated = [...result.content];
+        const block = updated[firstTextIdx] as { type: "text"; text: string };
+        updated[firstTextIdx] = { ...block, text: `${warningPrefix}\n${block.text}` };
+        return { ...result, content: updated };
+      }
+      return { ...result, content: [{ type: "text", text: warningPrefix }, ...result.content] };
+    },
+  };
+}
+
+export function createHostWorkspaceAppendTool(
+  root: string,
+  options?: { workspaceOnly?: boolean },
+): AnyAgentTool {
+  const workspaceOnly = options?.workspaceOnly ?? false;
+  return {
+    name: "append",
+    label: "append",
+    description:
+      "Append content to an existing file (or create if missing). Use this for memory/day-files and other append-only logs. Returns truthful 'Appended N bytes to PATH' message.",
+    parameters: {
+      type: "object",
+      required: ["path", "content"],
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the file to append to (relative or absolute)",
+        },
+        content: { type: "string", description: "Content to append to the file" },
+      },
+    } as unknown as AnyAgentTool["parameters"],
+    execute: async (_toolCallId, args, _signal) => {
+      const record = getToolParamsRecord(args);
+      const rawPath =
+        typeof record?.path === "string" && record.path.trim() ? record.path.trim() : undefined;
+      const content = typeof record?.content === "string" ? record.content : undefined;
+      if (!rawPath) {
+        throw new Error("path is required.");
+      }
+      if (content === undefined) {
+        throw new Error("content is required.");
+      }
+      if (workspaceOnly) {
+        const resolvedPath = resolveToolPathAgainstWorkspaceRoot({ filePath: rawPath, root });
+        await assertSandboxPath({ filePath: resolvedPath, cwd: root, root });
+        const relative = path.relative(root, resolvedPath);
+        await appendFileWithinRoot({
+          rootDir: root,
+          relativePath: relative,
+          data: content,
+          mkdir: true,
+          prependNewlineIfNeeded: true,
+        });
+        return {
+          content: [{ type: "text", text: `Appended ${content.length} bytes to ${rawPath}` }],
+          details: { path: rawPath },
+        };
+      }
+      const resolved = path.resolve(expandTildeToOsHome(rawPath));
+      await fs.mkdir(path.dirname(resolved), { recursive: true });
+      await fs.appendFile(resolved, content, "utf-8");
+      return {
+        content: [{ type: "text", text: `Appended ${content.length} bytes to ${rawPath}` }],
+        details: { path: rawPath },
+      };
+    },
+  };
+}
+
 export function wrapToolWorkspaceRootGuardWithOptions(
   tool: AnyAgentTool,
   root: string,

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -688,7 +688,10 @@ export function createHostWorkspaceAppendTool(
           details: { path: rawPath },
         };
       }
-      const resolved = path.resolve(expandTildeToOsHome(rawPath));
+      const expanded = expandTildeToOsHome(rawPath);
+      const resolved = path.isAbsolute(expanded)
+        ? path.resolve(expanded)
+        : path.resolve(root, expanded);
       await fs.mkdir(path.dirname(resolved), { recursive: true });
       await fs.appendFile(resolved, content, "utf-8");
       return {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -34,6 +34,7 @@ import {
 } from "./pi-tools.policy.js";
 import {
   assertRequiredParams,
+  createHostWorkspaceAppendTool,
   createHostWorkspaceEditTool,
   createHostWorkspaceWriteTool,
   createOpenClawReadTool,
@@ -41,6 +42,7 @@ import {
   createSandboxedReadTool,
   createSandboxedWriteTool,
   getToolParamsRecord,
+  wrapToolMemoryDayFileWriteGuard,
   wrapToolMemoryFlushAppendOnlyWrite,
   wrapToolWorkspaceRootGuard,
   wrapToolWorkspaceRootGuardWithOptions,
@@ -75,7 +77,7 @@ function isOpenAIProvider(provider?: string) {
   return normalized === "openai" || normalized === "openai-codex";
 }
 
-const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
+const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write", "append"]);
 
 type BashToolsModule = typeof import("./bash-tools.js");
 
@@ -497,7 +499,10 @@ export function createOpenClawCodingTools(options?: {
         return [];
       }
       const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const withRootGuard = workspaceOnly
+        ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot)
+        : wrapped;
+      return [wrapToolMemoryDayFileWriteGuard(withRootGuard)];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
@@ -577,18 +582,30 @@ export function createOpenClawCodingTools(options?: {
                   },
                 )
               : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
-            workspaceOnly
-              ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
-                  sandboxRoot,
-                  {
-                    containerWorkdir: sandbox.containerWorkdir,
-                  },
-                )
-              : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+            wrapToolMemoryDayFileWriteGuard(
+              workspaceOnly
+                ? wrapToolWorkspaceRootGuardWithOptions(
+                    createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                    sandboxRoot,
+                    {
+                      containerWorkdir: sandbox.containerWorkdir,
+                    },
+                  )
+                : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+            ),
           ]
         : []
       : []),
+    ...(sandboxRoot
+      ? []
+      : [
+          workspaceOnly
+            ? wrapToolWorkspaceRootGuard(
+                createHostWorkspaceAppendTool(workspaceRoot, { workspaceOnly }),
+                workspaceRoot,
+              )
+            : createHostWorkspaceAppendTool(workspaceRoot, { workspaceOnly }),
+        ]),
     ...(applyPatchTool ? [applyPatchTool as unknown as AnyAgentTool] : []),
     execTool as unknown as AnyAgentTool,
     processTool as unknown as AnyAgentTool,

--- a/src/agents/pi-tools.write.guard.test.ts
+++ b/src/agents/pi-tools.write.guard.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHostWorkspaceWriteTool, wrapToolMemoryDayFileWriteGuard } from "./pi-tools.read.js";
+
+vi.mock("@mariozechner/pi-ai", async () => {
+  const original =
+    await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+  return { ...original };
+});
+
+vi.mock("@mariozechner/pi-ai/oauth", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai/oauth")>(
+    "@mariozechner/pi-ai/oauth",
+  );
+  return {
+    ...actual,
+    getOAuthApiKey: () => undefined,
+    getOAuthProviders: () => [],
+  };
+});
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+describe("wrapToolMemoryDayFileWriteGuard", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-guard-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeWriteTool() {
+    return wrapToolMemoryDayFileWriteGuard(createHostWorkspaceWriteTool(tmpDir));
+  }
+
+  it("refuses memory/day-file path without overwrite", async () => {
+    const tool = makeWriteTool();
+    const result = await tool.execute("id1", {
+      path: "memory/2026-04-30.md",
+      content: "some content",
+    });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+    expect(text).toContain("Refusing to overwrite");
+    expect(text).toContain("memory/2026-04-30.md");
+    expect(text).toContain("append");
+    expect(text).toContain("overwrite:true");
+    expect((result.details as Record<string, unknown>)?.refused).toBe(true);
+  });
+
+  it("allows memory/day-file path with overwrite:true and emits warning prefix", async () => {
+    const filePath = path.join(tmpDir, "memory", "2026-04-30.md");
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "existing content", "utf-8");
+
+    const tool = makeWriteTool();
+    const result = await tool.execute("id2", {
+      path: "memory/2026-04-30.md",
+      content: "new content",
+      overwrite: true,
+    });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+    expect(text).toContain("WARNING: Overwrote memory/day-file path");
+    expect(text).toContain("Previous content lost");
+    const written = await fs.readFile(filePath, "utf-8");
+    expect(written).toBe("new content");
+  });
+
+  it("passes through non-matching paths without guard", async () => {
+    const tool = makeWriteTool();
+    for (const p of ["README.md", "src/foo.ts", "notes.txt"]) {
+      const result = await tool.execute("id3", { path: p, content: "hello" });
+      const text = result.content.find((c) => c.type === "text")?.text ?? "";
+      expect(text).not.toContain("Refusing");
+      expect(text).not.toContain("WARNING");
+    }
+  });
+
+  it("accepts custom glob patterns via options", async () => {
+    const tool = wrapToolMemoryDayFileWriteGuard(createHostWorkspaceWriteTool(tmpDir), {
+      patterns: [/^sovereign\/locked\.md$/],
+    });
+
+    const refused = await tool.execute("id4", { path: "sovereign/locked.md", content: "x" });
+    const refusedText = refused.content.find((c) => c.type === "text")?.text ?? "";
+    expect(refusedText).toContain("Refusing to overwrite");
+
+    // Default memory pattern should NOT be active when custom patterns provided
+    const allowed = await tool.execute("id5", {
+      path: "memory/2026-04-30.md",
+      content: "y",
+    });
+    const allowedText = allowed.content.find((c) => c.type === "text")?.text ?? "";
+    expect(allowedText).not.toContain("Refusing");
+  });
+});

--- a/src/agents/pi-tools.write.message-truthfulness.test.ts
+++ b/src/agents/pi-tools.write.message-truthfulness.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createHostWorkspaceWriteTool,
+  wrapToolMemoryFlushAppendOnlyWrite,
+} from "./pi-tools.read.js";
+
+vi.mock("@mariozechner/pi-ai", async () => {
+  const original =
+    await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+  return { ...original };
+});
+
+vi.mock("@mariozechner/pi-ai/oauth", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai/oauth")>(
+    "@mariozechner/pi-ai/oauth",
+  );
+  return {
+    ...actual,
+    getOAuthApiKey: () => undefined,
+    getOAuthProviders: () => [],
+  };
+});
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+describe("write tool result message truthfulness", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-truthfulness-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("regular write says 'Successfully wrote', never 'Appended'", async () => {
+    const tool = createHostWorkspaceWriteTool(tmpDir);
+    const result = await tool.execute("id1", { path: "test.md", content: "hello" });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+    expect(text).toMatch(/successfully wrote/i);
+    expect(text.toLowerCase()).not.toContain("appended");
+  });
+
+  it("flush wrapper says 'Appended content to' (correct behavior, not a bug)", async () => {
+    const base = createHostWorkspaceWriteTool(tmpDir);
+    const flushTool = wrapToolMemoryFlushAppendOnlyWrite(base, {
+      root: tmpDir,
+      relativePath: "memory/2026-04-30.md",
+    });
+    const result = await flushTool.execute("id2", {
+      path: "memory/2026-04-30.md",
+      content: "flush content",
+    });
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+    expect(text.toLowerCase()).toContain("appended");
+    expect((result.details as Record<string, unknown>)?.appendOnly).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #476 — `write` tool clobbers `memory/YYYY-MM-DD.md` paths non-deterministically.

## Root cause

Source-walk (🌻 + 🌫 pair, 2026-04-30):
- `wrapToolMemoryFlushAppendOnlyWrite` in flush context is **correct** (it appends).
- Bug lives in **unwrapped `write`** path used outside flush context: no path-shape check, direct overwrite.
- 🌫 reproduced 3× on urudyne (non-flush regular-mode, exact `memory/2026-04-30.md` match).

## Fix

1. **`wrapToolMemoryDayFileWriteGuard`** (new, src/agents/pi-tools.read.ts) — refuses overwrite of `memory/YYYY-MM-DD.md`-shape paths without explicit `overwrite:true`; suggests `append` op in error message; applied at both unwrapped and sandboxed write registration sites in `src/agents/pi-tools.ts`.
2. **`append` tool** (new, src/agents/pi-tools.read.ts) — first-class append op, callable in non-flush AND filtered-flush sessions; truthful 'Appended N bytes' message.
3. **Tests** — guard refusal, guard allow-with-overwrite, append create/extend, write-truthful-message.

## Verification

- `pnpm tsgo:core:test` ✅ green (exit 0)
- `pnpm vitest run src/agents/pi-tools.write.guard src/agents/pi-tools.append src/agents/pi-tools.write.message-truthfulness` ✅ green (exit 0)

## Lane topology note

Originally branched from `elliott/c5-repair-symlink-escape` (matched #478/#479 lane). Empirical evidence: rebasing onto `cael/325-canonical2` directly **succeeds clean with no conflicts** — the c5-repair c3-fixture commit is not load-bearing for this fix. PR base is canonical2 per frond-scribe WORKORDER; consistent with cohort lane-topology option (C) split-the-baby.

## Coding-agent

Implementation by claude-sonnet-4-6 in `/tmp/elliott-476-fix` worktree per BRIEF-476.md (committed in PR for traceability).

Refs: #476, #478, #479, openclaw-bootstrap#828