### PR TITLE
Log Discord native command failure metadata

### DIFF
--- a/extensions/discord/src/internal/rest.test.ts
+++ b/extensions/discord/src/internal/rest.test.ts
@@ -175,6 +175,39 @@ describe("RequestClient", () => {
     });
   });
 
+  it("adds request metadata to Discord REST abort errors", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn(
+      async (_input: string | URL | Request, init?: RequestInit) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("This operation was aborted", "AbortError"));
+          });
+        }),
+    );
+    const client = new RequestClient("test-token", {
+      queueRequests: false,
+      timeout: 5,
+      fetch: fetchSpy,
+    });
+
+    const request = client
+      .post("/interactions/interaction-1/sensitive-token/callback", {
+        body: { type: 5 },
+      })
+      .catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(5);
+
+    const error = await request;
+    expect(error).toBeInstanceOf(DOMException);
+    expect(String(error)).toContain(
+      "Discord REST request aborted: method=POST path=/interactions/interaction-1/<token>/callback",
+    );
+    expect(String(error)).toContain("timeoutMs=5");
+    expect(String(error)).toContain("timedOut=true");
+    expect(String(error)).not.toContain("sensitive-token");
+  });
+
   it("tracks invalid requests and exposes bucket scheduler metrics", async () => {
     const client = new RequestClient("test-token", {
       queueRequests: false,

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -1,4 +1,5 @@
 import { inspect } from "node:util";
+import { createSubsystemLogger, danger } from "openclaw/plugin-sdk/runtime-env";
 import { serializeRequestBody } from "./rest-body.js";
 import {
   DiscordError,
@@ -62,6 +63,33 @@ const defaultOptions = {
 };
 
 const DEFAULT_MAX_CONCURRENT_WORKERS = 4;
+const log = createSubsystemLogger("discord/rest");
+
+function sanitizeDiscordRestPath(path: string): string {
+  const [pathname = path] = path.split("?");
+  const parts = pathname.replace(/^\/+/, "").split("/");
+  if (parts[0] === "interactions" && parts.length >= 4) {
+    return `/${["interactions", parts[1] || "<unknown>", "<token>", ...parts.slice(3)].join("/")}`;
+  }
+  if (parts[0] === "webhooks" && parts.length >= 3) {
+    return `/${["webhooks", parts[1] || "<unknown>", "<token>", ...parts.slice(3)].join("/")}`;
+  }
+  return pathname;
+}
+
+function formatDiscordRestAbortMessage(params: {
+  method: string;
+  path: string;
+  routeKey: string;
+  timeoutMs: number;
+  elapsedMs: number;
+  timedOut: boolean;
+}): string {
+  const method = params.method.toUpperCase();
+  const path = sanitizeDiscordRestPath(params.path);
+  const routeKey = sanitizeDiscordRestPath(params.routeKey.replace(/^\S+\s+/, ""));
+  return `Discord REST request aborted: method=${method} path=${path} route=${method} ${routeKey} timeoutMs=${params.timeoutMs} elapsedMs=${params.elapsedMs} timedOut=${params.timedOut}`;
+}
 
 function coerceResponseBody(raw: string): unknown {
   if (!raw) {
@@ -147,7 +175,13 @@ export class RequestClient {
     }
     const body = serializeRequestBody(params.data, headers);
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.options.timeout ?? 15_000);
+    const timeoutMs = this.options.timeout ?? 15_000;
+    const startedAt = Date.now();
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeoutMs);
     timeout.unref?.();
     this.requestControllers.add(controller);
     try {
@@ -178,7 +212,16 @@ export class RequestClient {
       return parsed;
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
-        throw error;
+        const message = formatDiscordRestAbortMessage({
+          method,
+          path,
+          routeKey,
+          timeoutMs,
+          elapsedMs: Date.now() - startedAt,
+          timedOut,
+        });
+        log.warn(danger(message));
+        throw new DOMException(message, "AbortError");
       }
       if (error instanceof Error) {
         throw error;

--- a/extensions/discord/src/monitor/listeners.test.ts
+++ b/extensions/discord/src/monitor/listeners.test.ts
@@ -183,7 +183,29 @@ describe("DiscordInteractionListener", () => {
     await flushAsyncWork();
 
     expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining("discord interaction handler failed: Error: interaction boom"),
+      expect.stringContaining(
+        "discord interaction handler failed: interactionId=interaction-1 command=<unknown> type=<unknown> phase=receive error=Error: interaction boom",
+      ),
+    );
+  });
+
+  it("logs interaction id and command name for async interaction failures", async () => {
+    const handleInteraction = vi.fn(async () => {
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    });
+    const logger = createLogger();
+    const listener = new DiscordInteractionListener(logger as never);
+
+    await listener.handle(
+      { id: "interaction-2", type: "2", data: { name: "status" } } as never,
+      { handleInteraction } as never,
+    );
+    await flushAsyncWork();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "discord interaction handler failed: interactionId=interaction-2 command=status type=2 phase=receive error=AbortError: aborted",
+      ),
     );
   });
 

--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -54,6 +54,33 @@ export class DiscordMessageListener extends MessageCreateListener {
   }
 }
 
+function readInteractionString(data: DiscordInteractionEvent, key: string): string | undefined {
+  if (!data || typeof data !== "object" || !(key in data)) {
+    return undefined;
+  }
+  const value = (data as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function describeInteractionForLog(data: DiscordInteractionEvent): string {
+  const id = readInteractionString(data, "id") ?? "<unknown>";
+  const rawData =
+    data && typeof data === "object" && "data" in data
+      ? (data as { data?: unknown }).data
+      : undefined;
+  const nestedCommandName =
+    rawData && typeof rawData === "object" && "name" in rawData
+      ? (rawData as { name?: unknown }).name
+      : undefined;
+  const commandName =
+    readInteractionString(data, "name") ??
+    (typeof nestedCommandName === "string" && nestedCommandName.trim()
+      ? nestedCommandName
+      : "<unknown>");
+  const type = readInteractionString(data, "type") ?? "<unknown>";
+  return `interactionId=${id} command=${commandName} type=${type}`;
+}
+
 export class DiscordInteractionListener extends InteractionCreateListener {
   constructor(
     private logger?: Logger,
@@ -70,7 +97,11 @@ export class DiscordInteractionListener extends InteractionCreateListener {
       .then(() => client.handleInteraction(data as Parameters<Client["handleInteraction"]>[0], {}))
       .catch((err) => {
         const logger = this.logger ?? discordEventQueueLog;
-        logger.error(danger(`discord interaction handler failed: ${String(err)}`));
+        logger.error(
+          danger(
+            `discord interaction handler failed: ${describeInteractionForLog(data)} phase=receive error=${String(err)}`,
+          ),
+        );
       });
   }
 }

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -83,6 +83,30 @@ import type { ThreadBindingManager } from "./thread-bindings.js";
 const log = createSubsystemLogger("discord/native-command");
 export { __testing } from "./native-command.runtime.js";
 
+function formatNativeCommandError(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+function readInteractionId(
+  interaction: CommandInteraction | ButtonInteraction | StringSelectMenuInteraction,
+): string {
+  const rawId = (interaction as { rawData?: { id?: unknown } }).rawData?.id;
+  return typeof rawId === "string" && rawId.trim() ? rawId : "<unknown>";
+}
+
+type NativeCommandPhase = "received" | "defer" | "ack" | "auth" | "dispatch";
+
+type NativeCommandDiagnostics = {
+  phase?: NativeCommandPhase;
+  deferAttempted?: boolean;
+  deferSucceeded?: boolean;
+  authPhase?: "not-run" | "dm-auth" | "guild-auth";
+  authResult?: "not-run" | "allowed" | "allowed-bypass" | "denied";
+};
+
 export function createDiscordNativeCommand(params: {
   command: NativeCommandSpec;
   cfg: OpenClawConfig;
@@ -151,39 +175,63 @@ export function createDiscordNativeCommand(params: {
     options = options;
 
     async run(interaction: CommandInteraction) {
-      const deferred = await safeDiscordInteractionCall("interaction defer", () =>
-        interaction.defer({ ephemeral: this.ephemeral }),
-      );
-      if (deferred === null) {
-        return;
-      }
-      const commandArgs = argDefinitions?.length
-        ? readDiscordCommandArgs(interaction, argDefinitions)
-        : command.acceptsArgs
-          ? parseCommandArgs(commandDefinition, interaction.options.getString("input") ?? "")
+      const interactionId = readInteractionId(interaction);
+      const commandLogName = commandDefinition.nativeName ?? commandDefinition.key ?? command.name;
+      const diagnostics: NativeCommandDiagnostics = {
+        phase: "received",
+        deferAttempted: false,
+        deferSucceeded: false,
+        authPhase: "not-run",
+        authResult: "not-run",
+      };
+      try {
+        diagnostics.phase = "defer";
+        diagnostics.deferAttempted = true;
+        const deferred = await safeDiscordInteractionCall("interaction defer", () =>
+          interaction.defer({ ephemeral: this.ephemeral }),
+        );
+        if (deferred === null) {
+          log.warn(
+            `discord native command defer skipped: interactionId=${interactionId} command=${commandLogName} phase=defer deferAttempted=${diagnostics.deferAttempted ?? false} deferSucceeded=false reason=unknown_interaction`,
+          );
+          return;
+        }
+        diagnostics.deferSucceeded = true;
+        diagnostics.phase = "ack";
+        const commandArgs = argDefinitions?.length
+          ? readDiscordCommandArgs(interaction, argDefinitions)
+          : command.acceptsArgs
+            ? parseCommandArgs(commandDefinition, interaction.options.getString("input") ?? "")
+            : undefined;
+        const commandArgsWithRaw = commandArgs
+          ? ({
+              ...commandArgs,
+              raw: serializeCommandArgs(commandDefinition, commandArgs) ?? commandArgs.raw,
+            } satisfies DiscordCommandArgs)
           : undefined;
-      const commandArgsWithRaw = commandArgs
-        ? ({
-            ...commandArgs,
-            raw: serializeCommandArgs(commandDefinition, commandArgs) ?? commandArgs.raw,
-          } satisfies DiscordCommandArgs)
-        : undefined;
-      const prompt = buildCommandTextFromArgs(commandDefinition, commandArgsWithRaw);
-      await dispatchDiscordCommandInteraction({
-        interaction,
-        prompt,
-        command: commandDefinition,
-        commandArgs: commandArgsWithRaw,
-        cfg,
-        discordConfig,
-        accountId,
-        sessionPrefix,
-        // Slash commands are deferred up front, so all later responses must use
-        // follow-up/edit semantics instead of the initial reply endpoint.
-        preferFollowUp: true,
-        threadBindings,
-        responseEphemeral: ephemeralDefault,
-      });
+        const prompt = buildCommandTextFromArgs(commandDefinition, commandArgsWithRaw);
+        await dispatchDiscordCommandInteraction({
+          interaction,
+          prompt,
+          command: commandDefinition,
+          commandArgs: commandArgsWithRaw,
+          cfg,
+          discordConfig,
+          accountId,
+          sessionPrefix,
+          // Slash commands are deferred up front, so all later responses must use
+          // follow-up/edit semantics instead of the initial reply endpoint.
+          preferFollowUp: true,
+          threadBindings,
+          responseEphemeral: ephemeralDefault,
+          diagnostics,
+        });
+      } catch (error) {
+        log.error(
+          `discord native command failed: interactionId=${interactionId} command=${commandLogName} phase=${diagnostics.phase ?? "received"} deferAttempted=${diagnostics.deferAttempted ?? false} deferSucceeded=${diagnostics.deferSucceeded ?? false} authPhase=${diagnostics.authPhase ?? "not-run"} authResult=${diagnostics.authResult ?? "not-run"} error=${formatNativeCommandError(error)}`,
+        );
+        throw error;
+      }
     }
   })();
 }
@@ -201,6 +249,7 @@ async function dispatchDiscordCommandInteraction(params: {
   threadBindings: ThreadBindingManager;
   responseEphemeral?: boolean;
   suppressReplies?: boolean;
+  diagnostics?: NativeCommandDiagnostics;
 }): Promise<DispatchDiscordCommandInteractionResult> {
   const {
     interaction,
@@ -215,8 +264,10 @@ async function dispatchDiscordCommandInteraction(params: {
     threadBindings,
     responseEphemeral,
     suppressReplies,
+    diagnostics,
   } = params;
   const commandName = command.nativeName ?? command.key;
+  const interactionId = readInteractionId(interaction);
   const respond = async (content: string, options?: { ephemeral?: boolean }) => {
     const ephemeral = options?.ephemeral ?? responseEphemeral;
     const payload = {
@@ -369,6 +420,11 @@ async function dispatchDiscordCommandInteraction(params: {
   const dmPolicy = resolveDiscordAccountDmPolicy({ cfg, accountId }) ?? "pairing";
   let commandAuthorized = true;
   if (isDirectMessage) {
+    if (diagnostics) {
+      diagnostics.phase = "auth";
+      diagnostics.authPhase = "dm-auth";
+      diagnostics.authResult = "not-run";
+    }
     if (!dmEnabled || dmPolicy === "disabled") {
       await respond("Discord DMs are disabled.");
       return { accepted: false };
@@ -386,6 +442,9 @@ async function dispatchDiscordCommandInteraction(params: {
       useAccessGroups,
     });
     commandAuthorized = dmAccess.commandAuthorized;
+    if (dmAccess.decision === "allow" && diagnostics) {
+      diagnostics.authResult = "allowed";
+    }
     if (dmAccess.decision !== "allow") {
       await handleDiscordDmCommandDecision({
         dmAccess,
@@ -406,6 +465,12 @@ async function dispatchDiscordCommandInteraction(params: {
           );
         },
         onUnauthorized: async () => {
+          if (diagnostics) {
+            diagnostics.authResult = "denied";
+          }
+          log.warn(
+            `discord native command auth denied: interactionId=${interactionId} command=${commandName} phase=dm-auth sender=${sender.id} reason=${dmAccess.decision}`,
+          );
           await respond("You are not authorized to use this command.", { ephemeral: true });
         },
       });
@@ -429,6 +494,11 @@ async function dispatchDiscordCommandInteraction(params: {
     return { accepted: false };
   }
   if (!isDirectMessage) {
+    if (diagnostics) {
+      diagnostics.phase = "auth";
+      diagnostics.authPhase = "guild-auth";
+      diagnostics.authResult = "not-run";
+    }
     commandAuthorized = resolveDiscordGuildNativeCommandAuthorized({
       cfg,
       discordConfig,
@@ -442,10 +512,25 @@ async function dispatchDiscordCommandInteraction(params: {
       ownerAllowListConfigured: ownerAllowList != null,
       ownerAllowed: ownerOk,
     });
+    if (commandAuthorized && diagnostics) {
+      diagnostics.authResult = "allowed";
+    }
     if (!commandAuthorized && !(await canBypassConfiguredAcpGuildGuards())) {
+      if (diagnostics) {
+        diagnostics.authResult = "denied";
+      }
+      log.warn(
+        `discord native command auth denied: interactionId=${interactionId} command=${commandName} phase=guild-auth sender=${sender.id} guild=${interaction.guild?.id ?? "<none>"} channel=${rawChannelId || "<unknown>"} reason=command_authorized_false`,
+      );
       await respond("You are not authorized to use this command.", { ephemeral: true });
       return { accepted: false };
     }
+    if (!commandAuthorized && diagnostics) {
+      diagnostics.authResult = "allowed-bypass";
+    }
+  }
+  if (diagnostics) {
+    diagnostics.phase = "dispatch";
   }
 
   const menuNeedsModelContext =
@@ -570,7 +655,6 @@ async function dispatchDiscordCommandInteraction(params: {
 
   const isGuild = Boolean(interaction.guild);
   const channelId = rawChannelId || "unknown";
-  const interactionId = interaction.rawData.id;
   const routeState = await getNativeRouteState();
   if (routeState.bindingReadiness && !routeState.bindingReadiness.ok) {
     const configuredBinding = routeState.configuredBinding;


### PR DESCRIPTION
## Summary
- add Discord native slash-command failure logging with interaction id, command name, defer outcome, and auth phase/result
- add auth-denial journal receipts for DM/guild native command authorization failures
- enrich outer Discord interaction abort/error logs with interaction id and command name for timeout-path repros

Fixes karmaterminal/openclaw#527.

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/monitor/listeners.test.ts extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts --reporter=dot`
- `pnpm tsgo:extensions:test`
