### PR TITLE
fix(config): dynamic-read paths hot-reload

### DIFF
--- a/src/agents/openclaw-tools.sessions-visibility.test.ts
+++ b/src/agents/openclaw-tools.sessions-visibility.test.ts
@@ -26,6 +26,15 @@ function getSessionsHistoryTool(options?: { sandboxed?: boolean }) {
   });
 }
 
+function getLiveSessionsHistoryTool(options?: { sandboxed?: boolean }) {
+  return createSessionsHistoryTool({
+    agentSessionKey: "main",
+    sandboxed: options?.sandboxed,
+    getConfig: () => mockConfig as never,
+    callGateway: (opts: unknown) => callGatewayMock(opts),
+  });
+}
+
 function mockGatewayWithHistory(
   extra?: (req: { method?: string; params?: Record<string, unknown> }) => unknown,
 ) {
@@ -89,6 +98,31 @@ describe("sessions tools visibility", () => {
       sessionKey: "agent:main:quietchat:direct:someone-else",
     });
     expect(result.details).toMatchObject({
+      sessionKey: "agent:main:quietchat:direct:someone-else",
+    });
+  });
+
+  it("re-reads live session visibility config at execution time", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { agentToAgent: { enabled: false } },
+    };
+    mockGatewayWithHistory();
+    const tool = getLiveSessionsHistoryTool();
+
+    const denied = await tool.execute("call-live-before", {
+      sessionKey: "agent:main:quietchat:direct:someone-else",
+    });
+    expect(denied.details).toMatchObject({ status: "forbidden" });
+
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: false } },
+    };
+    const allowed = await tool.execute("call-live-after", {
+      sessionKey: "agent:main:quietchat:direct:someone-else",
+    });
+    expect(allowed.details).toMatchObject({
       sessionKey: "agent:main:quietchat:direct:someone-else",
     });
   });

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,3 +1,4 @@
+import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
@@ -103,6 +104,8 @@ export function createOpenClawTools(
     disableMessageTool?: boolean;
     /** If true, skip plugin tool resolution and return only shipped core tools. */
     disablePluginTools?: boolean;
+    /** If true, session tools read the active runtime config on each execution. */
+    liveSessionToolConfig?: boolean;
     /** Trusted sender id from inbound context (not tool args). */
     requesterSenderId?: string | null;
     /** Whether the requesting sender is an owner. */
@@ -255,6 +258,9 @@ export function createOpenClawTools(
   const effectiveCallGateway = embedded
     ? createEmbeddedCallGateway()
     : openClawToolsDeps.callGateway;
+  const sessionToolConfig = options?.liveSessionToolConfig
+    ? ({ getConfig: getRuntimeConfig } as const)
+    : ({ config: resolvedConfig } as const);
   const tools: AnyAgentTool[] = [
     ...(embedded
       ? []
@@ -306,13 +312,13 @@ export function createOpenClawTools(
     createSessionsListTool({
       agentSessionKey: options?.agentSessionKey,
       sandboxed: options?.sandboxed,
-      config: resolvedConfig,
+      ...sessionToolConfig,
       callGateway: effectiveCallGateway,
     }),
     createSessionsHistoryTool({
       agentSessionKey: options?.agentSessionKey,
       sandboxed: options?.sandboxed,
-      config: resolvedConfig,
+      ...sessionToolConfig,
       callGateway: effectiveCallGateway,
     }),
     ...(embedded
@@ -322,7 +328,7 @@ export function createOpenClawTools(
             agentSessionKey: options?.agentSessionKey,
             agentChannel: options?.agentChannel,
             sandboxed: options?.sandboxed,
-            config: resolvedConfig,
+            ...sessionToolConfig,
             callGateway: openClawToolsDeps.callGateway,
           }),
           createSessionsSpawnTool({
@@ -350,7 +356,7 @@ export function createOpenClawTools(
     }),
     createSessionStatusTool({
       agentSessionKey: options?.agentSessionKey,
-      config: resolvedConfig,
+      ...sessionToolConfig,
       sandboxed: options?.sandboxed,
     }),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -649,6 +649,7 @@ export function createOpenClawCodingTools(options?: {
         : undefined,
       sandboxed: !!sandbox,
       config: options?.config,
+      liveSessionToolConfig: true,
       pluginToolAllowlist: collectExplicitAllowlist([
         profilePolicy,
         providerProfilePolicy,

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -254,6 +254,7 @@ async function resolveModelOverride(params: {
 export function createSessionStatusTool(opts?: {
   agentSessionKey?: string;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
   sandboxed?: boolean;
 }): AnyAgentTool {
   return {
@@ -264,7 +265,7 @@ export function createSessionStatusTool(opts?: {
     parameters: SessionStatusToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
-      const cfg = opts?.config ?? getRuntimeConfig();
+      const cfg = opts?.getConfig?.() ?? opts?.config ?? getRuntimeConfig();
       const { mainKey, alias, effectiveRequesterKey } = resolveSandboxedSessionToolContext({
         cfg,
         agentSessionKey: opts?.agentSessionKey,

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -97,8 +97,9 @@ export function resolveSessionToolContext(opts?: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
 }) {
-  const cfg = opts?.config ?? getRuntimeConfig();
+  const cfg = opts?.getConfig?.() ?? opts?.config ?? getRuntimeConfig();
   return {
     cfg,
     ...resolveSandboxedSessionToolContext({

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -177,6 +177,7 @@ export function createSessionsHistoryTool(opts?: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
   callGateway?: GatewayCaller;
 }): AnyAgentTool {
   return {
@@ -191,7 +192,7 @@ export function createSessionsHistoryTool(opts?: {
       const sessionKeyParam = readStringParam(params, "sessionKey", {
         required: true,
       });
-      const cfg = opts?.config ?? getRuntimeConfig();
+      const cfg = opts?.getConfig?.() ?? opts?.config ?? getRuntimeConfig();
       const { mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
         resolveSandboxedSessionToolContext({
           cfg,

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -60,6 +60,7 @@ export function createSessionsListTool(opts?: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
   callGateway?: GatewayCaller;
 }): AnyAgentTool {
   return {
@@ -70,7 +71,7 @@ export function createSessionsListTool(opts?: {
     parameters: SessionsListToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
-      const cfg = opts?.config ?? getRuntimeConfig();
+      const cfg = opts?.getConfig?.() ?? opts?.config ?? getRuntimeConfig();
       const { mainKey, alias, requesterInternalKey, restrictToSpawned } =
         resolveSandboxedSessionToolContext({
           cfg,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -82,6 +82,7 @@ export function createSessionsSendTool(opts?: {
   agentChannel?: GatewayMessageChannel;
   sandboxed?: boolean;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
   callGateway?: GatewayCaller;
 }): AnyAgentTool {
   return {

--- a/src/auto-reply/continuation/config.test.ts
+++ b/src/auto-reply/continuation/config.test.ts
@@ -2,10 +2,18 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig: vi.fn(() => ({})),
+  getRuntimeConfigSnapshot: vi.fn(() => null),
 }));
 
-import { clampDelayMs, resolveContinuationRuntimeConfig } from "./config.js";
+import { getRuntimeConfigSnapshot } from "../../config/config.js";
+import {
+  clampDelayMs,
+  resolveContinuationRuntimeConfig,
+  resolveLiveContinuationRuntimeConfig,
+} from "./config.js";
 import type { ContinuationRuntimeConfig } from "./types.js";
+
+const getRuntimeConfigSnapshotMock = vi.mocked(getRuntimeConfigSnapshot);
 
 describe("resolveContinuationRuntimeConfig", () => {
   it("returns defaults when continuation is not configured", () => {
@@ -103,6 +111,36 @@ describe("resolveContinuationRuntimeConfig", () => {
   it("has no generationGuardTolerance field", () => {
     const config = resolveContinuationRuntimeConfig({} as never);
     expect("generationGuardTolerance" in config).toBe(false);
+  });
+
+  it("prefers the active runtime snapshot when resolving live config", () => {
+    getRuntimeConfigSnapshotMock.mockReturnValueOnce({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 9 } } },
+    } as never);
+
+    const config = resolveLiveContinuationRuntimeConfig({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 3 } } },
+    } as never);
+
+    expect(config.maxDelegatesPerTurn).toBe(9);
+  });
+
+  it("falls back to the provided config when no runtime snapshot is active", () => {
+    const config = resolveLiveContinuationRuntimeConfig({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 4 } } },
+    } as never);
+
+    expect(config.maxDelegatesPerTurn).toBe(4);
+  });
+
+  it("uses active runtime snapshot defaults when continuation config was unset", () => {
+    getRuntimeConfigSnapshotMock.mockReturnValueOnce({} as never);
+
+    const config = resolveLiveContinuationRuntimeConfig({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 6 } } },
+    } as never);
+
+    expect(config.maxDelegatesPerTurn).toBe(5);
   });
 });
 

--- a/src/auto-reply/continuation/config.ts
+++ b/src/auto-reply/continuation/config.ts
@@ -8,7 +8,7 @@
  * RFC: docs/design/continue-work-signal-v2.md §5
  */
 
-import { getRuntimeConfig } from "../../config/config.js";
+import { getRuntimeConfig, getRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContinuationRuntimeConfig } from "./types.js";
 
@@ -95,6 +95,12 @@ export function resolveContinuationRuntimeConfig(
     contextPressureThreshold: clampOptionalUnitInterval(continuation?.contextPressureThreshold),
     earlyWarningBand: clampEarlyWarningBand(continuation?.earlyWarningBand),
   };
+}
+
+export function resolveLiveContinuationRuntimeConfig(
+  fallbackCfg: OpenClawConfig,
+): ContinuationRuntimeConfig {
+  return resolveContinuationRuntimeConfig(getRuntimeConfigSnapshot() ?? fallbackCfg);
 }
 
 /**

--- a/src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts
@@ -7,6 +7,7 @@ import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
 } from "../../agents/pi-embedded-runner/runs.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   resetContinuationTracer,
@@ -215,6 +216,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  clearRuntimeConfigSnapshot();
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
@@ -292,6 +294,7 @@ async function runDelegateTurn(
   run: ReturnType<typeof createContinuationRun>,
   sessionStore: Record<string, SessionEntry>,
 ): Promise<unknown> {
+  setRuntimeConfigSnapshot(run.followupRun.run.config);
   return runReplyAgent({
     commandBody: "hello",
     followupRun: run.followupRun,

--- a/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
@@ -17,6 +17,7 @@ import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
 } from "../../agents/pi-embedded-runner/runs.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   resetContinuationTracer,
@@ -227,6 +228,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  clearRuntimeConfigSnapshot();
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
@@ -304,6 +306,7 @@ async function runWorkTurn(
   sessionStore: Record<string, SessionEntry>,
   _payloadText: string,
 ): Promise<unknown> {
+  setRuntimeConfigSnapshot(run.followupRun.run.config);
   return runReplyAgent({
     commandBody: "hello",
     followupRun: run.followupRun,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -7,6 +7,7 @@ import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
 } from "../../agents/pi-embedded-runner/runs.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import * as sessionTypesModule from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
@@ -200,6 +201,7 @@ beforeEach(() => {
 afterEach(() => {
   resetDiagnosticEventsForTest();
   vi.useRealTimers();
+  clearRuntimeConfigSnapshot();
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
@@ -266,6 +268,8 @@ describe("runReplyAgent continuation volatile state", () => {
         blockReplyBreak: "message_end",
       },
     } as unknown as FollowupRun;
+
+    setRuntimeConfigSnapshot(followupRun.run.config);
 
     return {
       sessionKey,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -59,7 +59,7 @@ import {
   stagedPostCompactionDelegateCount,
   takeDelayedContinuationReservation,
 } from "../continuation-delegate-store.js";
-import { resolveContinuationRuntimeConfig } from "../continuation/config.js";
+import { resolveLiveContinuationRuntimeConfig } from "../continuation/config.js";
 import { checkContextPressure } from "../continuation/context-pressure.js";
 import { extractContinuationSignal } from "../continuation/signal.js";
 import {
@@ -1427,7 +1427,8 @@ export async function runReplyAgent(params: {
     // crossed. Runs after setPhase("running") for state-tracking reasons,
     // but unconditionally before the actual provider request below.
     if (activeSessionEntry && sessionKey) {
-      const { contextPressureThreshold, earlyWarningBand } = resolveContinuationRuntimeConfig(cfg);
+      const { contextPressureThreshold, earlyWarningBand } =
+        resolveLiveContinuationRuntimeConfig(cfg);
       const contextWindowTokens =
         resolveContextTokensForModel({
           cfg,
@@ -2106,7 +2107,7 @@ export async function runReplyAgent(params: {
     let bracketTokensAccumulated = false;
     if (effectiveContinuationSignal && sessionKey) {
       const { maxChainLength, defaultDelayMs, minDelayMs, maxDelayMs, costCapTokens } =
-        resolveContinuationRuntimeConfig(cfg);
+        resolveLiveContinuationRuntimeConfig(cfg);
 
       {
         // continuation scheduling block
@@ -2506,7 +2507,7 @@ export async function runReplyAgent(params: {
       }
       if (toolDelegates.length > 0) {
         const { maxChainLength, minDelayMs, maxDelayMs, costCapTokens, maxDelegatesPerTurn } =
-          resolveContinuationRuntimeConfig(cfg);
+          resolveLiveContinuationRuntimeConfig(cfg);
         // If a bracket-signal delegate was already spawned this turn, count it
         // against the per-turn cap so mixed-signal turns cannot exceed the limit.
         const bracketDelegateCount = effectiveContinuationSignal?.kind === "delegate" ? 1 : 0;
@@ -2862,7 +2863,7 @@ export async function runReplyAgent(params: {
           agentTo: followupRun.originatingTo ?? undefined,
           agentThreadId: followupRun.originatingThreadId ?? undefined,
         },
-        maxChainLength: resolveContinuationRuntimeConfig(cfg).maxChainLength,
+        maxChainLength: resolveLiveContinuationRuntimeConfig(cfg).maxChainLength,
         // Pass a fresh-loader so the hedge timer re-loads the
         // chain state from the persisted session entry at fire time rather
         // than re-using the snapshot captured at arm time.

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -444,7 +444,7 @@ export function createFollowupRunner(params: {
       if (runtimeConfig?.agents?.defaults?.continuation?.enabled === true && sessionKey) {
         const [
           { dispatchToolDelegates },
-          { resolveContinuationRuntimeConfig },
+          { resolveLiveContinuationRuntimeConfig },
           { loadContinuationChainState, persistContinuationChainState },
           { updateSessionStore, resolveSessionStoreEntry },
         ] = await Promise.all([
@@ -467,7 +467,7 @@ export function createFollowupRunner(params: {
             agentTo: queued.originatingTo ?? undefined,
             agentThreadId: queued.originatingThreadId ?? undefined,
           },
-          maxChainLength: resolveContinuationRuntimeConfig(runtimeConfig).maxChainLength,
+          maxChainLength: resolveLiveContinuationRuntimeConfig(runtimeConfig).maxChainLength,
           // Hedge re-arm must see fresh chain state.
           loadFreshChainState: () => loadContinuationChainState(tailEntry, 0),
         });

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -278,6 +278,7 @@ export async function handleInlineActions(params: {
         agentDir,
         workspaceDir,
         config: cfg,
+        liveSessionToolConfig: true,
         allowGatewaySubagentBinding: true,
         senderIsOwner: command.senderIsOwner,
       });

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1042,6 +1042,47 @@ describe("config cli", () => {
       );
     });
 
+    it("does not print a restart hint for dynamic-read config paths", async () => {
+      const resolved: OpenClawConfig = {
+        tools: { sessions: { visibility: "tree" } },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "tools.sessions.visibility", "all"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const raw = String(mockLog.mock.calls.at(-1)?.[0]);
+      expect(raw).toContain("Updated tools.sessions.visibility.");
+      expect(raw).toContain("No gateway restart required.");
+      expect(raw).not.toContain("Restart the gateway to apply.");
+    });
+
+    it("keeps the restart hint for restart-required config paths", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "gateway.port", "19001"]);
+
+      const raw = String(mockLog.mock.calls.at(-1)?.[0]);
+      expect(raw).toContain("Updated gateway.port.");
+      expect(raw).toContain("Restart the gateway to apply.");
+    });
+
+    it("prints a hot-reload hint for hot config paths", async () => {
+      const resolved: OpenClawConfig = {
+        hooks: { gmail: { account: "old" } },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "hooks.gmail.account", "new"]);
+
+      const raw = String(mockLog.mock.calls.at(-1)?.[0]);
+      expect(raw).toContain("Updated hooks.gmail.account.");
+      expect(raw).toContain("Gateway hot reload will apply.");
+    });
+
     it("supports batch mode for refs/providers in dry-run", async () => {
       const resolved: OpenClawConfig = {
         gateway: { port: 18789 },
@@ -2209,6 +2250,20 @@ describe("config cli", () => {
       expect(mockWriteConfigFile.mock.calls[0]?.[1]).toEqual({
         unsetPaths: [["tools", "alsoAllow"]],
       });
+    });
+
+    it("does not print a restart hint when unsetting a dynamic-read config path", async () => {
+      const resolved: OpenClawConfig = {
+        tools: { sessions: { visibility: "all" } },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "unset", "tools.sessions.visibility"]);
+
+      const raw = String(mockLog.mock.calls.at(-1)?.[0]);
+      expect(raw).toContain("Removed tools.sessions.visibility.");
+      expect(raw).toContain("No gateway restart required.");
+      expect(raw).not.toContain("Restart the gateway to apply.");
     });
   });
 

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -21,6 +21,7 @@ import {
   validateConfigObjectRaw,
 } from "../config/validation.js";
 import { SecretProviderSchema } from "../config/zod-schema.core.js";
+import { buildGatewayReloadPlan, type GatewayReloadPlan } from "../gateway/config-reload-plan.js";
 import { danger, info, success } from "../globals.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
@@ -591,6 +592,23 @@ function pruneInactiveGatewayAuthCredentials(params: {
 
 function toDotPath(path: PathSegment[]): string {
   return path.join(".");
+}
+
+function formatConfigReloadHint(plan: GatewayReloadPlan): string {
+  if (plan.restartGateway) {
+    return "Restart the gateway to apply.";
+  }
+  if (plan.hotReasons.length > 0) {
+    return plan.noopPaths.length > 0
+      ? "Gateway hot reload and dynamic reads will apply."
+      : "Gateway hot reload will apply.";
+  }
+  return "No gateway restart required.";
+}
+
+function resolveConfigReloadHintForPaths(paths: Iterable<PathSegment[]>): string {
+  const changedPaths = [...paths].map(toDotPath).filter(Boolean);
+  return formatConfigReloadHint(buildGatewayReloadPlan(changedPaths));
 }
 
 function parseSecretRefSource(raw: string, label: string): SecretRefSource {
@@ -1540,16 +1558,18 @@ async function runConfigOperations(params: {
   if (params.successMode === "set" && operations.length === 1) {
     const operation = operations[0];
     const action = operation?.mutation === "delete" ? "Removed" : "Updated";
-    runtime.log(
-      info(`${action} ${toDotPath(operation?.requestedPath ?? [])}. Restart the gateway to apply.`),
-    );
+    const reloadHint = resolveConfigReloadHintForPaths([operation?.setPath ?? []]);
+    runtime.log(info(`${action} ${toDotPath(operation?.requestedPath ?? [])}. ${reloadHint}`));
     return;
   }
+  const reloadHint = resolveConfigReloadHintForPaths(
+    operations.map((operation) => operation.setPath),
+  );
   if (params.successMode === "set") {
-    runtime.log(info(`Updated ${operations.length} config paths. Restart the gateway to apply.`));
+    runtime.log(info(`Updated ${operations.length} config paths. ${reloadHint}`));
     return;
   }
-  runtime.log(info(`Applied ${operations.length} config update(s). Restart the gateway to apply.`));
+  runtime.log(info(`Applied ${operations.length} config update(s). ${reloadHint}`));
 }
 
 function handleConfigMutationError(params: {
@@ -1702,7 +1722,8 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
       ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
       writeOptions: { unsetPaths: [parsedPath] },
     });
-    runtime.log(info(`Removed ${opts.path}. Restart the gateway to apply.`));
+    const reloadHint = resolveConfigReloadHintForPaths([parsedPath]);
+    runtime.log(info(`Removed ${opts.path}. ${reloadHint}`));
   } catch (err) {
     runtime.error(danger(String(err)));
     runtime.exit(1);

--- a/src/config/zod-schema.continuation.test.ts
+++ b/src/config/zod-schema.continuation.test.ts
@@ -53,7 +53,7 @@ describe("continuation config schema validation", () => {
     if (!result.success) {
       return;
     }
-    expect(result.data.continuation?.earlyWarningBand).toBe(0.3125);
+    expect(result.data?.continuation?.earlyWarningBand).toBe(0.3125);
   });
 
   it("accepts earlyWarningBand = 0 as opt-out", () => {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -355,6 +355,18 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toContain("diagnostics.stuckSessionWarnMs");
   });
 
+  it("treats session tool visibility as a dynamic-read path", () => {
+    const plan = buildGatewayReloadPlan(["tools.sessions.visibility"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("tools.sessions.visibility");
+  });
+
+  it("treats continuation delegate limits as dynamic-read paths", () => {
+    const plan = buildGatewayReloadPlan(["agents.defaults.continuation.maxDelegatesPerTurn"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("agents.defaults.continuation.maxDelegatesPerTurn");
+  });
+
   it("restarts for gateway.auth.token changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.auth.token"]);
     expect(plan.restartGateway).toBe(true);

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -91,6 +91,7 @@ export function resolveGatewayScopedTools(params: {
     disablePluginTools: params.disablePluginTools,
     senderIsOwner: params.senderIsOwner,
     config: params.cfg,
+    liveSessionToolConfig: true,
     workspaceDir,
     pluginToolAllowlist: collectExplicitAllowlist([
       profilePolicy,


### PR DESCRIPTION
## Summary
- Hot-read `tools.sessions.visibility` for production session tools so visibility changes take effect without rebuilding tool instances.
- Resolve continuation runtime limits, including `agents.defaults.continuation.maxDelegatesPerTurn`, from the active runtime snapshot so gateway reloads apply to runner/delegate paths without restart.
- Gate `openclaw config set/patch/unset` reload hints through `buildGatewayReloadPlan` so dynamic-read paths no longer claim a restart is required.

Closes #19.
Closes #531.
Closes #533.

## Test evidence
- `pnpm test src/gateway/config-reload.test.ts src/cli/config-cli.test.ts src/agents/openclaw-tools.sessions-visibility.test.ts src/agents/tools/continue-delegate-tool.test.ts src/auto-reply/continuation/config.test.ts src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts src/auto-reply/reply/followup-runner.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/openclaw-tools.sessions-visibility.test.ts src/agents/openclaw-tools.ts src/agents/pi-tools.ts src/agents/tools/session-status-tool.ts src/agents/tools/sessions-helpers.ts src/agents/tools/sessions-history-tool.ts src/agents/tools/sessions-list-tool.ts src/agents/tools/sessions-send-tool.ts src/auto-reply/continuation/config.test.ts src/auto-reply/continuation/config.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/get-reply-inline-actions.ts src/cli/config-cli.test.ts src/cli/config-cli.ts src/config/zod-schema.continuation.test.ts src/gateway/config-reload.test.ts src/gateway/tool-resolution.ts`
- `OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`

Blacksmith Testbox warmup was attempted first, but the local CLI is not authenticated (`blacksmith auth login` required), so the broad changed gate was run locally with the repo's throttled local mode.
