### PR TITLE
fix(continuation): route continue_delegate(targetSessionKey) through hasContinuationTargeting branch in actual runtime (#580 finding 3)

### DIFF
--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -75,6 +75,11 @@ export type PendingContinuationDelegate = {
 /**
  * A delayed delegate reservation tracked between scheduling and spawn.
  * Timers are volatile (in-memory only) unless TaskFlow backing is enabled.
+ *
+ * Targeting fields (`targetSessionKey` / `targetSessionKeys` / `fanoutMode`)
+ * preserve `continue_delegate(targetSessionKey=...)` routing across the
+ * `setTimeout` boundary so timer-deferred targeted delegates reach the
+ * `hasContinuationTargeting` branch in `subagent-announce.ts`.
  */
 export type DelayedContinuationReservation = {
   id: string;
@@ -86,6 +91,9 @@ export type DelayedContinuationReservation = {
   silent?: boolean;
   silentWake?: boolean;
   traceparent?: string;
+  targetSessionKey?: string;
+  targetSessionKeys?: string[];
+  fanoutMode?: "tree" | "all";
 };
 
 // ---------------------------------------------------------------------------

--- a/src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts
@@ -473,3 +473,149 @@ describe("runReplyAgent :: continuation.delegate.fire span", () => {
     expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #580 Finding 3 (runtime-path-divergence): the runner-seat tool-delegate
+// dispatch closure (`doToolSpawn` in `agent-runner.ts`) must propagate
+// `continuationTargetSessionKey` / `continuationTargetSessionKeys` /
+// `continuationFanoutMode` through to `spawnSubagentDirect`. Without these,
+// the call-site at `subagent-announce.ts:1216` evaluates `hasContinuationTargeting`
+// to false even when the tool was invoked with `targetSessionKey=...`, and
+// completion routes to the dispatcher instead of the named recipient(s).
+//
+// Path B (`dispatchToolDelegates` in `delegate-dispatch.ts:255-267`) was given
+// targeting in PR #551; Path A in `agent-runner.ts:2643-2670` was missed.
+// Path A drains the queue first (immediate-due delegates), so the bug only
+// surfaces in production runs where Path A is the live dispatcher.
+// ---------------------------------------------------------------------------
+describe("runReplyAgent :: tool-delegate targeting routes through hasContinuationTargeting branch", () => {
+  it("singular targetSessionKey: tool delegate threads continuationTargetSessionKey to spawnSubagentDirect", async () => {
+    const sessionKey = "continuation-delegate-targeting-singular";
+    const targetSessionKey = "agent:main:discord:channel:1466192485440164011";
+    const run = createContinuationRun({ sessionKey });
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      enqueuePendingDelegate(sessionKey, {
+        task: "targeted ambient probe",
+        mode: "silent-wake",
+        targetSessionKey,
+      });
+      return {
+        payloads: [{ text: "Spawning a targeted delegate." }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    await runDelegateTurn(run, { [sessionKey]: run.sessionEntry });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    expect(spawnSubagentDirectMock.mock.calls[0]?.[0]).toMatchObject({
+      continuationTargetSessionKey: targetSessionKey,
+      silentAnnounce: true,
+      wakeOnReturn: true,
+    });
+  });
+
+  it("plural targetSessionKeys: tool delegate threads continuationTargetSessionKeys array to spawnSubagentDirect", async () => {
+    const sessionKey = "continuation-delegate-targeting-plural";
+    const targetSessionKeys = ["agent:main:discord:channel:a", "agent:main:discord:channel:b"];
+    const run = createContinuationRun({ sessionKey });
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      enqueuePendingDelegate(sessionKey, {
+        task: "byte-identical fan-out probe",
+        targetSessionKeys,
+      });
+      return {
+        payloads: [{ text: "Fanning out." }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    await runDelegateTurn(run, { [sessionKey]: run.sessionEntry });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    expect(spawnSubagentDirectMock.mock.calls[0]?.[0]).toMatchObject({
+      continuationTargetSessionKeys: targetSessionKeys,
+    });
+  });
+
+  it("fanoutMode='tree': tool delegate threads continuationFanoutMode to spawnSubagentDirect", async () => {
+    const sessionKey = "continuation-delegate-targeting-fanout-tree";
+    const run = createContinuationRun({ sessionKey });
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      enqueuePendingDelegate(sessionKey, {
+        task: "tree fan-out",
+        fanoutMode: "tree",
+      });
+      return {
+        payloads: [{ text: "Walking the tree." }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    await runDelegateTurn(run, { [sessionKey]: run.sessionEntry });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    expect(spawnSubagentDirectMock.mock.calls[0]?.[0]).toMatchObject({
+      continuationFanoutMode: "tree",
+    });
+  });
+
+  it("timer-deferred dispatch preserves targetSessionKey across the setTimeout boundary via DelayedContinuationReservation", async () => {
+    vi.useFakeTimers();
+    const sessionKey = "continuation-delegate-targeting-deferred";
+    const targetSessionKey = "agent:main:discord:channel:future";
+    const run = createContinuationRun({ sessionKey });
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      enqueuePendingDelegate(sessionKey, {
+        task: "deferred targeted probe",
+        delayMs: 1_000,
+        mode: "silent-wake",
+        targetSessionKey,
+      });
+      return {
+        payloads: [{ text: "Deferred dispatch." }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    await runDelegateTurn(run, { [sessionKey]: run.sessionEntry });
+
+    // Pre-fire: the reservation is armed, no spawn yet.
+    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    expect(spawnSubagentDirectMock.mock.calls[0]?.[0]).toMatchObject({
+      continuationTargetSessionKey: targetSessionKey,
+      silentAnnounce: true,
+      wakeOnReturn: true,
+    });
+  });
+
+  it("default routing (no target): tool delegate spawn omits continuationTarget* fields, regression guard for return-to-dispatcher", async () => {
+    const sessionKey = "continuation-delegate-targeting-default";
+    const run = createContinuationRun({ sessionKey });
+    runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+      enqueuePendingDelegate(sessionKey, {
+        task: "default-routing probe",
+        mode: "silent",
+      });
+      return {
+        payloads: [{ text: "Default routing." }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    await runDelegateTurn(run, { [sessionKey]: run.sessionEntry });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSubagentDirectMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(spawnArgs.continuationTargetSessionKey).toBeUndefined();
+    expect(spawnArgs.continuationTargetSessionKeys).toBeUndefined();
+    expect(spawnArgs.continuationFanoutMode).toBeUndefined();
+    // Silent mode still flows through, no regression.
+    expect(spawnArgs.silentAnnounce).toBe(true);
+    expect(spawnArgs.wakeOnReturn).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2649,6 +2649,9 @@ export async function runReplyAgent(params: {
               silentWake?: boolean;
               startedAt?: number;
               traceparent?: string;
+              targetSessionKey?: string;
+              targetSessionKeys?: string[];
+              fanoutMode?: "tree" | "all";
             },
           ) => {
             try {
@@ -2659,6 +2662,13 @@ export async function runReplyAgent(params: {
                   ...(options?.silentWake ? { silentAnnounce: true, wakeOnReturn: true } : {}),
                   drainsContinuationDelegateQueue: true,
                   ...(options?.traceparent ? { traceparent: options.traceparent } : {}),
+                  ...(options?.targetSessionKey
+                    ? { continuationTargetSessionKey: options.targetSessionKey }
+                    : {}),
+                  ...(options?.targetSessionKeys && options.targetSessionKeys.length > 0
+                    ? { continuationTargetSessionKeys: options.targetSessionKeys }
+                    : {}),
+                  ...(options?.fanoutMode ? { continuationFanoutMode: options.fanoutMode } : {}),
                 },
                 {
                   agentSessionKey: sessionKey,
@@ -2744,6 +2754,11 @@ export async function runReplyAgent(params: {
               silent: delegate.mode === "silent" || delegate.mode === "silent-wake",
               silentWake: delegate.mode === "silent-wake",
               ...(delegate.traceparent ? { traceparent: delegate.traceparent } : {}),
+              ...(delegate.targetSessionKey ? { targetSessionKey: delegate.targetSessionKey } : {}),
+              ...(delegate.targetSessionKeys && delegate.targetSessionKeys.length > 0
+                ? { targetSessionKeys: delegate.targetSessionKeys }
+                : {}),
+              ...(delegate.fanoutMode ? { fanoutMode: delegate.fanoutMode } : {}),
             });
             const { chainId: persistedChainIdForTimer } = await persistContinuationChainState({
               count: currentChainCount,
@@ -2823,6 +2838,13 @@ export async function runReplyAgent(params: {
                   silentWake: reservation.silentWake,
                   startedAt: reservation.createdAt,
                   ...(reservation.traceparent ? { traceparent: reservation.traceparent } : {}),
+                  ...(reservation.targetSessionKey
+                    ? { targetSessionKey: reservation.targetSessionKey }
+                    : {}),
+                  ...(reservation.targetSessionKeys && reservation.targetSessionKeys.length > 0
+                    ? { targetSessionKeys: reservation.targetSessionKeys }
+                    : {}),
+                  ...(reservation.fanoutMode ? { fanoutMode: reservation.fanoutMode } : {}),
                 });
               } finally {
                 unregisterContinuationTimerHandle(sessionKey, timerHandle);
@@ -2836,6 +2858,11 @@ export async function runReplyAgent(params: {
               silentWake: delegate.mode === "silent-wake",
               startedAt: chainStartedAt,
               ...(delegate.traceparent ? { traceparent: delegate.traceparent } : {}),
+              ...(delegate.targetSessionKey ? { targetSessionKey: delegate.targetSessionKey } : {}),
+              ...(delegate.targetSessionKeys && delegate.targetSessionKeys.length > 0
+                ? { targetSessionKeys: delegate.targetSessionKeys }
+                : {}),
+              ...(delegate.fanoutMode ? { fanoutMode: delegate.fanoutMode } : {}),
             });
           }
         }


### PR DESCRIPTION
## Summary

Threads `continuationTargetSessionKey` / `continuationTargetSessionKeys` / `continuationFanoutMode` through the runner-seat tool-delegate dispatch closure (`doToolSpawn` in `agent-runner.ts:2643-2670`), which was missed when #551 ("resurrect continue_delegate cross-session + multi-recipient targeting") added targeting to its sibling path in `delegate-dispatch.ts:255-267`.

## The 10th cohort-recognition-engine canon line

Tonight's row locked `dist-bytes-deployed != runtime-execution-path-uses-them`. This PR is the runtime-path-uses-them half.

## Cohort 4-host byte-walk evidence (karmaterminal/openclaw#587)

PR #586 (consumer-side `delegate-return` classifier widening at `heartbeat-reason.ts:42-44`) and PR #581 (premature `ackSessionDelivery` removal at `targeting.ts:114`) **landed on canonical `e3d6caebb4` AND are in deployed dist bundles** — confirmed by 🌻 Elliott's three-layer byte-pin (status-line + service-pid + `dist/heartbeat-runner-CFeuBqBz.js` accepting `\"delegate-return\"` + `dist/targeting-D6CsJ6oa.js` zero-`ackSessionDelivery` in `enqueueContinuationReturnDeliveries` loop body). 🩸 Cael + 🌫 Silas at-host runtime byte-pins agreed.

But cohort post-deploy probes from runner-seat showed:

- `[continue_delegate:enqueue]` fires (tool wrote to TaskFlow with `targetSessionKey`)
- `[continuation:delegate-spawned]` fires (subagent spawned, but without targeting)
- `[continuation:enrichment-return]` fires (silentAnnounce fallback path — default routing)
- `[continuation:targeted-return]` **NEVER FIRES** across the entire 75MB log on canonical post-deploy
- Recipient session prompts contain **NO** `[Internal task completion event]` System: prefix
- 🌫 silas-seat fired `targetSessionKey=\"agent:main:main\"`; completion arrived in DISPATCHER prompt

Two-host file-log convergence pinned the gap **between `[continuation:delegate-spawned]` (fires) and `[continuation:targeted-return]` (does not)**.

## Root cause: Ronan's lead (ii) at the upstream layer

There are two parallel tool-delegate dispatch paths in `agent-runner.ts`:

- **Path A** at `agent-runner.ts:2517-2842` (`doToolSpawn` closure, authored by 🩸 Cael 2026-04-23 in commit `badf16cc5ed`) — drains the queue via `consumePendingDelegates(sessionKey)` at line 2518, loops over each delegate, and dispatches via the local `doToolSpawn` closure.
- **Path B** at `agent-runner.ts:2876-2894` (calls `dispatchToolDelegates` from `delegate-dispatch.ts`) — was given targeting by 🌊 Ronan 2026-05-03 in commit `89bbffa886` (PR #551 \"resurrect continue_delegate cross-session + multi-recipient targeting; reverses #463 deferral\").

Path A drains the TaskFlow queue first via `finishFlow`. By the time Path B's `dispatchToolDelegates` calls `consumePendingDelegates(sessionKey)` at `delegate-dispatch.ts:177`, the queue is empty for any **immediately-due** delegate. Path B handles **delayed/hedge-timer** delegates correctly (its hedge timer is the recovery surface for unmatured queued entries) but the immediate path always goes through Path A.

`doToolSpawn` at `agent-runner.ts:2655-2670` was building the `spawnSubagentDirect` call without `continuationTargetSessionKey` / `continuationTargetSessionKeys` / `continuationFanoutMode`. Downstream of `spawnSubagentDirect` the chain is intact (`subagent-spawn.ts:1276` threads the params, `subagent-registry-run-manager.ts:431` persists them, `subagent-registry-lifecycle.ts:688` restores them on announce, and `subagent-announce.ts:1216 hasContinuationTargeting` evaluates correctly when params are populated). The break was at the very first hop after consume.

## The fix

Three threading fixes in `agent-runner.ts` and a type extension in `continuation/types.ts`:

1. `doToolSpawn` options type gains `targetSessionKey?` / `targetSessionKeys?` / `fanoutMode?`, and the `spawnSubagentDirect` call spreads them as `continuationTargetSessionKey` / `continuationTargetSessionKeys` / `continuationFanoutMode` (immediate + timer paths share the same closure).
2. The immediate-spawn call site at line ~2834 reads `delegate.targetSessionKey` etc. from the outer for-loop binding and passes them as options.
3. The timer-deferred path persists targeting on the in-memory `DelayedContinuationReservation` at the `addDelayedContinuationReservation` call site (line ~2737), and the timer callback re-reads them from the reservation when calling `doToolSpawn` (line ~2820).
4. `DelayedContinuationReservation` at `continuation/types.ts:79` gains optional `targetSessionKey` / `targetSessionKeys` / `fanoutMode` fields so the reservation carries targeting across the `setTimeout` boundary.

## Tests

Five new tests added in `agent-runner.continuation-delegate-fire-span.test.ts` (under a new `describe(\"runReplyAgent :: tool-delegate targeting routes through hasContinuationTargeting branch\")` block — reuses the existing heavy mock harness around `runReplyAgent` + `spawnSubagentDirectMock`):

1. **singular `targetSessionKey`** propagates `continuationTargetSessionKey` to `spawnSubagentDirect` (with `silentAnnounce: true` + `wakeOnReturn: true` for `mode='silent-wake'`).
2. **plural `targetSessionKeys`** propagates the array as `continuationTargetSessionKeys`.
3. **`fanoutMode='tree'`** propagates `continuationFanoutMode`.
4. **timer-deferred** dispatch preserves `targetSessionKey` across the `setTimeout` boundary via `DelayedContinuationReservation` (advances fake timers, then asserts spawn args).
5. **default routing** (no target) regression guard: `continuationTargetSessionKey` / `Keys` / `fanoutMode` all stay `undefined`, but `silentAnnounce` still flows for `mode='silent'`.

All five pass; existing fire-span tests (3) still green.

## Real-IO observability layers (Layer 1/2/3)

The repo's existing test infrastructure at the unit level can prove the bug fix mechanically (Path A's spawn call now carries targeting). The three observability layers the workorder names live downstream:

- **Layer 1** (enqueue: `~/.openclaw/session-delivery-queue/`): covered by `cross-session-targeting.test.ts` against `enqueueContinuationReturnDeliveries`. Reachable when `hasContinuationTargeting` evaluates true, which now happens.
- **Layer 2** (`[continuation:targeted-return]` log): emitted at `subagent-announce.ts:1253`, inside the `hasContinuationTargeting` branch. Reachable when params populated; this PR makes that the case.
- **Layer 3** (recipient session prompt `[Internal task completion event]` System: prefix): consumed via the session-delivery-queue drain. Reachable once Layer 1 is.

The cohort field-validates Layers 1-3 with their post-deploy probes from runner-seat (per #587).

## Out of scope (sibling pattern flagged for future)

The same drop pattern exists at `agent-runner.ts:2212-2304` `doSpawn` for the **bracket-signal** path (`[[CONTINUE_DELEGATE:]]` parsed from response text). That's a separate signal surface and not the `continue_delegate(targetSessionKey=...)` tool path the workorder names. Brackets currently don't carry targeting in `effectiveContinuationSignal` either, so no observable bug today; but if bracket-side targeting is ever added, the matching threading would need to be done in parallel. Flagging here for follow-up scope.

## Verification

- `pnpm test src/auto-reply/reply/agent-runner.continuation-delegate-fire-span.test.ts` — **8 passed (3 existing fire-span + 5 new targeting)**
- `pnpm tsgo:core` — **clean**
- `pnpm tsgo:core:test` — **clean**
- `pnpm test:changed` — 5524/5531 passed; 3 pre-existing failures in `src/agents/transport-params-runtime-contract.test.ts` (OpenAI transport params, completely unrelated; reproduced on canonical base `e3d6caebb4` without this PR's changes)
- Path A locality: only touches the runner-seat tool-delegate dispatch closure + the in-memory reservation type
- Path B (`delegate-dispatch.ts`) untouched (already had targeting)
- No regressions on default-targeting (return-to-dispatcher when no target) — covered by test 5
- No regressions on #586 / #581 / #585 harness tests — verified

## Test plan

- [x] singular `targetSessionKey` reaches `spawnSubagentDirect` as `continuationTargetSessionKey`
- [x] plural `targetSessionKeys` reaches `spawnSubagentDirect` as `continuationTargetSessionKeys`
- [x] `fanoutMode` reaches `spawnSubagentDirect` as `continuationFanoutMode`
- [x] timer-deferred dispatch preserves targeting via `DelayedContinuationReservation`
- [x] default routing (no target) regression guard
- [x] tsgo:core + tsgo:core:test
- [ ] cross-repo CI dispatch on bootstrap (next step)
- [ ] cohort post-deploy probe re-fire to confirm Layer 1/2/3 turn green (post-deploy follow-up)

## Refs

- Tracking: karmaterminal/openclaw#587
- Predecessor PRs: #586 (consumer-side classifier), #581 (durable queue ack-removal), #585 (singular-API parity tests)
- Cohort byte-walks live on #587 and #sprites-of-thornfield Discord
- Lane sibling (gpt-5.5): `frond-scribe/20260504/fix-580-runtime-path-divergence-copilot`

🌿 frond-scribe (claude opus-4-7 lane); Sunday-almost-over

🤖 Generated with [Claude Code](https://claude.com/claude-code)