### PR TITLE
fix(config): runtime hot-reload for sessions visibility, continuation knobs, plan-aware CLI hint (supersedes #536)

### DIFF
--- a/src/agents/openclaw-tools.sessions-visibility.test.ts
+++ b/src/agents/openclaw-tools.sessions-visibility.test.ts
@@ -26,6 +26,15 @@ function getSessionsHistoryTool(options?: { sandboxed?: boolean }) {
   });
 }
 
+function getLiveSessionsHistoryTool(options?: { sandboxed?: boolean }) {
+  return createSessionsHistoryTool({
+    agentSessionKey: "main",
+    sandboxed: options?.sandboxed,
+    getConfig: () => mockConfig as never,
+    callGateway: (opts: unknown) => callGatewayMock(opts),
+  });
+}
+
 function mockGatewayWithHistory(
   extra?: (req: { method?: string; params?: Record<string, unknown> }) => unknown,
 ) {
@@ -89,6 +98,31 @@ describe("sessions tools visibility", () => {
       sessionKey: "agent:main:quietchat:direct:someone-else",
     });
     expect(result.details).toMatchObject({
+      sessionKey: "agent:main:quietchat:direct:someone-else",
+    });
+  });
+
+  it("re-reads live session visibility config at execution time", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { agentToAgent: { enabled: false } },
+    };
+    mockGatewayWithHistory();
+    const tool = getLiveSessionsHistoryTool();
+
+    const denied = await tool.execute("call-live-before", {
+      sessionKey: "agent:main:quietchat:direct:someone-else",
+    });
+    expect(denied.details).toMatchObject({ status: "forbidden" });
+
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: false } },
+    };
+    const allowed = await tool.execute("call-live-after", {
+      sessionKey: "agent:main:quietchat:direct:someone-else",
+    });
+    expect(allowed.details).toMatchObject({
       sessionKey: "agent:main:quietchat:direct:someone-else",
     });
   });

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,4 +1,4 @@
-import { selectApplicableRuntimeConfig } from "../config/config.js";
+import { getRuntimeConfig, selectApplicableRuntimeConfig } from "../config/config.js";
 import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
