### PR TITLE
test(otel): pin delegate.continuation span uniformity across silent / silent-wake / post-compaction modes

### DIFF
--- a/src/agents/tools/continuation-tools-registration.test.ts
+++ b/src/agents/tools/continuation-tools-registration.test.ts
@@ -162,8 +162,8 @@ describe("continuation tool registration", { timeout: 240000 }, () => {
     const properties = params.properties ?? {};
 
     // Closed-set assertion: exactly these advertised keys, no more, no less.
-    const expectedKeys = ["task", "delaySeconds", "mode"].sort();
-    const actualKeys = Object.keys(properties).sort();
+    const expectedKeys = ["task", "delaySeconds", "mode"].toSorted();
+    const actualKeys = Object.keys(properties).toSorted();
     expect(
       actualKeys,
       `continue_delegate descriptor must advertise exactly [task, delaySeconds, mode]; got [${actualKeys.join(", ")}]`,
@@ -179,13 +179,19 @@ describe("continuation tool registration", { timeout: 240000 }, () => {
     };
     const modeEnumValues = new Set<string>();
     if (Array.isArray(modeProp.enum)) {
-      for (const v of modeProp.enum) modeEnumValues.add(v);
+      for (const v of modeProp.enum) {
+        modeEnumValues.add(v);
+      }
     }
     if (Array.isArray(modeProp.anyOf)) {
       for (const branch of modeProp.anyOf) {
-        if (typeof branch.const === "string") modeEnumValues.add(branch.const);
+        if (typeof branch.const === "string") {
+          modeEnumValues.add(branch.const);
+        }
         if (Array.isArray(branch.enum)) {
-          for (const v of branch.enum) modeEnumValues.add(v);
+          for (const v of branch.enum) {
+            modeEnumValues.add(v);
+          }
         }
       }
     }

--- a/src/auto-reply/continuation/types.mode-shape.test.ts
+++ b/src/auto-reply/continuation/types.mode-shape.test.ts
@@ -61,7 +61,7 @@ vi.mock("../../tasks/task-flow-registry.js", () => ({
       return { applied: false, reason: flow ? "revision_conflict" : "not_found" };
     }
     flow.status = "succeeded";
-    flow.revision = (flow.revision as number) + 1;
+    flow.revision = flow.revision + 1;
     return { applied: true, flow: { ...flow } };
   }),
   failFlow: vi.fn((params: { flowId: string }) => {
@@ -112,7 +112,7 @@ describe("[#438] keeps PendingContinuationDelegate mode-only at runtime boundari
         });
         const consumed = consumePendingDelegates(SESSION_KEY);
         expect(consumed).toHaveLength(1);
-        const delegate = consumed[0]!;
+        const delegate = consumed[0];
         for (const field of RUNTIME_BOOLEAN_FIELDS) {
           expect(
             Object.prototype.hasOwnProperty.call(delegate, field),
@@ -132,7 +132,7 @@ describe("[#438] keeps PendingContinuationDelegate mode-only at runtime boundari
       });
       const consumed = consumeStagedPostCompactionDelegates(SESSION_KEY);
       expect(consumed).toHaveLength(1);
-      const delegate = consumed[0]!;
+      const delegate = consumed[0];
       expect(delegate.mode).toBe("post-compaction");
       for (const field of RUNTIME_BOOLEAN_FIELDS) {
         expect(
@@ -159,7 +159,7 @@ describe("[#438] keeps PendingContinuationDelegate mode-only at runtime boundari
         } else {
           enqueuePendingDelegate(SESSION_KEY, { task: "back-compat", mode });
         }
-        const flow = [...mockFlows.values()][0]!;
+        const flow = [...mockFlows.values()][0];
         const stateJson = flow.stateJson as Record<string, unknown>;
         expect(stateJson[expectedBooleanField]).toBe(true);
       },
@@ -167,7 +167,7 @@ describe("[#438] keeps PendingContinuationDelegate mode-only at runtime boundari
 
     it("persisted stateJson for normal mode projects no boolean mode flags", () => {
       enqueuePendingDelegate(SESSION_KEY, { task: "normal" });
-      const flow = [...mockFlows.values()][0]!;
+      const flow = [...mockFlows.values()][0];
       const stateJson = flow.stateJson as Record<string, unknown>;
       for (const field of RUNTIME_BOOLEAN_FIELDS) {
         expect(stateJson[field]).toBeUndefined();
@@ -200,13 +200,19 @@ describe("[#438] continue_delegate tool descriptor exposes mode enum, not boolea
     // optionalStringEnum may render as anyOf [ { const: "normal" }, ... ] OR as enum.
     const enumValues = new Set<string>();
     if (Array.isArray(modeProp.enum)) {
-      for (const v of modeProp.enum) enumValues.add(v);
+      for (const v of modeProp.enum) {
+        enumValues.add(v);
+      }
     }
     if (Array.isArray(modeProp.anyOf)) {
       for (const branch of modeProp.anyOf) {
-        if (typeof branch.const === "string") enumValues.add(branch.const);
+        if (typeof branch.const === "string") {
+          enumValues.add(branch.const);
+        }
         if (Array.isArray(branch.enum)) {
-          for (const v of branch.enum) enumValues.add(v);
+          for (const v of branch.enum) {
+            enumValues.add(v);
+          }
         }
       }
     }

--- a/src/auto-reply/reply/agent-runner.continuation-span-uniformity.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-span-uniformity.test.ts
@@ -1,0 +1,402 @@
+// Integration pin for delegate-dispatch span shape across continuation modes.
+//
+// The current tracer contract names the span `continuation.delegate.dispatch`.
+// This test drives the runner-side tool delegate path for silent modes and
+// leaves the post-compaction mode as a production-gap TODO.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as embeddedRunTesting,
+  abortEmbeddedPiRun,
+  isEmbeddedPiRunActive,
+} from "../../agents/pi-embedded-runner/runs.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  resetContinuationTracer,
+  setContinuationTracer,
+  type Span,
+  type SpanAttributes,
+  type SpanStatus,
+  type StartSpanOptions,
+  type Tracer,
+} from "../../infra/continuation-tracer.js";
+import {
+  clearMemoryPluginState,
+  registerMemoryFlushPlanResolver,
+} from "../../plugins/memory-state.js";
+import { enqueuePendingDelegate } from "../continuation/delegate-store.js";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { __testing as replyRunRegistryTesting } from "./reply-run-registry.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+void registerMemoryFlushPlanResolver;
+
+const runEmbeddedPiAgentMock = vi.fn();
+const runCliAgentMock = vi.fn();
+const runWithModelFallbackMock = vi.fn();
+const runtimeErrorMock = vi.fn();
+const abortEmbeddedPiRunMock = vi.fn();
+const clearSessionQueuesMock = vi.fn();
+const refreshQueuedFollowupSessionMock = vi.fn();
+const compactState = vi.hoisted(() => ({
+  compactEmbeddedPiSessionMock: vi.fn(),
+}));
+const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
+const spawnSubagentDirectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: (params: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => runWithModelFallbackMock(params),
+  isFallbackSummaryError: (err: unknown) =>
+    err instanceof Error &&
+    err.name === "FallbackSummaryError" &&
+    Array.isArray((err as { attempts?: unknown[] }).attempts),
+}));
+
+vi.mock("../../agents/model-auth.js", () => ({
+  resolveModelAuthMode: () => "api-key",
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  compactEmbeddedPiSession: (params: unknown) => compactState.compactEmbeddedPiSessionMock(params),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+  abortEmbeddedPiRun: (sessionId: string) => {
+    abortEmbeddedPiRunMock(sessionId);
+    return abortEmbeddedPiRun(sessionId);
+  },
+  isEmbeddedPiRunActive: (sessionId: string) => isEmbeddedPiRunActive(sessionId),
+}));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: (...args: unknown[]) => runCliAgentMock(...args),
+}));
+
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  SUBAGENT_SPAWN_MODES: ["run", "session"],
+  SUBAGENT_SPAWN_SANDBOX_MODES: ["inherit", "require"],
+  SUBAGENT_SPAWN_CONTEXT_MODES: ["isolated", "fork"],
+  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: (...args: unknown[]) => runtimeErrorMock(...args),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
+}));
+
+vi.mock("./queue.js", () => ({
+  enqueueFollowupRun: vi.fn(),
+  scheduleFollowupDrain: vi.fn(),
+  clearSessionQueues: (...args: unknown[]) => clearSessionQueuesMock(...args),
+  refreshQueuedFollowupSession: (...args: unknown[]) => refreshQueuedFollowupSessionMock(...args),
+}));
+
+vi.mock("../../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: async ({ config }: { config: unknown }) => ({
+    resolvedConfig: config,
+    diagnostics: [],
+  }),
+}));
+
+vi.mock("../../utils/provider-utils.js", () => ({
+  isReasoningTagProvider: (provider: string | undefined | null) =>
+    provider === "google" || provider === "google-gemini-cli",
+}));
+
+const loadCronStoreMock = vi.fn();
+vi.mock("../../cron/store.js", () => ({
+  loadCronStore: (...args: unknown[]) => loadCronStoreMock(...args),
+  resolveCronStorePath: (storePath?: string) => storePath ?? "/tmp/openclaw-cron-store.json",
+}));
+
+vi.mock("../../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    resolveSession: () => ({ kind: "none" }),
+    cancelSession: async () => {},
+  }),
+}));
+
+vi.mock("../../agents/subagent-registry.js", () => ({
+  getLatestSubagentRunByChildSessionKey: () => null,
+  listSubagentRunsForController: () => [],
+  markSubagentRunTerminated: () => 0,
+}));
+
+import { runReplyAgent } from "./agent-runner.js";
+
+type RunWithModelFallbackParams = {
+  provider: string;
+  model: string;
+  run: (provider: string, model: string) => Promise<unknown>;
+};
+
+type RecordedSpan = {
+  name: string;
+  attributes: SpanAttributes;
+  status: SpanStatus | undefined;
+  ended: boolean;
+};
+
+type DelegateModeUnderTest = "silent" | "silent-wake";
+
+const PARENT_CHAIN_ID = "019dcf57-b536-77cc-834b-b803d9262032";
+
+function createRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+  const spans: RecordedSpan[] = [];
+  const tracer: Tracer = {
+    startSpan(name: string, opts?: StartSpanOptions): Span {
+      const rec: RecordedSpan = {
+        name,
+        attributes: { ...opts?.attributes },
+        status: undefined,
+        ended: false,
+      };
+      spans.push(rec);
+      const span: Span = {
+        setAttributes(attrs: SpanAttributes): void {
+          Object.assign(rec.attributes, attrs);
+        },
+        setStatus(status: SpanStatus, _message?: string): void {
+          rec.status = status;
+        },
+        recordException(_err: unknown): void {
+          // unused by the delegate dispatch accept path
+        },
+        end(): void {
+          rec.ended = true;
+        },
+      };
+      return span;
+    },
+  };
+  return { tracer, spans };
+}
+
+beforeEach(() => {
+  embeddedRunTesting.resetActiveEmbeddedRuns();
+  replyRunRegistryTesting.resetReplyRunRegistry();
+  runEmbeddedPiAgentMock.mockClear();
+  runCliAgentMock.mockClear();
+  runWithModelFallbackMock.mockClear();
+  runtimeErrorMock.mockClear();
+  abortEmbeddedPiRunMock.mockClear();
+  compactState.compactEmbeddedPiSessionMock.mockReset();
+  compactState.compactEmbeddedPiSessionMock.mockResolvedValue({
+    compacted: false,
+    reason: "test-preflight-disabled",
+  });
+  clearSessionQueuesMock.mockReset();
+  clearSessionQueuesMock.mockReturnValue({ followupCleared: 0, laneCleared: 0, keys: [] });
+  refreshQueuedFollowupSessionMock.mockReset();
+  refreshQueuedFollowupSessionMock.mockResolvedValue(undefined);
+  loadCronStoreMock.mockClear();
+  loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+  requestHeartbeatNowMock.mockReset();
+  spawnSubagentDirectMock.mockReset().mockResolvedValue({
+    status: "accepted",
+    childSessionKey: "agent:main:subagent:spawned",
+    runId: "run-spawned",
+  });
+  runWithModelFallbackMock.mockImplementation(
+    async ({ provider, model, run }: RunWithModelFallbackParams) => ({
+      result: await run(provider, model),
+      provider,
+      model,
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearMemoryPluginState();
+  replyRunRegistryTesting.resetReplyRunRegistry();
+  embeddedRunTesting.resetActiveEmbeddedRuns();
+  resetContinuationTracer();
+});
+
+function createContinuationRun(params: {
+  mode: DelegateModeUnderTest;
+  sessionKey: string;
+  currentChainCount: number;
+}) {
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: "discord",
+    OriginatingTo: "channel:1",
+    AccountId: "primary",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+  const sessionEntry = {
+    sessionId: "session",
+    updatedAt: Date.now(),
+    continuationChainId: PARENT_CHAIN_ID,
+    continuationChainCount: params.currentChainCount,
+    continuationChainStartedAt: 1_700_000_000_000,
+    continuationChainTokens: 0,
+  } satisfies SessionEntry;
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey: params.sessionKey,
+      messageProvider: "discord",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {
+        agents: {
+          defaults: {
+            continuation: {
+              enabled: true,
+              minDelayMs: 0,
+              maxDelayMs: 5_000,
+              defaultDelayMs: 1_000,
+              maxChainLength: 6,
+              maxDelegatesPerTurn: 4,
+            },
+          },
+        },
+      },
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return {
+    sessionKey: params.sessionKey,
+    sessionEntry,
+    typing,
+    sessionCtx,
+    resolvedQueue,
+    followupRun,
+  };
+}
+
+async function runDelegateTurn(
+  run: ReturnType<typeof createContinuationRun>,
+  sessionStore: Record<string, SessionEntry>,
+): Promise<unknown> {
+  return runReplyAgent({
+    commandBody: "hello",
+    followupRun: run.followupRun,
+    queueKey: run.sessionKey,
+    resolvedQueue: run.resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    isStreaming: false,
+    typing: run.typing,
+    sessionCtx: run.sessionCtx,
+    sessionEntry: run.sessionEntry,
+    sessionStore,
+    sessionKey: run.sessionKey,
+    defaultModel: "anthropic/claude-opus-4-6",
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: "instant",
+  });
+}
+
+async function dispatchToolDelegateMode(params: {
+  mode: DelegateModeUnderTest;
+  currentChainCount: number;
+}): Promise<RecordedSpan> {
+  const { tracer, spans } = createRecordingTracer();
+  setContinuationTracer(tracer);
+  const sessionKey = `continuation-span-uniformity-${params.mode}`;
+  const run = createContinuationRun({
+    mode: params.mode,
+    sessionKey,
+    currentChainCount: params.currentChainCount,
+  });
+  runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+    enqueuePendingDelegate(sessionKey, {
+      task: `check span uniformity for ${params.mode}`,
+      mode: params.mode,
+    });
+    return {
+      payloads: [{ text: "Queued delegate." }],
+      meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+    };
+  });
+
+  await runDelegateTurn(run, { [sessionKey]: run.sessionEntry });
+
+  const dispatchSpans = spans.filter((s) => s.name === "continuation.delegate.dispatch");
+  expect(dispatchSpans).toHaveLength(1);
+  const dispatchSpan = dispatchSpans[0];
+  if (!dispatchSpan) {
+    throw new Error(`expected continuation.delegate.dispatch span for ${params.mode}`);
+  }
+  return dispatchSpan;
+}
+
+describe("runReplyAgent :: delegate dispatch span uniformity", () => {
+  it("emits uniform continuation.delegate.dispatch spans for silent and silent-wake tool delegates", async () => {
+    const silent = await dispatchToolDelegateMode({ mode: "silent", currentChainCount: 1 });
+    const silentWake = await dispatchToolDelegateMode({
+      mode: "silent-wake",
+      currentChainCount: 2,
+    });
+
+    for (const [mode, span] of [
+      ["silent", silent],
+      ["silent-wake", silentWake],
+    ] as const) {
+      expect(span.status).toBe("OK");
+      expect(span.ended).toBe(true);
+      expect(span.attributes["chain.id"]).toBe(PARENT_CHAIN_ID);
+      expect(span.attributes["delay.ms"]).toBe(0);
+      expect(span.attributes["delegate.delivery"]).toBe("immediate");
+      expect(span.attributes["delegate.mode"]).toBe(mode);
+    }
+
+    expect(Object.keys(silent.attributes).toSorted()).toEqual(
+      Object.keys(silentWake.attributes).toSorted(),
+    );
+
+    const stableKeys = Object.keys(silent.attributes).filter(
+      (key) => key !== "delegate.mode" && key !== "chain.step.remaining",
+    );
+    for (const key of stableKeys) {
+      expect(silent.attributes[key]).toBe(silentWake.attributes[key]);
+    }
+    expect(silent.attributes["chain.step.remaining"]).toBe(4);
+    expect(silentWake.attributes["chain.step.remaining"]).toBe(3);
+  });
+
+  // Production gap: post-compaction delegate delivery persists continuation
+  // chain state but does not emit `continuation.delegate.dispatch` with
+  // `delegate.mode = "post-compaction"` yet. Leave this as the trap for the
+  // production lane rather than changing production in this test-only PR.
+  it.todo(
+    "emits exactly one continuation.delegate.dispatch span for post-compaction delegates with the same attribute-key shape",
+  );
+});

--- a/tmp-drop-me-otel-span-uniformity.md
+++ b/tmp-drop-me-otel-span-uniformity.md
@@ -1,0 +1,14 @@
+# OTEL delegate span uniformity journal
+
+- 2026-05-01T16:52:07-07:00 — Read `WORKORDER.md` and root guidance. `pnpm docs:list` is available and ran successfully.
+- 2026-05-01T16:53:00-07:00 — Attempted required bootstrap runbook read; environment denied access to the external bootstrap file, so I continued inside this worktree and kept the denial recorded here.
+- 2026-05-01T16:53:40-07:00 — Initial local branch was at an older copy of `cael/325-canonical2`; fetched `origin/cael/325-canonical2` and fast-forwarded `cael/otel-span-uniformity-test` to it. Preserved `WORKORDER.md` as an untracked local artifact.
+- 2026-05-01T16:54:16-07:00 — Read current continuation tracer, tracer tests, delegate dispatch paths, post-compaction dispatch path, and RFC §6.7. Current span name is `continuation.delegate.dispatch`; there is no literal `delegate.continuation` span name in this branch.
+- 2026-05-01T16:54:16-07:00 — Found silent and silent-wake delegate dispatch emission in `agent-runner.ts`; post-compaction delivery persists chain state but does not emit a delegate dispatch span, so that case will be pinned as a TODO gap per workorder.
+- 2026-05-01T16:54:54-07:00 — Added `agent-runner.continuation-span-uniformity.test.ts`. Targeted `pnpm test src/auto-reply/reply/agent-runner.continuation-span-uniformity.test.ts` passed: 1 passing assertion, 1 TODO.
+- 2026-05-01T16:55:14-07:00 — `pnpm tsgo` passed. Initial `pnpm check` failed on existing continuation-mode test lint in the updated base; made test-only lint cleanups in `types.mode-shape.test.ts` and `continuation-tools-registration.test.ts`.
+- 2026-05-01T16:56:00-07:00 — Rerun `pnpm check` passed.
+- 2026-05-01T17:00:00-07:00 — First full `pnpm test` failed in unrelated `src/gateway/server.roles-allowlist-update.test.ts`; isolated rerun of that file passed.
+- 2026-05-01T17:02:30-07:00 — Second full `pnpm test` failed in unrelated `extensions/amazon-bedrock/index.test.ts`; isolated rerun of that file passed.
+- 2026-05-01T17:03:00-07:00 — `pnpm build` passed.
+- 2026-05-01T17:05:00-07:00 — Final full `pnpm test` passed: 412 test files passed, 4551 tests passed, 4 skipped.


### PR DESCRIPTION
## Summary

Adds a runner integration trap for delegate-dispatch span uniformity across continuation delegate modes. The current tracer contract emits `continuation.delegate.dispatch`; the test covers the shipped silent and silent-wake tool-delegate paths and pins post-compaction as the remaining production gap with `it.todo`.

Gap-list reference: 🌊 Discord message `1499912840453296188` from the workorder (channel URL was not available in this worktree).

## Per-mode result

| Mode | Result | Evidence |
| --- | --- | --- |
| `silent` | PASS | Exactly one `continuation.delegate.dispatch` span; `delegate.mode=silent`; `chain.id` preserves the existing parent chain id; uniform key set. |
| `silent-wake` | PASS | Exactly one `continuation.delegate.dispatch` span; `delegate.mode=silent-wake`; `chain.id` preserves the existing parent chain id; uniform key set. |
| `post-compaction` | TODO | Production gap: post-compaction delegate delivery persists continuation chain state but does not emit `continuation.delegate.dispatch` with `delegate.mode=post-compaction` yet. |

## Sabotage walk

To fail this trap, remove or rename the runner-side `emitContinuationDelegateSpan` call for accepted tool delegates, drop `chain.id`, `delegate.mode`, `delegate.delivery`, or `chain.step.remaining` from the emitted attributes, mint a fresh chain id instead of preserving an existing parent chain id, or add the post-compaction production emitter without replacing the TODO with a passing assertion.

## Gates

| Command | Exit | Notes |
| --- | ---: | --- |
| `pnpm tsgo` | 0 | Passed. |
| `pnpm check` | 0 | Passed after test-only lint cleanup in existing continuation-mode tests. |
| `pnpm test src/auto-reply/reply/agent-runner.continuation-span-uniformity.test.ts` | 0 | 1 passed, 1 TODO. |
| `pnpm test` | 0 | Final full-suite rerun passed: 412 files, 4551 tests, 4 skipped. Earlier full reruns exposed unrelated flaky shards that both passed in isolation. |
| `pnpm build` | 0 | Passed. |
