### PR TITLE
test(continuation): pin request_compaction registration truth-table (#445)

### DIFF
--- a/src/agents/tools/continuation-tools-registration.test.ts
+++ b/src/agents/tools/continuation-tools-registration.test.ts
@@ -256,4 +256,63 @@ describe("continuation tool registration", { timeout: 240000 }, () => {
     expect(properties).toHaveProperty("targetSessionKeys");
     expect(properties).toHaveProperty("fanoutMode");
   });
+
+  // Truth-table coverage for request_compaction registration. Pins the
+  // three-state matrix (continuation enabled + opts present, continuation
+  // disabled, opts omitted) so a future refactor cannot silently drop the
+  // tool from normal runner wiring. Coverage shape mirrors the existing
+  // `drainsContinuationDelegateQueue` truth-table for continue_delegate.
+  // Tracked at #445.
+  describe("request_compaction registration truth-table (#445)", () => {
+    const requestCompactionOpts = {
+      sessionId: "sess-1",
+      getContextUsage: () => 0.85,
+      triggerCompaction: vi.fn(async () => ({ ok: true, compacted: true })),
+    };
+
+    it("exposes request_compaction when continuation enabled AND requestCompactionOpts wired", () => {
+      const tools = createOpenClawTools({
+        config,
+        agentSessionKey: "main",
+        requestCompactionOpts,
+      });
+      expect(tools.some((tool) => tool.name === "request_compaction")).toBe(true);
+    });
+
+    it("hides request_compaction when continuation disabled (regardless of opts)", () => {
+      const tools = createOpenClawTools({
+        config: {
+          ...config,
+          agents: { defaults: { continuation: { enabled: false } } },
+        },
+        agentSessionKey: "main",
+        requestCompactionOpts,
+      });
+      expect(tools.some((tool) => tool.name === "request_compaction")).toBe(false);
+    });
+
+    it("hides request_compaction when continuation enabled but opts omitted", () => {
+      const tools = createOpenClawTools({
+        config,
+        agentSessionKey: "main",
+        // requestCompactionOpts intentionally omitted
+      });
+      expect(tools.some((tool) => tool.name === "request_compaction")).toBe(false);
+    });
+
+    it("descriptor name is stable across registrations", () => {
+      const tools = createOpenClawTools({
+        config,
+        agentSessionKey: "main",
+        requestCompactionOpts,
+      });
+      const tool = tools.find((candidate) => candidate.name === "request_compaction");
+      if (!tool) {
+        throw new Error("request_compaction tool not registered");
+      }
+      // Descriptor name + presence pinned; reason-schema stability lives in
+      // the dedicated request-compaction-tool tests.
+      expect(tool.name).toBe("request_compaction");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Pins the truth-table coverage for `request_compaction` registration in `continuation-tools-registration.test.ts`, mirroring the existing truth-table patterns for `continue_delegate` (drainsContinuationDelegateQueue gate) and `continue_work`.

Closes #445.

## What it does

Adds 4 new tests under a dedicated `describe("request_compaction registration truth-table (#445)")` block:

| State | Expected |
|---|---|
| continuation enabled + requestCompactionOpts wired | tool registered ✓ |
| continuation disabled (regardless of opts) | tool absent |
| continuation enabled but opts omitted | tool absent |
| descriptor name stability | `request_compaction` |

Coverage shape mirrors the existing 3-state truth-table for `drainsContinuationDelegateQueue` (lines ~98-150 same file) so the regression-detection discipline is consistent across all three continuation tools.

## What it catches

Pre-PR, the `request_compaction` tool could silently disappear from normal runner wiring during a refactor (e.g. gate predicate flipped, opts wiring dropped from `agent-runner-execution.ts` line 1533, eager-vs-lazy import refactor) without any test catching the regression. `continue_delegate` has truth-table coverage, `continue_work` has truth-table coverage, `request_compaction` did not. This PR closes that gap per #445 issue body.

Per figs's tests-as-contract canon (msg `1500597...`-area, 2026-05-03): *"in-repo tests are not just for proof... they act to form contract-like assurance of behavior where we care. if someone else touches our surface and tests break, they are informed, same for us."*

## Verification

- `pnpm exec vitest run src/agents/tools/continuation-tools-registration.test.ts` → **26 passed** (4 new + 22 existing across both vitest projects)
- `pnpm exec tsgo --noEmit` → clean on this file (2 pre-existing errors in `attempt.test.ts` unrelated to this work, present on bare v5.2/canonical at `bac4caceac`)

## Topology

- Branch: `elliott/444-445-request-compaction-coverage`
- HEAD: `b9b21ee536`
- Base: `frond/v2026.5.2/canonical @ bac4caceac` (NOT `feature/context-pressure-squashed`)
- Doc-only test addition: +59 lines on `src/agents/tools/continuation-tools-registration.test.ts`, no behavior touched

## Related

- Sibling: silas's #558 (concurrent-consumer race contract for #448) — first cohort canon-application receipt landing within ~30min of figs's tests-as-contract directive
- Companion test-trap PR family: PR #462 (mode-only PendingContinuationDelegate), PR #463 (continue_delegate descriptor)
- #444 (request_compaction actual-callsite proof-vs-guard test) is sibling-issue but different scope-shape (deeply nested in `agent-runner-execution.ts`); deferred to separate PR

cc 🩸 🌫 🌊