### PR TITLE
feat(continuation): land crossSessionTargeting config gate on canonical-line (closes #654, #657)

### DIFF
--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -1384,6 +1384,36 @@ For single-human-user deployments, this usually aligns with the existing trust b
 
 Stronger options include HMAC signing, encrypted attachments, and signed announce payloads. None are required by the current implementation, but all are compatible with the present architecture.
 
+### 7.2 Cross-session targeting policy
+
+Cross-session delegate targeting — `targetSessionKey`, `targetSessionKeys`, and `fanoutMode: "all"` — is gated by a binary operator config:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "continuation": {
+        "crossSessionTargeting": "disabled"
+      }
+    }
+  }
+}
+```
+
+| Value                  | Behavior                                                                                                                                                                                                                                                                                                 |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"disabled"` (default) | Delegates can only return to the dispatching session or its lineage. Explicit cross-session targeting (`targetSessionKey` to a non-self/non-ancestor session, `targetSessionKeys`, `fanoutMode: "all"`) returns a tool error. `fanoutMode: "tree"` (lineage-only) and self-targeting are always allowed. |
+| `"enabled"`            | All targeting modes are available.                                                                                                                                                                                                                                                                       |
+
+The gate checks at two enforcement points:
+
+1. **Tool path:** `continue-delegate-tool.ts` rejects cross-session targeting params with a `ToolInputError` at param-validation time (fail-fast).
+2. **Bracket-syntax path:** `doSpawn()` in `agent-runner.ts` rejects cross-session targeting at spawn time, emitting a `continuation.disabled` span with `disabledReason: "policy.crossSessionTargeting"` and a system event.
+
+Both enforcement points read the config live (not cached at session-start), so hot-reload works: flipping `"disabled"` → `"enabled"` takes effect on the next delegate call without a gateway restart.
+
+The gate addresses the model-controlled cross-session context injection surface identified in code review: without it, a continuation-enabled session can affect unrelated sessions on the same host. With the gate default-deny, operators explicitly opt in to cross-session targeting when their deployment model requires it.
+
 Operational failure modes and inherited behavioral limitations are documented in [Appendix C](#appendix-c-failure-modes-and-behavioral-limitations).
 
 ## 8. Applicability Statement and Production Use Cases

--- a/src/agents/tools/continue-delegate-tool.test.ts
+++ b/src/agents/tools/continue-delegate-tool.test.ts
@@ -175,6 +175,9 @@ describe("continue_delegate tool", () => {
   });
 
   it("persists singular cross-session target metadata", async () => {
+    setRuntimeConfigSnapshot({
+      agents: { defaults: { continuation: { crossSessionTargeting: "enabled" } } },
+    });
     const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
 
     const result = await executeTool(tool, 0, {
@@ -195,6 +198,9 @@ describe("continue_delegate tool", () => {
   });
 
   it("persists multi-recipient target metadata from snake_case input", async () => {
+    setRuntimeConfigSnapshot({
+      agents: { defaults: { continuation: { crossSessionTargeting: "enabled" } } },
+    });
     const tool = createContinueDelegateTool({ agentSessionKey: "test-session" });
 
     const result = await executeTool(tool, 0, {
@@ -215,6 +221,9 @@ describe("continue_delegate tool", () => {
   });
 
   it("persists tree/all fanout metadata", async () => {
+    setRuntimeConfigSnapshot({
+      agents: { defaults: { continuation: { crossSessionTargeting: "enabled" } } },
+    });
     const treeTool = createContinueDelegateTool({ agentSessionKey: "test-session" });
     const treeResult = await executeTool(treeTool, 0, {
       task: "return up the chain",

--- a/src/agents/tools/continue-delegate-tool.ts
+++ b/src/agents/tools/continue-delegate-tool.ts
@@ -268,10 +268,15 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
 
       // Cross-session targeting policy gate. Read live config (hot-reloadable).
       // Tree routing + self-targeting are always allowed.
+      // Trim + normalize before checking: whitespace-padded self-keys are NOT cross-session.
+      const trimmedTargetKey = targetSessionKey?.trim();
+      const normalizedTargetKeys = targetSessionKeys
+        ?.map((k) => k.trim())
+        .filter((k) => k.length > 0 && k !== sessionKey);
       const hasCrossSessionTargeting =
         fanoutMode === "all" ||
-        (targetSessionKey !== undefined && targetSessionKey !== sessionKey) ||
-        (targetSessionKeys !== undefined && targetSessionKeys.length > 0);
+        (trimmedTargetKey !== undefined && trimmedTargetKey !== sessionKey) ||
+        (normalizedTargetKeys !== undefined && normalizedTargetKeys.length > 0);
       if (hasCrossSessionTargeting) {
         const continuationConfig = resolveContinuationRuntimeConfig();
         if (continuationConfig.crossSessionTargeting === "disabled") {
@@ -303,6 +308,19 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
       }
 
       if (isPostCompaction) {
+        // Cross-session targeting policy gate for post-compaction path.
+        // This bypasses doSpawn() so needs its own check.
+        if (hasCrossSessionTargeting) {
+          const continuationConfig = resolveContinuationRuntimeConfig();
+          if (continuationConfig.crossSessionTargeting === "disabled") {
+            throw new ToolInputError(
+              "Cross-session delegate targeting is disabled by policy. " +
+                "Only tree/lineage routing and self-targeting are allowed. " +
+                'Set agents.continuation.crossSessionTargeting to "enabled" to allow ' +
+                'targetSessionKey, targetSessionKeys, and fanoutMode="all".',
+            );
+          }
+        }
         stagePostCompactionDelegate(sessionKey, {
           task,
           stagedAt: Date.now(),

--- a/src/agents/tools/continue-delegate-tool.ts
+++ b/src/agents/tools/continue-delegate-tool.ts
@@ -1,5 +1,8 @@
 import { Type } from "typebox";
-import { resolveMaxDelegatesPerTurn } from "../../auto-reply/continuation/config.js";
+import {
+  resolveMaxDelegatesPerTurn,
+  resolveContinuationRuntimeConfig,
+} from "../../auto-reply/continuation/config.js";
 import {
   enqueuePendingDelegate,
   getContinuationDelegateQueueDepths,
@@ -262,6 +265,24 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
         ...(attachments && attachments.length > 0 ? { attachmentCount: attachments.length } : {}),
         ...(attachAs && Object.keys(attachAs).length > 0 ? { attachAs } : {}),
       };
+
+      // Cross-session targeting policy gate. Read live config (hot-reloadable).
+      // Tree routing + self-targeting are always allowed.
+      const hasCrossSessionTargeting =
+        fanoutMode === "all" ||
+        (targetSessionKey !== undefined && targetSessionKey !== sessionKey) ||
+        (targetSessionKeys !== undefined && targetSessionKeys.length > 0);
+      if (hasCrossSessionTargeting) {
+        const continuationConfig = resolveContinuationRuntimeConfig();
+        if (continuationConfig.crossSessionTargeting === "disabled") {
+          throw new ToolInputError(
+            "Cross-session delegate targeting is disabled by policy. " +
+              "Only tree/lineage routing and self-targeting are allowed. " +
+              'Set agents.continuation.crossSessionTargeting to "enabled" to allow ' +
+              'targetSessionKey, targetSessionKeys, and fanoutMode="all".',
+          );
+        }
+      }
 
       // Check per-turn delegate limit. Durable queued depth is reported for
       // visibility but does not consume this turn's admission budget.

--- a/src/agents/tools/continue-delegate-tool.ts
+++ b/src/agents/tools/continue-delegate-tool.ts
@@ -1,7 +1,7 @@
 import { Type } from "typebox";
 import {
   resolveMaxDelegatesPerTurn,
-  resolveContinuationRuntimeConfig,
+  resolveLiveContinuationRuntimeConfig,
 } from "../../auto-reply/continuation/config.js";
 import {
   enqueuePendingDelegate,
@@ -278,7 +278,7 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
         (trimmedTargetKey !== undefined && trimmedTargetKey !== sessionKey) ||
         (normalizedTargetKeys !== undefined && normalizedTargetKeys.length > 0);
       if (hasCrossSessionTargeting) {
-        const continuationConfig = resolveContinuationRuntimeConfig();
+        const continuationConfig = resolveLiveContinuationRuntimeConfig({});
         if (continuationConfig.crossSessionTargeting === "disabled") {
           throw new ToolInputError(
             "Cross-session delegate targeting is disabled by policy. " +
@@ -311,7 +311,7 @@ export function createContinueDelegateTool(opts: { agentSessionKey?: string }): 
         // Cross-session targeting policy gate for post-compaction path.
         // This bypasses doSpawn() so needs its own check.
         if (hasCrossSessionTargeting) {
-          const continuationConfig = resolveContinuationRuntimeConfig();
+          const continuationConfig = resolveLiveContinuationRuntimeConfig({});
           if (continuationConfig.crossSessionTargeting === "disabled") {
             throw new ToolInputError(
               "Cross-session delegate targeting is disabled by policy. " +

--- a/src/auto-reply/continuation/config.ts
+++ b/src/auto-reply/continuation/config.ts
@@ -94,6 +94,8 @@ export function resolveContinuationRuntimeConfig(
     ),
     contextPressureThreshold: clampOptionalUnitInterval(continuation?.contextPressureThreshold),
     earlyWarningBand: clampEarlyWarningBand(continuation?.earlyWarningBand),
+    crossSessionTargeting:
+      continuation?.crossSessionTargeting === "enabled" ? "enabled" : "disabled",
   };
 }
 

--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -123,6 +123,7 @@ export type ContinuationRuntimeConfig = {
   maxDelegatesPerTurn: number;
   contextPressureThreshold?: number;
   earlyWarningBand?: number;
+  crossSessionTargeting: "disabled" | "enabled";
 };
 
 // ---------------------------------------------------------------------------

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2260,6 +2260,44 @@ export async function runReplyAgent(params: {
                 },
               ) => {
                 try {
+                  // Cross-session targeting policy gate (bracket-syntax path).
+                  // Tool-path has its own gate at param-validation time;
+                  // this catches bracket-syntax delegates that parsed targeting
+                  // from [[CONTINUE_DELEGATE: task | target=X | fanout=all]].
+                  const hasCrossSessionTarget =
+                    options?.fanoutMode === "all" ||
+                    (options?.targetSessionKey !== undefined &&
+                      options.targetSessionKey !== sessionKey) ||
+                    (options?.targetSessionKeys !== undefined &&
+                      options.targetSessionKeys.length > 0);
+                  if (hasCrossSessionTarget) {
+                    const { crossSessionTargeting } = resolveLiveContinuationRuntimeConfig(cfg);
+                    if (crossSessionTargeting === "disabled") {
+                      defaultRuntime.log(
+                        `[continuation] Cross-session targeting rejected by policy for session ${sessionKey}`,
+                      );
+                      enqueueSystemEvent(
+                        "[continuation] Delegate rejected: cross-session targeting is disabled by policy. " +
+                          'Set agents.continuation.crossSessionTargeting to "enabled" to allow ' +
+                          'targetSessionKey, targetSessionKeys, and fanoutMode="all".',
+                        { sessionKey, trusted: true },
+                      );
+                      emitContinuationDisabledSpan({
+                        chainId: activeSessionEntry?.continuationChainId,
+                        chainStepRemaining: Math.max(0, maxChainLength - plannedHop),
+                        disabledReason: "policy.crossSessionTargeting",
+                        signalKind: "bracket-delegate",
+                        delegateDelivery: options?.timerTriggered ? "timer" : "immediate",
+                        delegateMode: options?.silentWake
+                          ? "silent-wake"
+                          : options?.silent
+                            ? "silent"
+                            : "normal",
+                        log: (message) => defaultRuntime.log(message),
+                      });
+                      return;
+                    }
+                  }
                   const spawnResult = await spawnSubagentDirect(
                     {
                       // The spawned child carries its current chain position in-band.

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2264,12 +2264,16 @@ export async function runReplyAgent(params: {
                   // Tool-path has its own gate at param-validation time;
                   // this catches bracket-syntax delegates that parsed targeting
                   // from [[CONTINUE_DELEGATE: task | target=X | fanout=all]].
+                  // Trim + normalize before checking: whitespace-padded self-keys are NOT cross-session.
+                  const trimmedSpawnTargetKey = options?.targetSessionKey?.trim();
+                  const normalizedSpawnTargetKeys = options?.targetSessionKeys
+                    ?.map((k) => k.trim())
+                    .filter((k) => k.length > 0 && k !== sessionKey);
                   const hasCrossSessionTarget =
                     options?.fanoutMode === "all" ||
-                    (options?.targetSessionKey !== undefined &&
-                      options.targetSessionKey !== sessionKey) ||
-                    (options?.targetSessionKeys !== undefined &&
-                      options.targetSessionKeys.length > 0);
+                    (trimmedSpawnTargetKey !== undefined && trimmedSpawnTargetKey !== sessionKey) ||
+                    (normalizedSpawnTargetKeys !== undefined &&
+                      normalizedSpawnTargetKeys.length > 0);
                   if (hasCrossSessionTarget) {
                     const { crossSessionTargeting } = resolveLiveContinuationRuntimeConfig(cfg);
                     if (crossSessionTargeting === "disabled") {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -463,6 +463,18 @@ export type AgentDefaultsConfig = {
      * which fires at 25% when the threshold is 0.8). Set to 0 to opt out.
      */
     earlyWarningBand?: number;
+    /**
+     * Cross-session delegate targeting policy.
+     * - `"disabled"` (default): delegates can only return to the dispatching session
+     *   or its lineage (tree/ancestor). Explicit `targetSessionKey`, `targetSessionKeys`,
+     *   and `fanoutMode: "all"` are rejected with a tool error.
+     * - `"enabled"`: all targeting modes are available, including cross-session
+     *   `targetSessionKey`, `targetSessionKeys`, and `fanoutMode: "all"`.
+     *
+     * `fanoutMode: "tree"` (lineage-only return) is always allowed regardless of this setting.
+     * Self-targeting (`targetSessionKey` matching the dispatching session) is always allowed.
+     */
+    crossSessionTargeting?: "disabled" | "enabled";
   };
 };
 

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -305,6 +305,7 @@ export const AgentDefaultsSchema = z
           .max(1)
           .optional(),
         earlyWarningBand: z.number().min(0).max(1).default(0.3125),
+        crossSessionTargeting: z.enum(["disabled", "enabled"]).optional(),
       })
       .strict()
       .refine(

--- a/src/infra/continuation-tracer.ts
+++ b/src/infra/continuation-tracer.ts
@@ -497,7 +497,12 @@ export function emitContinuationDelegateSpan(args: {
 export function emitContinuationDisabledSpan(args: {
   chainId: string | undefined;
   chainStepRemaining: number;
-  disabledReason: "cap.chain" | "cap.cost" | "cap.delegates_per_turn" | "reservation.missing";
+  disabledReason:
+    | "cap.chain"
+    | "cap.cost"
+    | "cap.delegates_per_turn"
+    | "reservation.missing"
+    | "policy.crossSessionTargeting";
   signalKind: ContinuationDisabledSignalKind;
   delegateDelivery?: "immediate" | "timer" | undefined;
   delegateMode?: string | undefined;


### PR DESCRIPTION
Closes #654 (OUTCOME-3 schema gate)
Closes #657 (boot-vs-live-read followup)

## What

Lands the `crossSessionTargeting` config gate from continuation-feature branches into canonical-line `frond/v2026.5.7/canonical`. Three commits cherry-picked from `cael/20260512/outcome3-crosssession-gate` plus a test-update commit.

- `feat(continuation): add crossSessionTargeting config gate (default-deny)` — `a99a160` cherry → `98c2d98`
- `fix(continuation): address 3 edge-case gaps in crossSessionTargeting gate` — `0915c3d` cherry → `b637e30` (Elliott code-walk findings)
- `fix(continuation): use resolveLiveContinuationRuntimeConfig for hot-reload-aware gate` — `e155ecd` cherry → `047e45e` (Ronan bug-finding for #657)
- `test(continue-delegate): set crossSessionTargeting=enabled in tests that exercise cross-session params` — new on this branch (8812daa)

## Why now

cohort-state at byte (2026-05-12 ~14:00 PDT):
- silas-seat + ronan-seat config files reference `crossSessionTargeting: enabled` per figs canon `1503806085`
- canonical-line tip `f7ede2b2` does NOT carry the schema → config-validate gate fires correctly at deploy-time, blocking deploys
- ronan-seat deploy `25755428492` failed with `agents.defaults.continuation: Unrecognized key: "crossSessionTargeting"`
- silas-seat hit same root cause earlier
- cael-seat deployed clean only because cael-config didn't have the key set

**Ordering canon** (cohort-named at `1503862666`/`1503865632`): schema-deploy MUST precede config-key-presence in `~/.openclaw/openclaw.json`. This PR closes that gap.

## Substrate-receipts

- Issue #654 source-canon: figs Discord `1503553293`
- clawsweeper review of upstream PR #79925 flagged 2× P1
- Cohort convergence on default-deny config gate (NOT 4-option): silas `1503535958`, cael `1503536202`, frond-scribe `1503535924925960334`
- Issue #657 root-cause walk: ronan `1503633582` + `1503635531`, cael diagnosis `1503635638`, silas ratification `1503635733`

## Verification

- `pnpm tsgo:core` — 0 errors
- `pnpm vitest run src/auto-reply/continuation/cross-session-targeting.test.ts src/agents/tools/continue-delegate-tool.test.ts` — 34/34 pass

## Scope

- Schema added at `src/config/zod-schema.agent-defaults.ts:308` + `src/config/types.agent-defaults.ts:477`
- Tool-path gate at `src/agents/tools/continue-delegate-tool.ts:282,315`
- Bracket-path gate at `src/auto-reply/reply/agent-runner.ts:2278`
- Config resolution at `src/auto-reply/continuation/config.ts:97`
- Live (hot-reload-aware) read via `resolveLiveContinuationRuntimeConfig`
- Default: `disabled` (safe upstream default)
- Our fleet sets `enabled` (zero functional loss)

`fanoutMode: "tree"` (lineage-only) and self-targeting always allowed regardless of this setting.

## Out of scope

- Config-key removal at ronan-seat as immediate-unblock fast-path (operator action, not code)
- Re-rebase of upstream PR #79925 onto current `upstream/main` (separate frond-scribe lane)

🩸 cael-authored. Lane co-walked with Elliott (gap-find), Ronan (bug-find for #657), Silas (cohort cosign at `1503865632` naming cael as PR-lane-author).
