### PR TITLE
fix(continuation): #715 thread continuationEnabled into buildSubagentSystemPrompt (RED-test-first)

### DIFF
--- a/src/agents/subagent-spawn.continuation-system-prompt.test.ts
+++ b/src/agents/subagent-spawn.continuation-system-prompt.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression test for #715:
+ *
+ * `buildSubagentSystemPrompt` gates the `## Continuation Chaining` block on
+ * `params.continuationEnabled` being truthy, but `subagent-spawn.ts` did not
+ * thread the runtime config's `agents.defaults.continuation.enabled` flag
+ * through to the call site. Result: production subagents never received the
+ * continuation chaining guidance, even when continuation was enabled in
+ * config.
+ *
+ * This test exercises the production caller path — spawnSubagentDirect →
+ * buildSubagentSystemPrompt → gateway "agent" request's `extraSystemPrompt` —
+ * so the bug is caught at the seam where it actually broke, not just by a
+ * direct unit-call to buildSubagentSystemPrompt with hand-supplied params.
+ */
+import os from "node:os";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSubagentSpawnTestConfig,
+  loadSubagentSpawnModuleForTest,
+} from "./subagent-spawn.test-helpers.js";
+import { buildSubagentSystemPrompt } from "./subagent-system-prompt.js";
+import { installAcceptedSubagentGatewayMock } from "./test-helpers/subagent-gateway.js";
+
+const hoisted = vi.hoisted(() => ({
+  callGatewayMock: vi.fn(),
+  configOverride: {} as Record<string, unknown>,
+}));
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected a non-array record");
+  }
+  return value as Record<string, unknown>;
+}
+
+function gatewayAgentRequestParams(): Record<string, unknown> {
+  const agentCall = hoisted.callGatewayMock.mock.calls
+    .map((call) => requireRecord(call[0]))
+    .find((entry) => entry.method === "agent");
+  if (!agentCall) {
+    throw new Error("expected a gateway 'agent' request to have been made");
+  }
+  return requireRecord(agentCall.params);
+}
+
+describe("spawnSubagentDirect: continuation chaining prompt block (#715)", () => {
+  let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
+
+  beforeAll(async () => {
+    ({ spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: hoisted.callGatewayMock,
+      getRuntimeConfig: () => hoisted.configOverride,
+      buildSubagentSystemPromptOverride: buildSubagentSystemPrompt,
+      resolveSubagentSpawnModelSelection: () => "openai-codex/gpt-5.4",
+      sessionStorePath: "/tmp/subagent-715-session-store.json",
+      resetModules: false,
+    }));
+  });
+
+  beforeEach(() => {
+    hoisted.callGatewayMock.mockReset();
+    installAcceptedSubagentGatewayMock(hoisted.callGatewayMock);
+  });
+
+  it("includes `## Continuation Chaining` in the spawned child's system prompt when config enables continuation", async () => {
+    hoisted.configOverride = createSubagentSpawnTestConfig(os.tmpdir(), {
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          continuation: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "do some chain-able work",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+
+    const agentParams = gatewayAgentRequestParams();
+    const extraSystemPrompt = agentParams.extraSystemPrompt;
+    expect(typeof extraSystemPrompt).toBe("string");
+    expect(extraSystemPrompt as string).toContain("## Continuation Chaining");
+    expect(extraSystemPrompt as string).toContain("[[CONTINUE_DELEGATE:");
+  });
+
+  it("omits `## Continuation Chaining` when config explicitly disables continuation", async () => {
+    hoisted.configOverride = createSubagentSpawnTestConfig(os.tmpdir(), {
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          continuation: {
+            enabled: false,
+          },
+        },
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "do some chain-able work",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+
+    const agentParams = gatewayAgentRequestParams();
+    const extraSystemPrompt = agentParams.extraSystemPrompt;
+    expect(typeof extraSystemPrompt).toBe("string");
+    expect(extraSystemPrompt as string).not.toContain("## Continuation Chaining");
+  });
+});

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -11,6 +11,8 @@ type SessionStore = Record<string, Record<string, unknown>>;
 type SessionStoreMutator = (store: SessionStore) => unknown;
 type HookRunner = Pick<SubagentLifecycleHookRunner, "hasHooks" | "runSubagentSpawning"> &
   Partial<Pick<SubagentLifecycleHookRunner, "runSubagentSpawned" | "runSubagentEnded">>;
+type BuildSubagentSystemPromptFn =
+  typeof import("./subagent-system-prompt.js").buildSubagentSystemPrompt;
 type SubagentSpawnModuleForTest = Awaited<typeof import("./subagent-spawn.js")> & {
   resetSubagentRegistryForTests: MockFn;
 };
@@ -154,6 +156,14 @@ export async function loadSubagentSpawnModuleForTest(params: {
   workspaceDir?: string;
   sessionStorePath?: string;
   resetModules?: boolean;
+  /**
+   * Override for `buildSubagentSystemPrompt`. Default stubs to a constant string
+   * because most tests don't care about prompt contents. Tests that exercise
+   * production threading of prompt parameters (e.g. continuationEnabled per
+   * issue #715) should pass the real builder so the end-to-end caller path
+   * is observable through gateway "agent" request params.
+   */
+  buildSubagentSystemPromptOverride?: BuildSubagentSystemPromptFn;
 }): Promise<SubagentSpawnModuleForTest> {
   if (params.resetModules ?? true) {
     vi.resetModules();
@@ -163,7 +173,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
 
   vi.doMock("./subagent-spawn.runtime.js", () => ({
     callGateway: (opts: unknown) => params.callGatewayMock(opts),
-    buildSubagentSystemPrompt: () => "system-prompt",
+    buildSubagentSystemPrompt: params.buildSubagentSystemPromptOverride ?? (() => "system-prompt"),
     forkSessionFromParent:
       params.forkSessionFromParentMock ??
       (async () => ({ sessionId: "forked-session-id", sessionFile: "/tmp/forked-session.jsonl" })),

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1079,6 +1079,10 @@ export async function spawnSubagentDirect(
       !cfg.tools?.subagents?.tools?.deny?.includes("continue_delegate")
         ? ["continue_delegate"]
         : undefined,
+    // Without this, `buildSubagentSystemPrompt` falls through the continuation
+    // chaining gate (#715) and subagents never see the guidance even when
+    // `agents.defaults.continuation.enabled === true`.
+    continuationEnabled: cfg.agents?.defaults?.continuation?.enabled === true,
   });
 
   let retainOnSessionKeep = false;


### PR DESCRIPTION
## Summary

Closes #715.

`buildSubagentSystemPrompt` at `src/agents/subagent-system-prompt.ts:111` gates the `## Continuation Chaining` block on `params.continuationEnabled` being truthy, but `spawnSubagentDirect` at `src/agents/subagent-spawn.ts:1057` only passed `toolNames` — never `continuationEnabled`. At runtime `params.continuationEnabled === undefined`, so the entire continuation-chaining guidance block silently disappeared from every production subagent system prompt, even when `agents.defaults.continuation.enabled === true`.

This PR threads `continuationEnabled: cfg.agents?.defaults?.continuation?.enabled === true` into the call.

## RED-test-first loop (workorder discipline)

1. **Wrote RED test** `src/agents/subagent-spawn.continuation-system-prompt.test.ts` that exercises the **production caller path** — `spawnSubagentDirect` → `buildSubagentSystemPrompt` — and asserts the gateway `agent` request's `extraSystemPrompt` contains `## Continuation Chaining` when config enables continuation. (A direct unit-call to `buildSubagentSystemPrompt` with hand-supplied params would not catch the threading bug; this test does, because the threading happens inside `spawnSubagentDirect`.)
2. **Ran test → RED**, as expected:
   ```
   × includes `## Continuation Chaining` in the spawned child's system prompt when config enables continuation  (agents-core)
   × includes `## Continuation Chaining` in the spawned child's system prompt when config enables continuation  (agents-support)
   Test Files  2 failed (2)
        Tests  2 failed | 2 passed (4)
   ```
3. **Applied fix** in `subagent-spawn.ts:1083`.
4. **Ran test → GREEN**: `Test Files 2 passed (2) | Tests 4 passed (4)`.
5. **Reverted fix → RED restored**, proving the test catches the bug.
6. **Re-applied fix → GREEN restored**.
7. **Broader suite**: 169/169 pass across `subagent-spawn.*.test.ts` + `system-prompt.test.ts`. Continuation neighborhood (`config.test.ts`, `system-prompt.continuation.test.ts`, `subagent-announce.continuation*.test.ts`): 70/70 pass.

## Real behavior proof

Behavior addressed: Subagents spawned in production never received continuation chaining guidance even when `agents.defaults.continuation.enabled === true`.
Real environment tested: Vitest via `node scripts/run-vitest.mjs` (Codex worktree, sparse checkout); local oxfmt + tsgo:core + tsgo:test:src clean.
Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/agents/subagent-spawn.continuation-system-prompt.test.ts`
  - `node scripts/run-vitest.mjs src/agents/subagent-spawn.test.ts src/agents/subagent-spawn.context.test.ts src/agents/subagent-spawn.depth-limits.test.ts src/agents/subagent-spawn.attachments.test.ts src/agents/subagent-spawn.continuation-system-prompt.test.ts src/agents/system-prompt.test.ts`
  - `node scripts/run-vitest.mjs src/auto-reply/continuation/config.test.ts src/agents/system-prompt.continuation.test.ts src/agents/subagent-announce.continuation.test.ts src/agents/subagent-announce.continuation-drain.test.ts`
  - `pnpm tsgo:core && pnpm tsgo:test:src`
  - `npx oxfmt --check --threads=1 src/agents/subagent-spawn.ts src/agents/subagent-spawn.test-helpers.ts src/agents/subagent-spawn.continuation-system-prompt.test.ts`
Evidence after fix: 4/4 new tests pass; 169/169 surrounding suite pass; 70/70 continuation neighborhood pass; tsgo clean; oxfmt clean.
Observed result after fix: With `agents.defaults.continuation.enabled === true`, the spawned child's gateway-bound `extraSystemPrompt` contains `## Continuation Chaining` + `[[CONTINUE_DELEGATE:` guidance. With `enabled: false`, the block is correctly omitted.
What was not tested: Live end-to-end run against a real provider (not required for the threading proof; the gateway request shape is the production seam).

## Test plan

- [x] New RED test catches the bug pre-fix (proven by revert)
- [x] New tests pass post-fix
- [x] Surrounding subagent-spawn + system-prompt suite unchanged
- [x] Continuation config/announce tests unchanged
- [x] tsgo:core + tsgo:test:src clean
- [x] oxfmt clean
- [ ] CI proof (covered by branch CI after merge)

## Cohort context

- Cohort triage at GH comment `4511162204` + prince-convergence at silas msg `1507088122`
- Codex review on PR #714 surfaced #715 as P2; cohort assessment is P1 (feature-broken-in-production)
- Originally ronan's lane (`1507073106`-class), now in quiet-pacing window — silas picked up per cael's `1507091824` parallel-shape direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)