### PR TITLE
fix: version-gate skill snapshot in commands-system-prompt (#633)

### DIFF
--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -9,7 +9,10 @@ import { resolveEmbeddedFullAccessState } from "../../agents/pi-embedded-runner/
 import { createOpenClawCodingTools } from "../../agents/pi-tools.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
-import { getSkillsSnapshotVersion } from "../../agents/skills/refresh-state.js";
+import {
+  getSkillsSnapshotVersion,
+  shouldRefreshSnapshotForVersion,
+} from "../../agents/skills/refresh-state.js";
 import { buildConfiguredAgentSystemPrompt } from "../../agents/system-prompt-config.js";
 import { buildSystemPromptParams } from "../../agents/system-prompt-params.js";
 import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
@@ -17,6 +20,12 @@ import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
+
+/** Process-level cache: avoids re-materializing skill snapshots every prompt turn when nothing changed. */
+const commandPromptSkillCache = new Map<
+  string,
+  { version: number; snapshot: ReturnType<typeof buildWorkspaceSkillSnapshot> }
+>();
 
 export type CommandsSystemPromptBundle = {
   systemPrompt: string;
@@ -58,7 +67,13 @@ export async function resolveCommandsSystemPromptBundle(
   });
   const skillsSnapshot = (() => {
     try {
-      return buildWorkspaceSkillSnapshot(workspaceDir, {
+      const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+      const cacheKey = `${workspaceDir}\0${sessionAgentId ?? ""}`;
+      const cached = commandPromptSkillCache.get(cacheKey);
+      if (cached && !shouldRefreshSnapshotForVersion(cached.version, snapshotVersion)) {
+        return cached.snapshot;
+      }
+      const snapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
         config: params.cfg,
         agentId: sessionAgentId,
         eligibility: {
@@ -71,8 +86,10 @@ export async function resolveCommandsSystemPromptBundle(
             }),
           }),
         },
-        snapshotVersion: getSkillsSnapshotVersion(workspaceDir),
+        snapshotVersion,
       });
+      commandPromptSkillCache.set(cacheKey, { version: snapshotVersion, snapshot });
+      return snapshot;
     } catch {
       return { prompt: "", skills: [], resolvedSkills: [] };
     }


### PR DESCRIPTION
## Summary

- **Fixes #633** — `buildWorkspaceSkillSnapshot` was called unconditionally on every prompt construction turn in `commands-system-prompt.ts`, causing ~2600 SKILL.md re-materializations per 67min observed.
- Adds a process-level `Map` cache keyed by `workspaceDir + agentId`, gated by `shouldRefreshSnapshotForVersion(cachedVersion, getSkillsSnapshotVersion(workspaceDir))` — the same version-gate pattern used in `session-updates.ts:160-183`.
- Cached snapshots are returned when the skill version hasn't advanced, reducing steady-state materializations to ~1 per unique version bump (effectively ~9 for the observed workspace).

## Architectural notes

**Cache location**: The `commandPromptSkillCache` Map lives as a module-level const in `commands-system-prompt.ts` itself. This was a judgment call — since this file is the only consumer and the cache is purely process-scoped, a local module-level Map avoids introducing a new shared module. If other callers need the same cache, it could be extracted to a shared helper later.

**Cache key shape**: `${workspaceDir}\0${sessionAgentId ?? ""}`. The null-byte separator prevents key collisions. `skillFilter` is not in the key because `commands-system-prompt.ts` does not pass an explicit `skillFilter` — the effective filter is derived internally from `config + agentId`, so the agentId component covers it.

**Eligibility not in the gate**: Consistent with `session-updates.ts`, remote eligibility changes (e.g. new remote node connecting) do not independently invalidate the cache. The version bump from the skills watcher is the authoritative invalidation signal. `ensureSkillsWatcher` is not called here — it's assumed to already be running via `session-updates.ts` in the same process.

## Verification

- `pnpm build` — passes
- `pnpm test src/auto-reply/reply/commands-system-prompt.test.ts` — 6/6 tests pass
- Net change: +20 lines, -3 lines (17 net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)