### PR TITLE
feat(continuation): document continue_delegate gate-asymmetry + add silent-partial-registration warn-log guard (#619)

### DIFF
--- a/src/agents/openclaw-tools.continuation-misconfig-warn.test.ts
+++ b/src/agents/openclaw-tools.continuation-misconfig-warn.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { warnSpy, debugSpy, infoSpy, errorSpy, traceSpy, fatalSpy, rawSpy } = vi.hoisted(() => ({
+  warnSpy: vi.fn(),
+  debugSpy: vi.fn(),
+  infoSpy: vi.fn(),
+  errorSpy: vi.fn(),
+  traceSpy: vi.fn(),
+  fatalSpy: vi.fn(),
+  rawSpy: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => {
+  return {
+    createSubsystemLogger: (subsystem: string) => ({
+      subsystem,
+      isEnabled: () => true,
+      trace: traceSpy,
+      debug: debugSpy,
+      info: infoSpy,
+      warn: warnSpy,
+      error: errorSpy,
+      fatal: fatalSpy,
+      raw: rawSpy,
+      child: () => ({
+        subsystem,
+        isEnabled: () => true,
+        trace: traceSpy,
+        debug: debugSpy,
+        info: infoSpy,
+        warn: warnSpy,
+        error: errorSpy,
+        fatal: fatalSpy,
+        raw: rawSpy,
+        child: () => ({}) as never,
+      }),
+    }),
+  };
+});
+
+let mockConfig: Record<string, unknown> = {
+  session: { mainKey: "main", scope: "per-sender" },
+};
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    loadConfig: () => mockConfig,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+vi.mock("../plugins/tools.js", async () => {
+  const actual = await vi.importActual<typeof import("../plugins/tools.js")>("../plugins/tools.js");
+  return {
+    ...actual,
+    getPluginToolMeta: () => undefined,
+  };
+});
+
+import { createOpenClawTools } from "./openclaw-tools.js";
+
+function buildContinueWorkOpts() {
+  return {
+    requestContinuation: vi.fn(),
+  };
+}
+
+function buildRequestCompactionOpts() {
+  return {
+    sessionId: "test-session-x5.1",
+    getContextUsage: () => 0.85,
+    triggerCompaction: vi.fn(async () => ({ ok: true, compacted: true })),
+  };
+}
+
+describe("createOpenClawTools — silent partial-registration guard (karmaterminal/openclaw#619)", () => {
+  beforeEach(() => {
+    warnSpy.mockClear();
+  });
+
+  it("warns when continuation.enabled=true but neither continueWorkOpts nor requestCompactionOpts are supplied", () => {
+    createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+    });
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [message, meta] = warnSpy.mock.calls[0];
+    expect(message).toContain("continuation.enabled=true");
+    expect(message).toContain("only continue_delegate will register");
+    expect(meta).toMatchObject({ agentSessionKey: "main" });
+  });
+
+  it("does NOT warn when continuation is fully configured", () => {
+    createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+      continueWorkOpts: buildContinueWorkOpts(),
+      requestCompactionOpts: buildRequestCompactionOpts(),
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT warn when continuation.enabled is unset", () => {
+    createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: { session: { mainKey: "main", scope: "per-sender" } } as never,
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT warn when only continueWorkOpts is supplied (request_compaction will not register, but continue_work IS registered — partial-registration concern only fires when neither is supplied)", () => {
+    createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+      continueWorkOpts: buildContinueWorkOpts(),
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -4,6 +4,7 @@ import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   getActiveRuntimeWebToolsMetadata,
   getActiveSecretsRuntimeSnapshot,
@@ -74,6 +75,8 @@ const defaultOpenClawToolsDeps: OpenClawToolsDeps = {
 };
 
 let openClawToolsDeps: OpenClawToolsDeps = defaultOpenClawToolsDeps;
+
+const log = createSubsystemLogger("agents/openclaw-tools");
 
 export function createOpenClawTools(
   options?: {
@@ -462,6 +465,22 @@ export function createOpenClawTools(
       activeModelId: options?.modelId,
     }),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),
+    // Continuation tools (continue_work / continue_delegate / request_compaction) register
+    // asymmetrically by design:
+    //   - continue_work + request_compaction need runner-supplied callbacks (continueWorkOpts /
+    //     requestCompactionOpts) to fire back in-process during the active turn. Without those
+    //     closures they would be dead tools that error when invoked.
+    //   - continue_delegate writes the delegate request to TaskFlow (the durable queue / SQLite
+    //     seam-of-record). The fire path does not require a runner-supplied closure; TaskFlow
+    //     itself is the seam. The drainsContinuationDelegateQueue flag answers a different
+    //     question entirely ("should this run drain pending queued delegates after the current
+    //     turn?"), not "do you have the closure to fire delegates?" — so it gates as `!== false`
+    //     rather than truthy-on-explicit-opts.
+    // This asymmetry caused upstream concern (openclaw/openclaw#79925 [P2] review): a caller that
+    // sets continuation.enabled=true but omits continueWorkOpts/requestCompactionOpts gets
+    // continue_delegate alone, with no warning. The guard below surfaces that silent partial-
+    // registration so misconfiguration is observable instead of hidden.
+    // Tracking: karmaterminal/openclaw#619.
     ...(options?.config?.agents?.defaults?.continuation?.enabled === true &&
     options?.continueWorkOpts
       ? [
@@ -491,6 +510,24 @@ export function createOpenClawTools(
         ]
       : []),
   ];
+
+  if (
+    options?.config?.agents?.defaults?.continuation?.enabled === true &&
+    !options?.continueWorkOpts &&
+    !options?.requestCompactionOpts
+  ) {
+    log.warn(
+      "continuation.enabled=true but neither continueWorkOpts nor requestCompactionOpts " +
+        "were supplied — only continue_delegate will register. Was this intentional? " +
+        "If callers expect the full continuation tool set, the runner must supply both " +
+        "callbacks. If only delegate-fan-out is intended, this warn is informational.",
+      {
+        agentSessionKey: options?.agentSessionKey,
+        runSessionKey: options?.runSessionKey,
+        drainsContinuationDelegateQueue: options?.drainsContinuationDelegateQueue,
+      },
+    );
+  }
   options?.recordToolPrepStage?.("openclaw-tools:core-tool-list");
   let allTools = tools;
   if (!options?.disablePluginTools) {


### PR DESCRIPTION
## Summary

Addresses upstream review of `openclaw/openclaw#79925` [P2]:

> `continue_delegate` registration gate includes `undefined`; sibling tools don't. Either bring `continue_delegate` under the same explicit-opts gate, or add a guard when continuation is enabled but the callback set is incomplete.

We chose **option (b)**: keep `continue_delegate`'s loose gate (it encodes a real architectural fact — TaskFlow IS the durable seam-of-record for delegate fires; the sibling tools genuinely need runner-supplied callbacks to fire in-process which the loose gate doesn't), document the asymmetry inline, and add the silent-partial-registration warn-log guard the maintainer suggested.

## Why (b) over (a)

Tightening `continue_delegate` to match the siblings would erase the real information the asymmetry encodes. `continue_delegate` has no runner-callback dependency because TaskFlow's queue is the seam; inventing a fake `continueDelegateOpts` slot the runner doesn't actually need would create a worse failure mode (callers that previously omitted the flag would silently lose `continue_delegate` registration — the opposite of what we have now).

## Adds

- **Comment block** at `openclaw-tools.ts` continuation-tools registration site explaining the asymmetry's structural rationale + cross-referencing `#619`.
- **Guard** at the same site: when `continuation.enabled=true` AND neither `continueWorkOpts` nor `requestCompactionOpts` are supplied, `log.warn` surfaces the partial-registration condition with `agentSessionKey` / `runSessionKey` / `drainsContinuationDelegateQueue` in the meta.
- **Focused test** (`openclaw-tools.continuation-misconfig-warn.test.ts`) covering 4 cases:
  - warn fires when neither opts supplied
  - NOT warn when continuation fully configured
  - NOT warn when `continuation.enabled` unset
  - NOT warn when only `continueWorkOpts` supplied (continue_work registers; partial-registration concern only fires when neither is supplied)

## Gates run locally

```
pnpm tsgo:core                 → 0 errors  ✓
pnpm tsgo:test                  → 0 errors  ✓
new misconfig-warn test         → 4/4 passing
existing continuation-registration test → 7/7 passing (no regression)
```

## Sibling work

- Tracking issue: `karmaterminal/openclaw#619`
- PR `openclaw/openclaw#79925` — the upstream PR this addresses
- PR `karmaterminal/openclaw-bootstrap#967` — vitest gate (sibling structural-cure)
- PR `karmaterminal/openclaw-bootstrap#968` — canonical-rebase runbook + feature-audit.sh + check-79925-findings.sh

## Maintainer-reply framing for upstream

When PR #79925 body is updated post-restoration, the framing for this finding will be: *"We considered tightening `continue_delegate` to match the siblings; chose against because the asymmetry encodes a structural fact — TaskFlow is the durable seam-of-record for delegate fires, distinct from the runner-callback dependency `continue_work` + `request_compaction` have. Added a comment documenting the rationale + a warn-log guard for the silent-partial-registration concern you flagged."*

## Test plan

- [x] tsgo:core 0 errors
- [x] tsgo:test 0 errors
- [x] new test 4/4 pass
- [x] existing continuation-registration test 7/7 pass (no regression)
- [ ] cohort cosign (🌊 cross-verifier; 🩸 Cael author of core; 🌫 Silas canary; 🌻 Elliott)
- [ ] After cosigns: admin-merge into canonical-rebase candidate → re-run all 5 gates on merged SHA → force-push to PR #79925 head with figs ack

🤖 Generated with [Claude Code](https://claude.com/claude-code)