### PR TITLE
test: stabilize PR #485 CI (wired-hooks shape + continuation-registration cold-start)

### DIFF
--- a/src/agents/openclaw-tools.continuation-registration.test.ts
+++ b/src/agents/openclaw-tools.continuation-registration.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
 // Mock loadConfig + resolveGatewayPort the same way other openclaw-tools.* tests do,
 // so calls inside createOpenClawTools that read shared config don't reach the real
@@ -52,6 +52,21 @@ function continuationToolNames(tools: Array<{ name: string }>): string[] {
 }
 
 describe("createOpenClawTools — continuation-tool registration visibility (#151)", () => {
+  // First call to createOpenClawTools pays the full import-graph + factory
+  // initialisation cost (~60–120s on cold CI workers — `openclaw-tools.ts`
+  // pulls ~30 tool factories + secrets/plugins runtime).  Amortise that cost
+  // in `beforeAll` so the first test case isn't the one that times out.
+  // Unrelated to PR #485 (reproduces on `cael/325-canonical2` base); see
+  // CI run 25203123808 / job 73898048609.
+  beforeAll(() => {
+    createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: { session: { mainKey: "main", scope: "per-sender" } } as never,
+    });
+  }, 180_000);
+
   it("registers no continuation tools when continuation.enabled is unset", () => {
     const tools = createOpenClawTools({
       agentSessionKey: "main",

--- a/src/plugins/wired-hooks-compaction.test.ts
+++ b/src/plugins/wired-hooks-compaction.test.ts
@@ -152,11 +152,11 @@ describe("compaction hook wiring", () => {
     expect(hookMocks.emitAgentEvent).toHaveBeenCalledWith({
       runId: "r1",
       stream: "compaction",
-      data: { phase: "start" },
+      data: { phase: "start", trigger: "unknown", sessionKey: "agent:main:web-abc123" },
     });
     expect(ctx.params.onAgentEvent).toHaveBeenCalledWith({
       stream: "compaction",
-      data: { phase: "start" },
+      data: { phase: "start", trigger: "unknown", sessionKey: "agent:main:web-abc123" },
     });
   });
 
@@ -188,7 +188,16 @@ describe("compaction hook wiring", () => {
     expect(hookMocks.emitAgentEvent).toHaveBeenCalledWith({
       runId: "r2",
       stream: "compaction",
-      data: { phase: "end", willRetry: false, completed: true },
+      data: {
+        phase: "end",
+        willRetry: false,
+        completed: true,
+        trigger: "unknown",
+        sessionKey: "agent:main:web-xyz",
+        compactionCountBefore: 1,
+        compactionCountAfter: 1,
+        compactionCountDelta: 0,
+      },
     });
   });
 
@@ -212,7 +221,16 @@ describe("compaction hook wiring", () => {
     expect(hookMocks.emitAgentEvent).toHaveBeenCalledWith({
       runId: "r3",
       stream: "compaction",
-      data: { phase: "end", willRetry: true, completed: true },
+      data: {
+        phase: "end",
+        willRetry: true,
+        completed: true,
+        trigger: "unknown",
+        sessionKey: undefined,
+        compactionCountBefore: 1,
+        compactionCountAfter: 1,
+        compactionCountDelta: 0,
+      },
     });
   });
 


### PR DESCRIPTION
Fixup for PR #485 CI failures.

## Root causes

**checks-node-agentic-plugins** `wired-hooks-compaction.test.ts × 3`:
The PR's compaction handlers now emit `trigger`, `sessionKey`, and (end-phase) `compactionCount{Before,After,Delta}` on the agent-event payload. Three assertions still expected the narrow pre-#485 shape. Updated the assertions.

**checks-node-agentic-agents** `openclaw-tools.continuation-registration.test.ts > registers no continuation tools when continuation.enabled is unset` (timeout ~121s):
**Brief's hypothesis (await-hang in `runId?` thread) is wrong** — `createOpenClawTools` is fully synchronous, no awaits in that codepath. Real cause: first call to `createOpenClawTools` pays ~60–120s of cold import-graph + ~30 tool-factory init. Reproduces on `origin/cael/325-canonical2` (PR base) too — pre-existing latency, exposed by #485 because the agentic-agents shard happens to schedule this file alongside other heavy ones. Hoisted the first call into `beforeAll(180_000)`; individual tests now run in 350–550ms.

**checks-node-core**: aggregate of the agentic-* failures; will go green once the above pass.

## Verification (local)
- `pnpm vitest run src/plugins/wired-hooks-compaction.test.ts`: 8/8 pass (15ms)
- `pnpm vitest run src/agents/openclaw-tools.continuation-registration.test.ts`: 7/7 pass (beforeAll ~67s, individual tests ~350–550ms)

Cherry-pick this branch into PR #485 (or merge this PR, depending on figs/Elliott's preference).