### PR TITLE
fix: preserve post-compaction delegate arm age

### DIFF
--- a/src/auto-reply/continuation-delegate-store.post-compaction-substrate.test.ts
+++ b/src/auto-reply/continuation-delegate-store.post-compaction-substrate.test.ts
@@ -36,10 +36,11 @@ describe("PR #423 gate 2 :: post-compaction substrate :: tool-stage and runner-c
   });
 
   it("delegate staged via tool path is visible to runner-side count + consume", () => {
+    const firstArmedAt = 1_700_000_000_000;
     expect(runnerCount(sessionKey)).toBe(0);
     toolStage(sessionKey, {
       task: "post-compaction probe",
-      createdAt: Date.now(),
+      createdAt: firstArmedAt,
       silent: true,
       silentWake: true,
     });
@@ -50,6 +51,8 @@ describe("PR #423 gate 2 :: post-compaction substrate :: tool-stage and runner-c
     expect(consumed).toHaveLength(1);
     expect(consumed[0]).toMatchObject({
       task: "post-compaction probe",
+      createdAt: firstArmedAt,
+      firstArmedAt,
       silent: true,
       silentWake: true,
     });

--- a/src/auto-reply/continuation-delegate-store.ts
+++ b/src/auto-reply/continuation-delegate-store.ts
@@ -44,28 +44,35 @@ export {
 // Post-compaction wrappers — adapt SessionPostCompactionDelegate ↔ TaskFlow
 //
 // Downstream callers (agent-runner persist path, delivery queue) speak
-// SessionPostCompactionDelegate { task, createdAt, silent?, silentWake? }.
-// The canonical store speaks StagedPostCompactionDelegate { task, stagedAt }
-// and returns PendingContinuationDelegate { task, mode? }.
+// SessionPostCompactionDelegate { task, createdAt, firstArmedAt?, silent?, silentWake? }.
+// The canonical store speaks StagedPostCompactionDelegate { task, stagedAt, firstArmedAt? }
+// and returns PendingContinuationDelegate { task, mode?, firstArmedAt? }.
 // ---------------------------------------------------------------------------
 
 export function stagePostCompactionDelegate(
   sessionKey: string,
   delegate: SessionPostCompactionDelegate,
 ): void {
+  const stagedAt = delegate.createdAt ?? Date.now();
   canonicalStage(sessionKey, {
     task: delegate.task,
-    stagedAt: delegate.createdAt ?? Date.now(),
+    stagedAt,
+    firstArmedAt: delegate.firstArmedAt ?? stagedAt,
   });
 }
 
 export function consumeStagedPostCompactionDelegates(
   sessionKey: string,
 ): SessionPostCompactionDelegate[] {
-  return canonicalConsumeStaged(sessionKey).map((d) => ({
-    task: d.task,
-    createdAt: Date.now(),
-    silent: true,
-    silentWake: true,
-  }));
+  const now = Date.now();
+  return canonicalConsumeStaged(sessionKey).map((d) => {
+    const firstArmedAt = d.firstArmedAt ?? now;
+    return {
+      task: d.task,
+      createdAt: firstArmedAt,
+      firstArmedAt,
+      silent: true,
+      silentWake: true,
+    };
+  });
 }

--- a/src/auto-reply/continuation/delegate-store.test.ts
+++ b/src/auto-reply/continuation/delegate-store.test.ts
@@ -150,6 +150,21 @@ describe("post-compaction delegate staging", () => {
     expect(stagedPostCompactionDelegateCount("session-1")).toBe(0);
   });
 
+  it("preserves firstArmedAt across post-compaction TaskFlow storage", () => {
+    stagePostCompactionDelegate("session-1", {
+      task: "old shard",
+      stagedAt: 20_000,
+      firstArmedAt: 10_000,
+    });
+
+    const delegates = consumeStagedPostCompactionDelegates("session-1");
+    expect(delegates[0]).toMatchObject({
+      task: "old shard",
+      mode: "post-compaction",
+      firstArmedAt: 10_000,
+    });
+  });
+
   it("does not mix regular and post-compaction delegates", () => {
     enqueuePendingDelegate("session-1", { task: "regular" });
     stagePostCompactionDelegate("session-1", { task: "post-compact", stagedAt: 1000 });

--- a/src/auto-reply/continuation/delegate-store.ts
+++ b/src/auto-reply/continuation/delegate-store.ts
@@ -46,6 +46,7 @@ const PendingDelegateStateSchema = z.object({
   silent: z.boolean().optional(),
   silentWake: z.boolean().optional(),
   postCompaction: z.boolean().optional(),
+  firstArmedAt: z.number().int().nonnegative().optional(),
 });
 
 type PendingDelegateState = z.infer<typeof PendingDelegateStateSchema>;
@@ -87,6 +88,7 @@ function buildDelegateState(delegate: PendingContinuationDelegate): PendingDeleg
     ...(delegate.mode === "silent" ? { silent: true } : {}),
     ...(delegate.mode === "silent-wake" ? { silentWake: true } : {}),
     ...(delegate.mode === "post-compaction" ? { postCompaction: true } : {}),
+    ...(delegate.firstArmedAt !== undefined ? { firstArmedAt: delegate.firstArmedAt } : {}),
   };
 }
 
@@ -142,6 +144,7 @@ function flowToDelegate(
     task: state.task,
     ...(state.delayMs !== undefined ? { delayMs: state.delayMs } : {}),
     ...(mode !== undefined ? { mode } : {}),
+    ...(state.firstArmedAt !== undefined ? { firstArmedAt: state.firstArmedAt } : {}),
   };
 }
 
@@ -317,6 +320,7 @@ export function stagePostCompactionDelegate(
   enqueuePendingDelegate(sessionKey, {
     task: delegate.task,
     mode: "post-compaction",
+    firstArmedAt: delegate.firstArmedAt ?? delegate.stagedAt,
   });
 }
 

--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -56,6 +56,7 @@ export type PendingContinuationDelegate = {
   task: string;
   delayMs?: number;
   mode?: "normal" | "silent" | "silent-wake" | "post-compaction";
+  firstArmedAt?: number;
 };
 
 /**
@@ -110,6 +111,7 @@ export type ContinuationRuntimeConfig = {
 export type StagedPostCompactionDelegate = {
   task: string;
   stagedAt: number;
+  firstArmedAt?: number;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts
+++ b/src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts
@@ -38,6 +38,7 @@ function delegate(
   return {
     task,
     createdAt: overrides?.createdAt ?? 1,
+    ...(overrides?.firstArmedAt != null ? { firstArmedAt: overrides.firstArmedAt } : {}),
     ...(overrides?.silent != null ? { silent: overrides.silent } : {}),
     ...(overrides?.silentWake != null ? { silentWake: overrides.silentWake } : {}),
   };
@@ -78,6 +79,7 @@ function createDispatchDeps(options?: {
   context?: string | null;
   rejectEnqueueAt?: number;
   runtimeConfig?: ContinuationRuntimeConfig;
+  now?: number;
 }) {
   const enqueueSystemEvent = vi.fn();
   const log = vi.fn();
@@ -99,6 +101,7 @@ function createDispatchDeps(options?: {
     enqueuePostCompactionDelegateDelivery,
     enqueueSystemEvent,
     log,
+    now: vi.fn(() => options?.now ?? 1),
     readPostCompactionContext,
     resolveAgentWorkspaceDir,
     resolveContinuationRuntimeConfig,
@@ -179,6 +182,7 @@ describe("post-compaction delegate dispatch extraction", () => {
     expect(normalizePostCompactionDelegate(delegate("legacy"))).toEqual({
       task: "legacy",
       createdAt: 1,
+      firstArmedAt: 1,
       silent: true,
       silentWake: true,
     });
@@ -188,6 +192,7 @@ describe("post-compaction delegate dispatch extraction", () => {
     expect(normalizePostCompactionDelegate(delegate("visible", { silent: false }))).toEqual({
       task: "visible",
       createdAt: 1,
+      firstArmedAt: 1,
       silent: false,
     });
   });
@@ -196,6 +201,21 @@ describe("post-compaction delegate dispatch extraction", () => {
     expect(normalizePostCompactionDelegate(delegate("wake", { silentWake: true }))).toEqual({
       task: "wake",
       createdAt: 1,
+      firstArmedAt: 1,
+      silentWake: true,
+    });
+  });
+
+  it("preserves explicit firstArmedAt while leaving createdAt unchanged", () => {
+    expect(
+      normalizePostCompactionDelegate(
+        delegate("requeued", { createdAt: 20_000, firstArmedAt: 10_000 }),
+      ),
+    ).toEqual({
+      task: "requeued",
+      createdAt: 20_000,
+      firstArmedAt: 10_000,
+      silent: true,
       silentWake: true,
     });
   });
@@ -386,6 +406,49 @@ describe("post-compaction delegate dispatch extraction", () => {
       expect.stringContaining("2 over maxDelegatesPerTurn budget (5, bracketOffset=0)"),
     );
     expect(preserve).toEqual([]);
+  });
+
+  it("drops stale delegates using stable firstArmedAt age", async () => {
+    const now = 1_700_000_000_000;
+    const staleFirstArmedAt = now - 8 * 24 * 60 * 60 * 1000;
+    const sessionEntry: SessionEntry = { sessionId: "session", updatedAt: 1 };
+    const preserve: SessionPostCompactionDelegate[] = [];
+    const { deps, enqueuePostCompactionDelegateDelivery, log } = createDispatchDeps({
+      staged: [
+        delegate("stale", {
+          createdAt: now,
+          firstArmedAt: staleFirstArmedAt,
+        }),
+        delegate("fresh", {
+          createdAt: now,
+          firstArmedAt: now - 60_000,
+        }),
+      ],
+      now,
+    });
+
+    const result = await dispatchPostCompactionDelegates(
+      {
+        cfg,
+        compactionCount: 1,
+        followupRun: createFollowupRun(),
+        postCompactionDelegatesToPreserve: preserve,
+        sessionEntry,
+        sessionKey: "main",
+      },
+      deps,
+    );
+
+    expect(result).toEqual({ queuedDelegates: 1, droppedDelegates: 1 });
+    expect(enqueuePostCompactionDelegateDelivery).toHaveBeenCalledTimes(1);
+    expect(enqueuePostCompactionDelegateDelivery.mock.calls[0]?.[0].delegate).toMatchObject({
+      task: "fresh",
+      firstArmedAt: now - 60_000,
+    });
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("Post-compaction delegate dropped as stale for main"),
+    );
+    expect(log).toHaveBeenCalledWith(expect.stringContaining(`firstArmedAt=${staleFirstArmedAt}`));
   });
 
   it("reduces compaction budget by one when a bracket delegate was already spawned this turn", async () => {

--- a/src/auto-reply/reply/post-compaction-delegate-dispatch.ts
+++ b/src/auto-reply/reply/post-compaction-delegate-dispatch.ts
@@ -70,6 +70,7 @@ export type PostCompactionDelegateDispatchDeps = {
   }): Promise<string>;
   enqueueSystemEvent(text: string, options: { sessionKey: string }): void;
   log(message: string): void;
+  now(): number;
   readPostCompactionContext(
     workspaceDir: string,
     options: { cfg: OpenClawConfig; agentId: string },
@@ -120,11 +121,14 @@ const defaultPostCompactionDelegateDispatchDeps: PostCompactionDelegateDispatchD
   enqueuePostCompactionDelegateDelivery,
   enqueueSystemEvent,
   log: (message) => defaultRuntime.log(message),
+  now: () => Date.now(),
   readPostCompactionContext,
   resolveAgentWorkspaceDir,
   resolveContinuationRuntimeConfig,
   resolveSessionAgentId,
 };
+
+export const POST_COMPACTION_DELEGATE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 function syncPendingPostCompactionDelegates(params: {
   sessionEntry?: SessionEntry;
@@ -149,13 +153,19 @@ export function normalizePostCompactionDelegate(
   const legacySilentWake = delegate.silent == null && delegate.silentWake == null;
   const silentWake = legacySilentWake ? true : delegate.silentWake === true;
   const silent = legacySilentWake ? true : delegate.silent === true || silentWake;
+  const firstArmedAt = delegate.firstArmedAt ?? delegate.createdAt;
 
   return {
     task: delegate.task,
     createdAt: delegate.createdAt,
+    firstArmedAt,
     ...(delegate.silent != null || legacySilentWake ? { silent } : {}),
     ...(delegate.silentWake != null || legacySilentWake ? { silentWake } : {}),
   };
+}
+
+function formatTaskPreview(task: string): string {
+  return JSON.stringify(task.length > 120 ? `${task.slice(0, 117)}...` : task);
 }
 
 export async function persistPendingPostCompactionDelegates(params: {
@@ -543,6 +553,20 @@ export async function dispatchPostCompactionDelegates(
     ...persistedCompactionDelegates,
     ...stagedCompactionDelegates,
   ].map(normalizePostCompactionDelegate);
+  const now = deps.now();
+  const freshCompactionDelegates: SessionPostCompactionDelegate[] = [];
+  let staleDroppedDelegates = 0;
+  for (const delegate of allCompactionDelegates) {
+    const ageMs = now - (delegate.firstArmedAt ?? delegate.createdAt);
+    if (ageMs > POST_COMPACTION_DELEGATE_TTL_MS) {
+      staleDroppedDelegates += 1;
+      deps.log(
+        `Post-compaction delegate dropped as stale for ${params.sessionKey}: ageMs=${ageMs} ttlMs=${POST_COMPACTION_DELEGATE_TTL_MS} firstArmedAt=${delegate.firstArmedAt ?? delegate.createdAt} task=${formatTaskPreview(delegate.task)}`,
+      );
+      continue;
+    }
+    freshCompactionDelegates.push(delegate);
+  }
 
   // Enforce maxDelegatesPerTurn budget. Account for any bracket-style delegate
   // already spawned this turn so the combined per-turn count cannot exceed
@@ -553,10 +577,10 @@ export async function dispatchPostCompactionDelegates(
   );
   const bracketDelegateOffset = params.continuationSignalKind === "delegate" ? 1 : 0;
   const compactionBudget = Math.max(0, maxCompactionDelegates - bracketDelegateOffset);
-  const releasedCompactionDelegates = allCompactionDelegates.slice(0, compactionBudget);
+  const releasedCompactionDelegates = freshCompactionDelegates.slice(0, compactionBudget);
   const overflowDroppedDelegates = Math.max(
     0,
-    allCompactionDelegates.length - releasedCompactionDelegates.length,
+    freshCompactionDelegates.length - releasedCompactionDelegates.length,
   );
   if (overflowDroppedDelegates > 0) {
     deps.log(
@@ -598,7 +622,7 @@ export async function dispatchPostCompactionDelegates(
   );
 
   const queuedEntryIds: string[] = [];
-  let droppedCompactionDelegates = overflowDroppedDelegates;
+  let droppedCompactionDelegates = staleDroppedDelegates + overflowDroppedDelegates;
   for (const [index, result] of enqueueResults.entries()) {
     if (result.status === "fulfilled") {
       queuedEntryIds.push(result.value);

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -113,6 +113,8 @@ export type SessionPluginDebugEntry = {
 export type SessionPostCompactionDelegate = {
   task: string;
   createdAt: number;
+  /** Stable original arm time, preserved across re-stage/restart cycles. */
+  firstArmedAt?: number;
   /**
    * Post-compaction delegates are silent by contract. Persist the explicit
    * flags so the intent survives session-store round trips.

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -86,6 +86,7 @@ export type QueuedSessionDeliveryPayload = (
       sessionKey: string;
       task: string;
       createdAt: number;
+      firstArmedAt?: number;
       silent?: boolean;
       silentWake?: boolean;
       deliveryContext?: SessionDeliveryContext;
@@ -133,7 +134,7 @@ function buildPostCompactionDelegateIdempotencyKey(params: {
     "post-compaction-delegate",
     params.sessionKey,
     String(params.compactionCount ?? "unknown"),
-    String(params.delegate.createdAt),
+    String(params.delegate.firstArmedAt ?? params.delegate.createdAt),
     String(params.sequence),
     taskHash,
   ].join(":");
@@ -152,6 +153,7 @@ export function buildPostCompactionDelegateDeliveryPayload(params: {
     sessionKey: params.sessionKey,
     task: params.delegate.task,
     createdAt: params.delegate.createdAt,
+    firstArmedAt: params.delegate.firstArmedAt ?? params.delegate.createdAt,
     ...(params.delegate.silent != null ? { silent: params.delegate.silent } : {}),
     ...(params.delegate.silentWake != null ? { silentWake: params.delegate.silentWake } : {}),
     ...(params.deliveryContext ? { deliveryContext: params.deliveryContext } : {}),

--- a/src/infra/session-delivery-queue.storage.test.ts
+++ b/src/infra/session-delivery-queue.storage.test.ts
@@ -128,6 +128,7 @@ describe("session-delivery queue storage", () => {
         sessionKey: "agent:main:main",
         task: "carry state forward",
         createdAt: 123,
+        firstArmedAt: 123,
         silent: true,
         silentWake: true,
         deliveryContext: {


### PR DESCRIPTION
## Summary

Fixes openclaw-bootstrap#823 by preserving stable post-compaction delegate arm age and dropping stale shards before they can be queued into the fresh session.

## Root cause

The TaskFlow-backed post-compaction adapter preserved shard bodies, but the legacy compatibility wrapper converted consumed staged delegates back into `SessionPostCompactionDelegate` with `createdAt: Date.now()`. That erased the original arm time whenever a shard crossed the TaskFlow/restart/re-stage boundary, making stale 10-day-old tasks look freshly armed and preventing age/TTL filtering.

## Fix

- Add `firstArmedAt` to post-compaction delegate state and preserve it through TaskFlow state, session-store delegates, and queued delivery payloads.
- Rehydrate wrapper-consumed staged delegates with `createdAt`/`firstArmedAt` from the original arm time instead of consume time.
- Normalize legacy delegates by treating `createdAt` as `firstArmedAt`.
- Drop post-compaction delegates older than 7 days by `firstArmedAt`, with an explicit stale-drop log containing age, TTL, and task preview.
- Keep queue idempotency keyed to stable arm age so requeues do not mint fresh identity solely from rewrite time.

## Validation

- `pnpm test src/auto-reply/continuation/delegate-store.test.ts src/auto-reply/continuation-delegate-store.post-compaction-substrate.test.ts src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts src/infra/session-delivery-queue.storage.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm lint`

`pnpm check:changed` expands to all lanes from canonical baseline unknown `.agents` surfaces and fails in existing extension typecheck baselines (`extensions/codex` duplicate `@mariozechner/pi-agent-core` identities and `extensions/qqbot` zod v3/v4 mismatch), unrelated to this delegate persistence/TTL fix.
