### PR TITLE
Fix request_compaction pending cleanup on sync throw

### DIFF
--- a/src/agents/tools/request-compaction-tool.test.ts
+++ b/src/agents/tools/request-compaction-tool.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../infra/continuation-tracer.js";
 import {
   createRequestCompactionTool,
+  _hasPendingCompactionSession,
   _resetGuardState,
   _resetVolitionalCounts,
   _setPending,
@@ -628,6 +629,30 @@ describe("request_compaction tool", () => {
         "and the second call would return `already_pending` (Guard 0) instead of " +
         "`rejected/rate_limit` (Guard 2)",
     ).not.toMatchObject({ status: "already_pending" });
+  });
+
+  it("clears pending compaction session when triggerCompaction throws synchronously", async () => {
+    mockTriggerCompaction
+      .mockImplementationOnce(() => {
+        throw new Error("simulated synchronous enqueue failure");
+      })
+      .mockResolvedValueOnce({ ok: true, compacted: true });
+
+    const tool = makeTool();
+
+    await expect(
+      tool.execute("call-sync-throw", { reason: "sync throw after pending add" }),
+    ).rejects.toThrow("simulated synchronous enqueue failure");
+
+    const pendingAfterSyncThrow = _hasPendingCompactionSession(SESSION_KEY);
+    const second = await executeTool(tool, { reason: "retry after sync throw" });
+
+    expect(
+      [pendingAfterSyncThrow, second.status],
+      "a synchronous triggerCompaction throw must not leak pendingCompactionSessions; " +
+        "otherwise the retry is rejected by Guard 0 as already_pending",
+    ).toEqual([false, "compaction_requested"]);
+    expect(mockTriggerCompaction).toHaveBeenCalledTimes(2);
   });
 
   // _resetGuardState restart/test-isolation contract.

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -277,49 +277,57 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
           code,
           reason,
         });
