### PR TITLE
fix(compaction): persist first-turn manual /compact via canonical primitives

### DIFF
--- a/src/auto-reply/reply/session-updates.compaction.test.ts
+++ b/src/auto-reply/reply/session-updates.compaction.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadSessionStore, type SessionEntry } from "../../config/sessions.js";
+import { incrementCompactionCount } from "./session-updates.js";
+
+// Regression coverage for the canonical-primitives fix in
+// `incrementCompactionCount` (replaces the b82fd65c00 shape that was stripped
+// from #542 because it dropped `mergeSessionEntry` semantics + the
+// `activeSessionKey` preserve-from-prune opt).
+//
+// These tests exercise the load-bearing edges via real fs:
+//   1. First-turn manual /compact: in-memory session has an entry but the
+//      on-disk store is fresh (no entry yet). The persist must merge-or-create
+//      from the active in-memory entry rather than silently dropping the count.
+//   2. sessionId rollover during compaction: the canonical merge primitive
+//      rolls `sessionStartedAt` to the new-session epoch when sessionId
+//      changes (existing.sessionId !== sessionId), which a raw spread would
+//      not do.
+//
+// Tests for monotonic-`updatedAt` under concurrent-compaction races and
+// activeSessionKey-preserve-from-enforce-mode-prune are queued for a follow-up
+// pass — they require concurrent-write simulation and enforce-mode trigger
+// staging that's beyond this PR's scope. The current fix uses the same
+// canonical primitives those scenarios depend on (mergeSessionEntry +
+// `{ activeSessionKey }`), so the structural protection is in place even
+// though the targeted tests are deferred.
+
+describe("incrementCompactionCount canonical-primitives fix", () => {
+  let tmp: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "openclaw-incr-compaction-"));
+    storePath = join(tmp, "sessions.json");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("persists count on first-turn /compact when on-disk store has no entry yet", async () => {
+    const sessionKey = "test:first-turn-compact";
+    const inMemoryEntry: SessionEntry = {
+      sessionId: "session-A",
+      compactionCount: 0,
+      updatedAt: 1_000_000,
+      sessionStartedAt: 900_000,
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: inMemoryEntry,
+    };
+
+    // Sanity: store path must not yet exist — this IS the first-turn case.
+    expect(loadSessionStore(storePath, { skipCache: true })).toEqual({});
+
+    const result = await incrementCompactionCount({
+      sessionStore,
+      sessionKey,
+      storePath,
+      now: 2_000_000,
+    });
+
+    // Count returned to caller.
+    expect(result).toBe(1);
+
+    // In-memory entry advanced.
+    expect(sessionStore[sessionKey]?.compactionCount).toBe(1);
+
+    // On-disk store now has the entry. (b82fd65c00's `updateSessionStoreEntry`
+    // call was a no-op here because the existing-entry check returned null;
+    // count was silently dropped on disk. The canonical-primitives fix
+    // merge-or-creates from the active in-memory entry.)
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(persisted[sessionKey]).toBeDefined();
+    expect(persisted[sessionKey]?.compactionCount).toBe(1);
+    expect(persisted[sessionKey]?.sessionId).toBe("session-A");
+  });
+
+  it("rolls sessionStartedAt to new-session epoch when sessionId changes during compaction", async () => {
+    const sessionKey = "test:sessionid-rollover";
+    // Use realistic timestamps because mergeSessionEntry's resolveMergedUpdatedAt
+    // monotonically clamps to Date.now() — that's the protection against
+    // backward time-travel. The test assertion is relational: sessionStartedAt
+    // rolls to the new-session updatedAt (NOT the prior sessionStartedAt).
+    const oldSessionStartedAt = Date.now() - 60_000;
+    const inMemoryEntry: SessionEntry = {
+      sessionId: "session-old",
+      compactionCount: 2,
+      updatedAt: Date.now() - 30_000,
+      sessionStartedAt: oldSessionStartedAt,
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: inMemoryEntry,
+    };
+
+    const compactionMoment = Date.now();
+    await incrementCompactionCount({
+      sessionStore,
+      sessionKey,
+      storePath,
+      now: compactionMoment,
+      newSessionId: "session-new",
+    });
+
+    // Canonical mergeSessionEntry rolls sessionStartedAt to the resolved
+    // updatedAt when sessionId changes. Raw spread would have kept the prior
+    // sessionStartedAt unchanged. Relational assertion: rolled forward AND
+    // distinct from the pre-rollover value.
+    const inMem = sessionStore[sessionKey];
+    expect(inMem?.sessionId).toBe("session-new");
+    expect(inMem?.sessionStartedAt).toBeGreaterThanOrEqual(compactionMoment);
+    expect(inMem?.sessionStartedAt).not.toBe(oldSessionStartedAt);
+    expect(inMem?.sessionStartedAt).toBe(inMem?.updatedAt);
+
+    // The on-disk merge is a SEPARATE invocation of mergeSessionEntry inside
+    // the disk lock (resolves against any concurrent writer's state). Its
+    // resolved updatedAt may differ from in-memory by milliseconds, so assert
+    // disk-side rollover invariants independently rather than equating the
+    // two timestamps.
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(persisted[sessionKey]?.sessionId).toBe("session-new");
+    expect(persisted[sessionKey]?.sessionStartedAt).toBeGreaterThanOrEqual(compactionMoment);
+    expect(persisted[sessionKey]?.sessionStartedAt).not.toBe(oldSessionStartedAt);
+    expect(persisted[sessionKey]?.sessionStartedAt).toBe(persisted[sessionKey]?.updatedAt);
+  });
+
+  it("merges count across multiple compactions when on-disk entry already exists", async () => {
+    const sessionKey = "test:merge-existing";
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId: "session-X",
+        compactionCount: 0,
+        updatedAt: 1_000_000,
+        sessionStartedAt: 1_000_000,
+      },
+    };
+
+    await incrementCompactionCount({
+      sessionStore,
+      sessionKey,
+      storePath,
+      now: 2_000_000,
+    });
+    await incrementCompactionCount({
+      sessionStore,
+      sessionKey,
+      storePath,
+      now: 3_000_000,
+    });
+
+    expect(sessionStore[sessionKey]?.compactionCount).toBe(2);
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(persisted[sessionKey]?.compactionCount).toBe(2);
+    // sessionStartedAt should remain the same (sessionId did not change).
+    expect(persisted[sessionKey]?.sessionStartedAt).toBe(1_000_000);
+  });
+});

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -11,12 +11,13 @@ import {
 } from "../../agents/skills/refresh-state.js";
 import { ensureSkillsWatcher } from "../../agents/skills/refresh.js";
 import {
+  mergeSessionEntry,
+  normalizeStoreSessionKey,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   resolveSessionStoreEntry,
   type SessionEntry,
   updateSessionStore,
-  updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveStableSessionEndTranscript } from "../../gateway/session-transcript-files.fs.js";
@@ -298,19 +299,30 @@ export async function incrementCompactionCount(params: {
     updates.cacheRead = undefined;
     updates.cacheWrite = undefined;
   }
-  sessionStore[memResolved.normalizedKey] = {
-    ...entry,
-    ...updates,
-  };
+  sessionStore[memResolved.normalizedKey] = mergeSessionEntry(entry, updates);
   for (const legacyKey of memResolved.legacyKeys) {
     delete sessionStore[legacyKey];
   }
   if (storePath) {
-    await updateSessionStoreEntry({
+    await updateSessionStore(
       storePath,
-      sessionKey,
-      update: async () => updates,
-    });
+      (store) => {
+        const resolved = resolveSessionStoreEntry({ store, sessionKey });
+        // Resolve-then-merge-or-create: when the on-disk store has no entry yet
+        // (first-turn manual /compact lands before any other persist), fall back
+        // to the active in-memory entry so the count is not silently dropped.
+        // mergeSessionEntry preserves monotonic updatedAt + sessionStartedAt
+        // rollover on sessionId change + stale-modelProvider scrub.
+        const storedEntry = resolved.existing ?? entry;
+        store[resolved.normalizedKey] = mergeSessionEntry(storedEntry, updates);
+        for (const legacyKey of resolved.legacyKeys) {
+          delete store[legacyKey];
+        }
+      },
+      // activeSessionKey opt protects this entry from enforce-mode pruning /
+      // disk-budget cleanup that runs inside the same lock window.
+      { activeSessionKey: normalizeStoreSessionKey(sessionKey) },
+    );
   }
   if ((sessionIdChanged || sessionFileChanged) && cfg) {
     emitCompactionSessionLifecycleHooks({

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -320,8 +320,12 @@ export async function incrementCompactionCount(params: {
         }
       },
       // activeSessionKey opt protects this entry from enforce-mode pruning /
-      // disk-budget cleanup that runs inside the same lock window.
-      { activeSessionKey: normalizeStoreSessionKey(sessionKey) },
+      // disk-budget cleanup that runs inside the same lock window. Must trim
+      // before normalize: resolveSessionStoreEntry computes its normalizedKey
+      // as normalize(trim(sessionKey)), so an untrimmed normalize here would
+      // mismatch any whitespace-padded sessionKey and silently miss the
+      // preserve guard.
+      { activeSessionKey: normalizeStoreSessionKey(sessionKey.trim()) },
     );
   }
   if ((sessionIdChanged || sessionFileChanged) && cfg) {


### PR DESCRIPTION
## Summary

Narrow follow-up PR for the compaction-count-persistence fix that was stripped from #542 per cohort verdict (A) (see karmaterminal/openclaw#541 Step 10 for the full story). Reapplies the fix using the canonical primitives Codex auto-review identified as load-bearing.

The original attempt (`b82fd65c00`) replaced `updateSessionStoreEntry` with bare `updateSessionStore` + raw object spread, which dropped two structural protections:

1. **`mergeSessionEntry` semantics** (`src/config/sessions/types.ts:510`): monotonic `updatedAt` clamp + `sessionStartedAt` rollover on sessionId change + stale-modelProvider scrub
2. **`activeSessionKey` preserve-from-prune** (`src/config/sessions/store.ts:541-543`): protects active session from enforce-mode pruning during the same lock window

This PR mirrors the canonical pattern at `recordSessionMetaFromInbound` (`src/config/sessions/store.ts:706-741`).

## Test plan

- [x] `pnpm tsgo` passes
- [x] `pnpm check` passes (import-cycles, lint, format)
- [x] `pnpm test src/auto-reply/reply/session-updates.{,lifecycle.,compaction.}test.ts` — 5/5 pass

**New regression coverage** at `src/auto-reply/reply/session-updates.compaction.test.ts`:

1. **First-turn /compact with empty on-disk store**: count persists from active in-memory entry. This is the original bug — `updateSessionStoreEntry` returned `null` and dropped the count when no on-disk entry existed yet (manual /compact lands before any other persist). The resolve-then-merge-or-create shape fixes it correctly.
2. **`sessionId` rollover during compaction**: `mergeSessionEntry` rolls `sessionStartedAt` to the resolved `updatedAt`. Verified against pre-rollover value (raw spread would have left it stale).
3. **Multi-compaction merge**: counts accumulate; `sessionStartedAt` stays stable when sessionId is unchanged.

**Test coverage queued for follow-up** (require concurrent-write / enforce-mode-trigger staging beyond this PR's scope; the canonical primitives provide the structural protection regardless):

- Monotonic `updatedAt` under concurrent-compaction-write races (would simulate concurrent `incrementCompactionCount` invocations and assert disk `updatedAt` never moves backward)
- `activeSessionKey` preserve-from-enforce-mode-prune (would set up enforce-mode disk-budget cleanup that fires inside the lock window and assert the active entry survives)

## Cohort context

- Stripped from #542 via `git rebase -i 55df7162c0` with `GIT_SEQUENCE_EDITOR='sed -i "/^pick c5792eb976/d"'` per cohort verdict (A)
- Cohort consensus on (A): 🌫 (msg `1500308473165123615`), 🌊 (msg `1500308822084943972`)
- 12th closure-costume catalogued: **fix-introduces-regressions-while-curing-original** — 8th-costume family (cohort byte-walked the FIX shape but not what the OLD API provided that the NEW path drops)
- Same shape lesson as Cael's #413 keypath-normalization: a real bug fix benefits from its own narrow PR with targeted test-coverage description, not buried inside a port-PR

Refs karmaterminal/openclaw#541 Step 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)