### PR TITLE
Fix continue_delegate cap to ignore far-future queue depth

### DIFF
--- a/src/agents/tools/continue-delegate-tool.test.ts
+++ b/src/agents/tools/continue-delegate-tool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  cancelPendingDelegates,
   consumePendingDelegates,
   consumeStagedPostCompactionDelegates,
 } from "../../auto-reply/continuation-delegate-store.js";
@@ -12,12 +13,14 @@ import { createContinueDelegateTool } from "./continue-delegate-tool.js";
 
 describe("continue_delegate tool", () => {
   beforeEach(() => {
+    cancelPendingDelegates("test-session");
     consumePendingDelegates("test-session");
     consumeStagedPostCompactionDelegates("test-session");
     clearRuntimeConfigSnapshot();
   });
 
   afterEach(() => {
+    cancelPendingDelegates("test-session");
     clearRuntimeConfigSnapshot();
   });
 
@@ -92,6 +95,48 @@ describe("continue_delegate tool", () => {
       status: "error",
       limit: 5,
     });
+  });
+
+  it("does not let far-future queued delegates consume a fresh turn budget", async () => {
+    setRuntimeConfigSnapshot({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 2 } } },
+    });
+    const firstTurnTool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+
+    await expect(
+      executeTool(firstTurnTool, 0, {
+        task: "delayed delegate 1",
+        delaySeconds: 86_400,
+      }),
+    ).resolves.toMatchObject({ status: "scheduled", delegatesThisTurn: 1 });
+    await expect(
+      executeTool(firstTurnTool, 1, {
+        task: "delayed delegate 2",
+        delaySeconds: 86_400,
+      }),
+    ).resolves.toMatchObject({ status: "scheduled", delegatesThisTurn: 2 });
+    await expect(
+      executeTool(firstTurnTool, 2, { task: "same-turn overflow" }),
+    ).resolves.toMatchObject({
+      status: "error",
+      delegatesThisTurn: 2,
+      limit: 2,
+      pendingQueuedDelegates: 2,
+      scheduledPendingDelegates: 2,
+      stagedPostCompactionDelegates: 0,
+    });
+
+    const nextTurnTool = createContinueDelegateTool({ agentSessionKey: "test-session" });
+    await expect(
+      executeTool(nextTurnTool, 0, { task: "fresh turn immediate" }),
+    ).resolves.toMatchObject({
+      status: "scheduled",
+      delegateIndex: 1,
+      delegatesThisTurn: 1,
+    });
+    expect(consumePendingDelegates("test-session")).toEqual([
+      expect.objectContaining({ task: "fresh turn immediate" }),
+    ]);
   });
 
   it("stages post-compaction delegates as silent-wake delegates", async () => {

--- a/src/agents/tools/continue-delegate-tool.ts
+++ b/src/agents/tools/continue-delegate-tool.ts
@@ -1,9 +1,8 @@
 import { Type } from "typebox";
 import {
   enqueuePendingDelegate,
-  pendingDelegateCount,
+  getContinuationDelegateQueueDepths,
   stagePostCompactionDelegate,
-  stagedPostCompactionDelegateCount,
 } from "../../auto-reply/continuation/delegate-store.js";
 import { resolveMaxDelegatesPerTurn } from "../../auto-reply/reply/continuation-runtime.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -60,6 +59,8 @@ const ContinueDelegateToolSchema = Type.Object({
  * 2026-04-15: unrelated inbound traffic does not cancel scheduled work).
  */
 export function createContinueDelegateTool(opts: { agentSessionKey?: string }): AnyAgentTool {
+  let delegatesThisTurn = 0;
+
   return {
     label: "Continuation",
     name: "continue_delegate",
@@ -103,16 +104,21 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
       const mode = (modeRaw || "normal") as (typeof DELEGATE_MODES)[number];
       const isPostCompaction = mode === "post-compaction";
 
-      // Check per-turn delegate limit
+      // Check per-turn delegate limit. Durable queued depth is reported for
+      // visibility but does not consume this turn's admission budget.
       const maxPerTurn = resolveMaxDelegatesPerTurn();
-      const currentCount =
-        pendingDelegateCount(sessionKey) + stagedPostCompactionDelegateCount(sessionKey);
-      if (currentCount >= maxPerTurn) {
+      if (delegatesThisTurn >= maxPerTurn) {
+        const queueDepths = getContinuationDelegateQueueDepths(sessionKey);
         return jsonResult({
           status: "error",
-          reason: `maxDelegatesPerTurn exceeded (${maxPerTurn}). Cannot dispatch more delegates this turn.`,
-          dispatched: currentCount,
+          reason: `maxDelegatesPerTurn exceeded (${maxPerTurn}). Cannot schedule more delegates in this turn.`,
+          delegatesThisTurn,
           limit: maxPerTurn,
+          queuedDelegateDepth: queueDepths.totalQueued,
+          pendingQueuedDelegates: queueDepths.pendingQueued,
+          runnablePendingDelegates: queueDepths.pendingRunnable,
+          scheduledPendingDelegates: queueDepths.pendingScheduled,
+          stagedPostCompactionDelegates: queueDepths.stagedPostCompaction,
         });
       }
 
@@ -121,10 +127,13 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
           task,
           stagedAt: Date.now(),
         });
+        delegatesThisTurn += 1;
 
         return jsonResult({
           status: "queued-for-compaction",
           mode: "post-compaction",
+          delegateIndex: delegatesThisTurn,
+          delegatesThisTurn,
           note:
             "Delegate will fire when compaction occurs, not on a timer. " +
             "The shard starts at the moment of compaction and returns to the post-compaction session. " +
@@ -141,7 +150,8 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
         ...(mode !== "normal" ? { mode } : {}),
       });
 
-      const dispatchIndex = currentCount + 1;
+      delegatesThisTurn += 1;
+      const dispatchIndex = delegatesThisTurn;
 
       return jsonResult({
         status: "scheduled",

--- a/src/auto-reply/continuation/delegate-store.ts
+++ b/src/auto-reply/continuation/delegate-store.ts
@@ -50,6 +50,14 @@ const PendingDelegateStateSchema = z.object({
 
 type PendingDelegateState = z.infer<typeof PendingDelegateStateSchema>;
 
+export type ContinuationDelegateQueueDepths = {
+  pendingQueued: number;
+  pendingRunnable: number;
+  pendingScheduled: number;
+  stagedPostCompaction: number;
+  totalQueued: number;
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -107,6 +115,10 @@ function listQueuedPostCompactionFlows(sessionKey: string): TaskFlowRecord[] {
 function decodeDelegateState(flow: TaskFlowRecord): PendingDelegateState | undefined {
   const parsed = PendingDelegateStateSchema.safeParse(flow.stateJson);
   return parsed.success ? parsed.data : undefined;
+}
+
+function delegateDueAt(flow: TaskFlowRecord, state: PendingDelegateState): number {
+  return flow.createdAt + (state.delayMs ?? 0);
 }
 
 function flowToDelegate(
@@ -202,7 +214,7 @@ export function consumePendingDelegates(sessionKey: string): PendingContinuation
     // response-finalize (or the hedge timer armed by the dispatch caller)
     // re-checks them. Honors `delayMs` on the tool path without threading a
     // wake-pathway timer (which would change `mode=silent` semantics).
-    const dueAt = flow.createdAt + (state.delayMs ?? 0);
+    const dueAt = delegateDueAt(flow, state);
     if (now < dueAt) {
       continue;
     }
@@ -240,7 +252,7 @@ export function peekSoonestUnmaturedDelegateDueAt(sessionKey: string): number | 
     if (!state) {
       continue;
     }
-    const dueAt = flow.createdAt + (state.delayMs ?? 0);
+    const dueAt = delegateDueAt(flow, state);
     if (dueAt <= now) {
       continue;
     }
@@ -256,6 +268,28 @@ export function peekSoonestUnmaturedDelegateDueAt(sessionKey: string): number | 
  */
 export function pendingDelegateCount(sessionKey: string): number {
   return listQueuedPendingFlows(sessionKey).length;
+}
+
+export function getContinuationDelegateQueueDepths(
+  sessionKey: string,
+  now = Date.now(),
+): ContinuationDelegateQueueDepths {
+  const pendingFlows = listQueuedPendingFlows(sessionKey);
+  let pendingRunnable = 0;
+  for (const flow of pendingFlows) {
+    const state = decodeDelegateState(flow);
+    if (state && delegateDueAt(flow, state) <= now) {
+      pendingRunnable += 1;
+    }
+  }
+  const stagedPostCompaction = listQueuedPostCompactionFlows(sessionKey).length;
+  return {
+    pendingQueued: pendingFlows.length,
+    pendingRunnable,
+    pendingScheduled: pendingFlows.length - pendingRunnable,
+    stagedPostCompaction,
+    totalQueued: pendingFlows.length + stagedPostCompaction,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Changes `continue_delegate` admission from durable queued-depth counting to a per-tool-turn counter.
- Keeps durable queue depth visible in cap-error telemetry (`pendingQueuedDelegates`, runnable/scheduled split, staged post-compaction count) instead of exposing opaque `dispatched`.
- Adds a regression where two far-future delayed delegates saturate the same turn but do not consume a fresh turn's immediate delegate budget.

Fixes https://github.com/karmaterminal/openclaw-bootstrap/issues/826.

## Validation
- `pnpm test src/agents/tools/continue-delegate-tool.test.ts src/auto-reply/continuation/delegate-store.test.ts src/auto-reply/continuation-delegate-store.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm lint`
- `pnpm check:changed` still expands to all lanes from canonical-baseline unknown `.agents` surfaces and fails in unrelated extension baselines: `extensions/codex` duplicate `@mariozechner/pi-agent-core` type identities and `extensions/qqbot` zod v3/v4 schema mismatch.
