### PR TITLE
fix: surface blocked agent liveness to channels

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -723,6 +723,62 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("success");
   });
 
+  it("surfaces blocked lifecycle liveness through the channel block surface", async () => {
+    const onBlockReply = vi.fn(async () => {});
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          livenessState: "blocked",
+          error: "compaction failed",
+        },
+      });
+      return {
+        payloads: [{ text: "terminal compaction failure" }],
+        meta: { livenessState: "blocked" },
+      };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        opts: { onBlockReply } satisfies GetReplyOptions,
+      }),
+    );
+
+    expect(result.kind).toBe("success");
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("Agent liveness: blocked"),
+        isError: true,
+        replyToCurrent: true,
+      }),
+    );
+    if (result.kind === "success") {
+      expect(result.runResult.payloads?.[0]?.text).toBe("terminal compaction failure");
+    }
+  });
+
+  it("injects blocked liveness into final payloads when no block surface is available", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "terminal compaction failure" }],
+      meta: { livenessState: "blocked" },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads?.[0]).toMatchObject({
+        text: expect.stringContaining("Agent liveness: blocked"),
+        isError: true,
+      });
+      expect(result.runResult.payloads?.[1]?.text).toBe("terminal compaction failure");
+    }
+  });
+
   it("classifies final GPT-5 terminal-empty results instead of silently succeeding", async () => {
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       const result = { payloads: [], meta: {} };

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -114,6 +114,8 @@ const GPT_CHAT_BREVITY_ACK_MAX_CHARS = 420;
 const GPT_CHAT_BREVITY_ACK_MAX_SENTENCES = 3;
 const GPT_CHAT_BREVITY_SOFT_MAX_CHARS = 900;
 const GPT_CHAT_BREVITY_SOFT_MAX_SENTENCES = 6;
+const BLOCKED_LIVENESS_NOTICE_TEXT =
+  "⚠️ Agent liveness: blocked. The run cannot make progress; try again or start a fresh conversation if this repeats.";
 
 function readApprovalScopeValue(value: unknown): "turn" | "session" | undefined {
   return value === "turn" || value === "session" ? value : undefined;
@@ -668,6 +670,24 @@ export async function runAgentTurnWithFallback(params: {
   const currentMessageId = params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid;
   const shouldNotifyUserAboutCompaction =
     runtimeConfig?.agents?.defaults?.compaction?.notifyUser === true;
+  let didSurfaceBlockedLivenessState = false;
+  const surfaceBlockedLivenessState = async () => {
+    if (didSurfaceBlockedLivenessState || !params.opts?.onBlockReply) {
+      return;
+    }
+    const noticePayload = params.applyReplyToMode({
+      text: BLOCKED_LIVENESS_NOTICE_TEXT,
+      replyToId: currentMessageId,
+      replyToCurrent: true,
+      isError: true,
+    });
+    try {
+      await params.opts.onBlockReply(noticePayload);
+      didSurfaceBlockedLivenessState = true;
+    } catch (err) {
+      logVerbose(`blocked liveness notice delivery failed (non-fatal): ${String(err)}`);
+    }
+  };
   const sendCompactionNotice = async (phase: "start" | "end" | "incomplete") => {
     if (!params.opts?.onBlockReply) {
       return;
@@ -1292,6 +1312,12 @@ export async function runAgentTurnWithFallback(params: {
                   if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
                     notifyAgentRunStart();
                   }
+                  if (
+                    evt.stream === "lifecycle" &&
+                    readStringValue(evt.data.livenessState) === "blocked"
+                  ) {
+                    await surfaceBlockedLivenessState();
+                  }
                   // Trigger typing when tools start executing.
                   // Must await to ensure typing indicator starts before tool summaries are emitted.
                   if (evt.stream === "tool") {
@@ -1791,6 +1817,16 @@ export async function runAgentTurnWithFallback(params: {
   // overflow errors were returned as embedded error payloads.
   const finalEmbeddedError = runResult?.meta?.error;
   const hasPayloadText = runResult?.payloads?.some((p) => normalizeOptionalString(p.text));
+  if (runResult?.meta?.livenessState === "blocked" && !didSurfaceBlockedLivenessState) {
+    runResult.payloads = [
+      {
+        text: BLOCKED_LIVENESS_NOTICE_TEXT,
+        isError: true,
+      },
+      ...(runResult.payloads ?? []),
+    ];
+    didSurfaceBlockedLivenessState = true;
+  }
   if (finalEmbeddedError && !hasPayloadText) {
     const errorMsg = finalEmbeddedError.message ?? "";
     if (isContextOverflowError(errorMsg)) {


### PR DESCRIPTION
## Summary

Fixes #475 by making embedded runner `livenessState: "blocked"` visible at the channel boundary instead of dropping it after lifecycle forwarding.

## Root cause

The embedded runner and lifecycle handler already produce and forward `livenessState` values, including blocked states for compaction-failure/terminal failure paths. `runAgentTurnWithFallback` consumed lifecycle `phase`, but never read `evt.data.livenessState`, so channel-facing surfaces saw only normal text/final payload behavior and had no explicit blocked marker.

## Fix

- Add a channel-visible blocked liveness notice when lifecycle events include `livenessState: "blocked"`.
- If no block-reply surface is available, inject the same blocked marker into final payloads when `runResult.meta.livenessState === "blocked"`.
- Deduplicate so channels that receive the lifecycle notice do not also get a duplicated final marker.
- Add focused regressions for lifecycle-event surfacing and final-payload fallback surfacing.

## Validation

- `pnpm test src/auto-reply/reply/agent-runner-execution.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm lint`

`pnpm check:changed` expands to all lanes from canonical baseline unknown `.agents` surfaces and fails in existing extension typecheck baselines (`extensions/codex` duplicate `@mariozechner/pi-agent-core` identities and `extensions/qqbot` zod v3/v4 mismatch), unrelated to this two-file runner/channel surface fix.
