### PR TITLE
fix(continuation): fail delegate rows on spawn failure (#449)

### DIFF
--- a/src/auto-reply/continuation-delegate-store.test.ts
+++ b/src/auto-reply/continuation-delegate-store.test.ts
@@ -95,7 +95,19 @@ describe("continuation-delegate-store", () => {
 
     const delegates = consumePendingDelegates("test-session");
     expect(delegates).toHaveLength(1);
-    expect(delegates[0]).toEqual({ task: "minimal task" });
+    // `flowId` + `expectedRevision` are carried through from the consumed
+    // TaskFlow row so dispatch-time spawn failures can mark the row failed
+    // without re-querying. The minimal-fields test only cares that no
+    // optional caller-set fields leak through, so assert on `task` and
+    // check the carry-through metadata shape separately.
+    expect(delegates[0].task).toBe("minimal task");
+    expect(typeof delegates[0].flowId).toBe("string");
+    expect(delegates[0].expectedRevision).toBe(1);
+    expect(delegates[0].delayMs).toBeUndefined();
+    expect(delegates[0].mode).toBeUndefined();
+    expect(delegates[0].targetSessionKey).toBeUndefined();
+    expect(delegates[0].targetSessionKeys).toBeUndefined();
+    expect(delegates[0].fanoutMode).toBeUndefined();
   });
 
   it("handles zero delay (immediate dispatch)", () => {

--- a/src/auto-reply/continuation/delegate-dispatch.test.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.test.ts
@@ -315,7 +315,7 @@ describe("tool delegate dispatch contract", () => {
     );
   });
 
-  it("counts spawn rejections and thrown spawn errors without aborting later delegates", async () => {
+  it("marks rejected/thrown delegates failed without aborting later delegates", async () => {
     const sessionKey = "session-delegate-spawn-failure";
     enqueuePendingDelegate(sessionKey, { task: "rejected" });
     enqueuePendingDelegate(sessionKey, { task: "throws" });
@@ -324,6 +324,10 @@ describe("tool delegate dispatch contract", () => {
       .mockResolvedValueOnce({ status: "forbidden" })
       .mockRejectedValueOnce(new Error("spawn unavailable"))
       .mockResolvedValueOnce({ status: "accepted" });
+
+    const queuedBefore = [...mockFlows.values()]
+      .filter((f) => f.ownerKey === sessionKey && f.status === "queued")
+      .map((f) => f.flowId as string);
 
     const result = await dispatchToolDelegates({
       sessionKey,
@@ -340,9 +344,32 @@ describe("tool delegate dispatch contract", () => {
       { sessionKey },
     );
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
-      expect.stringContaining("DELEGATE spawn failed: Error: spawn unavailable"),
+      expect.stringContaining("DELEGATE spawn failed: spawn unavailable"),
       { sessionKey },
     );
+    expect(mockFlows.get(queuedBefore[0])?.status).toBe("failed");
+    expect(mockFlows.get(queuedBefore[1])?.status).toBe("failed");
+    expect(mockFlows.get(queuedBefore[2])?.status).toBe("succeeded");
+  });
+
+  it("marks over-limit delegates failed instead of leaving them as silent success", async () => {
+    const sessionKey = "session-delegate-over-limit-status";
+    for (let index = 0; index < 6; index++) {
+      enqueuePendingDelegate(sessionKey, { task: `delegate-${index}` });
+    }
+
+    const queuedBefore = [...mockFlows.values()]
+      .filter((f) => f.ownerKey === sessionKey && f.status === "queued")
+      .map((f) => f.flowId as string);
+
+    await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(mockFlows.get(queuedBefore[5])?.status).toBe("failed");
   });
 });
 
@@ -370,11 +397,10 @@ describe("dispatchToolDelegates — TaskFlow status after spawn failure", () => 
   // Pin the contract here so a refactor that introduces retry semantics
   // OR moves finishFlow to after-spawn-success will surface as a test
   // failure rather than a silent invariant change. Architectural decision
-  // (one-shot-loss vs retry vs inspection-shape via failFlow) is figs's call;
-  // this test pins the CURRENT invariant so the call lands as a deliberate
-  // change, not an inferred drift.
+  // figs's call landed on the honest branch: keep one-shot / no-retry
+  // semantics, but do not silently present spawn failure as success.
 
-  it("leaves consumed flows in succeeded status after spawn rejection", async () => {
+  it("marks consumed flows failed after spawn rejection", async () => {
     const sessionKey = "session-449-rejected";
     enqueuePendingDelegate(sessionKey, { task: "rejected-task" });
     spawnSubagentDirectMock.mockResolvedValueOnce({ status: "forbidden" });
@@ -396,18 +422,12 @@ describe("dispatchToolDelegates — TaskFlow status after spawn failure", () => 
     expect(result.dispatched).toBe(0);
     expect(result.rejected).toBe(1);
 
-    // Substrate-state assertion: the TaskFlow record is in `succeeded` state
-    // (one-shot-loss invariant). The consumePendingDelegates call already
-    // ran finishFlow; the spawn-rejection does NOT roll the row back to
-    // queued, does NOT mark it as failed, does NOT increment a retry-count.
-    // If a future refactor moves finishFlow to after-spawn-success OR adds
-    // retry semantics, this assertion fails — and that failure is the signal
-    // that the architectural-invariant changed deliberately (or accidentally).
+    // Honest failure visibility on the same one-shot substrate.
     const finalized = mockFlows.get(flowId);
-    expect(finalized?.status).toBe("succeeded");
+    expect(finalized?.status).toBe("failed");
   });
 
-  it("leaves consumed flows in succeeded status after spawn throws", async () => {
+  it("marks consumed flows failed after spawn throws", async () => {
     const sessionKey = "session-449-thrown";
     enqueuePendingDelegate(sessionKey, { task: "throwing-task" });
     spawnSubagentDirectMock.mockRejectedValueOnce(new Error("spawn unavailable"));
@@ -428,19 +448,12 @@ describe("dispatchToolDelegates — TaskFlow status after spawn failure", () => 
     expect(result.dispatched).toBe(0);
     expect(result.rejected).toBe(1);
 
-    // Same invariant for the throw-path: spawn throwing does NOT change
-    // the TaskFlow state from succeeded back to queued/failed. Substrate
-    // remains one-shot-loss; only the system event captures the failure.
+    // Same shape for the throw-path: no retry, but durable failed-state.
     const finalized = mockFlows.get(flowId);
-    expect(finalized?.status).toBe("succeeded");
+    expect(finalized?.status).toBe("failed");
   });
 
-  it("preserves succeeded status across mixed spawn outcomes (rejected + thrown + accepted)", async () => {
-    // Mirror of existing "counts spawn rejections and thrown spawn errors
-    // without aborting later delegates" test, but with the substrate-state
-    // assertion added. Pins that mixed outcomes don't accidentally roll any
-    // record back — every consumed delegate stays in succeeded regardless of
-    // its individual spawn outcome.
+  it("preserves per-delegate terminal truth across mixed spawn outcomes (rejected + thrown + accepted)", async () => {
     const sessionKey = "session-449-mixed";
     enqueuePendingDelegate(sessionKey, { task: "rejected" });
     enqueuePendingDelegate(sessionKey, { task: "throws" });
@@ -462,11 +475,8 @@ describe("dispatchToolDelegates — TaskFlow status after spawn failure", () => 
       maxChainLength: 10,
     });
 
-    // All three flows reach `succeeded` status regardless of individual
-    // spawn outcome. The one-shot-loss invariant holds uniformly.
-    for (const flowId of queuedBefore) {
-      const finalized = mockFlows.get(flowId);
-      expect(finalized?.status).toBe("succeeded");
-    }
+    expect(mockFlows.get(queuedBefore[0])?.status).toBe("failed");
+    expect(mockFlows.get(queuedBefore[1])?.status).toBe("failed");
+    expect(mockFlows.get(queuedBefore[2])?.status).toBe("succeeded");
   });
 });

--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -16,6 +16,7 @@ import { spawnSubagentDirect } from "../../agents/subagent-spawn.js";
 import type { SpawnSubagentContext } from "../../agents/subagent-spawn.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { failFlow } from "../../tasks/task-flow-registry.js";
 import { resolveContinuationRuntimeConfig } from "./config.js";
 import { consumePendingDelegates, peekSoonestUnmaturedDelegateDueAt } from "./delegate-store.js";
 import { checkContinuationBudget, type ChainState } from "./scheduler.js";
@@ -141,6 +142,22 @@ export type DelegateDispatchContext = {
  * Called by agent-runner.ts after the response finalizes.
  * Each delegate goes through chain/cost enforcement and is spawned via spawnSubagentDirect.
  */
+function markDelegateFailed(
+  delegate: { flowId?: string; expectedRevision?: number; task: string },
+  summary: string,
+): void {
+  if (!delegate.flowId || delegate.expectedRevision === undefined) {
+    return;
+  }
+  failFlow({
+    flowId: delegate.flowId,
+    expectedRevision: delegate.expectedRevision,
+    currentStep: "Delegate spawn failed",
+    blockedSummary: summary,
+    updatedAt: Date.now(),
+  });
+}
+
 export async function dispatchToolDelegates(params: {
   sessionKey: string;
   chainState: ChainState;
@@ -187,13 +204,12 @@ export async function dispatchToolDelegates(params: {
   const delegatesOverLimit = toolDelegates.slice(maxDelegatesPerTurn);
 
   for (const dropped of delegatesOverLimit) {
+    const summary = `Tool delegate rejected: maxDelegatesPerTurn exceeded (${maxDelegatesPerTurn}).`;
     log.info(
       `[continuation:delegate-rejected] maxDelegatesPerTurn=${maxDelegatesPerTurn} task=${dropped.task.slice(0, 80)} session=${sessionKey}`,
     );
-    enqueueSystemEvent(
-      `[continuation] Tool delegate rejected: maxDelegatesPerTurn exceeded (${maxDelegatesPerTurn}). Task: ${dropped.task}`,
-      { sessionKey },
-    );
+    markDelegateFailed(dropped, summary);
+    enqueueSystemEvent(`[continuation] ${summary} Task: ${dropped.task}`, { sessionKey });
   }
 
   let dispatched = 0;
@@ -213,13 +229,12 @@ export async function dispatchToolDelegates(params: {
     });
 
     if (budgetCheck) {
+      const summary = `Tool delegate rejected: ${budgetCheck}.`;
       log.info(
         `[continuation:delegate-rejected] ${budgetCheck} task=${delegate.task.slice(0, 80)} session=${sessionKey}`,
       );
-      enqueueSystemEvent(
-        `[continuation] Tool delegate rejected: ${budgetCheck}. Task: ${delegate.task}`,
-        { sessionKey },
-      );
+      markDelegateFailed(delegate, summary);
+      enqueueSystemEvent(`[continuation] ${summary} Task: ${delegate.task}`, { sessionKey });
       rejected++;
       continue;
     }
@@ -266,23 +281,24 @@ export async function dispatchToolDelegates(params: {
         dispatched++;
         currentChainCount = nextHop;
       } else {
+        const summary = `DELEGATE spawn ${result.status}: delegation was not accepted.`;
         log.info(
           `[continuation:delegate-spawn-rejected] status=${result.status} session=${sessionKey} task=${delegate.task.slice(0, 80)}`,
         );
-        enqueueSystemEvent(
-          `[continuation] DELEGATE spawn ${result.status}: delegation was not accepted. Task: ${delegate.task}`,
-          { sessionKey },
-        );
+        markDelegateFailed(delegate, summary);
+        enqueueSystemEvent(`[continuation] ${summary} Task: ${delegate.task}`, {
+          sessionKey,
+        });
         rejected++;
       }
     } catch (err) {
-      log.info(
-        `[continuation:delegate-spawn-failed] error=${err instanceof Error ? err.message : String(err)} session=${sessionKey}`,
-      );
-      enqueueSystemEvent(
-        `[continuation] DELEGATE spawn failed: ${String(err)}. Task: ${delegate.task}`,
-        { sessionKey },
-      );
+      const message = err instanceof Error ? err.message : String(err);
+      const summary = `DELEGATE spawn failed: ${message}`;
+      log.info(`[continuation:delegate-spawn-failed] error=${message} session=${sessionKey}`);
+      markDelegateFailed(delegate, summary);
+      enqueueSystemEvent(`[continuation] ${summary}. Task: ${delegate.task}`, {
+        sessionKey,
+      });
       rejected++;
     }
   }

--- a/src/auto-reply/continuation/delegate-store.ts
+++ b/src/auto-reply/continuation/delegate-store.ts
@@ -382,6 +382,8 @@ function flowToDelegate(
       : {}),
     ...(state.fanoutMode ? { fanoutMode: state.fanoutMode } : {}),
     ...(state.traceparent ? { traceparent: state.traceparent } : {}),
+    flowId: flow.flowId,
+    expectedRevision: flow.revision,
   };
 }
 
@@ -465,11 +467,11 @@ export function consumePendingDelegates(sessionKey: string): PendingContinuation
       currentStep: "Released to continuation scheduler",
       stateJson: { ...state, releasedAt: Date.now() },
     });
-    if (!finished.applied) {
+    if (!finished.applied || !finished.flow) {
       continue;
     }
 
-    delegates.push(flowToDelegate(flow, state));
+    delegates.push(flowToDelegate(finished.flow, state));
   }
 
   return delegates;

--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -63,6 +63,13 @@ export type PendingContinuationDelegate = {
   targetSessionKeys?: string[];
   fanoutMode?: ContinuationDelegateFanoutMode;
   traceparent?: string;
+  /**
+   * Internal TaskFlow metadata carried from consume → dispatch so downstream
+   * spawn/release failures can flip the row from succeeded → failed without
+   * re-querying or guessing revision state.
+   */
+  flowId?: string;
+  expectedRevision?: number;
 };
 
 /**

--- a/src/tasks/task-boundaries.test.ts
+++ b/src/tasks/task-boundaries.test.ts
@@ -25,6 +25,7 @@ const RAW_TASK_MUTATOR_ALLOWED_CALLERS = new Set([
 ]);
 
 const TASK_FLOW_REGISTRY_ALLOWED_IMPORTERS = new Set([
+  "auto-reply/continuation/delegate-dispatch.ts",
   "tasks/task-flow-owner-access.ts",
   "tasks/task-flow-registry.audit.ts",
   "tasks/task-flow-registry.maintenance.ts",


### PR DESCRIPTION
## Summary
- flip delegate spawn rejection/throw paths from silent success to `failFlow(...)`
- carry TaskFlow flowId/revision metadata from consume to dispatch so downstream failure can update the correct row
- amend the #449 tests so rejected/thrown delegates end `failed` while accepted delegates remain `succeeded`

## Why
figs's call on the delegate-failure-semantics cluster was the honest/loud branch: preserve one-shot/no-retry substrate, but do not leave the caller with "I think that happened but it didn't and I don't know." This keeps the no-retry invariant while making failed spawns visible in queue diagnostics / `status --deep`.

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/auto-reply/continuation/delegate-dispatch.test.ts src/auto-reply/continuation/delegate-store.test.ts`
- `pnpm tsgo:test:src`
