### PR TITLE
test(continuation): pin TaskFlow status after delegate spawn failure (#449)

### DIFF
--- a/src/auto-reply/continuation/delegate-dispatch.test.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.test.ts
@@ -345,3 +345,128 @@ describe("tool delegate dispatch contract", () => {
     );
   });
 });
+
+describe("dispatchToolDelegates — TaskFlow status after spawn failure (#449)", () => {
+  // Pins the contract that #449 issue body called out as structurally-unpinned:
+  // "what is the intended TaskFlow status after spawn failure?"
+  //
+  // Current emergent behavior on v5.2 (`delegate-dispatch.ts:160 + 240-292`):
+  //   1. consumePendingDelegates(sessionKey) at line 160 calls finishFlow on
+  //      each consumed delegate → TaskFlow row → status="succeeded"
+  //   2. spawnSubagentDirect(...) per delegate
+  //   3. If spawn returns non-"accepted" status → log info + enqueue system
+  //      event + rejected++
+  //   4. If spawn throws → log info + enqueue system event + rejected++
+  //   5. NO retry, NO un-finish, NO mark-for-inspection — durable record is
+  //      already in succeeded state, only observability remains.
+  //
+  // This is the **one-shot-loss + observability-only** invariant. It is
+  // substrate-consistent with task-executor's exit-code-failure shape (also
+  // single-shot, no retry). The substrate has NO infrastructure for automatic
+  // re-enqueue, NO retry-count metadata field, NO transitional
+  // failed_retryable state — runaway-amplification-via-retry-storm is
+  // structurally pre-empted by the absence of those primitives.
+  //
+  // Pin the contract here so a refactor that introduces retry semantics
+  // OR moves finishFlow to after-spawn-success will surface as a test
+  // failure rather than a silent invariant change. Architectural decision
+  // (one-shot-loss vs retry vs inspection-shape via failFlow) is figs's call;
+  // this test pins the CURRENT invariant so the call lands as a deliberate
+  // change, not an inferred drift.
+
+  it("leaves consumed flows in succeeded status after spawn rejection", async () => {
+    const sessionKey = "session-449-rejected";
+    enqueuePendingDelegate(sessionKey, { task: "rejected-task" });
+    spawnSubagentDirectMock.mockResolvedValueOnce({ status: "forbidden" });
+
+    // Capture flowId before dispatch so we can inspect its post-dispatch state.
+    const queuedBefore = [...mockFlows.values()].filter(
+      (f) => f.ownerKey === sessionKey && f.status === "queued",
+    );
+    expect(queuedBefore).toHaveLength(1);
+    const flowId = queuedBefore[0].flowId as string;
+
+    const result = await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(result.dispatched).toBe(0);
+    expect(result.rejected).toBe(1);
+
+    // Substrate-state assertion: the TaskFlow record is in `succeeded` state
+    // (one-shot-loss invariant). The consumePendingDelegates call already
+    // ran finishFlow; the spawn-rejection does NOT roll the row back to
+    // queued, does NOT mark it as failed, does NOT increment a retry-count.
+    // If a future refactor moves finishFlow to after-spawn-success OR adds
+    // retry semantics, this assertion fails — and that failure is the signal
+    // that the architectural-invariant changed deliberately (or accidentally).
+    const finalized = mockFlows.get(flowId);
+    expect(finalized?.status).toBe("succeeded");
+  });
+
+  it("leaves consumed flows in succeeded status after spawn throws", async () => {
+    const sessionKey = "session-449-thrown";
+    enqueuePendingDelegate(sessionKey, { task: "throwing-task" });
+    spawnSubagentDirectMock.mockRejectedValueOnce(new Error("spawn unavailable"));
+
+    const queuedBefore = [...mockFlows.values()].filter(
+      (f) => f.ownerKey === sessionKey && f.status === "queued",
+    );
+    expect(queuedBefore).toHaveLength(1);
+    const flowId = queuedBefore[0].flowId as string;
+
+    const result = await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(result.dispatched).toBe(0);
+    expect(result.rejected).toBe(1);
+
+    // Same invariant for the throw-path: spawn throwing does NOT change
+    // the TaskFlow state from succeeded back to queued/failed. Substrate
+    // remains one-shot-loss; only the system event captures the failure.
+    const finalized = mockFlows.get(flowId);
+    expect(finalized?.status).toBe("succeeded");
+  });
+
+  it("preserves succeeded status across mixed spawn outcomes (rejected + thrown + accepted)", async () => {
+    // Mirror of existing "counts spawn rejections and thrown spawn errors
+    // without aborting later delegates" test, but with the substrate-state
+    // assertion added. Pins that mixed outcomes don't accidentally roll any
+    // record back — every consumed delegate stays in succeeded regardless of
+    // its individual spawn outcome.
+    const sessionKey = "session-449-mixed";
+    enqueuePendingDelegate(sessionKey, { task: "rejected" });
+    enqueuePendingDelegate(sessionKey, { task: "throws" });
+    enqueuePendingDelegate(sessionKey, { task: "accepted" });
+    spawnSubagentDirectMock
+      .mockResolvedValueOnce({ status: "forbidden" })
+      .mockRejectedValueOnce(new Error("spawn unavailable"))
+      .mockResolvedValueOnce({ status: "accepted" });
+
+    const queuedBefore = [...mockFlows.values()]
+      .filter((f) => f.ownerKey === sessionKey && f.status === "queued")
+      .map((f) => f.flowId as string);
+    expect(queuedBefore).toHaveLength(3);
+
+    await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    // All three flows reach `succeeded` status regardless of individual
+    // spawn outcome. The one-shot-loss invariant holds uniformly.
+    for (const flowId of queuedBefore) {
+      const finalized = mockFlows.get(flowId);
+      expect(finalized?.status).toBe("succeeded");
+    }
+  });
+});


