### PR TITLE
Fix sandbox memory-flush append writes

### DIFF
--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
-import { writeFileWithinRoot } from "openclaw/plugin-sdk/infra-runtime";
+import { appendFileWithinRoot, writeFileWithinRoot } from "openclaw/plugin-sdk/infra-runtime";
 import type {
   SandboxFsBridge,
   SandboxFsStat,
@@ -89,6 +89,37 @@ class OpenShellFsBridge implements SandboxFsBridge {
       relativePath: path.relative(target.mountHostRoot, hostPath),
       data: buffer,
       mkdir: params.mkdir,
+    });
+    await this.backend.syncLocalPathToRemote(hostPath, target.containerPath);
+  }
+
+  async appendFile(params: {
+    filePath: string;
+    cwd?: string;
+    data: Buffer | string;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    prependNewlineIfNeeded?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveTarget(params);
+    const hostPath = this.requireHostPath(target);
+    this.ensureWritable(target, "append files");
+    await assertLocalPathSafety({
+      target,
+      root: target.mountHostRoot,
+      allowMissingLeaf: true,
+      allowFinalSymlinkForUnlink: false,
+    });
+    const buffer = Buffer.isBuffer(params.data)
+      ? params.data
+      : Buffer.from(params.data, params.encoding ?? "utf8");
+    await appendFileWithinRoot({
+      rootDir: target.mountHostRoot,
+      relativePath: path.relative(target.mountHostRoot, hostPath),
+      data: buffer,
+      mkdir: params.mkdir,
+      prependNewlineIfNeeded: params.prependNewlineIfNeeded,
     });
     await this.backend.syncLocalPathToRemote(hostPath, target.containerPath);
   }

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -265,6 +265,41 @@ describe("openshell fs bridges", () => {
     );
   });
 
