### PR TITLE
fix(agents): correlate compaction attribution events (#825)

### DIFF
--- a/src/agents/compaction-attribution.ts
+++ b/src/agents/compaction-attribution.ts
@@ -1,0 +1,29 @@
+import { generateSecureToken } from "../infra/secure-random.js";
+
+export type RequestCompactionInvocation = {
+  sessionKey: string;
+  sessionId: string;
+  runId?: string;
+  diagId: string;
+  trigger: "volitional";
+  reason: string;
+  contextUsage: number;
+  requestedAtMs: number;
+};
+
+export type CompactionCounterAttribution = {
+  runId?: string;
+  trigger: string;
+  outcome: string;
+};
+
+export function createCompactionDiagId(now = Date.now()): string {
+  return `cmp-${now.toString(36)}-${generateSecureToken(4)}`;
+}
+
+export function normalizeCompactionTrigger(value: unknown): string {
+  if (value === "threshold") {
+    return "budget";
+  }
+  return typeof value === "string" && value.trim() ? value.trim() : "unknown";
+}

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -28,7 +28,10 @@ import { createMessageTool } from "./tools/message-tool.js";
 import { createMusicGenerateTool } from "./tools/music-generate-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
-import { createRequestCompactionTool } from "./tools/request-compaction-tool.js";
+import {
+  createRequestCompactionTool,
+  type RequestCompactionToolOpts,
+} from "./tools/request-compaction-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
@@ -104,6 +107,8 @@ export function createOpenClawTools(
     senderIsOwner?: boolean;
     /** Ephemeral session UUID — regenerated on /new and /reset. */
     sessionId?: string;
+    /** Stable run identifier for this agent invocation. */
+    runId?: string;
     /**
      * Workspace directory to pass to spawned subagents for inheritance.
      * Defaults to workspaceDir. Use this to pass the actual agent workspace when the
@@ -125,7 +130,7 @@ export function createOpenClawTools(
     requestCompactionOpts?: {
       sessionId?: string;
       getContextUsage: () => number | null;
-      triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+      triggerCompaction: RequestCompactionToolOpts["triggerCompaction"];
     };
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
@@ -358,6 +363,7 @@ export function createOpenClawTools(
           createRequestCompactionTool({
             agentSessionKey: options?.agentSessionKey,
             sessionId: options?.sessionId,
+            runId: options?.runId,
             ...options.requestCompactionOpts,
           }),
         ]

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -20,7 +20,6 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
-import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
@@ -48,6 +47,7 @@ import {
   resolveChannelMessageToolHints,
   resolveChannelReactionGuidance,
 } from "../channel-tools.js";
+import { createCompactionDiagId } from "../compaction-attribution.js";
 import {
   hasMeaningfulConversationContent,
   isRealConversationMessage,
@@ -155,10 +155,6 @@ function hasRealConversationContent(
   index: number,
 ): boolean {
   return isRealConversationMessage(msg, messages, index);
-}
-
-function createCompactionDiagId(): string {
-  return `cmp-${Date.now().toString(36)}-${generateSecureToken(4)}`;
 }
 
 function prepareCompactionSessionAgent(params: {
@@ -477,18 +473,19 @@ export async function compactEmbeddedPiSessionDirect(
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const resolvedMessageProvider = params.messageChannel ?? params.messageProvider;
     const contextInjectionMode = resolveContextInjectionMode(params.config);
-    const { contextFiles } = contextInjectionMode === "never"
-      ? { contextFiles: [] }
-      : await resolveBootstrapContextForRun({
-          workspaceDir: effectiveWorkspace,
-          config: params.config,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          warn: makeBootstrapWarn({
-            sessionLabel,
-            warn: (message) => log.warn(message),
-          }),
-        });
+    const { contextFiles } =
+      contextInjectionMode === "never"
+        ? { contextFiles: [] }
+        : await resolveBootstrapContextForRun({
+            workspaceDir: effectiveWorkspace,
+            config: params.config,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            warn: makeBootstrapWarn({
+              sessionLabel,
+              warn: (message) => log.warn(message),
+            }),
+          });
     // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
     // threshold uses the effective limit, not the native context window.
     const runtimeModelWithContext = runtimeModel as ProviderRuntimeModel;

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -15,6 +15,7 @@ import type {
   ToolResultFormat,
 } from "../../pi-embedded-subscribe.shared-types.js";
 import type { SkillSnapshot } from "../../skills.js";
+import type { RequestCompactionToolOpts } from "../../tools/request-compaction-tool.js";
 export type { ClientToolDefinition } from "../../command/shared-types.js";
 
 export type EmbeddedRunTrigger = "cron" | "heartbeat" | "manual" | "memory" | "overflow" | "user";
@@ -165,6 +166,6 @@ export type RunEmbeddedPiAgentParams = {
   requestCompactionOpts?: {
     sessionId?: string;
     getContextUsage: () => number | null;
-    triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+    triggerCompaction: RequestCompactionToolOpts["triggerCompaction"];
   };
 };

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.runtime.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.runtime.ts
@@ -1,4 +1,6 @@
 import { resolveStorePath, updateSessionStoreEntry } from "../config/sessions.js";
+import type { CompactionCounterAttribution } from "./compaction-attribution.js";
+import { log } from "./pi-embedded-runner/logger.js";
 
 export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   sessionKey?: string;
@@ -6,18 +8,30 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   configStore?: string;
   observedCompactionCount: number;
   now?: number;
+  attribution?: CompactionCounterAttribution;
 }): Promise<number | undefined> {
-  const { sessionKey, agentId, configStore, observedCompactionCount, now = Date.now() } = params;
+  const {
+    sessionKey,
+    agentId,
+    configStore,
+    observedCompactionCount,
+    now = Date.now(),
+    attribution,
+  } = params;
   if (!sessionKey || observedCompactionCount <= 0) {
     return undefined;
   }
   const storePath = resolveStorePath(configStore, { agentId });
+  let previousCompactionCount: number | undefined;
+  let nextCompactionCount: number | undefined;
   const nextEntry = await updateSessionStoreEntry({
     storePath,
     sessionKey,
     update: async (entry) => {
       const currentCount = Math.max(0, entry.compactionCount ?? 0);
       const nextCount = Math.max(currentCount, observedCompactionCount);
+      previousCompactionCount = currentCount;
+      nextCompactionCount = nextCount;
       if (nextCount === currentCount) {
         return null;
       }
@@ -27,5 +41,15 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
       };
     },
   });
+  if (attribution && previousCompactionCount !== undefined && nextCompactionCount !== undefined) {
+    const delta = nextCompactionCount - previousCompactionCount;
+    const level = delta > 0 ? "info" : "debug";
+    log[level](
+      `[compaction-counter] session=${sessionKey} runId=${attribution.runId ?? "unknown"} ` +
+        `trigger=${attribution.trigger} outcome=${attribution.outcome} ` +
+        `storeCount.before=${previousCompactionCount} storeCount.after=${nextCompactionCount} ` +
+        `storeCount.delta=${delta}`,
+    );
+  }
   return nextEntry?.compactionCount;
 }

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
@@ -23,6 +23,7 @@ function createCompactionContext(params: {
   sessionKey: string;
   agentId?: string;
   initialCount: number;
+  onAgentEvent?: EmbeddedPiSubscribeContext["params"]["onAgentEvent"];
 }): EmbeddedPiSubscribeContext {
   let compactionCount = params.initialCount;
   return {
@@ -33,7 +34,7 @@ function createCompactionContext(params: {
       sessionKey: params.sessionKey,
       sessionId: "session-1",
       agentId: params.agentId ?? "test-agent",
-      onAgentEvent: undefined,
+      onAgentEvent: params.onAgentEvent,
     },
     state: {
       compactionInFlight: true,
@@ -131,6 +132,7 @@ describe("handleCompactionEnd", () => {
 
     handleCompactionEnd(ctx, {
       type: "compaction_end",
+      reason: "threshold",
       result: { kept: 12 },
       willRetry: false,
       aborted: false,
@@ -143,5 +145,57 @@ describe("handleCompactionEnd", () => {
     });
 
     expect(await readCompactionCount(storePath, sessionKey)).toBe(2);
+    expect(ctx.log.debug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[compaction-attribution] end runId=run-test sessionKey=main trigger=budget outcome=compacted willRetry=false compactionCount.before=1 compactionCount.after=2 compactionCount.delta=1",
+      ),
+    );
+  });
+
+  it("emits terminal compaction attribution data for count deltas", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-attribution-"));
+    const storePath = path.join(tmp, "sessions.json");
+    await seedSessionStore({
+      storePath,
+      sessionKey: "main",
+      compactionCount: 4,
+    });
+    const events: Array<{ stream: string; data: Record<string, unknown> }> = [];
+    const ctx = createCompactionContext({
+      storePath,
+      sessionKey: "main",
+      initialCount: 4,
+      onAgentEvent: (event) => {
+        events.push(event as { stream: string; data: Record<string, unknown> });
+      },
+    });
+
+    handleCompactionEnd(ctx, {
+      type: "compaction_end",
+      reason: "overflow",
+      result: { kept: 12 },
+      willRetry: true,
+      aborted: false,
+    } as never);
+
+    await waitForCompactionCount({
+      storePath,
+      sessionKey: "main",
+      expected: 5,
+    });
+
+    expect(events).toContainEqual({
+      stream: "compaction",
+      data: {
+        phase: "end",
+        willRetry: true,
+        completed: true,
+        trigger: "overflow",
+        sessionKey: "main",
+        compactionCountBefore: 4,
+        compactionCountAfter: 5,
+        compactionCountDelta: 1,
+      },
+    });
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -1,22 +1,30 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import {
+  normalizeCompactionTrigger,
+  type CompactionCounterAttribution,
+} from "./compaction-attribution.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
-export function handleCompactionStart(ctx: EmbeddedPiSubscribeContext) {
+export function handleCompactionStart(
+  ctx: EmbeddedPiSubscribeContext,
+  evt?: AgentEvent & { reason?: unknown },
+) {
+  const trigger = normalizeCompactionTrigger(evt?.reason);
   ctx.state.compactionInFlight = true;
   ctx.state.livenessState = "paused";
   ctx.ensureCompactionPromise();
-  ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
+  ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId} trigger=${trigger}`);
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "compaction",
-    data: { phase: "start" },
+    data: { phase: "start", trigger, sessionKey: ctx.params.sessionKey },
   });
   void ctx.params.onAgentEvent?.({
     stream: "compaction",
-    data: { phase: "start" },
+    data: { phase: "start", trigger, sessionKey: ctx.params.sessionKey },
   });
 
   // Run before_compaction plugin hook (fire-and-forget)
@@ -41,9 +49,16 @@ export function handleCompactionStart(ctx: EmbeddedPiSubscribeContext) {
 
 export function handleCompactionEnd(
   ctx: EmbeddedPiSubscribeContext,
-  evt: AgentEvent & { willRetry?: unknown; result?: unknown; aborted?: unknown },
+  evt: AgentEvent & {
+    reason?: unknown;
+    willRetry?: unknown;
+    result?: unknown;
+    aborted?: unknown;
+    errorMessage?: unknown;
+  },
 ) {
   ctx.state.compactionInFlight = false;
+  const trigger = normalizeCompactionTrigger(evt.reason);
   const willRetry = Boolean(evt.willRetry);
   // Increment counter whenever compaction actually produced a result,
   // regardless of willRetry.  Overflow-triggered compaction sets willRetry=true
@@ -51,18 +66,34 @@ export function handleCompactionEnd(
   // and context was trimmed — the counter must reflect that.  (#38905)
   const hasResult = evt.result != null;
   const wasAborted = Boolean(evt.aborted);
+  const compactionCountBefore = ctx.getCompactionCount();
+  let compactionCountAfter = compactionCountBefore;
   if (hasResult && !wasAborted) {
     ctx.incrementCompactionCount();
-    const observedCompactionCount = ctx.getCompactionCount();
+    compactionCountAfter = ctx.getCompactionCount();
     void reconcileSessionStoreCompactionCountAfterSuccess({
       sessionKey: ctx.params.sessionKey,
       agentId: ctx.params.agentId,
       configStore: ctx.params.config?.session?.store,
-      observedCompactionCount,
+      observedCompactionCount: compactionCountAfter,
+      attribution: {
+        runId: ctx.params.runId,
+        trigger,
+        outcome: "compacted",
+      },
     }).catch((err) => {
       ctx.log.warn(`late compaction count reconcile failed: ${String(err)}`);
     });
   }
+  const completed = hasResult && !wasAborted;
+  const outcome = completed ? "compacted" : wasAborted ? "aborted" : "skipped";
+  const compactionCountDelta = compactionCountAfter - compactionCountBefore;
+  ctx.log.debug(
+    `[compaction-attribution] end runId=${ctx.params.runId} sessionKey=${ctx.params.sessionKey ?? ctx.params.sessionId} ` +
+      `trigger=${trigger} outcome=${outcome} willRetry=${willRetry} ` +
+      `compactionCount.before=${compactionCountBefore} compactionCount.after=${compactionCountAfter} ` +
+      `compactionCount.delta=${compactionCountDelta}`,
+  );
   if (willRetry) {
     ctx.noteCompactionRetry();
     ctx.resetForCompactionRetry();
@@ -77,11 +108,29 @@ export function handleCompactionEnd(
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    data: {
+      phase: "end",
+      willRetry,
+      completed,
+      trigger,
+      sessionKey: ctx.params.sessionKey,
+      compactionCountBefore,
+      compactionCountAfter,
+      compactionCountDelta,
+    },
   });
   void ctx.params.onAgentEvent?.({
     stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    data: {
+      phase: "end",
+      willRetry,
+      completed,
+      trigger,
+      sessionKey: ctx.params.sessionKey,
+      compactionCountBefore,
+      compactionCountAfter,
+      compactionCountDelta,
+    },
   });
 
   // Run after_compaction plugin hook (fire-and-forget)
@@ -110,6 +159,7 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   configStore?: string;
   observedCompactionCount: number;
   now?: number;
+  attribution?: CompactionCounterAttribution;
 }): Promise<number | undefined> {
   const { reconcileSessionStoreCompactionCountAfterSuccess: reconcile } =
     await import("./pi-embedded-subscribe.handlers.compaction.runtime.js");

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -115,7 +115,7 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
         return;
       case "compaction_start":
         scheduleEvent(evt, () => {
-          handleCompactionStart(ctx);
+          handleCompactionStart(ctx, evt as never);
         });
         return;
       case "compaction_end":

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -68,6 +68,7 @@ import {
   mergeAlsoAllowPolicy,
   resolveToolProfilePolicy,
 } from "./tool-policy.js";
+import type { RequestCompactionToolOpts } from "./tools/request-compaction-tool.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 function isOpenAIProvider(provider?: string) {
@@ -352,7 +353,7 @@ export function createOpenClawCodingTools(options?: {
   requestCompactionOpts?: {
     sessionId?: string;
     getContextUsage: () => number | null;
-    triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+    triggerCompaction: RequestCompactionToolOpts["triggerCompaction"];
   };
 }): AnyAgentTool[] {
   const execToolName = "exec";
@@ -642,6 +643,7 @@ export function createOpenClawCodingTools(options?: {
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
       sessionId: options?.sessionId,
+      runId: options?.runId,
       onYield: options?.onYield,
       allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
       continueWorkOpts: options?.continueWorkOpts,

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -2,6 +2,10 @@ import { Type } from "typebox";
 import { createExpiringMapCache } from "../../config/cache-utils.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
+  createCompactionDiagId,
+  type RequestCompactionInvocation,
+} from "../compaction-attribution.js";
+import {
   classifyCompactionReason,
   isCompactionSkipCode,
 } from "../pi-embedded-runner/compact-reasons.js";
@@ -69,6 +73,8 @@ export type RequestCompactionToolOpts = {
   agentSessionKey?: string;
   /** Session id (the Pi session UUID). */
   sessionId?: string;
+  /** Stable run identifier for this agent invocation. */
+  runId?: string;
   /**
    * Returns the current context usage as a fraction (0-1), or null when unknown
    * (e.g. inventory-only path used by /status surface reflection).
@@ -80,7 +86,9 @@ export type RequestCompactionToolOpts = {
    * import the heavy compaction module directly. The caller provides a
    * closure over `compactEmbeddedPiSession` with all required session params.
    */
-  triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+  triggerCompaction: (
+    request: RequestCompactionInvocation,
+  ) => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
 };
 
 // ---------------------------------------------------------------------------
@@ -170,6 +178,7 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
 
       // ----- Guard 2: Rate limit -----
       const now = Date.now();
+      const diagId = createCompactionDiagId(now);
       const guard = sessionGuardState.get(sessionKey);
       if (guard && now - guard.lastRequestMs < RATE_LIMIT_MS) {
         const remainingMs = RATE_LIMIT_MS - (now - guard.lastRequestMs);
@@ -189,7 +198,8 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
       // No generation guard (removed 2026-04-15 RFC): compaction is not blocked
       // by unrelated channel activity.
       log.info(
-        `[request_compaction:enqueuing] session=${sessionKey} usage=${(contextUsage * 100).toFixed(1)}% reason=${reason}`,
+        `[request_compaction:enqueuing] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+          `diagId=${diagId} trigger=volitional usage=${(contextUsage * 100).toFixed(1)}% reason=${reason}`,
       );
 
       // Update rate-limit state BEFORE firing so a second call in the same
@@ -202,11 +212,25 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
       // agent turn releases the session lane. We do NOT await — the tool
       // returns immediately so the agent can finish its response.
       pendingCompactionSessions.add(sessionKey);
+      const request: RequestCompactionInvocation = {
+        sessionKey,
+        sessionId: opts.sessionId,
+        ...(opts.runId ? { runId: opts.runId } : {}),
+        diagId,
+        trigger: "volitional",
+        reason,
+        contextUsage,
+        requestedAtMs: now,
+      };
       void opts
-        .triggerCompaction()
+        .triggerCompaction(request)
         .then(
           (result) => {
             if (result.ok && result.compacted) {
+              log.info(
+                `[request_compaction:resolved-success] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                  `diagId=${diagId} trigger=volitional outcome=compacted`,
+              );
               incrementVolitionalCompactionCount(sessionKey);
               return;
             }
@@ -214,19 +238,22 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
             const reason = result.reason ?? "";
             if (result.ok && isCompactionSkipCode(code)) {
               log.info(
-                `[request_compaction:resolved-skip] session=${sessionKey} code=${code} reason=${reason}`,
+                `[request_compaction:resolved-skip] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                  `diagId=${diagId} trigger=volitional outcome=skipped code=${code} reason=${reason}`,
               );
               return;
             }
             log.warn(
-              `[request_compaction:resolved-failure] session=${sessionKey} code=${code} ok=${result.ok} compacted=${result.compacted} reason=${reason}`,
+              `[request_compaction:resolved-failure] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                `diagId=${diagId} trigger=volitional outcome=failed code=${code} ok=${result.ok} compacted=${result.compacted} reason=${reason}`,
             );
           },
           (err: unknown) => {
             const message = err instanceof Error ? err.message : String(err);
             const code = classifyCompactionReason(message);
             log.error(
-              `[request_compaction:background-error] session=${sessionKey} code=${code} error=${message}`,
+              `[request_compaction:background-error] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                `diagId=${diagId} trigger=volitional outcome=failed code=${code} error=${message}`,
             );
           },
         )
@@ -236,6 +263,8 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
 
       return jsonResult({
         status: "compaction_requested",
+        compactionRequestId: diagId,
+        trigger: "volitional",
         contextUsage: Math.round(contextUsage * 100),
         reason,
         note:

--- a/src/agents/tools/request-compaction-tool.volitional-threading.test.ts
+++ b/src/agents/tools/request-compaction-tool.volitional-threading.test.ts
@@ -103,7 +103,10 @@ describe("volitional compaction counter truthfulness (#639)", () => {
   });
 
   it("increments counter on {ok:true, compacted:true}", async () => {
-    const triggerCompaction = vi.fn(async () => ({ ok: true, compacted: true }));
+    const triggerCompaction = vi.fn<RequestCompactionToolOpts["triggerCompaction"]>(async () => ({
+      ok: true,
+      compacted: true,
+    }));
     const countBefore = getVolitionalCompactionCount(SESSION_KEY);
 
     await executeTool(buildOpts({ triggerCompaction }));
@@ -112,6 +115,51 @@ describe("volitional compaction counter truthfulness (#639)", () => {
     const countAfter = getVolitionalCompactionCount(SESSION_KEY);
     expect(countAfter).toBe(countBefore + 1);
     expect(triggerCompaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("threads run and diag attribution from enqueue to background compaction", async () => {
+    const triggerCompaction = vi.fn<RequestCompactionToolOpts["triggerCompaction"]>(async () => ({
+      ok: true,
+      compacted: true,
+    }));
+
+    const result = await executeTool(
+      buildOpts({
+        runId: "run-volitional-1",
+        triggerCompaction,
+      }),
+    );
+    await drainMicrotasks();
+
+    const request = triggerCompaction.mock.calls[0]?.[0];
+    expect(request).toBeDefined();
+    if (!request) {
+      throw new Error("expected request_compaction attribution payload");
+    }
+    expect(request).toMatchObject({
+      sessionKey: SESSION_KEY,
+      sessionId: SESSION_ID,
+      runId: "run-volitional-1",
+      trigger: "volitional",
+      reason: TURN_REASON,
+      contextUsage: 0.85,
+    });
+    expect(request.diagId).toMatch(/^cmp-/u);
+    expect(result).toMatchObject({
+      status: "compaction_requested",
+      compactionRequestId: request.diagId,
+      trigger: "volitional",
+    });
+    expect(logMocks.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `[request_compaction:enqueuing] session=${SESSION_KEY} runId=run-volitional-1 diagId=${request.diagId} trigger=volitional`,
+      ),
+    );
+    expect(logMocks.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `[request_compaction:resolved-success] session=${SESSION_KEY} runId=run-volitional-1 diagId=${request.diagId} trigger=volitional outcome=compacted`,
+      ),
+    );
   });
 
   it("does NOT increment counter on {ok:true, compacted:false, reason:'nothing to compact'}", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1199,7 +1199,7 @@ export async function runAgentTurnWithFallback(params: {
                             200_000;
                           return contextWindow > 0 ? totalTokens / contextWindow : 0;
                         },
-                        triggerCompaction: async () => {
+                        triggerCompaction: async (request) => {
                           try {
                             const { compactEmbeddedPiSession } =
                               await import("../../agents/pi-embedded-runner/compact.queued.js");
@@ -1222,6 +1222,7 @@ export async function runAgentTurnWithFallback(params: {
                                 : undefined;
                             const result = await compactEmbeddedPiSession({
                               sessionId: params.followupRun.run.sessionId ?? "",
+                              runId: request.runId ?? runId,
                               sessionKey: params.sessionKey,
                               sessionFile: params.followupRun.run.sessionFile ?? "",
                               workspaceDir: params.followupRun.run.workspaceDir ?? process.cwd(),
@@ -1229,6 +1230,8 @@ export async function runAgentTurnWithFallback(params: {
                               provider,
                               model,
                               authProfileId: compactionAuthProfileId,
+                              trigger: request.trigger,
+                              diagId: request.diagId,
                             });
                             // bug karmaterminal/openclaw#639: honor real result instead of unconditionally claiming
                             // success — otherwise volitional-compaction telemetry lies and the

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -350,7 +350,7 @@ export function createFollowupRunner(params: {
                           // from sessionTokenInfo. Refs karmaterminal/openclaw#222.
                           return null;
                         },
-                        triggerCompaction: async () => {
+                        triggerCompaction: async (request) => {
                           try {
                             const { compactEmbeddedPiSession } =
                               await import("../../agents/pi-embedded-runner/compact.queued.js");
@@ -370,6 +370,7 @@ export function createFollowupRunner(params: {
                               provider === run.provider ? run.authProfileId : undefined;
                             const result = await compactEmbeddedPiSession({
                               sessionId: run.sessionId ?? "",
+                              runId: request.runId ?? runId,
                               sessionKey: run.sessionKey,
                               sessionFile: run.sessionFile ?? "",
                               workspaceDir: run.workspaceDir ?? process.cwd(),
@@ -377,6 +378,8 @@ export function createFollowupRunner(params: {
                               provider,
                               model,
                               authProfileId: compactionAuthProfileId,
+                              trigger: request.trigger,
+                              diagId: request.diagId,
                             });
                             // bug karmaterminal/openclaw#639: honor real result instead of unconditionally claiming
                             // success — otherwise volitional-compaction telemetry lies and the


### PR DESCRIPTION
## Summary

- Problem: compaction observability emitted independent `request_compaction`, `[compaction-diag]`, and session-store counter signals without enough shared attribution to join trigger, outcome, and count deltas.
- Why it matters: SWIM/cohort debugging could see `compactionCount` move without knowing which terminal compaction event caused it, or whether a volitional enqueue reached the matching runtime compaction attempt.
- What changed: `request_compaction` now creates a shared `diagId`, logs `runId`/`diagId`/`trigger=volitional` at enqueue and terminal resolution, and threads that attribution into `compactEmbeddedPiSession`; embedded compaction events now expose/log normalized trigger plus count before/after/delta; session-store count reconcile logs the same run/trigger/outcome attribution.
- What did NOT change (scope boundary): no compaction scheduling, threshold, provider selection, delegate dispatch, or counter increment semantics changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/karmaterminal/openclaw-bootstrap/issues/825
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `request_compaction` logged only session/usage/reason, the runtime compaction diagnostic owned its own `diagId`, and the session-store compaction count reconcile updated state without logging a joinable terminal attribution record.
- Missing detection / guardrail: the existing tests proved counter truthfulness and runtime request behavior independently, but did not assert that enqueue attribution is threaded into execution or that terminal compaction events include count deltas.
- Contributing context (if known): upstream pi-coding-agent compaction events carry a `reason` but no OpenClaw correlation id, so OpenClaw must add run/trigger/count attribution at the subscribe boundary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tools/request-compaction-tool.volitional-threading.test.ts` and `src/agents/pi-embedded-subscribe.handlers.compaction.test.ts`
- Scenario the test should lock in: volitional compaction request attribution reaches `triggerCompaction`, result details, and enqueue/terminal logs; compaction-end handling emits trigger/count-before/count-after/count-delta attribution.
- Why this is the smallest reliable guardrail: it covers the OpenClaw-owned boundaries without running a full embedded agent session.
- Existing test that already covers this (if any): existing counter truthfulness and session-store reconcile tests were extended with attribution assertions.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None for ordinary users. Diagnostic logs/events now include correlation fields (`runId`, `diagId`, `trigger`, and compaction count deltas) for compaction attribution.

## Diagram (if applicable)

```text
Before:
request_compaction enqueue -> runtime compaction diag -> sessions.json count
(no shared join key/count delta)

After:
request_compaction enqueue(runId, diagId, trigger)
  -> runtime compaction diag(runId, diagId, trigger, outcome)
  -> compaction terminal event/store reconcile(runId, trigger, outcome, count delta)
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): embedded runner compaction diagnostics
- Relevant config (redacted): N/A

### Steps

1. Trigger a volitional `request_compaction` with continuation enabled and a live run id.
2. Observe enqueue and terminal `request_compaction` logs.
3. Observe embedded compaction terminal event/session-store count reconcile when a compaction succeeds.

### Expected

- Volitional enqueue, runtime compaction, and terminal result share `runId` and `diagId` where applicable.
- Terminal compaction events/reconcile logs include trigger, outcome, and compaction count before/after/delta.

### Actual

- Before this PR, enqueue had no trigger/run/diag id, runtime diag ids were not threaded from the enqueue, and session-store count updates had no joinable terminal attribution.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verified after the fix:

- `pnpm test src/agents/tools/request-compaction-tool.volitional-threading.test.ts src/agents/tools/request-compaction-tool.test.ts src/agents/pi-embedded-subscribe.handlers.compaction.test.ts`
- `pnpm test src/agents/openclaw-tools.continuation-registration.test.ts src/agents/tools-effective-inventory.test.ts src/auto-reply/reply/commands-system-prompt.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm lint`

Gate notes:

- `pnpm check` / `pnpm tsgo:extensions` fail in untouched extension baselines: `extensions/codex` duplicate `@mariozechner/pi-agent-core` type identities and `extensions/qqbot` zod v3/v4 mismatch.
- `pnpm check:test-types` passes core test types, then fails in the same untouched extension type baseline.
- `pnpm check:changed` expands to all lanes from canonical-branch baseline surfaces and stops at the same extension type failures.
- `pnpm format:check` reports broad pre-existing formatting drift outside this PR; `scripts/committer` formatted the staged PR files.

## Human Verification (required)

- Verified scenarios: request_compaction attribution payload/logs, compaction-end terminal event data, session-store count reconcile path, tool registration/inventory wiring.
- Edge cases checked: threshold reason normalizes to `budget`; `willRetry=true` successful overflow compaction still records a count delta.
- What you did **not** verify: a live SWIM channel run with real provider compaction.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: new diagnostic fields could be interpreted as product API by downstream consumers.
  - Mitigation: fields are additive and confined to diagnostic compaction stream/log payloads; no behavior changes depend on them.
