### PR TITLE
Fix continuation pending state substrate guard

### DIFF
--- a/src/auto-reply/reply/continuation-state.test.ts
+++ b/src/auto-reply/reply/continuation-state.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  addDelayedContinuationReservation,
+  cancelPendingDelegates,
+  clearDelayedContinuationReservations,
+  enqueuePendingDelegate,
+  stagePostCompactionDelegate,
+} from "../continuation-delegate-store.js";
+import { hasDelegatePending, setDelegatePending } from "./continuation-state.js";
+
+const sessionKey = "continuation-state-test-session";
+
+beforeEach(() => {
+  cancelPendingDelegates(sessionKey);
+  clearDelayedContinuationReservations(sessionKey);
+});
+
+afterEach(() => {
+  cancelPendingDelegates(sessionKey);
+  clearDelayedContinuationReservations(sessionKey);
+});
+
+describe("reply continuation state", () => {
+  it("derives delegate pending state from TaskFlow and timer reservations", () => {
+    expect(hasDelegatePending(sessionKey)).toBe(false);
+
+    setDelegatePending(sessionKey);
+    expect(hasDelegatePending(sessionKey)).toBe(false);
+
+    enqueuePendingDelegate(sessionKey, { task: "queued delegate" });
+    expect(hasDelegatePending(sessionKey)).toBe(true);
+    cancelPendingDelegates(sessionKey);
+    expect(hasDelegatePending(sessionKey)).toBe(false);
+
+    stagePostCompactionDelegate(sessionKey, {
+      task: "post-compaction delegate",
+      createdAt: Date.now(),
+    });
+    expect(hasDelegatePending(sessionKey)).toBe(true);
+    cancelPendingDelegates(sessionKey);
+    expect(hasDelegatePending(sessionKey)).toBe(false);
+
+    addDelayedContinuationReservation(sessionKey, {
+      id: "timer-reservation",
+      source: "tool",
+      task: "timer delegate",
+      createdAt: Date.now(),
+      fireAt: Date.now() + 60_000,
+      plannedHop: 1,
+    });
+    expect(hasDelegatePending(sessionKey)).toBe(true);
+    clearDelayedContinuationReservations(sessionKey);
+    expect(hasDelegatePending(sessionKey)).toBe(false);
+  });
+});
+
+describe("continuation volatile-map guard", () => {
+  async function collectProdContinuationFiles(): Promise<string[]> {
+    const continuationDir = path.join(process.cwd(), "src/auto-reply/continuation");
+    const continuationEntries = await fs.readdir(continuationDir, { withFileTypes: true });
+    const continuationFiles = continuationEntries
+      .filter(
+        (entry) => entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts"),
+      )
+      .map((entry) => path.posix.join("src/auto-reply/continuation", entry.name));
+    const replyDir = path.join(process.cwd(), "src/auto-reply/reply");
+    const replyEntries = await fs.readdir(replyDir, { withFileTypes: true });
+    const replyContinuationFiles = replyEntries
+      .filter(
+        (entry) =>
+          entry.isFile() &&
+          entry.name.startsWith("continuation") &&
+          entry.name.endsWith(".ts") &&
+          !entry.name.endsWith(".test.ts"),
+      )
+      .map((entry) => path.posix.join("src/auto-reply/reply", entry.name));
+    return [...continuationFiles, ...replyContinuationFiles].toSorted();
+  }
+
+  const allowedSessionKeyedMaps = new Map<string, Set<string>>([
+    ["src/auto-reply/continuation/delegate-dispatch.ts", new Set(["hedgeTimers"])],
+    ["src/auto-reply/continuation/delegate-store.ts", new Set(["delayedReservations"])],
+    [
+      "src/auto-reply/continuation/state.ts",
+      new Set(["continuationTimerHandles", "continuationTimerRefs"]),
+    ],
+    ["src/auto-reply/continuation/context-pressure.ts", new Set(["lastFiredBand"])],
+    [
+      "src/auto-reply/reply/continuation-state.ts",
+      new Set(["continuationGenerations", "continuationTimerRefs", "continuationTimerHandles"]),
+    ],
+  ]);
+
+  it("allowlists every session-keyed volatile Map in continuation code", async () => {
+    const unexpected: string[] = [];
+    const mapDeclarationPattern = /\b(?:const|let)\s+([A-Za-z0-9_]+)\s*=\s*new Map<string\s*,/g;
+
+    for (const relativePath of await collectProdContinuationFiles()) {
+      const allowedNames = allowedSessionKeyedMaps.get(relativePath) ?? new Set<string>();
+      const source = await fs.readFile(path.join(process.cwd(), relativePath), "utf8");
+      for (const match of source.matchAll(mapDeclarationPattern)) {
+        const name = match[1];
+        if (!allowedNames.has(name)) {
+          unexpected.push(`${relativePath}:${name}`);
+        }
+      }
+    }
+
+    expect(unexpected).toEqual([]);
+  });
+});

--- a/src/auto-reply/reply/continuation-state.ts
+++ b/src/auto-reply/reply/continuation-state.ts
@@ -1,22 +1,29 @@
-import { delayedContinuationReservationCount } from "../continuation-delegate-store.js";
+import {
+  delayedContinuationReservationCount,
+  pendingDelegateCount,
+  stagedPostCompactionDelegateCount,
+} from "../continuation-delegate-store.js";
 
 type ContinuationTimerHandle = ReturnType<typeof setTimeout>;
 
 const continuationGenerations = new Map<string, number>();
 const continuationTimerRefs = new Map<string, number>();
 const continuationTimerHandles = new Map<string, Set<ContinuationTimerHandle>>();
-const delegatePendingFlags = new Map<string, boolean>();
 
 export function setDelegatePending(sessionKey: string): void {
-  delegatePendingFlags.set(sessionKey, true);
+  // Compatibility no-op: pending state is derived from TaskFlow and timer reservations.
+  void sessionKey;
 }
 
 export function hasDelegatePending(sessionKey: string): boolean {
-  return delegatePendingFlags.get(sessionKey) === true;
+  return (
+    pendingDelegateCount(sessionKey) > 0 ||
+    stagedPostCompactionDelegateCount(sessionKey) > 0 ||
+    delayedContinuationReservationCount(sessionKey) > 0
+  );
 }
 
 export function clearDelegatePending(sessionKey: string): void {
-  delegatePendingFlags.delete(sessionKey);
   bumpContinuationGeneration(sessionKey);
   maybeDropContinuationGeneration(sessionKey);
 }


### PR DESCRIPTION
## Summary
- Removes the reply-side `delegatePendingFlags` volatile Map and derives pending state from TaskFlow queue depth plus timer reservations.
- Keeps the legacy `setDelegatePending` call surface as a compatibility no-op while removing the duplicate volatile state substrate.
- Adds a dynamic guard test that scans production continuation files and fails on any new session-keyed volatile `Map<string, ...>` unless explicitly allowlisted.

Refs https://github.com/karmaterminal/openclaw/issues/473.

This is the remaining volatile-map/guard slice of #473. Companion SWIM-39 PRs cover the other folded surfaces: #483 removes the `taskFlowDelegates` config/schema echo, and #490 changes the queued-depth cap behavior/telemetry.

## Validation
- `pnpm test src/auto-reply/reply/continuation-state.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/continuation-delegate-store.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm lint`
- `pnpm check:changed` still expands to all lanes from canonical-baseline unknown `.agents` surfaces and fails in unrelated extension baselines: `extensions/codex` duplicate `@mariozechner/pi-agent-core` type identities and `extensions/qqbot` zod v3/v4 schema mismatch.
