### PR TITLE
🚨 P1 hotfix to #515: restore dropped nativeCommandAuthorized plumbing (security-boundary regression)

### DIFF
--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -99,6 +99,31 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.senderIsOwner).toBe(false);
   });
 
+  it("does not let native command authorization bypass explicit owner allowlists", () => {
+    const cfg = {
+      channels: { telegram: {} },
+      commands: { ownerAllowFrom: ["456"] },
+    } as OpenClawConfig;
+
+    const ctx = {
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SenderId: "200482621",
+      CommandSource: "native",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(false);
+  });
+
   it("senderIsOwner is true when ownerAllowFrom matches sender", () => {
     const cfg = {
       channels: { discord: {} },

--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -53,6 +53,30 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.isAuthorizedSender).toBe(true);
   });
 
+  it("keeps channel-validated native group commands authorized without owner status", () => {
+    const cfg = {
+      channels: { telegram: {} },
+    } as OpenClawConfig;
+
+    const ctx = {
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SenderId: "200482621",
+      CommandSource: "native",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
   it("senderIsOwner is false when ownerAllowFrom is configured and sender does not match", () => {
     const cfg = {
       channels: { discord: {} },

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -429,6 +429,7 @@ function resolveOwnerAuthorizationState(params: {
 
 function resolveCommandSenderAuthorization(params: {
   commandAuthorized: boolean;
+  nativeCommandAuthorized: boolean;
   isOwnerForCommands: boolean;
   senderCandidates: string[];
   commandsAllowFromList: string[] | null;
@@ -450,10 +451,7 @@ function resolveCommandSenderAuthorization(params: {
       !params.providerResolutionError && (commandsAllowAll || Boolean(matchedCommandsAllowFrom))
     );
   }
-  if (params.commandAuthorized) {
-    return true;
-  }
-  return params.isOwnerForCommands;
+  return params.commandAuthorized && (params.isOwnerForCommands || params.nativeCommandAuthorized);
 }
 
 function isConversationLikeIdentity(value: string): boolean {
@@ -707,8 +705,11 @@ export function resolveCommandAuthorization(params: {
       : ownerAllowlistConfigured
         ? senderIsOwner
         : senderIsOwnerByScope || Boolean(matchedCommandOwner);
+  const nativeCommandAuthorized =
+    commandAuthorized && ctx.CommandSource === "native" && !ownerAllowlistConfigured;
   const isAuthorizedSender = resolveCommandSenderAuthorization({
     commandAuthorized,
+    nativeCommandAuthorized,
     isOwnerForCommands,
     senderCandidates,
     commandsAllowFromList,

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -450,7 +450,10 @@ function resolveCommandSenderAuthorization(params: {
       !params.providerResolutionError && (commandsAllowAll || Boolean(matchedCommandsAllowFrom))
     );
   }
-  return params.commandAuthorized && params.isOwnerForCommands;
+  if (params.commandAuthorized) {
+    return true;
+  }
+  return params.isOwnerForCommands;
 }
 
 function isConversationLikeIdentity(value: string): boolean {

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -202,6 +202,49 @@ describe("resolveCommandAuthorization", () => {
     expect(auth.isAuthorizedSender).toBe(false);
   });
 
+  it("allows channel-validated native commands when plugin owner enforcement has no owner allowlist", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          plugin: {
+            ...createOutboundTestPlugin({
+              id: "discord",
+              outbound: { deliveryMode: "direct" },
+            }),
+            commands: { enforceOwnerForCommands: true },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({}),
+              resolveAllowFrom: () => ["*"],
+              formatAllowFrom,
+            },
+          },
+          source: "test",
+        },
+      ]),
+    );
+    const cfg = {
+      channels: { discord: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+
+    const auth = resolveCommandAuthorization({
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "direct",
+        From: "discord:123",
+        SenderId: "123",
+        CommandSource: "native",
+      } as MsgContext,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
   it("uses explicit owner allowlist when allowFrom is empty", () => {
     const cfg = {
       commands: { ownerAllowFrom: ["whatsapp:+15551234567"] },


### PR DESCRIPTION
## 🚨 P1 hotfix to #515: restore dropped `nativeCommandAuthorized` plumbing

### Severity

**Privilege-boundary regression on the shipped cut-frame `a1c5b13458ce`.** Native channel-validated group commands (e.g. Telegram `/command` in groups, Discord slash commands) are rejected for non-owner senders even when no explicit `ownerAllowFrom` is configured. Silent at HEAD because the covering tests were also dropped by the same squash.

### Root cause

`cael/325-canonical2` fork-point hygiene: PR #515's Path-B v3 cleanup squash flattened the rebase branch and **dropped two commits authored by Ayaan Zaidi during canonical2 churn**:
- `7b91f06384` — `fix(commands): honor channel-native command auth` (3-line semantic delta in `resolveCommandSenderAuthorization` + 24 lines of test coverage)
- `8af50b5b4c` — `fix(commands): preserve owner allowlists for native auth` (9-line refinement + 25 + 43 lines of test coverage across `command-auth.owner-default.test.ts` and `command-control.test.ts`)

🩸's frond-scribe-pattern-g-bisect lane on `claude-opus-4-6` root-caused this from issue #518's 7/8 failing test bisect. Full receipts: <https://github.com/karmaterminal/openclaw/issues/518#issuecomment-4362660947>.

🌻's byte-walk verification on `cael/325-canonical2` (post-#515): `command-auth.ts` is 728 → 725 lines (3-line delta missing); `command-auth.owner-default.test.ts` is 163 → 139 lines (24-line test coverage missing). Confirmed the squash ate both fix and tests.

### Fix shape

Pure cherry-pick of the two original commits onto post-#515 `cael/325-canonical2` HEAD `a1c5b13458ce`. Both commits applied clean:

- `c1c51def99` ← `7b91f06384`: 2 files +28/-1
- `dfd81ea2d0` ← `8af50b5b4c`: 3 files +73/-4

### Verification

Local target test pass: **51/51 ✅** on `command-auth.owner-default.test.ts` (8) + `command-control.test.ts` (43).

### Cohort cosign needed

Lane is sensitive (security-boundary). 🩸 / 🌫 / 🌊 — please byte-walk the two commits before merge.

🌻 — provisional cosign in body (root-cause + verify confirmed from cael-spark seat).

### Author attribution

Cherry-picks preserve `Ayaan Zaidi <hi@obviy.us>` original authorship, as the fixes are upstream-authored.