+  it("appends locally and syncs the file to the remote workspace", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    await fs.mkdir(path.join(workspaceDir, "nested"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "nested", "file.txt"), "seed", "utf8");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    if (!bridge.appendFile) {
+      throw new Error("OpenShell fs bridge must support appendFile");
+    }
+    await bridge.appendFile({
+      filePath: "nested/file.txt",
+      data: "next",
+      mkdir: true,
+      prependNewlineIfNeeded: true,
+    });
+
+    expect(await fs.readFile(path.join(workspaceDir, "nested", "file.txt"), "utf8")).toBe(
+      "seed\nnext",
+    );
+    expect(backend.syncLocalPathToRemote).toHaveBeenCalledWith(
+      path.join(workspaceDir, "nested", "file.txt"),
+      "/sandbox/nested/file.txt",
+    );
+  });
+
   it("rejects symlink-parent writes instead of escaping the local mount root", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
     const outsideDir = await makeTempDir("openclaw-openshell-outside-");

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -152,6 +152,10 @@ function createMemoryPatchSandbox(initialFiles: Record<string, string> = {}) {
     writeFile: async ({ filePath, data }) => {
       files.set(filePath, Buffer.isBuffer(data) ? data.toString("utf8") : data);
     },
+    appendFile: async ({ filePath, data }) => {
+      const current = files.get(filePath) ?? "";
+      files.set(filePath, `${current}${Buffer.isBuffer(data) ? data.toString("utf8") : data}`);
+    },
     remove: async ({ filePath }) => {
       files.delete(filePath);
     },

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -32,6 +32,7 @@ describe("Agent-specific tool filtering", () => {
     }),
     readFile: async () => Buffer.from(""),
     writeFile: async () => {},
+    appendFile: async () => {},
     mkdirp: async () => {},
     remove: async () => {},
     rename: async () => {},

--- a/src/agents/pi-tools.read.host-edit-recovery.test.ts
+++ b/src/agents/pi-tools.read.host-edit-recovery.test.ts
@@ -43,6 +43,14 @@ function createInMemoryBridge(root: string, files: Map<string, string>): Sandbox
       const absolutePath = resolveAbsolute(filePath, cwd);
       files.set(absolutePath, typeof data === "string" ? data : Buffer.from(data).toString("utf8"));
     },
+    appendFile: async ({ filePath, cwd, data }) => {
+      const absolutePath = resolveAbsolute(filePath, cwd);
+      const current = files.get(absolutePath) ?? "";
+      files.set(
+        absolutePath,
+        `${current}${typeof data === "string" ? data : Buffer.from(data).toString("utf8")}`,
+      );
+    },
     mkdirp: async () => {},
     remove: async ({ filePath, cwd }) => {
       files.delete(resolveAbsolute(filePath, cwd));

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -450,38 +450,6 @@ type MemoryFlushAppendOnlyWriteOptions = {
   };
 };
 
-async function readOptionalUtf8File(params: {
-  absolutePath: string;
-  relativePath: string;
-  sandbox?: MemoryFlushAppendOnlyWriteOptions["sandbox"];
-  signal?: AbortSignal;
-}): Promise<string> {
-  try {
-    if (params.sandbox) {
-      const stat = await params.sandbox.bridge.stat({
-        filePath: params.relativePath,
-        cwd: params.sandbox.root,
-        signal: params.signal,
-      });
-      if (!stat) {
-        return "";
-      }
-      const buffer = await params.sandbox.bridge.readFile({
-        filePath: params.relativePath,
-        cwd: params.sandbox.root,
-        signal: params.signal,
-      });
-      return buffer.toString("utf-8");
-    }
-    return await fs.readFile(params.absolutePath, "utf-8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
-      return "";
-    }
-    throw error;
-  }
-}
-
 async function appendMemoryFlushContent(params: {
   absolutePath: string;
   root: string;
@@ -501,35 +469,19 @@ async function appendMemoryFlushContent(params: {
     return;
   }
 
-  const existing = await readOptionalUtf8File({
-    absolutePath: params.absolutePath,
-    relativePath: params.relativePath,
-    sandbox: params.sandbox,
+  if (!params.sandbox.bridge.appendFile) {
+    throw new Error(
+      `Sandbox file bridge does not support safe append for memory flush: ${params.relativePath}`,
+    );
+  }
+  await params.sandbox.bridge.appendFile({
+    filePath: params.relativePath,
+    cwd: params.sandbox.root,
+    data: params.content,
+    mkdir: true,
+    prependNewlineIfNeeded: true,
     signal: params.signal,
   });
-  const separator =
-    existing.length > 0 && !existing.endsWith("\n") && !params.content.startsWith("\n") ? "\n" : "";
-  const next = `${existing}${separator}${params.content}`;
-  if (params.sandbox) {
-    const parent = path.posix.dirname(params.relativePath);
-    if (parent && parent !== ".") {
-      await params.sandbox.bridge.mkdirp({
-        filePath: parent,
-        cwd: params.sandbox.root,
-        signal: params.signal,
-      });
-    }
-    await params.sandbox.bridge.writeFile({
-      filePath: params.relativePath,
-      cwd: params.sandbox.root,
-      data: next,
-      mkdir: true,
-      signal: params.signal,
-    });
-    return;
-  }
-  await fs.mkdir(path.dirname(params.absolutePath), { recursive: true });
-  await fs.writeFile(params.absolutePath, next, "utf-8");
 }
 
 export function wrapToolMemoryFlushAppendOnlyWrite(

--- a/src/agents/pi-tools.workspace-only-false.test.ts
+++ b/src/agents/pi-tools.workspace-only-false.test.ts
@@ -30,6 +30,7 @@ import {
   wrapToolMemoryFlushAppendOnlyWrite,
   wrapToolWorkspaceRootGuard,
 } from "./pi-tools.read.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 describe("FS tools with workspaceOnly=false", () => {
@@ -237,5 +238,65 @@ describe("FS tools with workspaceOnly=false", () => {
       text: "Appended content to memory/2026-03-07.md.",
     });
     await expect(fs.readFile(allowedAbsolutePath, "utf-8")).resolves.toBe("seed\nnew note");
+  });
+
+  it("uses the sandbox append primitive for memory-triggered writes", async () => {
+    const allowedRelativePath = "memory/2026-03-07.md";
+    const fallbackWrite = vi.fn(async () => {
+      throw new Error("append-only wrapper should not delegate to base write");
+    });
+    const appendFile = vi.fn(async () => {});
+    const readFile = vi.fn(async () => Buffer.from("stale"));
+    const writeFile = vi.fn(async () => {});
+    const bridge: SandboxFsBridge = {
+      resolvePath: ({ filePath }) => ({
+        relativePath: filePath,
+        containerPath: `/workspace/${filePath}`,
+      }),
+      readFile,
+      writeFile,
+      appendFile,
+      mkdirp: vi.fn(async () => {}),
+      remove: vi.fn(async () => {}),
+      rename: vi.fn(async () => {}),
+      stat: vi.fn(async () => ({ type: "file" as const, size: 5, mtimeMs: 0 })),
+    };
+    const writeTool: AnyAgentTool = {
+      name: "write",
+      label: "write",
+      description: "Write content to a file.",
+      parameters: { type: "object", properties: {} },
+      execute: fallbackWrite,
+    };
+    const wrapped = wrapToolMemoryFlushAppendOnlyWrite(writeTool, {
+      root: workspaceDir,
+      relativePath: allowedRelativePath,
+      sandbox: {
+        root: workspaceDir,
+        bridge,
+      },
+    });
+
+    const result = await wrapped.execute("test-call-memory-sandbox-append", {
+      path: allowedRelativePath,
+      content: "new note",
+    });
+
+    expect(hasToolError(result)).toBe(false);
+    expect(result.content).toContainEqual({
+      type: "text",
+      text: "Appended content to memory/2026-03-07.md.",
+    });
+    expect(appendFile).toHaveBeenCalledWith({
+      filePath: allowedRelativePath,
+      cwd: workspaceDir,
+      data: "new note",
+      mkdir: true,
+      prependNewlineIfNeeded: true,
+      signal: undefined,
+    });
+    expect(readFile).not.toHaveBeenCalled();
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(fallbackWrite).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/sandbox/fs-bridge-mutation-helper.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-helper.ts
@@ -36,6 +36,10 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "if hasattr(os, 'O_NOFOLLOW'):",
   "    WRITE_FLAGS |= os.O_NOFOLLOW",
   "",
+  "APPEND_FLAGS = os.O_RDWR | os.O_CREAT | os.O_APPEND",
+  "if hasattr(os, 'O_NOFOLLOW'):",
+  "    APPEND_FLAGS |= os.O_NOFOLLOW",
+  "",
   "def split_relative(path_value):",
   "    segments = []",
   "    for segment in path_value.split('/'):",
@@ -113,6 +117,28 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "                os.unlink(temp_name, dir_fd=parent_fd)",
   "            except FileNotFoundError:",
   "                pass",
+  "",
+  "def append_file(parent_fd, basename, stdin_buffer, prepend_newline):",
+  "    file_fd = os.open(basename, APPEND_FLAGS, 0o666, dir_fd=parent_fd)",
+  "    try:",
+  "        file_stat = os.fstat(file_fd)",
+  "        if not stat.S_ISREG(file_stat.st_mode):",
+  "            raise OSError(errno.EPERM, 'only regular files are allowed', basename)",
+  "        if file_stat.st_nlink > 1:",
+  "            raise OSError(errno.EPERM, 'hardlinked file is not allowed', basename)",
+  "        data = stdin_buffer.read()",
+  "        if prepend_newline and file_stat.st_size > 0 and not data.startswith(b'\\n'):",
+  "            os.lseek(file_fd, -1, os.SEEK_END)",
+  "            last_byte = os.read(file_fd, 1)",
+  "            os.lseek(file_fd, 0, os.SEEK_END)",
+  "            if last_byte != b'\\n':",
+  "                os.write(file_fd, b'\\n')",
+  "        if data:",
+  "            os.write(file_fd, data)",
+  "        os.fsync(file_fd)",
+  "        os.fsync(parent_fd)",
+  "    finally:",
+  "        os.close(file_fd)",
   "",
   "def read_file(parent_fd, basename):",
   "    file_fd = os.open(basename, READ_FLAGS, dir_fd=parent_fd)",
@@ -236,6 +262,16 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "        if parent_fd is not None:",
   "            os.close(parent_fd)",
   "        os.close(root_fd)",
+  "elif operation == 'append':",
+  "    root_fd = open_dir(sys.argv[2])",
+  "    parent_fd = None",
+  "    try:",
+  "        parent_fd = walk_dir(root_fd, sys.argv[3], sys.argv[5] == '1')",
+  "        append_file(parent_fd, sys.argv[4], sys.stdin.buffer, sys.argv[6] == '1')",
+  "    finally:",
+  "        if parent_fd is not None:",
+  "            os.close(parent_fd)",
+  "        os.close(root_fd)",
   "elif operation == 'mkdirp':",
   "    root_fd = open_dir(sys.argv[2])",
   "    target_fd = None",
@@ -330,6 +366,25 @@ export function buildPinnedWritePlan(params: {
       params.pinned.relativeParentPath,
       params.pinned.basename,
       params.mkdir ? "1" : "0",
+    ],
+  });
+}
+
+export function buildPinnedAppendPlan(params: {
+  check: PathSafetyCheck;
+  pinned: PinnedSandboxEntry;
+  mkdir: boolean;
+  prependNewlineIfNeeded?: boolean;
+}): SandboxFsCommandPlan {
+  return buildPinnedMutationPlan({
+    checks: [params.check],
+    args: [
+      "append",
+      params.pinned.mountRootPath,
+      params.pinned.relativeParentPath,
+      params.pinned.basename,
+      params.mkdir ? "1" : "0",
+      params.prependNewlineIfNeeded ? "1" : "0",
     ],
   });
 }

--- a/src/agents/sandbox/fs-bridge.shell.test.ts
+++ b/src/agents/sandbox/fs-bridge.shell.test.ts
@@ -31,6 +31,10 @@ describe("sandbox fs bridge shell compatibility", () => {
 
       await bridge.readFile({ filePath: "a.txt" });
       await bridge.writeFile({ filePath: "b.txt", data: "hello" });
+      if (!bridge.appendFile) {
+        throw new Error("sandbox fs bridge must support appendFile");
+      }
+      await bridge.appendFile({ filePath: "b.txt", data: " again", prependNewlineIfNeeded: true });
       await bridge.mkdirp({ filePath: "nested" });
       await bridge.remove({ filePath: "b.txt" });
       await bridge.rename({ from: "a.txt", to: "c.txt" });

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -6,6 +6,7 @@ import type {
 } from "./backend-handle.types.js";
 import { runDockerSandboxShellCommand } from "./docker-backend.js";
 import {
+  buildPinnedAppendPlan,
   buildPinnedMkdirpPlan,
   buildPinnedRemovePlan,
   buildPinnedRenamePlan,
@@ -98,6 +99,41 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
         check: writeCheck,
         pinned: pinnedWriteTarget,
         mkdir: params.mkdir !== false,
+      }),
+      stdin: buffer,
+      signal: params.signal,
+    });
+  }
+
+  async appendFile(params: {
+    filePath: string;
+    cwd?: string;
+    data: Buffer | string;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    prependNewlineIfNeeded?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveResolvedPath(params);
+    this.ensureWriteAccess(target, "append files");
+    const appendCheck = {
+      target,
+      options: { action: "append files", requireWritable: true } as const,
+    };
+    await this.pathGuard.assertPathSafety(target, appendCheck.options);
+    const buffer = Buffer.isBuffer(params.data)
+      ? params.data
+      : Buffer.from(params.data, params.encoding ?? "utf8");
+    const pinnedAppendTarget = await this.pathGuard.resolveAnchoredPinnedEntry(
+      target,
+      "append files",
+    );
+    await this.runCheckedCommand({
+      ...buildPinnedAppendPlan({
+        check: appendCheck,
+        pinned: pinnedAppendTarget,
+        mkdir: params.mkdir !== false,
+        prependNewlineIfNeeded: params.prependNewlineIfNeeded,
       }),
       stdin: buffer,
       signal: params.signal,

--- a/src/agents/sandbox/fs-bridge.types.ts
+++ b/src/agents/sandbox/fs-bridge.types.ts
@@ -21,6 +21,15 @@ export type SandboxFsBridge = {
     mkdir?: boolean;
     signal?: AbortSignal;
   }): Promise<void>;
+  appendFile?(params: {
+    filePath: string;
+    cwd?: string;
+    data: Buffer | string;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    prependNewlineIfNeeded?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void>;
   mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void>;
   remove(params: {
     filePath: string;

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -120,6 +120,44 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
   }
 
+  async appendFile(params: {
+    filePath: string;
+    cwd?: string;
+    data: Buffer | string;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    prependNewlineIfNeeded?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const target = this.resolveTarget(params);
+    this.ensureWritable(target, "append files");
+    const pinned = await this.resolvePinnedParent({
+      containerPath: target.containerPath,
+      action: "append files",
+      requireWritable: true,
+    });
+    await this.assertNoHardlinkedFile({
+      containerPath: target.containerPath,
+      action: "append files",
+      signal: params.signal,
+    });
+    const buffer = Buffer.isBuffer(params.data)
+      ? params.data
+      : Buffer.from(params.data, params.encoding ?? "utf8");
+    await this.runMutation({
+      args: [
+        "append",
+        pinned.mountRootPath,
+        pinned.relativeParentPath,
+        pinned.basename,
+        params.mkdir !== false ? "1" : "0",
+        params.prependNewlineIfNeeded ? "1" : "0",
+      ],
+      stdin: buffer,
+      signal: params.signal,
+    });
+  }
+
   async mkdirp(params: { filePath: string; cwd?: string; signal?: AbortSignal }): Promise<void> {
     const target = this.resolveTarget(params);
     this.ensureWritable(target, "create directories");

--- a/src/agents/test-helpers/host-sandbox-fs-bridge.ts
+++ b/src/agents/test-helpers/host-sandbox-fs-bridge.ts
@@ -26,6 +26,42 @@ export function createSandboxFsBridgeFromResolver(
       const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
       await fs.writeFile(target.hostPath, buffer);
     },
+    appendFile: async ({ filePath, cwd, data, mkdir = true, prependNewlineIfNeeded = false }) => {
+      const target = resolvePath(filePath, cwd);
+      if (!target.hostPath) {
+        throw new Error(`Expected hostPath for ${target.containerPath}`);
+      }
+      if (mkdir) {
+        await fs.mkdir(path.dirname(target.hostPath), { recursive: true });
+      }
+      const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
+      let prefix = Buffer.alloc(0);
+      if (prependNewlineIfNeeded && buffer[0] !== 0x0a) {
+        try {
+          const handle = await fs.open(target.hostPath, "r");
+          try {
+            const stat = await handle.stat();
+            if (stat.size > 0) {
+              const last = Buffer.alloc(1);
+              await handle.read(last, 0, 1, stat.size - 1);
+              if (last[0] !== 0x0a) {
+                prefix = Buffer.from("\n");
+              }
+            }
+          } finally {
+            await handle.close();
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw error;
+          }
+        }
+      }
+      await fs.appendFile(
+        target.hostPath,
+        prefix.length > 0 ? Buffer.concat([prefix, buffer]) : buffer,
+      );
+    },
     mkdirp: async ({ filePath, cwd }) => {
       const target = resolvePath(filePath, cwd);
       if (!target.hostPath) {


### PR DESCRIPTION
## Summary
- Adds a true sandbox `appendFile` primitive for local, remote-shell, OpenShell, and host test bridges.
- Routes memory-flush append-only writes through that primitive instead of sandbox read-modify-write.
- Keeps the plugin-facing bridge contract additive by making `appendFile` optional and failing explicitly when a bridge cannot safely append.

Fixes https://github.com/karmaterminal/openclaw/issues/476.

## Validation
- `pnpm test src/agents/pi-tools.workspace-only-false.test.ts src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts src/agents/sandbox/fs-bridge.shell.test.ts src/agents/sandbox/remote-fs-bridge.test.ts extensions/openshell/src/openshell-core.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm lint`
- `pnpm plugin-sdk:api:check`
- `pnpm check:changed` still expands to all lanes from canonical-baseline unknown `.agents` surfaces and fails in unrelated extension baselines: `extensions/codex` duplicate `@mariozechner/pi-agent-core` type identities and `extensions/qqbot` zod v3/v4 schema mismatch.
