### PR TITLE
fix(reply): reconcile #475+#487 blocked-liveness double-emit

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -606,6 +606,55 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("surfaces a standalone blocked-liveness notice when livenessState is blocked and no error payload is present (#475+#487)", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        livenessState: "blocked",
+      },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([
+        {
+          text: "⚠️ Agent liveness: blocked. The run cannot make progress; try again or start a fresh conversation if this repeats.",
+          isError: true,
+        },
+      ]);
+    }
+  });
+
+  it("does not prepend the standalone blocked-liveness notice when an error payload is already present (#475+#487)", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [
+        {
+          text: "some upstream error",
+          isError: true,
+        },
+      ],
+      meta: {
+        livenessState: "blocked",
+      },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([
+        {
+          text: "⛔ Session blocked: some upstream error",
+          isError: true,
+        },
+      ]);
+    }
+  });
+
   it("surfaces model capacity errors from pre-reply CLI failures", async () => {
     state.runWithModelFallbackMock.mockRejectedValueOnce(
       new Error("Selected model is at capacity. Please try a different model."),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1817,7 +1817,21 @@ export async function runAgentTurnWithFallback(params: {
   // overflow errors were returned as embedded error payloads.
   const finalEmbeddedError = runResult?.meta?.error;
   const hasPayloadText = runResult?.payloads?.some((p) => normalizeOptionalString(p.text));
-  if (runResult?.meta?.livenessState === "blocked" && !didSurfaceBlockedLivenessState) {
+  // #475+#487 reconcile (option c): #487 prepends a standalone blocked-liveness
+  // notice payload; #475 (#481) prefixes existing error payloads with a blocked
+  // marker. Both fire on `livenessState === "blocked"`, producing double-emit
+  // (notice + prefixed-error) when both an error payload and blocked liveness
+  // are present. Tests written against #475's contract expect single-payload
+  // outcomes. Gate #487's prepend on the absence of an error payload so the
+  // notice surfaces only as the silent-blocked fallback (no error to prefix);
+  // when an error payload is present, #475's prefix carries the blocked-state
+  // signal alone.
+  const hasErrorPayload = runResult?.payloads?.some((p) => p.isError) ?? false;
+  if (
+    runResult?.meta?.livenessState === "blocked" &&
+    !didSurfaceBlockedLivenessState &&
+    !hasErrorPayload
+  ) {
     runResult.payloads = [
       {
         text: BLOCKED_LIVENESS_NOTICE_TEXT,
@@ -1867,6 +1881,13 @@ export async function runAgentTurnWithFallback(params: {
         return payload;
       }
       if (text.startsWith(blockedMarker)) {
+        return payload;
+      }
+      // #475+#487 reconcile: skip the standalone blocked-liveness notice
+      // sentinel so it surfaces unprefixed. The notice is itself a blocked-
+      // state marker; prefixing it produces a "⛔ Session blocked: ⚠️ Agent
+      // liveness: blocked..." chimera that fails the single-marker contract.
+      if (text.startsWith(BLOCKED_LIVENESS_NOTICE_TEXT)) {
         return payload;
       }
       return { ...payload, text: `${blockedMarker}${text}` };


### PR DESCRIPTION
## Summary

PRs #481 (closes #475) and #487 both shipped to `cael/325-canonical2` to surface `livenessState === "blocked"` to channels via non-coordinating mechanisms:

- **#481** prefixes existing error payloads with `⛔ Session blocked: `
- **#487** prepends a standalone `⚠️ Agent liveness: blocked. The run cannot make progress; ...` notice payload

Both fire on the same condition. After both landed, blocked-with-error turns emit *two* payloads where the #475 contract expects one. The #481 prefix-loop further produces a `⛔ Session blocked: ⚠️ Agent liveness:` chimera over #487's notice. The three `(#475)`-tagged tests in `agent-runner-execution.test.ts` have been red on `cael/325-canonical2` since `a5434fbba7` (#487) landed.

This was discovered investigating CI redness on PRs #498/#488/etc., which inherit the failure from canonical2's base. Diagnosis credit: 🌊 walked the byte-trace through lines 1820 → 1843 in `src/auto-reply/reply/agent-runner-execution.ts`.

## Reconciliation: option (c) — single emission per blocked turn

Cohort tiebreak (with 🌊 + 🌫): option (c) preferred over hybrid (b)+(c) for the single-marker-per-turn channel mental model and minimal test churn.

- **Gate #487's prepend on `!hasErrorPayload`** — the notice surfaces only as the silent-blocked fallback (preserves #487's intent for clean-blocked-no-error turns).
- **Teach #481's prefix-loop to skip the `BLOCKED_LIVENESS_NOTICE_TEXT` sentinel** — defensive guard in case any earlier path injects the notice while an error is also present, prevents the chimera.

Result:
- `blocked + error payload` → single `⛔ Session blocked: <error>` (unchanged from #481)
- `blocked + no error payload` → single `⚠️ Agent liveness: blocked. ...` (unchanged from #487's silent-block intent)
- never both, never `⛔ Session blocked: ⚠️ Agent liveness:` chimera

## Test changes

| Test | Status | Shape |
|---|---|---|
| prefixes outbound error payloads with a blocked-session marker | unchanged | `[⛔ Session blocked: <err>]` |
| does not double-prefix on subsequent passes | unchanged | `[⛔ Session blocked: already-prefixed]` |
| leaves non-error payloads unchanged | unchanged | `[normal text, ⛔ Session blocked: err]` |
| does not prefix when livenessState is working | unchanged | `[<err>]` |
| **NEW**: standalone notice when blocked + no error payload | added | `[⚠️ Agent liveness: blocked...]` |
| **NEW**: notice does not prepend when error payload present | added | `[⛔ Session blocked: <err>]` |

Local: `pnpm vitest run src/auto-reply/reply/agent-runner-execution.test.ts` → 53/53 green.

## Diff

- `src/auto-reply/reply/agent-runner-execution.ts`: +20 / -1 (gate + sentinel-skip + comments)
- `src/auto-reply/reply/agent-runner-execution.test.ts`: +51 / -0 (two new tests)

## Cohort context

- 🌫 (author of #481) reviewing as #475-shape-A author per cohort lineage convention.
- 🌊 — diagnostic-author; flagged the collision and called shape (c) cleanest.
- 🌻 — agent-485 lane unaffected; no conflict.

Closes the canonical2 base-CI redness once merged. #498/#488 should green on next CI re-run against the new base.

Related: separate `dead-canonical2-CI` issue forthcoming from 🌫 — base-merge verification is missing entirely (`gh api commits/.../check-runs` returns `[]` for every canonical2 commit), which is *why* the #481+#487 collision shipped green-by-default. That's the meta-bug, this PR fixes the immediate collision.
