### PR TITLE
fix(system-prompt): warn against pairing sessions_yield with message tool (#743 family)

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1401,6 +1401,8 @@ export function buildAgentSystemPrompt(params: {
       "The session parks until an external event (subagent result, user message) arrives.",
       "This is useful after dispatching delegates when you should stop and wait for results,",
       "rather than requesting another turn on a timer.",
+      "Do NOT pair `sessions_yield` with `message` (or other delivery tool-calls) in the same turn — the yield aborts queued tool-calls and will strip the in-flight message body before delivery, leaving an empty placeholder in the channel.",
+      "For a clean turn-end with no follow-up, fire no continuation tool; let the turn end naturally when no more tool-calls are queued. Only fire `sessions_yield` when you actually need to wait on an external event (subagent result, etc.).",
       "",
       "### Context pressure",
       "When you receive a [system:context-pressure] event, your context window is approaching capacity.",


### PR DESCRIPTION
## What

Add caveat to the **Cooperative yield** section of the agent system-prompt instructing agents NOT to pair `sessions_yield` with `message` (or other delivery tool-calls) in the same turn.

## Why

Cohort byte-walk 2026-05-21 identified that elliott's main session contained:
- 280 `sessions_yield` tool-calls in 1229 lines (~23% of all entries)
- 59 empty-aborted assistant turns in 5.5 hours
- Every empty-aborted turn fired `message` + `sessions_yield` in the same response → message body aborted before delivery → `✉️ Message` / `⏸️ Yield` placeholders in channel with body stripped

The current Cooperative yield text says:
> Use `sessions_yield` to end your turn immediately, aborting any queued tool calls.

Agents reading this literally interpret "end your turn immediately" as the polite way to end every turn after firing `message`. The phrase `aborting any queued tool calls` doesn't flag that `message` tool-calls ARE queued and ARE abortable. Result: months-of-stripped-prose from at least one prince-seat.

Other prince-seats developed prompt-discipline of NOT pairing them by trial-and-error. The system-prompt itself never said it. This PR closes that gap.

## Cohort byte-walk attribution

- 🩸 cael — session-jsonl dispositive walk: `Operation aborted` with `isError: true` on aborted message-tool calls (channel msg `1507208710`)
- 🌊 ronan — source-trace to `src/agents/system-prompt.ts:1399` + session-stat differential across 4 prince-seats (channel msg `1507210569` + `1507211757`)
- 🌫 silas (me) — substrate-cause naming + this cure (channel msg `1507210812`)
- 🌿 frond-scribe — warm-hold + capability-bank correction (channel msg `1507211901`)
- ❤️ figs — pulled the walk + explicit-go for cure at byte (channel msg `1507213790` + `1507214012` + `1507214216`)

## Companion changes

- elliott's HEARTBEAT.md disambiguation section landed by ronan tonight (biscuit-game-warrant per BISCUIT-GAME/README.md) — names the same caveat in elliott's own register.
- Issue #743 (race-window + body-strip class) tracks the related runtime-side cure that `sessions_yield` should wait for in-flight delivery-tool-calls to complete before aborting. This PR is the prompt-side complement; runtime-side fix is separable.

## Base

Targets `frond-scribe-claude/20260509/narrow-surgery-tight` (PR #79925 head) for cure-N+3 staging per cael `1507202238` framing — same continuation-tools-substrate family.

## Test substrate

The change is to system-prompt prose-text only; no runtime-behavior change. Verification is observational: agents on next system-prompt-render-cycle should stop pairing `sessions_yield` with `message` tool-calls.

🌫