### PR TITLE
test(config): pin continuation delay bounds cross-field guard (#452)

### DIFF
--- a/src/config/zod-schema.continuation.test.ts
+++ b/src/config/zod-schema.continuation.test.ts
@@ -143,6 +143,100 @@ describe("continuation config schema validation", () => {
   });
 
   /* ---------------------------------------------------------------- */
+  /*  delay bounds cross-field guard (#452):                          */
+  /*    refine: minDelayMs ≤ defaultDelayMs ≤ maxDelayMs              */
+  /*  Pinned by tests so refactors that drop/break the guard are      */
+  /*  caught at parse-time, not silently at runtime via clampDelayMs  */
+  /*  returning a value outside the configured contract.              */
+  /* ---------------------------------------------------------------- */
+
+  it("accepts well-ordered delay bounds (min < default < max)", () => {
+    const result = parseContinuation({
+      minDelayMs: 100,
+      defaultDelayMs: 1000,
+      maxDelayMs: 60000,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts equal delay bounds (min = default = max)", () => {
+    const result = parseContinuation({
+      minDelayMs: 5000,
+      defaultDelayMs: 5000,
+      maxDelayMs: 5000,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects inverted minDelayMs > maxDelayMs (the original #452 bug-shape)", () => {
+    const result = parseContinuation({
+      minDelayMs: 60000,
+      maxDelayMs: 1000,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.message.includes("continuation delay bounds violate")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects minDelayMs > defaultDelayMs (default below floor)", () => {
+    const result = parseContinuation({
+      minDelayMs: 5000,
+      defaultDelayMs: 1000,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.message.includes("continuation delay bounds violate")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects defaultDelayMs > maxDelayMs (default above ceiling)", () => {
+    const result = parseContinuation({
+      defaultDelayMs: 60000,
+      maxDelayMs: 5000,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.message.includes("continuation delay bounds violate")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects all three inverted (min > default > max)", () => {
+    const result = parseContinuation({
+      minDelayMs: 60000,
+      defaultDelayMs: 30000,
+      maxDelayMs: 1000,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.message.includes("continuation delay bounds violate")),
+      ).toBe(true);
+    }
+  });
+
+  it("accepts only minDelayMs set (no cross-field constraint to violate)", () => {
+    const result = parseContinuation({ minDelayMs: 60000 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts only maxDelayMs set (no cross-field constraint to violate)", () => {
+    const result = parseContinuation({ maxDelayMs: 1000 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts only defaultDelayMs set (no cross-field constraint to violate)", () => {
+    const result = parseContinuation({ defaultDelayMs: 5000 });
+    expect(result.success).toBe(true);
+  });
+
+  /* ---------------------------------------------------------------- */
   /*  strict mode: unknown keys rejected                               */
   /* ---------------------------------------------------------------- */
 


### PR DESCRIPTION
## What this resolves

Per figs's missing-coverage canon (msg `1500600929655975946`): "missing coverage you see → add it OR dispatch a code-agent to add it." Tests are **contract-shape, not just proof-shape**.

Closes #452.

## Substrate-state context

Ronan-seat byte-walk on `frond/v2026.5.2/canonical @ bac4caceac` surfaced that the production `.refine()` cross-field guard for continuation delay bounds (`minDelayMs ≤ defaultDelayMs ≤ maxDelayMs`) **exists** at `src/config/zod-schema.agent-defaults.ts:309-330` BUT has **zero test coverage**.

Without these tests, a refactor that drops/weakens/breaks the `.refine` wouldn't be caught at parse-time. The downstream consumer `clampDelayMs` (`src/auto-reply/continuation/config.ts`) does `Math.max(min, Math.min(max, requested))` — if min > max bypasses validation, the function silently returns values OUTSIDE the configured contract, which is exactly the bug-shape #452 names.

This PR converts that KEEP-OPEN-NEEDS-REWORK substrate-evidence verdict (issuecomment `4367126577`) into a concrete contract-test that informs the next-toucher (us or anyone) before runtime surprises. Per figs's canon: missing-coverage = action-item, not observation.

## Diff scope

Single file +86/-0:
- `src/config/zod-schema.continuation.test.ts` adds 9 tests in a new comment-block section before `strict mode`

## Test coverage added (9 tests)

- accepts well-ordered bounds (min < default < max)
- accepts equal bounds (min = default = max edge case)
- rejects inverted `minDelayMs > maxDelayMs` (the original #452 bug-shape from issue body)
- rejects `minDelayMs > defaultDelayMs` (default below floor)
- rejects `defaultDelayMs > maxDelayMs` (default above ceiling)
- rejects all three inverted (min > default > max)
- accepts only `minDelayMs` set (no cross-field constraint to violate)
- accepts only `maxDelayMs` set (no cross-field constraint to violate)
- accepts only `defaultDelayMs` set (no cross-field constraint to violate)

Tests assert the `.refine` error-message includes `'continuation delay bounds violate'` so consumers parsing structured zod errors can route on the specific violation.

## Verification

- `pnpm test --run src/config/zod-schema.continuation.test.ts`: **32 passed** (23 existing + 9 new)
- `pnpm tsgo`: green (exit 0, ~1.2s on incremental)
- Worktree off `frond/v2026.5.2/canonical @ bac4caceac` (NOT `feature/context-pressure-squashed`; do-not-modify rail respected)

## Branch hygiene

Base = `frond/v2026.5.2/canonical` ✓ (substrate-development line). NOT `feature/context-pressure-squashed` (live upstream-presentation branch for openclaw/openclaw#38780, do-not-modify per figs canon msgs `1500552700524236990` + `1500554211761983549`).

Test-only diff. No production code touched. No behavior change.

## Cohort cycle pattern

Sibling-shape PR to:
- #558 (🌫 silas-seat #448 concurrent-consumer race contract test, MERGED-readiness with 2-prince APPROVE)

Both demonstrate figs's canon-internalization-velocity: missing-coverage byte-walk → prince-direct test-write → PR within ~30-60min cohort-cycle. Per Cael's earlier framing applied at canon-internalization scope: bank-without-application = sedative-shape; canon-internalization = act on it within the same cohort-cycle.

## Cosign discipline

Per cohort cosign-with-rigor-check pattern this turn: byte-walk the diff against v5.2 substrate it tests, verify the test-shapes pin the contract per #452 issue body, confirm `pnpm tsgo` + scoped test run, then APPROVE-or-push-back.