### PR TITLE
Fix Discord slash open guild auth

### DIFF
--- a/extensions/discord/src/monitor/allow-list.ts
+++ b/extensions/discord/src/monitor/allow-list.ts
@@ -542,9 +542,14 @@ export function resolveDiscordChannelPolicyCommandAuthorizer(params: {
   const channelAllowlistConfigured =
     Boolean(params.guildInfo?.channels) && Object.keys(params.guildInfo?.channels ?? {}).length > 0;
   return {
+    // For command authorization, an explicitly open guild policy is itself a
+    // configured authorizer. Without this, guild slash commands can pass the
+    // route gate above but still fail the later command-auth aggregation when
+    // commands.allowFrom and per-guild/member restrictions are absent.
     configured:
-      params.groupPolicy === "allowlist" &&
-      (Boolean(params.guildInfo) || channelAllowlistConfigured),
+      params.groupPolicy === "open" ||
+      (params.groupPolicy === "allowlist" &&
+        (Boolean(params.guildInfo) || channelAllowlistConfigured)),
     allowed: isDiscordGroupAllowedByPolicy({
       groupPolicy: params.groupPolicy,
       guildAllowlisted: Boolean(params.guildInfo),

--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -152,6 +152,26 @@ describe("Discord native slash commands with commands.allowFrom", () => {
     expectNotUnauthorizedReply(interaction);
   });
 
+  it("authorizes guild slash commands when Discord groupPolicy is open and commands.allowFrom is not configured", async () => {
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      mutateConfig: (cfg) => {
+        cfg.commands = {
+          ...cfg.commands,
+          allowFrom: undefined,
+        };
+        cfg.channels = {
+          ...cfg.channels,
+          discord: {
+            groupPolicy: "open",
+            allowFrom: ["*"],
+          },
+        };
+      },
+    });
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expectNotUnauthorizedReply(interaction);
+  });
+
   it("authorizes guild slash commands from an allowlisted channel when commands.allowFrom is not configured", async () => {
     const { dispatchSpy, interaction } = await runGuildSlashCommand({
       mutateConfig: (cfg) => {


### PR DESCRIPTION
## Summary
- Treat `channels.discord.groupPolicy="open"` as a configured command authorizer for native Discord slash command auth.
- Add a regression case for the Silas-shaped config: no `commands.allowFrom`, access groups on by default, `channels.discord.groupPolicy="open"`, and permissive `channels.discord.allowFrom=["*"]`.

## Why
Guild slash commands already pass the route-policy gate under `groupPolicy="open"`, but the later command-auth aggregation only considered allowlist policy/guild/member/commands authorizers as “configured”. With access groups enabled and no `commands.allowFrom`, that made the authorizer set effectively empty and returned `You are not authorized to use this command.`

## Verification
- `pnpm vitest --config test/vitest/vitest.extension-channels.config.ts extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts --run --reporter=dot` — 1 file / 12 tests passed
- `pnpm tsgo` — passed
- commit hook `pnpm check` — passed during commit
