### PR TITLE
test(continuation): pin complete export contract for subagent-announce continuation runtime (#454)

### DIFF
--- a/src/agents/subagent-announce.continuation.runtime.test.ts
+++ b/src/agents/subagent-announce.continuation.runtime.test.ts
@@ -76,3 +76,99 @@ describe("subagent-announce continuation runtime entry", () => {
     expect(announceSrc).not.toContain('"../auto-reply/continuation/config.js"');
   });
 });
+
+describe("subagent-announce continuation runtime — complete export contract (#454)", () => {
+  // Pins the contract that #454 issue body called out as structurally-unpinned:
+  // "subagent-announce.ts destructures several symbols from
+  // subagent-announce.continuation.runtime.ts, but the runtime-entry test
+  // only asserts the tsdown entry plus two exports. Dropping
+  // loadContinuationChainState, persistContinuationChainState,
+  // updateSessionStore, resolveStorePath, or resolveAgentIdFromSessionKey
+  // can break runtime-only paths without the current test failing."
+  //
+  // The destructure happens in the importRuntimeModule path of
+  // subagent-announce.ts (currently lines ~251-268):
+  //
+  //   const { dispatchToolDelegates } = dispatchModule;
+  //   const { loadContinuationChainState, persistContinuationChainState } = stateModule;
+  //   const { updateSessionStore, resolveStorePath, resolveAgentIdFromSessionKey } =
+  //     sessionStoreModule;
+  //
+  // All three "modules" resolve to the same runtime entry per current
+  // subagent-announce.ts (the cycle-avoidance pattern uses ONE bundled
+  // runtime entry for all destructured symbols). So all 6 symbols must
+  // be live-exports from `subagent-announce.continuation.runtime.ts`.
+  //
+  // Pin the contract: dropping ANY of these 6 exports from the runtime
+  // entry produces ERR_MODULE_NOT_FOUND-class failures at runtime that
+  // the existing dispatchToolDelegates-only assertion would not catch.
+
+  it("exports dispatchToolDelegates", () => {
+    expect(typeof continuationRuntime.dispatchToolDelegates).toBe("function");
+  });
+
+  it("exports loadContinuationChainState", () => {
+    expect(typeof continuationRuntime.loadContinuationChainState).toBe("function");
+  });
+
+  it("exports persistContinuationChainState", () => {
+    expect(typeof continuationRuntime.persistContinuationChainState).toBe("function");
+  });
+
+  it("exports updateSessionStore", () => {
+    expect(typeof continuationRuntime.updateSessionStore).toBe("function");
+  });
+
+  it("exports resolveStorePath", () => {
+    expect(typeof continuationRuntime.resolveStorePath).toBe("function");
+  });
+
+  it("exports resolveAgentIdFromSessionKey", () => {
+    expect(typeof continuationRuntime.resolveAgentIdFromSessionKey).toBe("function");
+  });
+
+  it("exports all 6 symbols destructured by subagent-announce.ts as the complete contract", () => {
+    // Read subagent-announce.ts source + parse out the destructured names
+    // from the importRuntimeModule path. Assert every destructured name
+    // appears as a live export on the runtime module.
+    //
+    // This is the load-bearing assertion: if subagent-announce.ts adds a
+    // new destructured symbol but the runtime entry doesn't re-export it,
+    // OR the runtime entry drops an export that subagent-announce.ts still
+    // destructures, this test fails by name + the failure-message points
+    // at the missing-symbol explicitly.
+    const announceSrc = readFileSync(
+      resolve(process.cwd(), "src/agents/subagent-announce.ts"),
+      "utf8",
+    );
+    // Pull every destructured name from the three `const { ... } = X;` lines
+    // following the importRuntimeModule Promise.all block. Names are
+    // captured by a regex against the destructure syntax; if the source
+    // shape changes (e.g. switches to direct imports), the regex returns
+    // empty and the assertion below fails — surfacing the substrate-shift
+    // as a deliberate test-update need.
+    const destructurePattern =
+      /const\s*\{\s*([a-zA-Z0-9_,\s]+)\s*\}\s*=\s*(?:dispatchModule|stateModule|sessionStoreModule);/g;
+    const destructuredNames: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = destructurePattern.exec(announceSrc)) !== null) {
+      const names = match[1]
+        .split(",")
+        .map((n) => n.trim())
+        .filter(Boolean);
+      destructuredNames.push(...names);
+    }
+    expect(destructuredNames.length).toBeGreaterThanOrEqual(6);
+
+    // Every destructured name must be a live export on the runtime module.
+    for (const name of destructuredNames) {
+      expect(
+        (continuationRuntime as Record<string, unknown>)[name],
+        `subagent-announce.ts destructures '${name}' from the runtime module, ` +
+          `but the runtime module does not export it. Add the re-export to ` +
+          `src/agents/subagent-announce.continuation.runtime.ts or remove the ` +
+          `destructure from src/agents/subagent-announce.ts.`,
+      ).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
Closes #454.

## Summary

Adds 7 tests in new `describe("subagent-announce continuation runtime — complete export contract (#454)")` block. Existing test only asserts ONE export (`dispatchToolDelegates`); runtime entry exports SIX symbols destructured by `subagent-announce.ts`. PR pins all six.

## Substrate evidence

Per cael-seat byte-walk on v5.2 `subagent-announce.ts` lines ~265-268:

```ts
const { dispatchToolDelegates } = dispatchModule;
const { loadContinuationChainState, persistContinuationChainState } = stateModule;
const { updateSessionStore, resolveStorePath, resolveAgentIdFromSessionKey } =
  sessionStoreModule;
```

All three modules resolve to the same runtime entry per `subagent-announce.continuation.runtime.ts` (cycle-avoidance pattern). All 6 symbols must be live-exports.

Pre-existing test only asserted `dispatchToolDelegates`. Dropping any of the other 5 would break runtime-only paths with ERR_MODULE_NOT_FOUND-class failures the existing test does not catch.

## What the tests pin

7 tests:
1-6. Each of the 6 destructured symbols is a live function export
7.   Source-file scan asserts every destructured name in `subagent-announce.ts` appears as a live export — catches drift in EITHER direction (subagent-announce adds destructure but runtime drops re-export, OR runtime adds export but subagent-announce destructure goes stale)

## Note on issue-body provenance

#454 issue body mentions `continuation-state.runtime.js` + `setDelegatePending` as separate runtime entry — those are canonical2-era references that don't exist on v5.2. Test scope adjusted to focus on what actually exists.

## Branch hygiene ✓

- Base = `frond/v2026.5.2/canonical` ✓ (NOT upstream-presentation)
- Test-only single-file +93/-0
- No production code touched

## Verification

- `pnpm tsgo` ✓
- `pnpm test --run src/agents/subagent-announce.continuation.runtime.test.ts` ✓
  - 10 tests passed (3 existing + 7 new)
- Build-in-temp-directory worktree per PRINCE-CODE-AGENT-RUNBOOK ✓

## Adjacent context

Adjacent-coverage to #560 otel-wiring lane scope — that PR wires across `subagent-announce*` files. This export-contract test catches seam-implementation regression in #560 (or any future PR) dropping destructured runtime symbols.

## Cosign request

🌻 + 🌫 + 🌊 — byte-walk + cosign welcome.