-      void opts
-        .triggerCompaction(request)
-        .then(
-          (result) => {
-            if (result.ok && result.compacted) {
-              sessionGuardState.set(sessionKey, {
-                lastRequestMs: Date.now(),
-              });
-              log.info(
-                `[request_compaction:resolved-success] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
-                  `diagId=${diagId} trigger=volitional outcome=compacted`,
+      let asyncCleanupRegistered = false;
+      try {
+        void opts
+          .triggerCompaction(request)
+          .then(
+            (result) => {
+              if (result.ok && result.compacted) {
+                sessionGuardState.set(sessionKey, {
+                  lastRequestMs: Date.now(),
+                });
+                log.info(
+                  `[request_compaction:resolved-success] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                    `diagId=${diagId} trigger=volitional outcome=compacted`,
+                );
+                incrementVolitionalCompactionCount(sessionKey);
+                return;
+              }
+              const code = classifyCompactionReason(result.reason);
+              const reason = result.reason ?? "";
+              if (result.ok && isCompactionSkipCode(code)) {
+                log.info(
+                  `[request_compaction:resolved-skip] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                    `diagId=${diagId} trigger=volitional outcome=skipped code=${code} reason=${reason}`,
+                );
+                return;
+              }
+              log.warn(
+                `[request_compaction:resolved-failure] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                  `diagId=${diagId} trigger=volitional outcome=failed code=${code} ok=${result.ok} compacted=${result.compacted} reason=${reason}`,
               );
-              incrementVolitionalCompactionCount(sessionKey);
-              return;
-            }
-            const code = classifyCompactionReason(result.reason);
-            const reason = result.reason ?? "";
-            if (result.ok && isCompactionSkipCode(code)) {
-              log.info(
-                `[request_compaction:resolved-skip] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
-                  `diagId=${diagId} trigger=volitional outcome=skipped code=${code} reason=${reason}`,
+              notifyFailure(code, reason);
+            },
+            (err: unknown) => {
+              const message = formatErrorMessage(err);
+              const code = classifyCompactionReason(message);
+              log.error(
+                `[request_compaction:background-error] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
+                  `diagId=${diagId} trigger=volitional outcome=failed code=${code} error=${message}`,
               );
-              return;
-            }
-            log.warn(
-              `[request_compaction:resolved-failure] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
-                `diagId=${diagId} trigger=volitional outcome=failed code=${code} ok=${result.ok} compacted=${result.compacted} reason=${reason}`,
-            );
-            notifyFailure(code, reason);
-          },
-          (err: unknown) => {
-            const message = formatErrorMessage(err);
-            const code = classifyCompactionReason(message);
-            log.error(
-              `[request_compaction:background-error] session=${sessionKey} runId=${opts.runId ?? opts.sessionId} ` +
-                `diagId=${diagId} trigger=volitional outcome=failed code=${code} error=${message}`,
-            );
-            notifyFailure(code, message);
-          },
-        )
-        .finally(() => {
+              notifyFailure(code, message);
+            },
+          )
+          .finally(() => {
+            pendingCompactionSessions.delete(sessionKey);
+          });
+        asyncCleanupRegistered = true;
+      } finally {
+        if (!asyncCleanupRegistered) {
           pendingCompactionSessions.delete(sessionKey);
-        });
+        }
+      }
 
       return jsonResult({
         status: "compaction_requested",
@@ -373,6 +381,11 @@ export function _resetGuardState(sessionKey?: string): void {
 /** Mark a session as having a pending compaction. Exported for tests only. */
 export function _setPending(sessionKey: string): void {
   pendingCompactionSessions.add(sessionKey);
+}
+
+/** Check whether a session has a pending compaction. Exported for tests only. */
+export function _hasPendingCompactionSession(sessionKey: string): boolean {
+  return pendingCompactionSessions.has(sessionKey);
 }
 
 /** Reset volitional compaction counters. Exported for tests only. */


### PR DESCRIPTION
## Summary

- Add a RED regression test for request_compaction when triggerCompaction throws synchronously after pendingCompactionSessions is marked pending.
- Clear pendingCompactionSessions on synchronous trigger setup failures while preserving the existing async resolve/reject cleanup path.
- Expose a test-only pending-session query helper for the regression assertion.

## Verification

- RED before fix: `CI=1 node scripts/run-vitest.mjs src/agents/tools/request-compaction-tool.test.ts -- -t "clears pending compaction session when triggerCompaction throws synchronously" --reporter=verbose --run` failed with pending=true and retry status=already_pending.
- Fixed regression: `CI=1 node scripts/run-vitest.mjs src/agents/tools/request-compaction-tool.test.ts -- -t "clears pending compaction session when triggerCompaction throws synchronously" --reporter=verbose --run`
- Revert proof: temporarily removed the cleanup fix and reran the same focused command; it failed again with pending=true and retry status=already_pending.
- Surrounding file: `CI=1 node scripts/run-vitest.mjs src/agents/tools/request-compaction-tool.test.ts -- --reporter=verbose --run`
- Type check: `pnpm tsgo`
- Whitespace: `git diff --check -- src/agents/tools/request-compaction-tool.ts src/agents/tools/request-compaction-tool.test.ts`
- Review: `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` was stopped after hanging without findings; scoped code-review subagent reported no blocking findings.

## Real behavior proof

Behavior addressed: request_compaction no longer leaves a session permanently already_pending when triggerCompaction throws synchronously after the pending flag is set.

Real environment tested: Local Linux checkout on branch ronan/720-redtest with injected unit coverage for the synchronous trigger failure path.

Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs src/agents/tools/request-compaction-tool.test.ts -- --reporter=verbose --run` and `pnpm tsgo`.

Evidence after fix: The new regression passes and the full request-compaction-tool test file passes; the temporary revert made the same regression fail again with the leaked pending flag.

Observed result after fix: After a synchronous triggerCompaction throw, pendingCompactionSessions is cleared and a retry reaches compaction_requested instead of already_pending.

What was not tested: No live gateway compaction session was run; the bug shape is covered by direct injected triggerCompaction behavior.