@@ -292,6 +292,13 @@ export function createOpenClawTools(
     enableHeartbeatTool?: boolean;
     /** If true, skip plugin tool resolution and return only shipped core tools. */
     disablePluginTools?: boolean;
+    /**
+     * If true, session tools resolve config from the active runtime snapshot at
+     * each execution rather than capturing the construction-time config. Lets
+     * `tools.sessions.visibility` and other session-tool-relevant keys hot-reload
+     * without rebuilding the tool list. RFC §6.5.
+     */
+    liveSessionToolConfig?: boolean;
     /** Records hot-path tool-prep stages for reply startup diagnostics. */
     recordToolPrepStage?: (name: string) => void;
     /** Trusted sender id from inbound context (not tool args). */
@@ -491,6 +498,9 @@ export function createOpenClawTools(
   const effectiveCallGateway = embedded
     ? createEmbeddedCallGateway()
     : openClawToolsDeps.callGateway;
+  const sessionToolConfig = options?.liveSessionToolConfig
+    ? ({ getConfig: getRuntimeConfig } as const)
+    : ({ config: resolvedConfig } as const);
   const tools: AnyAgentTool[] = [
     ...(embedded
       ? []
@@ -543,13 +553,13 @@ export function createOpenClawTools(
     createSessionsListTool({
       agentSessionKey: options?.agentSessionKey,
       sandboxed: options?.sandboxed,
-      config: resolvedConfig,
+      ...sessionToolConfig,
       callGateway: effectiveCallGateway,
     }),
     createSessionsHistoryTool({
       agentSessionKey: options?.agentSessionKey,
       sandboxed: options?.sandboxed,
-      config: resolvedConfig,
+      ...sessionToolConfig,
       callGateway: effectiveCallGateway,
     }),
     ...(embedded
@@ -559,7 +569,7 @@ export function createOpenClawTools(
             agentSessionKey: options?.agentSessionKey,
             agentChannel: options?.agentChannel,
             sandboxed: options?.sandboxed,
-            config: resolvedConfig,
+            ...sessionToolConfig,
             callGateway: openClawToolsDeps.callGateway,
           }),
           createSessionsSpawnTool({
@@ -587,7 +597,7 @@ export function createOpenClawTools(
     }),
     createSessionStatusTool({
       agentSessionKey: options?.agentSessionKey,
-      config: resolvedConfig,
+      ...sessionToolConfig,
       sandboxed: options?.sandboxed,
     }),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -734,6 +734,7 @@ export function createOpenClawCodingTools(options?: {
             : undefined,
           sandboxed: !!sandbox,
           config: options?.config,
+          liveSessionToolConfig: true,
           pluginToolAllowlist,
           currentChannelId: options?.currentChannelId,
           currentThreadTs: options?.currentThreadTs,

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -277,6 +277,7 @@ async function resolveModelOverride(params: {
 export function createSessionStatusTool(opts?: {
   agentSessionKey?: string;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
   sandboxed?: boolean;
 }): AnyAgentTool {
   return {
@@ -287,7 +288,7 @@ export function createSessionStatusTool(opts?: {
     parameters: SessionStatusToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
-      const cfg = opts?.config ?? getRuntimeConfig();
+      const cfg = opts?.getConfig?.() ?? opts?.config ?? getRuntimeConfig();
       const { mainKey, alias, effectiveRequesterKey } = resolveSandboxedSessionToolContext({
         cfg,
         agentSessionKey: opts?.agentSessionKey,

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -82,8 +82,9 @@ export function resolveSessionToolContext(opts?: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
 }) {
-  const cfg = opts?.config ?? getRuntimeConfig();
+  const cfg = opts?.getConfig?.() ?? opts?.config ?? getRuntimeConfig();
   return {
     cfg,
     ...resolveSandboxedSessionToolContext({

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -177,6 +177,7 @@ export function createSessionsHistoryTool(opts?: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
   callGateway?: GatewayCaller;
 }): AnyAgentTool {
   return {
@@ -191,7 +192,7 @@ export function createSessionsHistoryTool(opts?: {
       const sessionKeyParam = readStringParam(params, "sessionKey", {
         required: true,
       });
-      const cfg = opts?.config ?? getRuntimeConfig();
+      const cfg = opts?.getConfig?.() ?? opts?.config ?? getRuntimeConfig();
       const { mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
         resolveSandboxedSessionToolContext({
           cfg,

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -65,6 +65,7 @@ export function createSessionsListTool(opts?: {
   agentSessionKey?: string;
   sandboxed?: boolean;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
   callGateway?: GatewayCaller;
 }): AnyAgentTool {
   return {
@@ -75,7 +76,7 @@ export function createSessionsListTool(opts?: {
     parameters: SessionsListToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
-      const cfg = opts?.config ?? getRuntimeConfig();
+      const cfg = opts?.getConfig?.() ?? opts?.config ?? getRuntimeConfig();
       const { mainKey, alias, requesterInternalKey, restrictToSpawned } =
         resolveSandboxedSessionToolContext({
           cfg,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -107,6 +107,7 @@ export function createSessionsSendTool(opts?: {
   agentChannel?: GatewayMessageChannel;
   sandboxed?: boolean;
   config?: OpenClawConfig;
+  getConfig?: () => OpenClawConfig;
   callGateway?: GatewayCaller;
 }): AnyAgentTool {
   return {

--- a/src/auto-reply/continuation/config.test.ts
+++ b/src/auto-reply/continuation/config.test.ts
@@ -2,10 +2,18 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig: vi.fn(() => ({})),
+  getRuntimeConfigSnapshot: vi.fn(() => null),
 }));
 
-import { clampDelayMs, resolveContinuationRuntimeConfig } from "./config.js";
+import { getRuntimeConfigSnapshot } from "../../config/config.js";
+import {
+  clampDelayMs,
+  resolveContinuationRuntimeConfig,
+  resolveLiveContinuationRuntimeConfig,
+} from "./config.js";
 import type { ContinuationRuntimeConfig } from "./types.js";
+
+const getRuntimeConfigSnapshotMock = vi.mocked(getRuntimeConfigSnapshot);
 
 describe("resolveContinuationRuntimeConfig", () => {
   it("returns defaults when continuation is not configured", () => {
@@ -103,6 +111,36 @@ describe("resolveContinuationRuntimeConfig", () => {
   it("has no generationGuardTolerance field", () => {
     const config = resolveContinuationRuntimeConfig({} as never);
     expect("generationGuardTolerance" in config).toBe(false);
+  });
+
+  it("prefers the active runtime snapshot when resolving live config", () => {
+    getRuntimeConfigSnapshotMock.mockReturnValueOnce({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 9 } } },
+    } as never);
+
+    const config = resolveLiveContinuationRuntimeConfig({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 3 } } },
+    } as never);
+
+    expect(config.maxDelegatesPerTurn).toBe(9);
+  });
+
+  it("falls back to the provided config when no runtime snapshot is active", () => {
+    const config = resolveLiveContinuationRuntimeConfig({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 4 } } },
+    } as never);
+
+    expect(config.maxDelegatesPerTurn).toBe(4);
+  });
+
+  it("uses active runtime snapshot defaults when continuation config was unset", () => {
+    getRuntimeConfigSnapshotMock.mockReturnValueOnce({} as never);
+
+    const config = resolveLiveContinuationRuntimeConfig({
+      agents: { defaults: { continuation: { maxDelegatesPerTurn: 6 } } },
+    } as never);
+
+    expect(config.maxDelegatesPerTurn).toBe(5);
   });
 });
 

--- a/src/auto-reply/continuation/config.ts
+++ b/src/auto-reply/continuation/config.ts
@@ -8,7 +8,7 @@
  * RFC: docs/design/continue-work-signal-v2.md §5
  */
 
-import { getRuntimeConfig } from "../../config/config.js";
+import { getRuntimeConfig, getRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContinuationRuntimeConfig } from "./types.js";
 
@@ -95,6 +95,24 @@ export function resolveContinuationRuntimeConfig(
     contextPressureThreshold: clampOptionalUnitInterval(continuation?.contextPressureThreshold),
     earlyWarningBand: clampEarlyWarningBand(continuation?.earlyWarningBand),
   };
+}
+
+/**
+ * Resolve continuation runtime config preferring the active runtime snapshot.
+ *
+ * `resolveContinuationRuntimeConfig` accepts whatever cfg the caller passes,
+ * which is usually a snapshot captured at run construction. That captured
+ * snapshot is stale across hot-reloads: a `gateway/reload config change applied`
+ * will update the runtime snapshot but the followup-turn already holds the old
+ * cfg. Using this helper at per-turn enforcement points (chain caps, cost caps,
+ * pressure thresholds, schedule-time delay reads) lets reloaded values take
+ * effect at the next decision-point without invalidating already-armed timers
+ * or queued retries (RFC §6.5 in-flight-state invariant).
+ */
+export function resolveLiveContinuationRuntimeConfig(
+  fallbackCfg: OpenClawConfig,
+): ContinuationRuntimeConfig {
+  return resolveContinuationRuntimeConfig(getRuntimeConfigSnapshot() ?? fallbackCfg);
 }
 
 /**

--- a/src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts
@@ -7,6 +7,7 @@ import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
 } from "../../agents/pi-embedded-runner/runs.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   resetContinuationTracer,
@@ -217,6 +218,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  clearRuntimeConfigSnapshot();
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
@@ -294,6 +296,7 @@ async function runDelegateTurn(
   run: ReturnType<typeof createContinuationRun>,
   sessionStore: Record<string, SessionEntry>,
 ): Promise<unknown> {
+  setRuntimeConfigSnapshot(run.followupRun.run.config);
   return runReplyAgent({
     commandBody: "hello",
     followupRun: run.followupRun,

--- a/src/auto-reply/reply/agent-runner.continuation-span-uniformity.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-span-uniformity.test.ts
@@ -10,6 +10,7 @@ import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
 } from "../../agents/pi-embedded-runner/runs.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   resetContinuationTracer,
@@ -219,6 +220,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  clearRuntimeConfigSnapshot();
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
@@ -300,6 +302,7 @@ async function runDelegateTurn(
   run: ReturnType<typeof createContinuationRun>,
   sessionStore: Record<string, SessionEntry>,
 ): Promise<unknown> {
+  setRuntimeConfigSnapshot(run.followupRun.run.config);
   return runReplyAgent({
     commandBody: "hello",
     followupRun: run.followupRun,

--- a/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
@@ -17,6 +17,7 @@ import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
 } from "../../agents/pi-embedded-runner/runs.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   resetContinuationTracer,
@@ -227,6 +228,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  clearRuntimeConfigSnapshot();
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
@@ -304,6 +306,7 @@ async function runWorkTurn(
   sessionStore: Record<string, SessionEntry>,
   _payloadText: string,
 ): Promise<unknown> {
+  setRuntimeConfigSnapshot(run.followupRun.run.config);
   return runReplyAgent({
     commandBody: "hello",
     followupRun: run.followupRun,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -7,6 +7,7 @@ import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
 } from "../../agents/pi-embedded-runner/runs.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import * as sessionTypesModule from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
@@ -205,6 +206,7 @@ beforeEach(() => {
 afterEach(() => {
   resetDiagnosticEventsForTest();
   vi.useRealTimers();
+  clearRuntimeConfigSnapshot();
   clearMemoryPluginState();
   replyRunRegistryTesting.resetReplyRunRegistry();
   embeddedRunTesting.resetActiveEmbeddedRuns();
@@ -271,6 +273,8 @@ describe("runReplyAgent continuation volatile state", () => {
         blockReplyBreak: "message_end",
       },
     } as unknown as FollowupRun;
+
+    setRuntimeConfigSnapshot(followupRun.run.config);
 
     return {
       sessionKey,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -59,7 +59,7 @@ import {
   stagedPostCompactionDelegateCount,
   takeDelayedContinuationReservation,
 } from "../continuation-delegate-store.js";
-import { resolveContinuationRuntimeConfig } from "../continuation/config.js";
+import { resolveLiveContinuationRuntimeConfig } from "../continuation/config.js";
 import { checkContextPressure } from "../continuation/context-pressure.js";
 import { extractContinuationSignal } from "../continuation/signal.js";
 import {
@@ -1432,7 +1432,8 @@ export async function runReplyAgent(params: {
     // crossed. Runs after setPhase("running") for state-tracking reasons,
     // but unconditionally before the actual provider request below.
     if (activeSessionEntry && sessionKey) {
-      const { contextPressureThreshold, earlyWarningBand } = resolveContinuationRuntimeConfig(cfg);
+      const { contextPressureThreshold, earlyWarningBand } =
+        resolveLiveContinuationRuntimeConfig(cfg);
       const contextWindowTokens =
         resolveContextTokensForModel({
           cfg,
@@ -2111,7 +2112,7 @@ export async function runReplyAgent(params: {
     let bracketTokensAccumulated = false;
     if (effectiveContinuationSignal && sessionKey) {
       const { maxChainLength, defaultDelayMs, minDelayMs, maxDelayMs, costCapTokens } =
-        resolveContinuationRuntimeConfig(cfg);
+        resolveLiveContinuationRuntimeConfig(cfg);
 
       {
         // continuation scheduling block
@@ -2522,7 +2523,7 @@ export async function runReplyAgent(params: {
       }
       if (toolDelegates.length > 0) {
         const { maxChainLength, minDelayMs, maxDelayMs, costCapTokens, maxDelegatesPerTurn } =
-          resolveContinuationRuntimeConfig(cfg);
+          resolveLiveContinuationRuntimeConfig(cfg);
         // If a bracket-signal delegate was already spawned this turn, count it
         // against the per-turn cap so mixed-signal turns cannot exceed the limit.
         const bracketDelegateCount = effectiveContinuationSignal?.kind === "delegate" ? 1 : 0;
@@ -2885,7 +2886,7 @@ export async function runReplyAgent(params: {
           agentTo: followupRun.originatingTo ?? undefined,
           agentThreadId: followupRun.originatingThreadId ?? undefined,
         },
-        maxChainLength: resolveContinuationRuntimeConfig(cfg).maxChainLength,
+        maxChainLength: resolveLiveContinuationRuntimeConfig(cfg).maxChainLength,
         // Pass a fresh-loader so the hedge timer re-loads the
         // chain state from the persisted session entry at fire time rather
         // than re-using the snapshot captured at arm time.

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -451,7 +451,7 @@ export function createFollowupRunner(params: {
       if (runtimeConfig?.agents?.defaults?.continuation?.enabled === true && sessionKey) {
         const [
           { dispatchToolDelegates },
-          { resolveContinuationRuntimeConfig },
+          { resolveLiveContinuationRuntimeConfig },
           { loadContinuationChainState, persistContinuationChainState },
           { updateSessionStore, resolveSessionStoreEntry },
         ] = await Promise.all([
@@ -474,7 +474,7 @@ export function createFollowupRunner(params: {
             agentTo: queued.originatingTo ?? undefined,
             agentThreadId: queued.originatingThreadId ?? undefined,
           },
-          maxChainLength: resolveContinuationRuntimeConfig(runtimeConfig).maxChainLength,
+          maxChainLength: resolveLiveContinuationRuntimeConfig(runtimeConfig).maxChainLength,
           // Hedge re-arm must see fresh chain state.
           loadFreshChainState: () => loadContinuationChainState(tailEntry, 0),
         });

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -283,6 +283,7 @@ export async function handleInlineActions(params: {
         agentDir,
         workspaceDir,
         config: cfg,
+        liveSessionToolConfig: true,
         allowGatewaySubagentBinding: true,
         senderIsOwner: command.senderIsOwner,
       });

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2180,6 +2180,63 @@ describe("config cli", () => {
     });
   });
 
+  describe("config reload hint", () => {
+    it("does not print a restart hint for dynamic-read config paths", async () => {
+      const resolved: OpenClawConfig = {
+        tools: { sessions: { visibility: "tree" } },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "tools.sessions.visibility", "all"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const raw = String(mockLog.mock.calls.at(-1)?.[0]);
+      expect(raw).toContain("Updated tools.sessions.visibility.");
+      expect(raw).toContain("No gateway restart required.");
+      expect(raw).not.toContain("Restart the gateway to apply.");
+    });
+
+    it("keeps the restart hint for restart-required config paths", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "gateway.port", "19001"]);
+
+      const raw = String(mockLog.mock.calls.at(-1)?.[0]);
+      expect(raw).toContain("Updated gateway.port.");
+      expect(raw).toContain("Restart the gateway to apply.");
+    });
+
+    it("prints a hot-reload hint for hot config paths", async () => {
+      const resolved: OpenClawConfig = {
+        hooks: { gmail: { account: "old" } },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "hooks.gmail.account", "new"]);
+
+      const raw = String(mockLog.mock.calls.at(-1)?.[0]);
+      expect(raw).toContain("Updated hooks.gmail.account.");
+      expect(raw).toContain("Gateway hot reload will apply.");
+    });
+
+    it("does not print a restart hint when unsetting a dynamic-read config path", async () => {
+      const resolved: OpenClawConfig = {
+        tools: { sessions: { visibility: "all" } },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "unset", "tools.sessions.visibility"]);
+
+      const raw = String(mockLog.mock.calls.at(-1)?.[0]);
+      expect(raw).toContain("Removed tools.sessions.visibility.");
+      expect(raw).toContain("No gateway restart required.");
+      expect(raw).not.toContain("Restart the gateway to apply.");
+    });
+  });
+
   describe("config unset - issue #6070", () => {
     it("preserves existing config keys when unsetting a value", async () => {
       const resolved: OpenClawConfig = {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -21,6 +21,7 @@ import {
   validateConfigObjectRaw,
 } from "../config/validation.js";
 import { SecretProviderSchema } from "../config/zod-schema.core.js";
+import { buildGatewayReloadPlan, type GatewayReloadPlan } from "../gateway/config-reload-plan.js";
 import { danger, info, success } from "../globals.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
@@ -591,6 +592,23 @@ function pruneInactiveGatewayAuthCredentials(params: {
 
 function toDotPath(path: PathSegment[]): string {
   return path.join(".");
+}
+
+function formatConfigReloadHint(plan: GatewayReloadPlan): string {
+  if (plan.restartGateway) {
+    return "Restart the gateway to apply.";
+  }
+  if (plan.hotReasons.length > 0) {
+    return plan.noopPaths.length > 0
+      ? "Gateway hot reload and dynamic reads will apply."
+      : "Gateway hot reload will apply.";
+  }
+  return "No gateway restart required.";
+}
+
+function resolveConfigReloadHintForPaths(paths: Iterable<PathSegment[]>): string {
+  const changedPaths = [...paths].map(toDotPath).filter(Boolean);
+  return formatConfigReloadHint(buildGatewayReloadPlan(changedPaths));
 }
 
 function parseSecretRefSource(raw: string, label: string): SecretRefSource {
@@ -1540,16 +1558,18 @@ async function runConfigOperations(params: {
   if (params.successMode === "set" && operations.length === 1) {
     const operation = operations[0];
     const action = operation?.mutation === "delete" ? "Removed" : "Updated";
-    runtime.log(
-      info(`${action} ${toDotPath(operation?.requestedPath ?? [])}. Restart the gateway to apply.`),
-    );
+    const reloadHint = resolveConfigReloadHintForPaths([operation?.setPath ?? []]);
+    runtime.log(info(`${action} ${toDotPath(operation?.requestedPath ?? [])}. ${reloadHint}`));
     return;
   }
+  const reloadHint = resolveConfigReloadHintForPaths(
+    operations.map((operation) => operation.setPath),
+  );
   if (params.successMode === "set") {
-    runtime.log(info(`Updated ${operations.length} config paths. Restart the gateway to apply.`));
+    runtime.log(info(`Updated ${operations.length} config paths. ${reloadHint}`));
     return;
   }
-  runtime.log(info(`Applied ${operations.length} config update(s). Restart the gateway to apply.`));
+  runtime.log(info(`Applied ${operations.length} config update(s). ${reloadHint}`));
 }
 
 function handleConfigMutationError(params: {
@@ -1702,7 +1722,8 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
       ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
       writeOptions: { unsetPaths: [parsedPath] },
     });
-    runtime.log(info(`Removed ${opts.path}. Restart the gateway to apply.`));
+    const reloadHint = resolveConfigReloadHintForPaths([parsedPath]);
+    runtime.log(info(`Removed ${opts.path}. ${reloadHint}`));
   } catch (err) {
     runtime.error(danger(String(err)));
     runtime.exit(1);

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -394,6 +394,18 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toContain("diagnostics.stuckSessionWarnMs");
   });
 
+  it("treats session tool visibility as a dynamic-read path", () => {
+    const plan = buildGatewayReloadPlan(["tools.sessions.visibility"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("tools.sessions.visibility");
+  });
+
+  it("treats continuation delegate limits as dynamic-read paths", () => {
+    const plan = buildGatewayReloadPlan(["agents.defaults.continuation.maxDelegatesPerTurn"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("agents.defaults.continuation.maxDelegatesPerTurn");
+  });
+
   it("restarts for gateway.auth.token changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.auth.token"]);
     expect(plan.restartGateway).toBe(true);

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -91,6 +91,7 @@ export function resolveGatewayScopedTools(params: {
     disablePluginTools: params.disablePluginTools,
     senderIsOwner: params.senderIsOwner,
     config: params.cfg,
+    liveSessionToolConfig: true,
     workspaceDir,
     pluginToolAllowlist: collectExplicitAllowlist([
       profilePolicy,


### PR DESCRIPTION
## Summary

Three sibling fixes against the RFC §6.5 hot-reload contract for the dynamic-read paths claimed in `agents.defaults.continuation` and `tools.sessions.visibility`. Supersedes karmaterminal/openclaw#536, which was 1626 commits behind canonical against an ancient base — this lane re-applies the fix-pattern fresh against `frond/v2026.5.2/canonical` rather than rebasing the stale diff.

- **#533 — sessions visibility live-read.** `tools.sessions.visibility` is classified by `buildGatewayReloadPlan` as a no-op (no restart) but the session-tool guards captured config at construction time, so a hot reload of the visibility key didn't reach the running guards. Adds `getConfig` opt-in on session-tool factories and a `liveSessionToolConfig` toggle on `createOpenClawTools`; production wiring (pi-tools, gateway tool-resolution, inline-action skill dispatch) opts in.
- **#19 — continuation knobs live-read at next decision-point.** `agents.defaults.continuation.*` runtime knobs are evaluated at each per-turn enforcement point but the `OpenClawConfig` snapshot was the captured `cfg` from run construction, not the active runtime snapshot. Adds `resolveLiveContinuationRuntimeConfig(fallbackCfg)` that prefers `getRuntimeConfigSnapshot()` when present. Switched call sites in `agent-runner.ts` and `followup-runner.ts` to the live variant. Span-tests carry `setRuntimeConfigSnapshot` / `clearRuntimeConfigSnapshot` setup so the new resolution path is exercised under test.
- **#531 — CLI plan-aware reload hint.** `openclaw config set/patch/unset` always printed *Restart the gateway to apply.* even for paths the gateway reload planner already classifies as dynamic-read or hot-reload. Routed the message through `buildGatewayReloadPlan` so the user sees the truth: `No gateway restart required.` for dynamic-read paths, `Gateway hot reload will apply.` for hot paths, and the original restart hint only when the planner actually requires one.

Closes karmaterminal/openclaw#533.
Closes karmaterminal/openclaw#19.
Closes karmaterminal/openclaw#531.

## RFC §6.5 invariant — preserved

> *no in-flight delegate, queued retry, or staged post-compaction handoff should be invalidated by a hot-reload.*

This lane preserves the invariant by design: every live-read happens at a **decision-point** (next dispatch / next chain step / next pressure check / next CLI ack), not mid-flight. Already-armed timers, queued retries, and staged post-compaction handoffs continue to use their captured values. The "schedule-time-captured" disposition the workorder calls out IS what live-read at decision-points yields — new schedules use new values, in-flight items keep theirs.

## Per-knob safety audit

| Knob | Live-read site | Re-read safe? | Disposition |
|---|---|---|---|
| `tools.sessions.visibility` | `sessions-{list,history,send,status}-tool.ts` execute-time guard | YES — stateless decision per call | live-read |
| `agents.defaults.continuation.maxDelegatesPerTurn` | `agent-runner.ts` toolDelegates dispatch (`src/auto-reply/reply/agent-runner.ts:2525`) | YES — checked at dispatch decision | live-read |
| `agents.defaults.continuation.maxChainLength` | bracket scheduler (`agent-runner.ts:2114`); tool-delegates dispatch (`agent-runner.ts:2525`); hedge timer arm (`agent-runner.ts:2888`); followup-runner dispatch (`followup-runner.ts:477`) | YES — captured at schedule/arm time, in-flight timers keep their value | live-read |
| `agents.defaults.continuation.costCapTokens` | bracket scheduler (`agent-runner.ts:2114`); tool-delegates dispatch (`agent-runner.ts:2525`) | YES — checked at dispatch decision | live-read |
| `agents.defaults.continuation.contextPressureThreshold` | pre-run pressure check (`agent-runner.ts:1435`) | YES — checked at next pressure check | live-read |
| `agents.defaults.continuation.earlyWarningBand` | pre-run pressure check (`agent-runner.ts:1435`) | YES — checked at next pressure check | live-read |
| `agents.defaults.continuation.defaultDelayMs` / `minDelayMs` / `maxDelayMs` | bracket scheduler (`agent-runner.ts:2114`) — used to compute new schedules | YES — captured at schedule-time; armed timers keep their `delayMs` | live-read at next schedule, captured for in-flight |
| `agents.defaults.continuation.enabled` | followup-runner gate (`followup-runner.ts:451`) — note: this gate reads the captured `runtimeConfig` (not live) by design, so disabling continuation does not invalidate a followup turn already mid-flight | n/a | unchanged (intentional) |

`buildGatewayReloadPlan` already classifies both `tools.*` and `agents.*` as `kind: "none"` via the tail rules. The bug was on the runtime side: the planner promised dynamic-read, the runtime snapshot wasn't reaching the consumers. This PR makes the runtime honor the contract the planner already advertised.

## Tests
- `pnpm test src/agents/openclaw-tools.sessions-visibility.test.ts` — pins live re-read behavior under `getConfig` (mid-execution config flip).
- `pnpm test src/auto-reply/continuation/config.test.ts` — pins `resolveLiveContinuationRuntimeConfig` snapshot-prefers / fallback-on-no-snapshot / defaults-on-empty-snapshot.
- `pnpm test src/cli/config-cli.test.ts` — pins three-state CLI hint (no-restart / hot-reload / restart-required).
- `pnpm test src/gateway/config-reload.test.ts` — pins `tools.sessions.visibility` and `agents.defaults.continuation.maxDelegatesPerTurn` as dynamic-read paths.
- Continuation span tests in `src/auto-reply/reply/agent-runner.*.test.ts` carry `setRuntimeConfigSnapshot` / `clearRuntimeConfigSnapshot` lifecycle hooks so `resolveLiveContinuationRuntimeConfig` resolves under test.

## Test plan

- [ ] `pnpm test` covers each touched test file.
- [ ] `pnpm exec oxfmt --check --threads=1` clean for touched files.
- [ ] `pnpm check:changed` (Testbox throttled) clean.
- [ ] Manual: `openclaw config set tools.sessions.visibility=all` (no restart) → outside-tree session-send no longer blocked.
- [ ] Manual: `openclaw config set agents.defaults.continuation.maxDelegatesPerTurn 7` (no restart) → next dispatch honors the new cap.
- [ ] Manual: `openclaw config set tools.sessions.visibility=all` prints `No gateway restart required.` (not the restart hint).

## Why supersede instead of rebase #536

#536's base (`frond-scribe/20260429/v3-cohort-fixes`) is 1626 commits behind canonical. v5.2 has shipped substantial substrate (OOM hot-loop cure, traceparent propagation per RFC §6.8, otel adapter wiring, strip-marks lane, dev-detritus drops). The conflict surface for a direct rebase is larger than the actual fix. This lane re-applies the same fix-pattern fresh against canonical: same shape, same end state, but reviewable against current code rather than reading three months of churn out of the diff.

🌿 Authored by frond-scribe; the gh CLI on this host posts as ronan-dandelion-cult (impersonation caveat per host-config) — commits are frond-scribe-authored.