### PR TITLE
fix(continuation): stabilize runId thread in createRequestCompactionTool (#485 P0)

### DIFF
--- a/src/agents/compaction-attribution.ts
+++ b/src/agents/compaction-attribution.ts
@@ -1,0 +1,30 @@
+export type RequestCompactionInvocation = {
+  sessionKey: string;
+  sessionId: string;
+  runId?: string;
+  diagId: string;
+  trigger: "volitional";
+  reason: string;
+  contextUsage: number;
+  requestedAtMs: number;
+};
+
+export type CompactionCounterAttribution = {
+  runId?: string;
+  trigger: string;
+  outcome: string;
+};
+
+let compactionDiagCounter = 0;
+
+export function createCompactionDiagId(now = Date.now()): string {
+  compactionDiagCounter = (compactionDiagCounter + 1) % 0x100_000;
+  return `cmp-${now.toString(36)}-${compactionDiagCounter.toString(36).padStart(4, "0")}`;
+}
+
+export function normalizeCompactionTrigger(value: unknown): string {
+  if (value === "threshold") {
+    return "budget";
+  }
+  return typeof value === "string" && value.trim() ? value.trim() : "unknown";
+}

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -28,7 +28,10 @@ import { createMessageTool } from "./tools/message-tool.js";
 import { createMusicGenerateTool } from "./tools/music-generate-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
 import { createPdfTool } from "./tools/pdf-tool.js";
-import { createRequestCompactionTool } from "./tools/request-compaction-tool.js";
+import {
+  createRequestCompactionTool,
+  type RequestCompactionToolOpts,
+} from "./tools/request-compaction-tool.js";
 import { createSessionStatusTool } from "./tools/session-status-tool.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
@@ -104,6 +107,8 @@ export function createOpenClawTools(
     senderIsOwner?: boolean;
     /** Ephemeral session UUID — regenerated on /new and /reset. */
     sessionId?: string;
+    /** Stable run identifier for this agent invocation. */
+    runId?: string;
     /**
      * Workspace directory to pass to spawned subagents for inheritance.
      * Defaults to workspaceDir. Use this to pass the actual agent workspace when the
@@ -125,7 +130,7 @@ export function createOpenClawTools(
     requestCompactionOpts?: {
       sessionId?: string;
       getContextUsage: () => number | null;
-      triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+      triggerCompaction: RequestCompactionToolOpts["triggerCompaction"];
     };
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
@@ -358,6 +363,7 @@ export function createOpenClawTools(
           createRequestCompactionTool({
             agentSessionKey: options?.agentSessionKey,
             sessionId: options?.sessionId,
+            runId: options?.runId,
             ...options.requestCompactionOpts,
           }),
         ]

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -20,7 +20,6 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
-import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
@@ -48,6 +47,7 @@ import {
   resolveChannelMessageToolHints,
   resolveChannelReactionGuidance,
 } from "../channel-tools.js";
+import { createCompactionDiagId } from "../compaction-attribution.js";
 import {
   hasMeaningfulConversationContent,
   isRealConversationMessage,
@@ -155,10 +155,6 @@ function hasRealConversationContent(
   index: number,
 ): boolean {
   return isRealConversationMessage(msg, messages, index);
-}
-
-function createCompactionDiagId(): string {
-  return `cmp-${Date.now().toString(36)}-${generateSecureToken(4)}`;
 }
 
 function prepareCompactionSessionAgent(params: {
@@ -477,18 +473,19 @@ export async function compactEmbeddedPiSessionDirect(
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const resolvedMessageProvider = params.messageChannel ?? params.messageProvider;
     const contextInjectionMode = resolveContextInjectionMode(params.config);
-    const { contextFiles } = contextInjectionMode === "never"
-      ? { contextFiles: [] }
-      : await resolveBootstrapContextForRun({
-          workspaceDir: effectiveWorkspace,
-          config: params.config,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          warn: makeBootstrapWarn({
-            sessionLabel,
-            warn: (message) => log.warn(message),
-          }),
-        });
+    const { contextFiles } =
+      contextInjectionMode === "never"
+        ? { contextFiles: [] }
+        : await resolveBootstrapContextForRun({
+            workspaceDir: effectiveWorkspace,
+            config: params.config,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            warn: makeBootstrapWarn({
+              sessionLabel,
+              warn: (message) => log.warn(message),
+            }),
+          });
     // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
     // threshold uses the effective limit, not the native context window.
     const runtimeModelWithContext = runtimeModel as ProviderRuntimeModel;

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -15,6 +15,7 @@ import type {
   ToolResultFormat,
 } from "../../pi-embedded-subscribe.shared-types.js";
 import type { SkillSnapshot } from "../../skills.js";
+import type { RequestCompactionToolOpts } from "../../tools/request-compaction-tool.js";
 export type { ClientToolDefinition } from "../../command/shared-types.js";
 
 export type EmbeddedRunTrigger = "cron" | "heartbeat" | "manual" | "memory" | "overflow" | "user";
@@ -165,6 +166,6 @@ export type RunEmbeddedPiAgentParams = {
   requestCompactionOpts?: {
     sessionId?: string;
     getContextUsage: () => number | null;
-    triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+    triggerCompaction: RequestCompactionToolOpts["triggerCompaction"];
   };
 };

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.runtime.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.runtime.ts
@@ -1,4 +1,6 @@
 import { resolveStorePath, updateSessionStoreEntry } from "../config/sessions.js";
+import type { CompactionCounterAttribution } from "./compaction-attribution.js";
+import { log } from "./pi-embedded-runner/logger.js";
 
 export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   sessionKey?: string;
@@ -6,18 +8,30 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   configStore?: string;
   observedCompactionCount: number;
   now?: number;
+  attribution?: CompactionCounterAttribution;
 }): Promise<number | undefined> {
-  const { sessionKey, agentId, configStore, observedCompactionCount, now = Date.now() } = params;
+  const {
+    sessionKey,
+    agentId,
+    configStore,
+    observedCompactionCount,
+    now = Date.now(),
+    attribution,
+  } = params;
   if (!sessionKey || observedCompactionCount <= 0) {
     return undefined;
   }
   const storePath = resolveStorePath(configStore, { agentId });
+  let previousCompactionCount: number | undefined;
+  let nextCompactionCount: number | undefined;
   const nextEntry = await updateSessionStoreEntry({
     storePath,
     sessionKey,
     update: async (entry) => {
       const currentCount = Math.max(0, entry.compactionCount ?? 0);
       const nextCount = Math.max(currentCount, observedCompactionCount);
+      previousCompactionCount = currentCount;
+      nextCompactionCount = nextCount;
       if (nextCount === currentCount) {
         return null;
       }
@@ -27,5 +41,15 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
       };
     },
   });
+  if (attribution && previousCompactionCount !== undefined && nextCompactionCount !== undefined) {
+    const delta = nextCompactionCount - previousCompactionCount;
+    const level = delta > 0 ? "info" : "debug";
+    log[level](
+      `[compaction-counter] session=${sessionKey} runId=${attribution.runId ?? "unknown"} ` +
+        `trigger=${attribution.trigger} outcome=${attribution.outcome} ` +
+        `storeCount.before=${previousCompactionCount} storeCount.after=${nextCompactionCount} ` +
+        `storeCount.delta=${delta}`,
+    );
+  }
   return nextEntry?.compactionCount;
 }

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -1,14 +1,22 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import {
+  normalizeCompactionTrigger,
+  type CompactionCounterAttribution,
+} from "./compaction-attribution.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
-export function handleCompactionStart(ctx: EmbeddedPiSubscribeContext) {
+export function handleCompactionStart(
+  ctx: EmbeddedPiSubscribeContext,
+  evt?: AgentEvent & { reason?: unknown },
+) {
+  const trigger = normalizeCompactionTrigger(evt?.reason);
   ctx.state.compactionInFlight = true;
   ctx.state.livenessState = "paused";
   ctx.ensureCompactionPromise();
-  ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
+  ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId} trigger=${trigger}`);
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "compaction",
@@ -41,9 +49,16 @@ export function handleCompactionStart(ctx: EmbeddedPiSubscribeContext) {
 
 export function handleCompactionEnd(
   ctx: EmbeddedPiSubscribeContext,
-  evt: AgentEvent & { willRetry?: unknown; result?: unknown; aborted?: unknown },
+  evt: AgentEvent & {
+    reason?: unknown;
+    willRetry?: unknown;
+    result?: unknown;
+    aborted?: unknown;
+    errorMessage?: unknown;
+  },
 ) {
   ctx.state.compactionInFlight = false;
+  const trigger = normalizeCompactionTrigger(evt.reason);
   const willRetry = Boolean(evt.willRetry);
   // Increment counter whenever compaction actually produced a result,
   // regardless of willRetry.  Overflow-triggered compaction sets willRetry=true
@@ -51,18 +66,34 @@ export function handleCompactionEnd(
   // and context was trimmed — the counter must reflect that.  (#38905)
   const hasResult = evt.result != null;
   const wasAborted = Boolean(evt.aborted);
+  const compactionCountBefore = ctx.getCompactionCount();
+  let compactionCountAfter = compactionCountBefore;
   if (hasResult && !wasAborted) {
     ctx.incrementCompactionCount();
-    const observedCompactionCount = ctx.getCompactionCount();
+    compactionCountAfter = ctx.getCompactionCount();
     void reconcileSessionStoreCompactionCountAfterSuccess({
       sessionKey: ctx.params.sessionKey,
       agentId: ctx.params.agentId,
       configStore: ctx.params.config?.session?.store,
-      observedCompactionCount,
+      observedCompactionCount: compactionCountAfter,
+      attribution: {
+        runId: ctx.params.runId,
+        trigger,
+        outcome: "compacted",
+      },
     }).catch((err) => {
       ctx.log.warn(`late compaction count reconcile failed: ${String(err)}`);
     });
   }
+  const completed = hasResult && !wasAborted;
+  const outcome = completed ? "compacted" : wasAborted ? "aborted" : "skipped";
+  const compactionCountDelta = compactionCountAfter - compactionCountBefore;
+  ctx.log.debug(
+    `[compaction-attribution] end runId=${ctx.params.runId} sessionKey=${ctx.params.sessionKey ?? ctx.params.sessionId} ` +
+      `trigger=${trigger} outcome=${outcome} willRetry=${willRetry} ` +
+      `compactionCount.before=${compactionCountBefore} compactionCount.after=${compactionCountAfter} ` +
+      `compactionCount.delta=${compactionCountDelta}`,
+  );
   if (willRetry) {
     ctx.noteCompactionRetry();
     ctx.resetForCompactionRetry();
@@ -77,11 +108,11 @@ export function handleCompactionEnd(
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    data: { phase: "end", willRetry, completed },
   });
   void ctx.params.onAgentEvent?.({
     stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    data: { phase: "end", willRetry, completed },
   });
 
   // Run after_compaction plugin hook (fire-and-forget)
@@ -110,6 +141,7 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   configStore?: string;
   observedCompactionCount: number;
   now?: number;
+  attribution?: CompactionCounterAttribution;
 }): Promise<number | undefined> {
   const { reconcileSessionStoreCompactionCountAfterSuccess: reconcile } =
     await import("./pi-embedded-subscribe.handlers.compaction.runtime.js");

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -115,7 +115,7 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
         return;
       case "compaction_start":
         scheduleEvent(evt, () => {
-          handleCompactionStart(ctx);
+          handleCompactionStart(ctx, evt as never);
         });
         return;
       case "compaction_end":

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -68,6 +68,7 @@ import {
   mergeAlsoAllowPolicy,
   resolveToolProfilePolicy,
 } from "./tool-policy.js";
+import type { RequestCompactionToolOpts } from "./tools/request-compaction-tool.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 function isOpenAIProvider(provider?: string) {
@@ -352,7 +353,7 @@ export function createOpenClawCodingTools(options?: {
   requestCompactionOpts?: {
     sessionId?: string;
     getContextUsage: () => number | null;
-    triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+    triggerCompaction: RequestCompactionToolOpts["triggerCompaction"];
   };
 }): AnyAgentTool[] {
   const execToolName = "exec";
@@ -642,6 +643,7 @@ export function createOpenClawCodingTools(options?: {
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
       sessionId: options?.sessionId,
+      runId: options?.runId,
       onYield: options?.onYield,
       allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
       continueWorkOpts: options?.continueWorkOpts,

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -2,6 +2,10 @@ import { Type } from "typebox";
 import { createExpiringMapCache } from "../../config/cache-utils.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
+  createCompactionDiagId,
+  type RequestCompactionInvocation,
+} from "../compaction-attribution.js";
+import {
   classifyCompactionReason,
   isCompactionSkipCode,
 } from "../pi-embedded-runner/compact-reasons.js";
@@ -69,6 +73,8 @@ export type RequestCompactionToolOpts = {
   agentSessionKey?: string;
   /** Session id (the Pi session UUID). */
   sessionId?: string;
+  /** Stable run identifier for this agent invocation. */
+  runId?: string;
   /**
    * Returns the current context usage as a fraction (0-1), or null when unknown
    * (e.g. inventory-only path used by /status surface reflection).
@@ -80,7 +86,9 @@ export type RequestCompactionToolOpts = {
    * import the heavy compaction module directly. The caller provides a
    * closure over `compactEmbeddedPiSession` with all required session params.
    */
-  triggerCompaction: () => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
+  triggerCompaction: (
+    request: RequestCompactionInvocation,
+  ) => Promise<{ ok: boolean; compacted: boolean; reason?: string }>;
 };
 
 // ---------------------------------------------------------------------------
@@ -170,6 +178,7 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
 
       // ----- Guard 2: Rate limit -----
       const now = Date.now();
+      const diagId = createCompactionDiagId(now);
       const guard = sessionGuardState.get(sessionKey);
       if (guard && now - guard.lastRequestMs < RATE_LIMIT_MS) {
         const remainingMs = RATE_LIMIT_MS - (now - guard.lastRequestMs);
@@ -189,7 +198,8 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
       // No generation guard (removed 2026-04-15 RFC): compaction is not blocked
       // by unrelated channel activity.
       log.info(
-        `[request_compaction:enqueuing] session=${sessionKey} usage=${(contextUsage * 100).toFixed(1)}% reason=${reason}`,
+        `[request_compaction:enqueuing] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+          `diagId=${diagId} trigger=volitional usage=${(contextUsage * 100).toFixed(1)}% reason=${reason}`,
       );
 
       // Update rate-limit state BEFORE firing so a second call in the same
@@ -202,11 +212,25 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
       // agent turn releases the session lane. We do NOT await — the tool
       // returns immediately so the agent can finish its response.
       pendingCompactionSessions.add(sessionKey);
+      const request: RequestCompactionInvocation = {
+        sessionKey,
+        sessionId: opts.sessionId,
+        ...(opts.runId ? { runId: opts.runId } : {}),
+        diagId,
+        trigger: "volitional",
+        reason,
+        contextUsage,
+        requestedAtMs: now,
+      };
       void opts
-        .triggerCompaction()
+        .triggerCompaction(request)
         .then(
           (result) => {
             if (result.ok && result.compacted) {
+              log.info(
+                `[request_compaction:resolved-success] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                  `diagId=${diagId} trigger=volitional outcome=compacted`,
+              );
               incrementVolitionalCompactionCount(sessionKey);
               return;
             }
@@ -214,19 +238,22 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
             const reason = result.reason ?? "";
             if (result.ok && isCompactionSkipCode(code)) {
               log.info(
-                `[request_compaction:resolved-skip] session=${sessionKey} code=${code} reason=${reason}`,
+                `[request_compaction:resolved-skip] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                  `diagId=${diagId} trigger=volitional outcome=skipped code=${code} reason=${reason}`,
               );
               return;
             }
             log.warn(
-              `[request_compaction:resolved-failure] session=${sessionKey} code=${code} ok=${result.ok} compacted=${result.compacted} reason=${reason}`,
+              `[request_compaction:resolved-failure] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                `diagId=${diagId} trigger=volitional outcome=failed code=${code} ok=${result.ok} compacted=${result.compacted} reason=${reason}`,
             );
           },
           (err: unknown) => {
             const message = err instanceof Error ? err.message : String(err);
             const code = classifyCompactionReason(message);
             log.error(
-              `[request_compaction:background-error] session=${sessionKey} code=${code} error=${message}`,
+              `[request_compaction:background-error] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                `diagId=${diagId} trigger=volitional outcome=failed code=${code} error=${message}`,
             );
           },
         )
@@ -236,6 +263,8 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
 
       return jsonResult({
         status: "compaction_requested",
+        compactionRequestId: diagId,
+        trigger: "volitional",
         contextUsage: Math.round(contextUsage * 100),
         reason,
         note:


### PR DESCRIPTION
## Summary
- threads the stable agent `runId` into `createRequestCompactionTool` / volitional compaction requests so request, embedded compaction, and hook telemetry can be correlated
- adds diagnostic request ids + attribution logging without pulling heavy/random dependencies into the continuation tool registration path
- keeps compaction hook event payloads stable while still using `runId` for internal event routing and reconciliation attribution

## Cross-links
- Fixup for #485 P0 deadlock-suspect triage
- Related: #488, #492
- Triage shelf artifact: e55384f

## Verification
- `pnpm vitest run src/agents/openclaw-tools.continuation-registration.test.ts --testTimeout=120000` ✅ 1 file / 7 tests passed
- `pnpm vitest run src/plugins/wired-hooks-compaction.test.ts --testTimeout=120000` ✅ run 1: 1 file / 8 tests passed
- `pnpm vitest run src/plugins/wired-hooks-compaction.test.ts --testTimeout=120000` ✅ run 2: 1 file / 8 tests passed
- `pnpm vitest run src/plugins/wired-hooks-compaction.test.ts --testTimeout=120000` ✅ run 3: 1 file / 8 tests passed

Journal: `/tmp/oc-485-fixup-20260501/journal-1777618196.log`
