### PR TITLE
test(runtime-context): repro body-duplication bug in resolveRuntimeContextPromptParts

### DIFF
--- a/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts
@@ -118,4 +118,105 @@ describe("runtime context prompt submission", () => {
     expect(buildRuntimeEventSystemContext("internal event")).toContain("OpenClaw runtime event.");
     expect(buildRuntimeEventSystemContext("internal event")).toContain("not user-authored");
   });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Body-duplication bug repros (figs WO 2026-05-11, 🩸 source-walk)
+  //
+  // Substrate-leak shape: trailing `||` fallback in resolveRuntimeContextPromptParts
+  // turns an empty-string return from removeLastPromptOccurrence into a full
+  // duplicate of effectivePrompt as runtimeContext. Both then get sent to the
+  // model: prompt as user-role message + runtimeContext as runtime-context
+  // custom_message, so the body lands TWICE in the model context per turn.
+  //
+  // Each test names the substrate condition that triggers the duplication.
+  // ─────────────────────────────────────────────────────────────────────────
+  describe("body-duplication bug repros", () => {
+    it("BUG: when transcriptPrompt equals effectivePrompt with only whitespace\n      delta, runtimeContext duplicates the full prompt body", () => {
+      // effectivePrompt has the same content as transcriptPrompt but with
+      // surrounding whitespace (a real-world shape: discord trims, internal
+      // pipeline doesn't). Whitespace delta means transcriptPrompt !==
+      // effectivePrompt, so the early-return doesn't fire, but
+      // removeLastPromptOccurrence returns "" because the prompt is the
+      // entire text. The `||` fallback then duplicates the full body.
+      const body = "Hello world this is a substantive message that should not duplicate.";
+      const result = resolveRuntimeContextPromptParts({
+        effectivePrompt: `\n${body}\n`,
+        transcriptPrompt: body,
+      });
+
+      // Bug behavior (current): runtimeContext is set to a full copy of the body
+      expect(result.runtimeContext).toBeDefined();
+      // The duplication: prompt and runtimeContext both contain the same body
+      expect(result.prompt).toContain(body);
+      expect(result.runtimeContext).toContain(body);
+      // BYTE-PROOF: the two fields contain identical body content (the leak)
+      expect(result.runtimeContext).toBe(result.prompt);
+    });
+
+    it("BUG: when removeLastPromptOccurrence returns empty string, fallback\n      duplicates entire effectivePrompt instead of yielding undefined runtimeContext", () => {
+      // Construct effectivePrompt to be exactly transcriptPrompt with leading
+      // whitespace — a one-byte difference forces the inequality check to fail
+      // (so we don't hit the early return), yet removeLastPromptOccurrence
+      // strips the prompt and returns nothing meaningful.
+      const transcriptPrompt = "the body";
+      const effectivePrompt = `\n${transcriptPrompt}`;
+
+      const result = resolveRuntimeContextPromptParts({
+        effectivePrompt,
+        transcriptPrompt,
+      });
+
+      // EXPECTED (post-fix): no duplication — runtimeContext should be
+      // undefined because there's no actual additional context to convey.
+      // CURRENT (bug): runtimeContext is the full effectivePrompt, duplicating
+      // the body that's already in `prompt`.
+      expect(
+        result.runtimeContext,
+        "runtimeContext should be undefined when there is no real runtime\n           context beyond the prompt — currently it duplicates the prompt body",
+      ).toBeUndefined();
+    });
+
+    it("BUG: with empty transcriptPrompt and matching effectivePrompt,\n      duplicates body via runtime-only event branch", () => {
+      // When transcriptPrompt is "" (e.g. a runtime-only event), prompt becomes
+      // OPENCLAW_RUNTIME_EVENT_USER_PROMPT marker and runtimeContext becomes the
+      // event body. That's correct semantics. But check: when effectivePrompt
+      // happens to be the same as the user-prompt-marker, no duplication should
+      // arise. (defensive test against future fix regressions.)
+      const result = resolveRuntimeContextPromptParts({
+        effectivePrompt: "Continue the OpenClaw runtime event.",
+        transcriptPrompt: "",
+      });
+
+      // No body to duplicate; runtimeContext should be the event content,
+      // distinct from the marker prompt.
+      expect(result.prompt).toBe("Continue the OpenClaw runtime event.");
+      expect(result.runtimeOnly).toBe(true);
+      expect(result.runtimeContext).toBe("Continue the OpenClaw runtime event.");
+      // Note: this case IS a duplication too, but it's the documented
+      // runtime-event shape, not the user-prompt body-leak shape.
+    });
+
+    it("PROOF that fix is needed: removeLastPromptOccurrence returns empty\n      when text and prompt are byte-identical", async () => {
+      // We import the internal function via the module to assert the
+      // current behavior the bug depends on. This is the substrate the
+      // `||` fallback is gated on.
+      // (re-import to access non-exported helper via test module side-channel
+      //  if needed — for now just assert via resolveRuntimeContextPromptParts
+      //  the empty-string return path)
+      const result = resolveRuntimeContextPromptParts({
+        effectivePrompt: "abc",
+        transcriptPrompt: "abc ", // trailing space ≠ effectivePrompt
+      });
+
+      // transcriptPrompt.trim() === effectivePrompt → prompt = "abc"
+      // removeLastPromptOccurrence("abc", "abc ") → null (prompt-with-space
+      // not found in text), so runtimeContext = effectivePrompt.trim() = "abc"
+      // → DUPLICATION even when the only difference is a trailing space.
+      expect(result.prompt).toBe("abc");
+      expect(
+        result.runtimeContext,
+        "runtimeContext should be undefined — it has no information beyond prompt",
+      ).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Why

Per figs WO at `1503386692294279271` (2026-05-11 06:21 PDT): prove 🩸's source-walk finding in unit tests.

🩸 traced the body-duplication shape to `resolveRuntimeContextPromptParts` in `src/agents/pi-embedded-runner/run/runtime-context-prompt.ts:60`:

```ts
const runtimeContext =
  removeLastPromptOccurrence(params.effectivePrompt, transcriptPrompt)?.trim() ||
  params.effectivePrompt.trim();
```

When `removeLastPromptOccurrence` returns empty (transcriptPrompt matches whole effectivePrompt with no extra delta), `runtimeContext` falls through the `||` to the full prompt — duplicating it as a runtime-context custom_message in the model context.

This PR is **tests only** (no fix). Fix lane belongs to whoever takes `resolveRuntimeContextPromptParts` fallback semantics + 🩸's two-part proposal (return `undefined` on empty + consider whether `runtime-context custom_message` even needs to re-render the body).

## Tests

4 unit tests added:

| # | Test | Result today | Proves |
|---|------|--------------|--------|
| 1 | whitespace delta, runtimeContext duplicates body | ✓ PASS | `result.runtimeContext === result.prompt` byte-confirmed |
| 2 | empty-return + fallback duplicates | ✗ FAIL | post-fix: should be `undefined`; got `"the body"` |
| 3 | empty transcriptPrompt + matching effectivePrompt | ✓ PASS | defensive coverage for runtime-event branch |
| 4 | byte-identical text+prompt → empty | ✗ FAIL | post-fix: should be `undefined`; got `"abc"` |

**2 PASS = current bug shape byte-confirmed. 2 FAIL = post-fix contract.**

## Run

```
npx vitest run \
  src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts \
  -t 'body-duplication'
```

Expected today: 2 passed | 2 failed per project (× 2 projects = 4 of 8 outcomes failed).

## Live-substrate evidence

Heap-dump K-pattern findings (🌊 seat 2026-05-11 06:18 PDT, gcore on PID 200924, 10h49m uptime):
- 61× `<<<EXTERNAL_UNTRUSTED_CONTENT>>>` markers retained
- Per-skill description × ~3,665-3,668 retained copies
- IDENTITY.md path × 3,676
- Session-key × 4,296

Yesterday (cael-host 🩸 on elliott snaps): 122× untrusted-content markers, 264× SKILL.md per skill. Mechanism is fleet-wide and growing per turn.

## Refs

- figs WO: discord msg `1503386692294279271`
- 🩸 source-walk: discord msg `1503386306435350548` (referenced in WO reply)
- Cohort canon: figs 2026-05-03 `1500600...` — missing test coverage where we care = ADD or DISPATCH

## Lane allocation

- 🌊 (this PR): tests proving the bug
- 🩸 (or whoever): the fix in `resolveRuntimeContextPromptParts` + design call on runtime-context custom_message body re-render

When the fix lands, these tests turn green by changing the fallback from `params.effectivePrompt.trim()` to `undefined` when `removeLastPromptOccurrence` returns empty/null.

🌊