### PR DESCRIPTION
Closes #449.

## Summary

Adds 3 tests in new `describe("dispatchToolDelegates — TaskFlow status after spawn failure (#449)")` block to pin the contract that #449 issue body called out as structurally-unpinned.

## Substrate evidence (cael-seat byte-walk)

Per substrate-walk at Discord msg `1500603939454718053`:

Current emergent behavior on v5.2 (`delegate-dispatch.ts:160 + 240-292`) is **one-shot-loss + observability-only**:

1. `consumePendingDelegates(sessionKey)` calls `finishFlow` on each consumed delegate → TaskFlow row → `status="succeeded"`
2. `spawnSubagentDirect(...)` per delegate
3. Spawn rejection or throw → log + system event + `rejected++`
4. **NO retry, NO un-finish, NO mark-for-inspection** — durable record already in succeeded state

Substrate-consistent with `task-executor`'s exit-code-failure shape (also single-shot, no retry). Substrate has no infrastructure for automatic re-enqueue, no retry-count metadata, no transitional `failed_retryable` state — runaway-amplification-via-retry-storm structurally pre-empted.

## What the tests pin

3 tests covering:
1. **Spawn rejection** → TaskFlow row stays `succeeded`
2. **Spawn throws** → TaskFlow row stays `succeeded`
3. **Mixed outcomes** (rejected + thrown + accepted) → all rows reach `succeeded`

Substrate-state assertions go beyond existing test ("counts spawn rejections...without aborting later delegates") which pins counts + system-event content but NOT TaskFlow-status. These tests pin the durable-record-state-after-failure invariant directly.

## Architectural-decision pre-emption

The architectural decision (one-shot-loss vs retry-shape vs inspection-shape) remains figs's call per cael-seat surfacing at Discord msg `1500599956988362834`. This PR pins the CURRENT invariant so any future change surfaces as a deliberate test failure rather than silent drift.

If figs wants hybrid-(A)+(C) inspection-shape (failFlow on spawn rejection for queue-diagnostics visibility), production code change + amended test land as separate PR — substrate-evidence walk recommended that direction but pure-A pin here is smallest reasonable scope per figs's tests-as-contract canon.

## Branch hygiene ✓

- Base = `frond/v2026.5.2/canonical` ✓ (NOT `feature/context-pressure-squashed` upstream-presentation branch)
- Test-only single-file +125/-0
- No production code touched

## Verification

- `pnpm tsgo` ✓
- `pnpm test --run src/auto-reply/continuation/delegate-dispatch.test.ts` ✓
  - 11 tests passed (8 existing + 3 new)
- Build-in-temp-directory worktree per PRINCE-CODE-AGENT-RUNBOOK ✓

## Cosign request

🌻 + 🌫 + 🌊 — byte-walk + cosign welcome on the contract-shape.