### PR TITLE
fix(agents): emit subagent announce runtime beside bundle (#822)

### DIFF
--- a/src/agents/subagent-announce.continuation.runtime.test.ts
+++ b/src/agents/subagent-announce.continuation.runtime.test.ts
@@ -52,8 +52,8 @@ function entriesOfMainGraph(): Record<string, string> {
 describe("subagent-announce continuation runtime entry (issue karmaterminal/openclaw#473)", () => {
   it("registers the continuation runtime as a tsdown bundler entry", () => {
     const entries = entriesOfMainGraph();
-    expect(entries).toHaveProperty("agents/subagent-announce.continuation.runtime");
-    expect(entries["agents/subagent-announce.continuation.runtime"]).toBe(
+    expect(entries).toHaveProperty("subagent-announce.continuation.runtime");
+    expect(entries["subagent-announce.continuation.runtime"]).toBe(
       "src/agents/subagent-announce.continuation.runtime.ts",
     );
   });
@@ -67,7 +67,7 @@ describe("subagent-announce continuation runtime entry (issue karmaterminal/open
   });
 
   it("subagent-announce lazy-imports the runtime entry by its co-located path, not the source-tree path", () => {
-    // Post-bundle, the dist emits `agents/subagent-announce.continuation.runtime.js`
+    // Post-bundle, the dist emits `subagent-announce.continuation.runtime.js`
     // adjacent to the bundled subagent-announce code. The pre-fix path
     // (`../auto-reply/continuation/delegate-dispatch.js`) does not exist
     // post-bundle and would resolve to a non-existent nested path.

--- a/src/agents/subagent-announce.continuation.runtime.ts
+++ b/src/agents/subagent-announce.continuation.runtime.ts
@@ -13,7 +13,7 @@
 // (delegate-dispatch never enters the static graph of subagent-announce)
 // while giving the bundler a stable on-disk target.
 //
-// Registered as a tsdown bundler entry: `agents/subagent-announce.continuation.runtime`
+// Registered as a tsdown bundler entry: `subagent-announce.continuation.runtime`
 // in `tsdown.config.ts`.
 export { dispatchToolDelegates } from "../auto-reply/continuation/delegate-dispatch.js";
 export { resolveContinuationRuntimeConfig } from "../auto-reply/continuation/config.js";

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -235,7 +235,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
     "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
-    "agents/subagent-announce.continuation.runtime":
+    "subagent-announce.continuation.runtime":
       "src/agents/subagent-announce.continuation.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",


### PR DESCRIPTION
## Summary

- Problem: bootstrap issue #822 reported the subagent-announce continuation drain lazy import resolving to `dist/subagent-announce.continuation.runtime.js`, while the tsdown entry emitted the runtime under `dist/agents/`.
- Why it matters: a packaged build could fail the continuation-drain runtime import with `ERR_MODULE_NOT_FOUND` even though the source/runtime entry exists.
- What changed: the tsdown entry now emits `subagent-announce.continuation.runtime` at the dist root, matching the co-located `importRuntimeModule(import.meta.url, ["./subagent-announce.continuation.runtime", ".js"])` path; the regression test/comment now assert that artifact contract.
- What did NOT change (scope boundary): no continuation drain behavior, delegate dispatch logic, or runtime exports changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/karmaterminal/openclaw-bootstrap/issues/822
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `subagent-announce.ts` lazy-loads the continuation runtime relative to its bundled dist chunk, but `tsdown.config.ts` registered the runtime entry as `agents/subagent-announce.continuation.runtime`, producing `dist/agents/subagent-announce.continuation.runtime.js` instead of the root-level file the lazy import resolves.
- Missing detection / guardrail: the existing regression test asserted that the runtime was registered, but it asserted the wrong nested entry key and therefore did not catch the packaged artifact mismatch.
- Contributing context (if known): the runtime module itself and its exports were present; only the emitted artifact location was wrong.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/subagent-announce.continuation.runtime.test.ts`
- Scenario the test should lock in: the tsdown entry key must produce `dist/subagent-announce.continuation.runtime.js`, matching the lazy import path in `subagent-announce.ts`.
- Why this is the smallest reliable guardrail: it locks the build-entry contract without booting a full agent/session runtime.
- Existing test that already covers this (if any): the existing runtime-entry test now asserts the correct flat artifact contract.
- If no new test is added, why not: updated the existing focused regression test instead of adding duplicate coverage.

## User-visible / Behavior Changes

None beyond fixing the packaged lazy-import path.

## Diagram (if applicable)

```text
Before:
bundled subagent-announce chunk -> ./subagent-announce.continuation.runtime.js -> missing
built artifact -> dist/agents/subagent-announce.continuation.runtime.js

After:
bundled subagent-announce chunk -> ./subagent-announce.continuation.runtime.js -> dist/subagent-announce.continuation.runtime.js
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): subagent continuation runtime packaging
- Relevant config (redacted): N/A

### Steps

1. Build the canonical branch packaging graph.
2. Inspect the emitted continuation runtime artifact path.
3. Compare that artifact path to the runtime import in the bundled `subagent-announce` chunk.

### Expected

- `dist/subagent-announce.continuation.runtime.js` exists and is importable.
- `dist/agents/subagent-announce.continuation.runtime.js` is not required for this lazy import.

### Actual

- Before this PR, the build emitted `dist/agents/subagent-announce.continuation.runtime.js`, while the built subagent-announce chunk imported `./subagent-announce.continuation.runtime.js` from the dist root.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Pre-fix build evidence: `pnpm build` emitted `dist/agents/subagent-announce.continuation.runtime.js` while the bundled announce chunk contained `importRuntimeModule(import.meta.url, ["./subagent-announce.continuation.runtime", ".js"])`.

Verified after the fix:

- `pnpm test src/agents/subagent-announce.continuation.runtime.test.ts`
- `pnpm tsgo`
- `pnpm check`
- `pnpm build`
- `test -f dist/subagent-announce.continuation.runtime.js`
- `test ! -e dist/agents/subagent-announce.continuation.runtime.js`
- `node -e "import('./dist/subagent-announce.continuation.runtime.js')..."`
- `pnpm test src/agents/openclaw-tools.continuation-registration.test.ts src/agents/subagent-registry.persistence.test.ts`

Note: `pnpm check:changed` expanded to all lanes because of canonical-branch baseline `.agents` surfaces and failed on unrelated agents/gateway timeout failures; the reported agents files passed in isolation after the failure.

## Human Verification (required)

- Verified scenarios: before/after dist artifact location, runtime module dynamic importability, tsdown entry contract, exported runtime function surface.
- Edge cases checked: stale nested `dist/agents/subagent-announce.continuation.runtime.js` is not present after a clean build.
- What you did **not** verify: a live continuation drain through a packaged gateway process.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: changing a tsdown entry path could strand an external consumer of the nested artifact.
  - Mitigation: this is an internal runtime boundary whose sole production lazy import resolves the flat root-level path; the PR aligns build output to that runtime contract.
