### PR TITLE
fix(#518): forward-port channel-native command auth from upstream

### DIFF
--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -99,6 +99,31 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.senderIsOwner).toBe(false);
   });
 
+  it("does not let native command authorization bypass explicit owner allowlists", () => {
+    const cfg = {
+      channels: { telegram: {} },
+      commands: { ownerAllowFrom: ["456"] },
+    } as OpenClawConfig;
+
+    const ctx = {
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SenderId: "200482621",
+      CommandSource: "native",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(false);
+  });
+
   it("senderIsOwner is true when ownerAllowFrom matches sender", () => {
     const cfg = {
       channels: { discord: {} },

--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -53,6 +53,30 @@ describe("senderIsOwner only reflects explicit owner authorization", () => {
     expect(auth.isAuthorizedSender).toBe(true);
   });
 
+  it("keeps channel-validated native group commands authorized without owner status", () => {
+    const cfg = {
+      channels: { telegram: {} },
+    } as OpenClawConfig;
+
+    const ctx = {
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+      From: "telegram:group:-100123",
+      SenderId: "200482621",
+      CommandSource: "native",
+    } as MsgContext;
+
+    const auth = resolveCommandAuthorization({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
   it("senderIsOwner is false when ownerAllowFrom is configured and sender does not match", () => {
     const cfg = {
       channels: { discord: {} },

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -429,6 +429,7 @@ function resolveOwnerAuthorizationState(params: {
 
 function resolveCommandSenderAuthorization(params: {
   commandAuthorized: boolean;
+  nativeCommandAuthorized: boolean;
   isOwnerForCommands: boolean;
   senderCandidates: string[];
   commandsAllowFromList: string[] | null;
@@ -450,10 +451,7 @@ function resolveCommandSenderAuthorization(params: {
       !params.providerResolutionError && (commandsAllowAll || Boolean(matchedCommandsAllowFrom))
     );
   }
-  if (params.commandAuthorized) {
-    return true;
-  }
-  return params.isOwnerForCommands;
+  return params.commandAuthorized && (params.isOwnerForCommands || params.nativeCommandAuthorized);
 }
 
 function isConversationLikeIdentity(value: string): boolean {
@@ -707,8 +705,11 @@ export function resolveCommandAuthorization(params: {
       : ownerAllowlistConfigured
         ? senderIsOwner
         : senderIsOwnerByScope || Boolean(matchedCommandOwner);
+  const nativeCommandAuthorized =
+    commandAuthorized && ctx.CommandSource === "native" && !ownerAllowlistConfigured;
   const isAuthorizedSender = resolveCommandSenderAuthorization({
     commandAuthorized,
+    nativeCommandAuthorized,
     isOwnerForCommands,
     senderCandidates,
     commandsAllowFromList,

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -450,7 +450,10 @@ function resolveCommandSenderAuthorization(params: {
       !params.providerResolutionError && (commandsAllowAll || Boolean(matchedCommandsAllowFrom))
     );
   }
-  return params.commandAuthorized && params.isOwnerForCommands;
+  if (params.commandAuthorized) {
+    return true;
+  }
+  return params.isOwnerForCommands;
 }
 
 function isConversationLikeIdentity(value: string): boolean {

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -202,6 +202,49 @@ describe("resolveCommandAuthorization", () => {
     expect(auth.isAuthorizedSender).toBe(false);
   });
 
+  it("allows channel-validated native commands when plugin owner enforcement has no owner allowlist", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          plugin: {
+            ...createOutboundTestPlugin({
+              id: "discord",
+              outbound: { deliveryMode: "direct" },
+            }),
+            commands: { enforceOwnerForCommands: true },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({}),
+              resolveAllowFrom: () => ["*"],
+              formatAllowFrom,
+            },
+          },
+          source: "test",
+        },
+      ]),
+    );
+    const cfg = {
+      channels: { discord: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+
+    const auth = resolveCommandAuthorization({
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "direct",
+        From: "discord:123",
+        SenderId: "123",
+        CommandSource: "native",
+      } as MsgContext,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
+  });
+
   it("uses explicit owner allowlist when allowFrom is empty", () => {
     const cfg = {
       commands: { ownerAllowFrom: ["whatsapp:+15551234567"] },


### PR DESCRIPTION
Fixes #518.

## Summary

Forward-ports two upstream commits onto `cael/325-canonical2` HEAD `a1c5b13458c`:

- `7b91f06384` — `fix(commands): honor channel-native command auth` (Ayaan Zaidi, Apr 28)
- `8af50b5b4c` — `fix(commands): preserve owner allowlists for native auth`

Lands as:
- `1586b00e` (cherry-pick of 7b91f06384)
- `923089a6` (cherry-pick of 8af50b5b4c)

**3 files, +97/-1.**

## Why forward-port (not hotfix-restore)

The frond-scribe-pattern-g-bisect lane characterized #518 as "squash dropped the fix." Byte-walk says otherwise:

```
$ git merge-base --is-ancestor 7b91f06384 origin/frond-scribe/325-canonical2-pathB-rebase ; echo $?
1   # NOT-ANCESTOR
$ git merge-base --is-ancestor 8af50b5b4c origin/frond-scribe/325-canonical2-pathB-rebase ; echo $?
1   # NOT-ANCESTOR
$ git log 9b31762f611..origin/frond-scribe/325-canonical2-pathB-rebase -- src/auto-reply/command-auth.ts
(empty)
```

Neither fix was ever on `frond-scribe/325-canonical2-pathB-rebase`. The path-B branch never touched `command-auth.ts` between fork-point `9b31762f611` and squash. The #515 squash had nothing to drop. Both fixes live only on `upstream/main` + `ronan/v2-tsgo-repair`. canonical2's fork-point predates the upstream landings being picked up.

This is **missing-from-fork-point, forward-port from upstream** — not a hotfix-restore. Same operational severity, cleaner audit trail.

## Production impact (severity: figs-tier)

At HEAD of `cael/325-canonical2`, `src/auto-reply/command-auth.ts:453` reads:

```ts
return params.commandAuthorized && params.isOwnerForCommands;
```

This AND-gates channel-native command authorization against owner-identity. **Native channel-validated group commands (e.g. Telegram `/command` in groups, Discord native slash commands) get rejected for non-owner senders even when the channel-native auth path explicitly authorizes them.**

The forward-port flips this to:

```ts
if (params.commandAuthorized) return true;
return params.isOwnerForCommands;
```

— `commandAuthorized` (channel-native auth saying yes) becomes SUFFICIENT, restoring the channel-native auth path.

The second cherry-pick adds `nativeCommandAuthorized` plumbing + owner-allowlist preservation so that explicit `ownerAllowFrom` config still gates as expected when present.

## Carrier-branch verification (anti-stale-fork-point check)

Branch was opened from a fresh clone of `cael/325-canonical2` HEAD `a1c5b13458c` (depth 50). Cherry-picks via `git format-patch` + `git am` (cleaner than via cherry-pick when the SHAs aren't in the local clone's reachable history). Diff vs base = exactly the 3 files / +97/-1 above. **No fork-point drag, no collateral reverts.**

This is the pattern PR #523 should have used.

## Closes / supersedes

- Closes #518
- Supersedes PR #523 (recommend close — that one would un-ship #515 + the entire canonical2 wave; CHANGES_REQUESTED filed there)

## Test coverage

Cherry-pick `923089a6` brings `command-auth.owner-default.test.ts` (+49) + `command-control.test.ts` (+43). Coverage matches the 7/8 fail surface frond-scribe characterized — those tests live only in this forward-port, which is why the scribe couldn't reproduce the failures standalone at `90ff152548` (the tests don't exist in path-B's lineage).

🌊