### PR TITLE
fix(commands): restore channel-native command auth + owner allowlist preservation (Refs #518)

### DIFF
--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -99,6 +99,31 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.senderIsOwner).toBe(false);
   });
 
+  it("does not let native command authorization bypass explicit owner allowlists", () => {
+    const cfg = {
+      channels: { telegram: {} },
+      commands: { ownerAllowFrom: ["456"] },
+    } as OpenClawConfig;
+
+    const ctx = {
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SenderId: "200482621",
+      CommandSource: "native",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(false);
+  });
+
   it("senderIsOwner is true when ownerAllowFrom matches sender", () => {
     const cfg = {
       channels: { discord: {} },

--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -53,6 +53,30 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.isAuthorizedSender).toBe(true);
   });
 
+  it("keeps channel-validated native group commands authorized without owner status", () => {
+    const cfg = {
+      channels: { telegram: {} },
+    } as OpenClawConfig;
+
+    const ctx = {
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SenderId: "200482621",
+      CommandSource: "native",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
   it("senderIsOwner is false when ownerAllowFrom is configured and sender does not match", () => {
     const cfg = {
       channels: { discord: {} },

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -429,6 +429,7 @@ function resolveOwnerAuthorizationState(params: {
 
 function resolveCommandSenderAuthorization(params: {
   commandAuthorized: boolean;
+  nativeCommandAuthorized: boolean;
   isOwnerForCommands: boolean;
   senderCandidates: string[];
   commandsAllowFromList: string[] | null;
@@ -450,10 +451,7 @@ function resolveCommandSenderAuthorization(params: {
       !params.providerResolutionError && (commandsAllowAll || Boolean(matchedCommandsAllowFrom))
     );
   }
-  if (params.commandAuthorized) {
-    return true;
-  }
-  return params.isOwnerForCommands;
+  return params.commandAuthorized && (params.isOwnerForCommands || params.nativeCommandAuthorized);
 }
 
 function isConversationLikeIdentity(value: string): boolean {
@@ -707,8 +705,11 @@ export function resolveCommandAuthorization(params: {
       : ownerAllowlistConfigured
         ? senderIsOwner
         : senderIsOwnerByScope || Boolean(matchedCommandOwner);
+  const nativeCommandAuthorized =
+    commandAuthorized && ctx.CommandSource === "native" && !ownerAllowlistConfigured;
   const isAuthorizedSender = resolveCommandSenderAuthorization({
     commandAuthorized,
+    nativeCommandAuthorized,
     isOwnerForCommands,
     senderCandidates,
     commandsAllowFromList,

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -450,7 +450,10 @@ function resolveCommandSenderAuthorization(params: {
       !params.providerResolutionError && (commandsAllowAll || Boolean(matchedCommandsAllowFrom))
     );
   }
-  return params.commandAuthorized && params.isOwnerForCommands;
+  if (params.commandAuthorized) {
+    return true;
+  }
+  return params.isOwnerForCommands;
 }
 
 function isConversationLikeIdentity(value: string): boolean {

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -202,6 +202,49 @@ describe("resolveCommandAuthorization", () => {
     expect(auth.isAuthorizedSender).toBe(false);
   });
 
+  it("allows channel-validated native commands when plugin owner enforcement has no owner allowlist", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          plugin: {
+            ...createOutboundTestPlugin({
+              id: "discord",
+              outbound: { deliveryMode: "direct" },
+            }),
+            commands: { enforceOwnerForCommands: true },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({}),
+              resolveAllowFrom: () => ["*"],
+              formatAllowFrom,
+            },
+          },
+          source: "test",
+        },
+      ]),
+    );
+    const cfg = {
+      channels: { discord: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+
+    const auth = resolveCommandAuthorization({
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "direct",
+        From: "discord:123",
+        SenderId: "123",
+        CommandSource: "native",
+      } as MsgContext,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
   it("uses explicit owner allowlist when allowFrom is empty", () => {
     const cfg = {
       commands: { ownerAllowFrom: ["whatsapp:+15551234567"] },


### PR DESCRIPTION
Restores `nativeCommandAuthorized` plumbing missing from `cael/325-canonical2` fork-point. Cherry-picks Ayaan Zaidi's two upstream fixes verbatim:

- `7b91f06384` fix(commands): honor channel-native command auth — `command-auth.ts` AND-gate flip + 1 test case
- `8af50b5b4c` fix(commands): preserve owner allowlists for native auth — `command-auth.ts` allowlist-aware fallback + 2 test cases (`command-auth.owner-default.test.ts`, `command-control.test.ts`)

## Why

Per 🩸's frond-scribe-pattern-g-bisect (#518) + 🌊's mechanism correction (msg `1499960459053502494`):

- HEAD `a1c5b13458` carries the **pre-fix AND-gate** at `command-auth.ts:453`: `return params.commandAuthorized && params.isOwnerForCommands`
- Native channel-validated group commands (e.g. Telegram `/command` in groups, channel-native operator.admin) get **rejected for non-owner senders** even when no `ownerAllowFrom` is configured
- Privilege-boundary regression — silent at HEAD because covering tests were never on this fork-point

Mechanism correction per 🌊: `7b91f06384` is **not an ancestor** of `cael/325-canonical2`. Canonical2 fork-point predates the upstream landing; #515 squash didn't touch `command-auth.ts`. This is a missing-from-fork-point hole, not a squash-drop. Cure is the same: cherry-pick the two fix commits onto current HEAD.

## Verification

Local on `cael/325-canonical2` HEAD `a1c5b13458` post-cherry-pick:

- `src/auto-reply/command-auth.owner-default.test.ts`: **8/8 ✅** (was 7/8 pre-fix per #518)
- `src/auto-reply/command-control.test.ts`: **43/43 ✅**

## Diff scope

5 files, +101/-5:
- `src/auto-reply/command-auth.ts` — AND-gate flip + allowlist-aware fallback
- `src/auto-reply/command-auth.owner-default.test.ts` — +49 lines, 2 new test cases
- `src/auto-reply/command-control.test.ts` — +43 lines, 1 new test case

No production-code drift outside `command-auth.ts`. Surgical.

## Refs

- Closes #518
- Bisect comment: https://github.com/karmaterminal/openclaw/issues/518#issuecomment-4362660947
- 🌊 mechanism correction: msg `1499960459053502494` in #sprites-of-thornfield
- Original upstream commits authored by Ayaan Zaidi <hi@obviy.us> (Apr 28); cherry-picked verbatim, attribution preserved

Co-authored-by: Ayaan Zaidi <hi@obviy.us>
Co-authored-by: Cael 🩸 <cael.dandelion.cult@hotmail.com>
Co-authored-by: Ronan 🌊 <ronan@dandelion.cult>