### PR TITLE
fix(continuation): #718 use resolvedConfig (not options.config) for continuation registration gates (RED-test-first)

### DIFF
--- a/src/agents/openclaw-tools.continuation-registration-default-config.test.ts
+++ b/src/agents/openclaw-tools.continuation-registration-default-config.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Same mock shape as openclaw-tools.continuation-registration.test.ts so we
+// don't drag the disk-backed config loader or plugin runtime into this file.
+let mockConfig: Record<string, unknown> = {
+  session: { mainKey: "main", scope: "per-sender" },
+};
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    loadConfig: () => mockConfig,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+vi.mock("../plugins/tools.js", async () => {
+  const actual = await vi.importActual<typeof import("../plugins/tools.js")>("../plugins/tools.js");
+  return {
+    ...actual,
+    getPluginToolMeta: () => undefined,
+  };
+});
+
+import { __testing, createOpenClawTools } from "./openclaw-tools.js";
+
+const CONTINUATION_TOOLS = ["continue_work", "continue_delegate", "request_compaction"] as const;
+
+function buildRequestCompactionOpts() {
+  return {
+    sessionId: "test-session-x718",
+    getContextUsage: () => 0.85,
+    triggerCompaction: vi.fn(async () => ({ ok: true, compacted: true })),
+  };
+}
+
+function buildContinueWorkOpts() {
+  return { requestContinuation: vi.fn() };
+}
+
+function continuationToolNames(tools: Array<{ name: string }>): string[] {
+  return tools
+    .map((t) => t.name)
+    .filter((name): name is (typeof CONTINUATION_TOOLS)[number] =>
+      (CONTINUATION_TOOLS as readonly string[]).includes(name),
+    );
+}
+
+describe("createOpenClawTools — #718 continuation registration uses resolvedConfig (default/dep-provided config path)", () => {
+  afterEach(() => {
+    __testing.setDepsForTest();
+  });
+
+  // RED proof: bug surface is `options?.config?.agents?.defaults?.continuation?.enabled`.
+  // When the caller omits options.config and instead relies on the dependency-injected
+  // config (openClawToolsDeps.config), the gates evaluate undefined and silently skip
+  // registering ALL THREE continuation tools — even though resolvedConfig itself enables
+  // continuation. The fix: gates must check `resolvedConfig?.agents?.defaults?.continuation?.enabled`.
+  it("registers all 3 continuation tools when continuation.enabled is true via dep-provided config (no options.config supplied)", () => {
+    __testing.setDepsForTest({
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+    });
+
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      // NOTE: deliberately NO `config:` field — exercise the resolvedConfig fall-through
+      // to openClawToolsDeps.config. This is the production path for callers that rely
+      // on the module-level dependency-injected config.
+      continueWorkOpts: buildContinueWorkOpts(),
+      requestCompactionOpts: buildRequestCompactionOpts(),
+    });
+
+    const names = continuationToolNames(tools);
+    expect(names).toContain("continue_work");
+    expect(names).toContain("continue_delegate");
+    expect(names).toContain("request_compaction");
+  }, 240_000);
+
+  it("registers continue_delegate alone via dep-provided config when only continuation.enabled=true (no opts threaded)", () => {
+    __testing.setDepsForTest({
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+    });
+
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      // No options.config, no continueWorkOpts, no requestCompactionOpts.
+      // Per the asymmetric design (see openclaw-tools.ts:503-518): continue_delegate fires
+      // through TaskFlow and only needs continuation.enabled — so it MUST register via the
+      // dep-provided config path. continue_work + request_compaction stay off (no closures).
+    });
+
+    const names = continuationToolNames(tools);
+    expect(names).toContain("continue_delegate");
+    expect(names).not.toContain("continue_work");
+    expect(names).not.toContain("request_compaction");
+  });
+
+  it("registers nothing via dep-provided config when continuation.enabled is unset", () => {
+    __testing.setDepsForTest({
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        // no agents.defaults.continuation
+      } as never,
+    });
+
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      continueWorkOpts: buildContinueWorkOpts(),
+      requestCompactionOpts: buildRequestCompactionOpts(),
+    });
+
+    expect(continuationToolNames(tools)).toEqual([]);
+  });
+
+  it("options.config still wins when supplied (resolvedConfig = options.config ?? openClawToolsDeps.config)", () => {
+    __testing.setDepsForTest({
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: false } } },
+      } as never,
+    });
+
+    const tools = createOpenClawTools({
+      agentSessionKey: "main",
+      disablePluginTools: true,
+      disableMessageTool: true,
+      // options.config overrides dep-provided config and enables continuation.
+      config: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { continuation: { enabled: true } } },
+      } as never,
+      continueWorkOpts: buildContinueWorkOpts(),
+      requestCompactionOpts: buildRequestCompactionOpts(),
+    });
+
+    const names = continuationToolNames(tools);
+    expect(names).toContain("continue_work");
+    expect(names).toContain("continue_delegate");
+    expect(names).toContain("request_compaction");
+  });
+});

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -516,7 +516,7 @@ export function createOpenClawTools(
     // continue_delegate alone, with no warning. The guard below surfaces that silent partial-
     // registration so misconfiguration is observable instead of hidden.
     // Tracking: karmaterminal/openclaw#619.
-    ...(options?.config?.agents?.defaults?.continuation?.enabled === true &&
+    ...(resolvedConfig?.agents?.defaults?.continuation?.enabled === true &&
     options?.continueWorkOpts
       ? [
           createContinueWorkTool({
@@ -525,7 +525,7 @@ export function createOpenClawTools(
           }),
         ]
       : []),
-    ...(options?.config?.agents?.defaults?.continuation?.enabled === true &&
+    ...(resolvedConfig?.agents?.defaults?.continuation?.enabled === true &&
     options?.drainsContinuationDelegateQueue !== false
       ? [
           createContinueDelegateTool({
@@ -533,7 +533,7 @@ export function createOpenClawTools(
           }),
         ]
       : []),
-    ...(options?.config?.agents?.defaults?.continuation?.enabled === true &&
+    ...(resolvedConfig?.agents?.defaults?.continuation?.enabled === true &&
     options?.requestCompactionOpts
       ? [
           createRequestCompactionTool({
@@ -547,7 +547,7 @@ export function createOpenClawTools(
   ];
 
   if (
-    options?.config?.agents?.defaults?.continuation?.enabled === true &&
+    resolvedConfig?.agents?.defaults?.continuation?.enabled === true &&
     !options?.continueWorkOpts &&
     !options?.requestCompactionOpts
   ) {


### PR DESCRIPTION
Closes karmaterminal/openclaw#718 (P2).

## Summary

The 3 continuation-tool gates plus the partial-registration warn-gate in `src/agents/openclaw-tools.ts:519,528,536,550` each checked `options?.config?.agents?.defaults?.continuation?.enabled` **directly** instead of `resolvedConfig` (computed at line 193 as `options?.config ?? openClawToolsDeps.config`).

Effect: callers that relied on the module-level dependency-injected config (omitting `options.config`) got silently **NO continuation tools** registered, even when runtime config enabled continuation — tool surface diverged from active config with no warning.

Same axis as openclaw/openclaw#79925 [P2] (silent partial-registration) + karmaterminal/openclaw#619 (warn-gate concern).

## Fix

4 surgical line changes — all 4 continuation registration decisions (3 tool gates + 1 warn-gate) now route through the same single resolved-config seam:

```diff
-...(options?.config?.agents?.defaults?.continuation?.enabled === true &&
+...(resolvedConfig?.agents?.defaults?.continuation?.enabled === true &&
```

`options.config` callers are unaffected because `resolvedConfig = options?.config ?? openClawToolsDeps.config` — `options.config` still wins when supplied.

## RED-test-first loop (per figs 1507060469 discipline)

Same shape silas/715-redtest used + same shape cael's #725 cure landed at `d8dad480bb`. NO test-after-code.

1. **Wrote** new test file `src/agents/openclaw-tools.continuation-registration-default-config.test.ts` — 4 cases exercising the dep-provided config path via `__testing.setDepsForTest({ config: ... })` *without* `options.config`. (None of the existing `continuation-registration*.test.ts` tests exercised this path.)
2. **Ran test against unfixed code** — 2 FAIL (`continue_work`/`continue_delegate` missing) + 2 PASS (negative-case + `options.config`-wins). RED proven.
3. **Applied fix** — flipped the 4 gates from `options?.config` to `resolvedConfig`.
4. **Re-ran test** — 8/8 pass (×2 vitest projects). GREEN proven.
5. **`git stash` the fix, re-ran test** — 4 FAIL again. Test catches the regression.
6. **`git stash pop`** to restore fix — 8/8 pass.
7. **Broader neighborhood** (`openclaw-tools.continuation-registration` + `openclaw-tools.continuation-misconfig-warn` + new file + `subagent-spawn.continuation-system-prompt` + `context-pressure.ordering` + `request-compaction-tool.descriptor-ordering`): **48/48 pass.**

## Verification

**Behavior addressed**: Continuation tools (continue_work / continue_delegate / request_compaction) silently skip registering when caller relies on dep-provided config instead of explicit `options.config`.

**Real environment tested**: `/tmp/silas-718-redtest` worktree on `silas/718-redtest` branch (base `d8dad480bb` = cael/continuation-tools-natural-reach + #715 + #725 cures).

**Exact steps or command run after this patch**:
```
node scripts/run-vitest.mjs \
  src/agents/openclaw-tools.continuation-registration-default-config.test.ts \
  src/agents/openclaw-tools.continuation-registration.test.ts \
  src/agents/openclaw-tools.continuation-misconfig-warn.test.ts \
  src/agents/subagent-spawn.continuation-system-prompt.test.ts \
  src/auto-reply/continuation/context-pressure.ordering.test.ts \
  src/agents/tools/request-compaction-tool.descriptor-ordering.test.ts
```

**Evidence after fix**:
- 8/8 new-test pass (4 cases × 2 vitest projects)
- 30/30 narrow continuation-registration neighborhood pass
- 48/48 broader continuation suite pass
- Stash-and-rerun proves the new test catches the bug (4 FAIL when fix absent)

**Observed result after fix**: dep-provided config path now correctly registers continuation tools when continuation.enabled=true; `options.config` callers unchanged.

**What was not tested**: Full repo suite (out of scope; touched surface is the 4 gates inside a single helper). Crabbox not requested for this ship-block cure.

## Test plan
- [x] RED test fails against unfixed code (verified twice — initial + post-stash)
- [x] GREEN test passes against fixed code (verified twice — initial + post-unstash)
- [x] Narrow neighborhood passes (30/30)
- [x] Broader continuation neighborhood passes (48/48)
- [x] No regression in `options.config`-supplied callers (test #4 exercises that path)
- [x] Warn-gate also routes through `resolvedConfig` (consistent surface)

Cross-references: openclaw/openclaw#79925 (P2 silent-skip concern), karmaterminal/openclaw#619 (warn-gate same-axis).