### PR TITLE
fix(github-copilot): correct Claude model contextWindow and maxTokens in catalog

### DIFF
--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -61,6 +61,15 @@
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {
+            "id": "claude-opus-4.7-1m-internal",
+            "name": "Claude Opus 4.7 (1M Internal)",
+            "api": "anthropic-messages",
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
             "id": "claude-sonnet-4",
             "name": "Claude Sonnet 4",
             "api": "anthropic-messages",

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -29,8 +29,8 @@
             "name": "Claude Haiku 4.5",
             "api": "anthropic-messages",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 200000,
+            "maxTokens": 64000,
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {
@@ -38,8 +38,8 @@
             "name": "Claude Opus 4.5",
             "api": "anthropic-messages",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 200000,
+            "maxTokens": 64000,
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {
@@ -47,8 +47,8 @@
             "name": "Claude Opus 4.6",
             "api": "anthropic-messages",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {
@@ -56,8 +56,8 @@
             "name": "Claude Opus 4.7",
             "api": "anthropic-messages",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {
@@ -65,8 +65,8 @@
             "name": "Claude Sonnet 4",
             "api": "anthropic-messages",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 200000,
+            "maxTokens": 64000,
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {
@@ -74,8 +74,8 @@
             "name": "Claude Sonnet 4.5",
             "api": "anthropic-messages",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 200000,
+            "maxTokens": 64000,
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {
@@ -83,8 +83,8 @@
             "name": "Claude Sonnet 4.6",
             "api": "anthropic-messages",
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
+            "contextWindow": 1000000,
+            "maxTokens": 64000,
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
           },
           {


### PR DESCRIPTION
## Summary

Corrects all Claude model `contextWindow` and `maxTokens` values in the GitHub Copilot plugin catalog (`openclaw.plugin.json`). All entries had synthetic defaults (`contextWindow: 128000`, `maxTokens: 8192`) that do not match Anthropic's documented per-model values.

## Root Cause

The catalog defaults caused OpenClaw to treat 1M-context models (opus-4.7, opus-4.6, sonnet-4.6) as 128k context. With a 16k compaction reserve, this produced a prompt budget of ~112k tokens — triggering spurious context-overflow compaction and model fallback on sessions that exceeded ~112k.

**Journal evidence** (cael-seat, 14:01:39 PDT):
```
promptBudgetBeforeReserve=111616
```

**Silas-seat byte-confirmation** (14:10:10 PDT):
```
[continuation/request-compaction] trigger=volitional usage=125.2% reason=Context at 125% (160k/128k).
```

## Changes

Per [Anthropic docs](https://platform.claude.com/docs/en/about-claude/models/overview):

| Model | Old contextWindow | Correct | Old maxTokens | Correct |
|---|---|---|---|---|
| claude-opus-4.7 | 128000 | **1000000** | 8192 | **128000** |
| claude-opus-4.6 | 128000 | **1000000** | 8192 | **128000** |
| claude-sonnet-4.6 | 128000 | **1000000** | 8192 | **64000** |
| claude-sonnet-4.5 | 128000 | **200000** | 8192 | **64000** |
| claude-opus-4.5 | 128000 | **200000** | 8192 | **64000** |
| claude-sonnet-4 | 128000 | **200000** | 8192 | **64000** |
| claude-haiku-4.5 | 128000 | **200000** | 8192 | **64000** |
| claude-opus-4.7-1m-internal | MISSING | **1000000** | MISSING | **128000** |

Also adds `claude-opus-4.7-1m-internal` entry for the GitHub Copilot internal variant.

## Testing

- JSON validates cleanly
- Verified all values against Anthropic's models overview page
- Pre-restart sessions bind at old values; post-restart sessions pick up correct context window (confirmed on silas-seat)

## Upstream

This affects ALL OpenClaw users on the GitHub Copilot provider. Upstream issue + PR warranted after fleet validation.

Refs: karmaterminal/openclaw-bootstrap#573, karmaterminal/openclaw#647
