### PR TITLE
fix(continuation): preserve durable session-delivery queue for non-attached targeted recipients (Finding 2 of #580)

### DIFF
--- a/src/agents/subagent-announce.continuation-drain.test.ts
+++ b/src/agents/subagent-announce.continuation-drain.test.ts
@@ -556,6 +556,75 @@ describe("subagent-announce continuation drain (F7)", () => {
     );
   });
 
+  // Regression test for karmaterminal/openclaw#578 (cohort fire-1 scenario):
+  // continue_delegate({ targetSessionKey: "agent:main:main", mode: "silent-wake" })
+  // must route the return to the named single target, not to the dispatcher.
+  // The cohort 5-seat byte-pin showed the singular `continuationTargetSessionKey`
+  // form was silently retargeting back to the dispatcher despite tool-surface
+  // acceptance + state_json preservation. Plural form is exercised above; this
+  // test pins the singular form's path through the same announce-return seam.
+  it("routes singular continuationTargetSessionKey to the named recipient (not dispatcher)", async () => {
+    loadSessionStoreMock.mockImplementation(
+      () =>
+        ({
+          "agent:main:subagent:test": {
+            sessionId: "session-child",
+            updatedAt: Date.now(),
+          },
+          "agent:main:discord:channel:1466192485440164011": {
+            sessionId: "session-dispatcher",
+            updatedAt: Date.now(),
+          },
+          "agent:main:main": {
+            sessionId: "session-target",
+            updatedAt: Date.now(),
+          },
+        }) as Record<string, unknown>,
+    );
+
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-singular-targeted",
+      requesterSessionKey: "agent:main:discord:channel:1466192485440164011",
+      requesterDisplayKey: "discord-channel",
+      task: "[continuation:chain-hop:1] OV-1 fire-1 reproduction",
+      timeoutMs: 100,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "received delegate at agent:main:main",
+      silentAnnounce: true,
+      wakeOnReturn: true,
+      continuationTargetSessionKey: "agent:main:main",
+    });
+
+    // The resolver must see the singular targetSessionKey (not the
+    // dispatcher's session) and the dispatcher only as the fallback default.
+    expect(
+      continuationTargetingMock.resolveContinuationReturnTargetSessionKeys,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultSessionKey: "agent:main:discord:channel:1466192485440164011",
+        targetSessionKey: "agent:main:main",
+      }),
+    );
+    // The enqueue must target the named recipient ONLY — not the dispatcher.
+    expect(continuationTargetingMock.enqueueContinuationReturnDeliveries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetSessionKeys: ["agent:main:main"],
+        wakeRecipients: true,
+        childRunId: "run-singular-targeted",
+      }),
+    );
+    const enqueueCall =
+      continuationTargetingMock.enqueueContinuationReturnDeliveries.mock.calls[0]?.[0];
+    expect((enqueueCall as { targetSessionKeys: string[] })?.targetSessionKeys).not.toContain(
+      "agent:main:discord:channel:1466192485440164011",
+    );
+  });
+
   it("fanoutMode=all spends one chain step per completion, not per recipient", async () => {
     const knownSessionKeys = [
       "agent:main:main",

--- a/src/agents/subagent-announce.continuation-drain.test.ts
+++ b/src/agents/subagent-announce.continuation-drain.test.ts
@@ -634,6 +634,16 @@ describe("subagent-announce continuation drain (F7)", () => {
     expect((enqueueCall as { targetSessionKeys: string[] })?.targetSessionKeys).not.toContain(
       "agent:main:discord:channel:1466192485440164011",
     );
+    // Idempotency-key shape carries an index + sessionKey suffix per RFC §6.7
+    // so the durable session-delivery-queue file under the recipient's key
+    // resolves to a stable hash that the recovery loop can replay
+    // post-restart (the durable-write contract that #578/#580 was filed
+    // against). The actual file-write + ack-skip behavior is exercised
+    // against the real `enqueueContinuationReturnDeliveries` in
+    // `cross-session-targeting.test.ts`.
+    expect((enqueueCall as { idempotencyKeyBase: string })?.idempotencyKeyBase).toMatch(
+      /^continuation-return:/,
+    );
   });
 
   it("fanoutMode=all spends one chain step per completion, not per recipient", async () => {

--- a/src/agents/subagent-announce.continuation-drain.test.ts
+++ b/src/agents/subagent-announce.continuation-drain.test.ts
@@ -556,13 +556,24 @@ describe("subagent-announce continuation drain (F7)", () => {
     );
   });
 
-  // Regression test for karmaterminal/openclaw#578 (cohort fire-1 scenario):
+  // Regression test for karmaterminal/openclaw#580 (cohort fire-1 scenario;
+  // #578 substrate-evidence anchor, #579 closed dupe):
   // continue_delegate({ targetSessionKey: "agent:main:main", mode: "silent-wake" })
   // must route the return to the named single target, not to the dispatcher.
-  // The cohort 5-seat byte-pin showed the singular `continuationTargetSessionKey`
-  // form was silently retargeting back to the dispatcher despite tool-surface
-  // acceptance + state_json preservation. Plural form is exercised above; this
-  // test pins the singular form's path through the same announce-return seam.
+  // Plural `continuationTargetSessionKeys` form is exercised above; this test
+  // pins the singular form's path through the same announce-return seam.
+  //
+  // Cohort 3-host convergent refinement (~02:37Z 2026-05-04): branch-entry IS
+  // honored at this layer (the test passes); the substrate-finding has narrowed
+  // to the durable-store step inside `enqueueSessionDelivery` /
+  // `ackSessionDelivery` ordering — file substrate at
+  // `<state-dir>/session-delivery-queue/` stays empty for named recipients
+  // because `targeting.ts:114` immediately acks the file after the in-memory
+  // `enqueueSystemEvent` delivery. Whether durable-write should persist for
+  // non-attached recipients is an open semantic question for figs.
+  // This test pins the branch-entry contract; the I/O-level enqueue-vs-ack
+  // contract is pinned by `cross-session-targeting.test.ts` against the real
+  // `enqueueContinuationReturnDeliveries` with mocked deps.
   it("routes singular continuationTargetSessionKey to the named recipient (not dispatcher)", async () => {
     loadSessionStoreMock.mockImplementation(
       () =>

--- a/src/auto-reply/continuation/cross-session-targeting.test.ts
+++ b/src/auto-reply/continuation/cross-session-targeting.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   resetContinuationTracer,
@@ -7,7 +9,15 @@ import {
   type StartSpanOptions,
   type Tracer,
 } from "../../infra/continuation-tracer.js";
-import type { QueuedSessionDeliveryPayload } from "../../infra/session-delivery-queue-storage.js";
+import type {
+  QueuedSessionDelivery,
+  QueuedSessionDeliveryPayload,
+} from "../../infra/session-delivery-queue-storage.js";
+import {
+  ackSessionDelivery as realAckSessionDelivery,
+  enqueueSessionDelivery as realEnqueueSessionDelivery,
+} from "../../infra/session-delivery-queue-storage.js";
+import { withTempDir } from "../../test-helpers/temp-dir.js";
 import {
   enqueueContinuationReturnDeliveries,
   resolveContinuationReturnTargetSessionKeys,
@@ -121,7 +131,13 @@ describe("continuation cross-session targeting", () => {
       },
     ]);
     expect(requestHeartbeatNow).toHaveBeenCalledTimes(2);
-    expect(ackSessionDelivery).toHaveBeenCalledTimes(2);
+    // Per #578/#580 fix: do NOT immediately ack the durable file. The
+    // in-memory enqueueSystemEvent call above is process-local; non-attached
+    // recipients (different process / pre-restart) cannot see it. The durable
+    // queue file must persist until the recipient consumes it via the recovery
+    // loop. Acking here would destroy the only durable channel and leave
+    // targeted recipients silently unreached.
+    expect(ackSessionDelivery).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -277,5 +293,101 @@ describe("continuation cross-session targeting", () => {
     expect(attrs["fanout.delivered_count"]).toBe(50);
     expect(attrs["fanout.recipient.outcomes"]).toEqual(targetSessionKeys.map(() => "delivered"));
     expect(attrs["chain.step.remaining"]).toBe(9);
+  });
+
+  // Real-chain regression for karmaterminal/openclaw#578/#580.
+  // Cohort verdict (Cael nonce-test 02:46Z 2026-05-04): explicit-targeted
+  // deliveries do NOT reach the named recipient at runtime — 0 nonce-hits in
+  // #heartbeat for three probes despite tool-surface accepting the param.
+  // Bug-shape: targeting.ts called `ackSessionDelivery` immediately after
+  // `enqueueSessionDelivery` + `enqueueSystemEvent`. The ack renamed the
+  // queue file to `.delivered` and unlinked it (storage.ts:326-340), leaving
+  // ZERO durable record for non-attached recipients (different process
+  // and/or pre-restart) to pick up. This test exercises the REAL
+  // `enqueueSessionDelivery` + `ackSessionDelivery` chain (no I/O mocking
+  // for the queue layer per figs's directive) and asserts the queue file
+  // PERSISTS in the flat `<state-dir>/session-delivery-queue/<id>.json`
+  // location until the recovery loop drains it post-restart.
+  it("persists the durable queue file for non-attached recipients (no immediate ack)", async () => {
+    await withTempDir({ prefix: "openclaw-targeting-durable-" }, async (stateDir) => {
+      const enqueueSystemEvent = vi.fn<EnqueueSystemEvent>(() => true);
+      const requestHeartbeatNow = vi.fn();
+
+      const result = await enqueueContinuationReturnDeliveries(
+        {
+          targetSessionKeys: ["agent:main:other"],
+          text: "[continuation:enrichment-return] non-attached recipient",
+          idempotencyKeyBase: "continuation-return:durable-test",
+          stateDir,
+          wakeRecipients: true,
+          childRunId: "run-durable",
+        },
+        {
+          enqueueSessionDelivery: realEnqueueSessionDelivery,
+          ackSessionDelivery: realAckSessionDelivery,
+          enqueueSystemEvent,
+          requestHeartbeatNow,
+        },
+      );
+
+      expect(result).toMatchObject({ enqueued: 1, delivered: 1 });
+
+      const queueDir = path.join(stateDir, "session-delivery-queue");
+      const entries = await fs.readdir(queueDir);
+      const jsonFiles = entries.filter((entry) => entry.endsWith(".json"));
+      const deliveredMarkers = entries.filter((entry) => entry.endsWith(".delivered"));
+
+      // Per #578/#580 fix: durable queue file must persist (NOT renamed to
+      // .delivered, NOT unlinked). The recovery loop on next gateway
+      // restart picks it up via `recoverPendingRestartContinuationDeliveries`.
+      expect(jsonFiles).toHaveLength(1);
+      expect(deliveredMarkers).toHaveLength(0);
+
+      const persistedPath = path.join(queueDir, jsonFiles[0]);
+      const persisted = JSON.parse(
+        await fs.readFile(persistedPath, "utf-8"),
+      ) as QueuedSessionDelivery;
+      expect(persisted.kind).toBe("systemEvent");
+      expect(persisted.sessionKey).toBe("agent:main:other");
+      expect(persisted.idempotencyKey).toBe("continuation-return:durable-test:0:agent:main:other");
+    });
+  });
+
+  it("persists one durable queue file per recipient on multi-target fanout", async () => {
+    await withTempDir({ prefix: "openclaw-targeting-fanout-durable-" }, async (stateDir) => {
+      await enqueueContinuationReturnDeliveries(
+        {
+          targetSessionKeys: ["agent:main:root", "agent:main:sibling"],
+          text: "[continuation:enrichment-return] fanout durable",
+          idempotencyKeyBase: "continuation-return:fanout-durable",
+          stateDir,
+          wakeRecipients: false,
+        },
+        {
+          enqueueSessionDelivery: realEnqueueSessionDelivery,
+          ackSessionDelivery: realAckSessionDelivery,
+          enqueueSystemEvent: vi.fn<EnqueueSystemEvent>(() => true),
+          requestHeartbeatNow: vi.fn(),
+        },
+      );
+
+      const queueDir = path.join(stateDir, "session-delivery-queue");
+      const entries = await fs.readdir(queueDir);
+      const jsonFiles = entries.filter((entry) => entry.endsWith(".json"));
+
+      expect(jsonFiles).toHaveLength(2);
+      const persisted: QueuedSessionDelivery[] = [];
+      for (const file of jsonFiles) {
+        persisted.push(
+          JSON.parse(
+            await fs.readFile(path.join(queueDir, file), "utf-8"),
+          ) as QueuedSessionDelivery,
+        );
+      }
+      expect(persisted.map((entry) => entry.sessionKey).toSorted()).toEqual([
+        "agent:main:root",
+        "agent:main:sibling",
+      ]);
+    });
   });
 });

--- a/src/auto-reply/continuation/targeting.ts
+++ b/src/auto-reply/continuation/targeting.ts
@@ -111,7 +111,14 @@ export async function enqueueContinuationReturnDeliveries(
         parentRunId: params.childRunId,
       });
     }
-    await deps.ackSessionDelivery(deliveryId, params.stateDir);
+    // Do NOT ack the durable file here. enqueueSystemEvent above is in-memory
+    // (process-local globalThis Map) — non-attached recipients (different
+    // process / restart-pending) cannot see it. The durable file must persist
+    // until recipient consumption so the recovery loop can replay on next
+    // gateway restart. Per figs 2026-05-04 (c)-discriminator decision: durable
+    // write IS expected for non-attached recipients per RFC §2.4. Acking
+    // immediately destroyed the only durable channel and left targeted
+    // recipients silently unreached. karmaterminal/openclaw#578 / #580.
     delivered += 1;
   }
 


### PR DESCRIPTION
## Summary

Fixes **karmaterminal/openclaw#580** (frond-scribe live tracker; karmaterminal/openclaw#578 substrate-evidence anchor; #579 closed dupe).

`continue_delegate({ targetSessionKey: <other-session> })` accepted the parameter at the tool surface, persisted it through the dispatch chain, and reached `enqueueContinuationReturnDeliveries` with the right targets — but the durable queue file at `<state-dir>/session-delivery-queue/<id>.json` was being **acked-and-unlinked immediately** at `src/auto-reply/continuation/targeting.ts:114`, leaving zero durable record for non-attached recipients (different process / pre-restart) to consume.

## Bug-shape (verdict closed Path B per cohort + figs-sharpened nonce test)

`enqueueSystemEvent` is process-local — `globalThis` Map keyed by session key. Recipients in a different process on the same host, or any session pre-restart, cannot see the in-memory event. The durable file under `<state-dir>/session-delivery-queue/` was the ONLY channel that could reach them.

**Cael's nonce-test** (`#heartbeat` channel `1473320126433464465`) returned **0 nonce-hits** for three explicit-targeted probes despite tool-surface acceptance of `targetSessionKey`. The 5-seat byte-pin convergence on swim-42 OV-1 plus the chronology-fold caught the immediate-ack as the silent corruption.

Three earlier readings — (1) substrate-correct + misleading prose, (2) silent-retarget bug, (3) substrate-correct + byte-pin at wrong layer — collapsed to **(2)** under nonce methodology.

## Fix

`src/auto-reply/continuation/targeting.ts:114` — skip the immediate `ackSessionDelivery` call. The durable file persists in the flat `<state-dir>/session-delivery-queue/` (recipient encoded in file content's `sessionKey` field, not in path; queue is flat per `storage.ts:265-303`). On next gateway startup, `recoverPendingRestartContinuationDeliveries` loops over pending entries and re-enqueues each system event in the recovering process before acking.

Minimum-diff: a single removed `await deps.ackSessionDelivery(...)` plus comment explaining why. No architectural change to `session-delivery-queue-storage.ts`.

## Test coverage

**`src/auto-reply/continuation/cross-session-targeting.test.ts`**:
- Pre-existing mocked test (`queues byte-identical return payloads...`) now asserts `ackSessionDelivery` is **NOT called** per recipient.
- **NEW** `persists the durable queue file for non-attached recipients (no immediate ack)` — uses **real** `enqueueSessionDelivery` + `ackSessionDelivery` against a `withTempDir` state-dir; asserts the `.json` file persists in `<state-dir>/session-delivery-queue/` and is not renamed to `.delivered` or unlinked. Verifies file content carries the recipient's session key + the expected idempotency key.
- **NEW** `persists one durable queue file per recipient on multi-target fanout` — same real-chain shape against a 2-target fanout, asserts both files persist with the right `sessionKey` content.

Per figs's directive: **no mocking** of `enqueueSessionDelivery` + `ackSessionDelivery` in the new tests — the real chain is exercised so the layer at which the bug actually lives is covered.

**`src/agents/subagent-announce.continuation-drain.test.ts`**:
- Singular `continuationTargetSessionKey` branch-entry coverage gap filled (was previously only covered through plural `continuationTargetSessionKeys`).

## Bug-catch verification

Stashing `targeting.ts` (restoring the buggy immediate-ack), `cross-session-targeting.test.ts` produces 3 failures:
- Pre-existing test: `ackSessionDelivery` was called (expected NOT called).
- New singular durable-write test: `jsonFiles` length 0, expected 1 (file was acked-and-unlinked).
- New fanout durable-write test: `jsonFiles` length 0, expected 2.

With the fix restored, all 14 tests pass. This proves the regression coverage actually catches the layer that was silently corrupting cross-session targeted return.

## Tradeoff

Queue file accumulation during long-uptime gateways without restart. Bounded by the existing `DEFAULT_QUEUE_DIR_MAX_FILES = 10_000` soft cap. Follow-up work (out-of-scope for this PR): add a per-attach drain trigger so non-restart scenarios also drain.

## Refs

- Tracker: karmaterminal/openclaw#580
- Substrate-evidence anchor: karmaterminal/openclaw#578
- Cohort byte-pins: `karmaterminal/karmaterminal-openclaw-docs:swims/swim-42/rows/cross-session-targeted-return/`
- Pinned source locations (per Ronan):
  - `src/infra/session-delivery-queue-storage.ts:265-303` (flat queue dir, recipient in file content)
  - `src/infra/session-delivery-queue-storage.ts:326-340` (rename .json → .delivered → unlink)
  - `src/auto-reply/continuation/targeting.ts:89-114` (the loop with immediate ack)
- RFC: `docs/design/continue-work-signal-v2.md` §2.4, §3.6, §6.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
