### PR TITLE
fix(test): bump first-test timeout to absorb cold module-load cost in openclaw-tools continuation-registration (unblocks #485, #488, #468)

### DIFF
--- a/src/agents/openclaw-tools.continuation-registration.test.ts
+++ b/src/agents/openclaw-tools.continuation-registration.test.ts
@@ -52,15 +52,25 @@ function continuationToolNames(tools: Array<{ name: string }>): string[] {
 }
 
 describe("createOpenClawTools — continuation-tool registration visibility (#151)", () => {
-  it("registers no continuation tools when continuation.enabled is unset", () => {
-    const tools = createOpenClawTools({
-      agentSessionKey: "main",
-      disablePluginTools: true,
-      disableMessageTool: true,
-      config: { session: { mainKey: "main", scope: "per-sender" } } as never,
-    });
-    expect(continuationToolNames(tools)).toEqual([]);
-  });
+  it(
+    "registers no continuation tools when continuation.enabled is unset",
+    () => {
+      const tools = createOpenClawTools({
+        agentSessionKey: "main",
+        disablePluginTools: true,
+        disableMessageTool: true,
+        config: { session: { mainKey: "main", scope: "per-sender" } } as never,
+      });
+      expect(continuationToolNames(tools)).toEqual([]);
+    },
+    // First test in this file pays the cold module-load cost for
+    // createOpenClawTools + transitive imports (compaction-attribution,
+    // pi-embedded-*, plugins/tools, config/config). Quiet-box cost ≈ 95s;
+    // CI noise pushes it past vitest's 120s default and produces a flaky
+    // timeout shared across PRs that don't touch this file (#485, #488,
+    // #468 all observed). Tests 2–7 reuse the warm cache (~360ms each).
+    240_000,
+  );
 
   it("registers no continuation tools when continuation.enabled is explicitly false", () => {
     const tools = createOpenClawTools({


### PR DESCRIPTION
## Problem

The first test in `src/agents/openclaw-tools.continuation-registration.test.ts` (line 55, *"registers no continuation tools when continuation.enabled is unset"*) is a flaky CI timeout that has been incorrectly attributed to multiple unrelated PRs as a regression.

## Byte-truth

Subagent verification (2026-05-01 07:29 UTC):

| Run | SHA | First-test duration | Result |
|---|---|---|---|
| Local on base | `cael/325-canonical2 @ a3dcc2adc2` | **95023 ms** | passed (25s margin to 120s) |
| CI on #485 head | `9f25f9116f` | **>120000 ms** | timed out |
| CI on #468 head (UNRELATED, doesn't touch this file) | run `25169814732` | **>120000 ms** | timed out — **same test, same file** |

**Test file content is byte-identical between base and #485 head** (`diff` empty). #468 doesn't touch the file at all. The timeout is not a regression introduced by any of these PRs.

## Mechanism

The failing test is the **first** test in the file. It pays the cold module-load cost for `createOpenClawTools` plus its transitive imports (`compaction-attribution`, `pi-embedded-*`, `plugins/tools`, `config/config`) under the agent project's 400+ concurrent test files.

Quiet-box first-test cost ≈ 95s. CI noise pushes it past vitest's 120s per-test default. Tests 2-7 in this file reuse the warm cache (~360ms each) and are unaffected.

Both feature gates in the failing test are `false` → the runId branch is never reached → prior runId-thread regression hypothesis correctly abandoned.

## Cure

One-line per-test timeout bump on the first test only, with a comment documenting the cold-start mechanism so future readers know why this single test has a non-default timeout.

```diff
-  it("registers no continuation tools when continuation.enabled is unset", () => {
+  it(
+    "registers no continuation tools when continuation.enabled is unset",
+    () => {
       // ...unchanged...
-  });
+    },
+    // First test in this file pays the cold module-load cost ...
+    240_000,
+  );
```

## Scope discipline

**Standalone fix, deliberately NOT folded into #485** to keep its compaction-attribution scope clean. Mixing test-infra fixes into feature PRs hurts attribution and hides the underlying base fragility (which deserves its own follow-up issue for an eager-load audit).

## Unblocks

- #485 (compaction-attribution)
- #488 (downstream of #485)
- #468 (unrelated, hit by same flake)
- Any future PR randomly tripped by the same first-test cold-start flake

## Follow-up (not in this PR)

The base headroom on this test is at 87% on a quiet box (95s / 120s) — that's structurally fragile even with the bump. Worth a separate issue to audit which imports under `createOpenClawTools` are heaviest and can be lazy-loaded. Filing that as a follow-up issue, not coupled to this fix.

## Provenance

Verified by a fresh subagent run (`silas-pr485-fixup-v2`, 15m26s, 2026-05-01 07:29 UTC) after a prior runId-thread hypothesis was disproved when an earlier subagent surfaced *"the timeout happens on the FIRST test regardless of which one runs first"* — pointing at module-load cost rather than feature-gated logic.

Cohort cross-eye welcome on the patch shape.