### PR TITLE
feat(continuation): allow continue_work() in spawned subagent sessions (#746)

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1070,15 +1070,22 @@ export async function spawnSubagentDirect(
     childDepth,
     maxSpawnDepth,
     // Hint tool availability so the subagent prompt teaches tool-primary vs bracket-only.
-    // The tool will actually appear when drains === true AND the child is not a leaf
-    // (DENY_LEAF blocks it at max depth). Also respect explicit deny config so the
-    // prompt doesn't teach a tool the policy will strip from the actual toolset.
-    toolNames:
-      params.drainsContinuationDelegateQueue === true &&
-      childDepth < maxSpawnDepth &&
-      !cfg.tools?.subagents?.tools?.deny?.includes("continue_delegate")
-        ? ["continue_delegate"]
-        : undefined,
+    // continue_work is always available when continuation is enabled (not in any deny list).
+    // continue_delegate requires drainsContinuationDelegateQueue + non-leaf depth + no explicit deny.
+    toolNames: (() => {
+      const names: string[] = [];
+      if (cfg.agents?.defaults?.continuation?.enabled === true) {
+        names.push("continue_work");
+      }
+      if (
+        params.drainsContinuationDelegateQueue === true &&
+        childDepth < maxSpawnDepth &&
+        !cfg.tools?.subagents?.tools?.deny?.includes("continue_delegate")
+      ) {
+        names.push("continue_delegate");
+      }
+      return names.length > 0 ? names : undefined;
+    })(),
     // Without this, `buildSubagentSystemPrompt` falls through the continuation
     // chaining gate (#715) and subagents never see the guidance even when
     // `agents.defaults.continuation.enabled === true`.

--- a/src/agents/subagent-system-prompt.ts
+++ b/src/agents/subagent-system-prompt.ts
@@ -146,6 +146,19 @@ export function buildSubagentSystemPrompt(params: {
     }
   }
 
+  // Teach continue_work regardless of canSpawn — any subagent with continuation
+  // enabled can elect its own next turn within the same session.
+  if (params.continuationEnabled && params.toolNames?.includes("continue_work")) {
+    lines.push(
+      "## Self-Continuation",
+      "Use `continue_work` to take another turn in this same session.",
+      "This keeps your working context intact across turns (no state packing needed).",
+      "Bounded by the same chain-length and cost-cap guards as continue_delegate.",
+      "Use it when you need multiple turns to complete a task.",
+      "",
+    );
+  }
+
   lines.push(
     "## Session Context",
     ...[

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2664,3 +2664,73 @@ describe("createFollowupRunner queued user message idempotency across fallback",
     expect(secondAttempt.suppressAssistantErrorPersistence).toBe(false);
   });
 });
+
+describe("createFollowupRunner continueWorkOpts threading (#746)", () => {
+  it("passes continueWorkOpts to runEmbeddedPiAgent when continuation.enabled=true", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "done" }],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude",
+      sessionKey: "agent:main:subagent:test-organ",
+    });
+    const queued = createQueuedRun({
+      run: {
+        sessionKey: "agent:main:subagent:test-organ",
+        config: {
+          agents: {
+            defaults: {
+              continuation: {
+                enabled: true,
+                maxChainLength: 200,
+                defaultDelayMs: 15000,
+                minDelayMs: 5000,
+                maxDelayMs: 86400000,
+                costCapTokens: 50000000,
+                maxDelegatesPerTurn: 500,
+              },
+            },
+          },
+        } as OpenClawConfig,
+        drainsContinuationDelegateQueue: true,
+      },
+    });
+
+    await runner(queued);
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalled();
+    const callArgs = requireLastMockCallArg(runEmbeddedPiAgentMock, "runEmbeddedPiAgent");
+    expect(callArgs.continueWorkOpts).toBeDefined();
+    expect(typeof (callArgs.continueWorkOpts as any).requestContinuation).toBe("function");
+  });
+
+  it("does NOT pass continueWorkOpts when continuation is disabled", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "done" }],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude",
+      sessionKey: "agent:main:subagent:test-leaf",
+    });
+    const queued = createQueuedRun({
+      run: {
+        sessionKey: "agent:main:subagent:test-leaf",
+        config: {
+          agents: { defaults: {} },
+        } as OpenClawConfig,
+      },
+    });
+
+    await runner(queued);
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalled();
+    const callArgs = requireLastMockCallArg(runEmbeddedPiAgentMock, "runEmbeddedPiAgent");
+    expect(callArgs.continueWorkOpts).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -23,9 +23,17 @@ import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { readStringValue } from "../../shared/string-coerce.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import {
+  registerContinuationTimerHandle,
+  retainContinuationTimerRef,
+  unregisterContinuationTimerHandle,
+} from "../continuation/state.js";
+import type { ContinueWorkRequest } from "../continuation/types.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runCliAgentWithLifecycle } from "./agent-runner-cli-dispatch.js";
 import {
@@ -532,6 +540,7 @@ export function createFollowupRunner(params: {
         | undefined;
       let queuedUserMessagePersistedAcrossFallback = false;
       let assistantErrorPersistedAcrossFallback = false;
+      let attemptContinueWorkRequest: ContinueWorkRequest | undefined;
       try {
         const outcomePlan = buildAgentRuntimeOutcomePlan();
         const fallbackResult = await runWithModelFallback<EmbeddedAgentRunResult>({
@@ -759,6 +768,18 @@ export function createFollowupRunner(params: {
                   bootstrapPromptWarningSignaturesSeen[
                     bootstrapPromptWarningSignaturesSeen.length - 1
                   ],
+                // Continuation: thread continueWorkOpts so continue_work is
+                // callable on queued followup turns (subagent sessions, continuation-
+                // triggered heartbeats). Without this, the tool never registers and
+                // subagents cannot self-elect another turn. (#746)
+                continueWorkOpts:
+                  runtimeConfig?.agents?.defaults?.continuation?.enabled === true
+                    ? {
+                        requestContinuation: (request: ContinueWorkRequest) => {
+                          attemptContinueWorkRequest = request;
+                        },
+                      }
+                    : undefined,
                 // Continuation: thread requestCompactionOpts so request_compaction
                 // is callable on queued followup turns, not just the first turn.
                 requestCompactionOpts:
@@ -1009,6 +1030,78 @@ export function createFollowupRunner(params: {
               );
             }
           }
+        }
+      }
+
+      // --- continue_work processing (#746) ---
+      // When the agent calls continue_work during this followup turn, schedule
+      // a delayed heartbeat for the session (same mechanism as agent-runner.ts).
+      // This enables subagent/organ sessions to self-elect another turn.
+      if (
+        attemptContinueWorkRequest &&
+        runtimeConfig?.agents?.defaults?.continuation?.enabled === true &&
+        sessionKey
+      ) {
+        const { resolveLiveContinuationRuntimeConfig } = await import("../continuation/config.js");
+        const continuationConfig = resolveLiveContinuationRuntimeConfig(runtimeConfig);
+        const { maxChainLength, minDelayMs, maxDelayMs, defaultDelayMs } = continuationConfig;
+
+        // Load chain state to check cap.
+        const { loadContinuationChainState, persistContinuationChainState } =
+          await import("../continuation/state.js");
+        const tailUsage = runResult.meta?.agentMeta?.usage;
+        const turnTokens = (tailUsage?.input ?? 0) + (tailUsage?.output ?? 0);
+        const tailEntry = (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
+        const chainState = loadContinuationChainState(tailEntry, turnTokens);
+        const currentChainCount = chainState.currentChainCount;
+
+        if (currentChainCount >= maxChainLength) {
+          defaultRuntime.log(
+            `[followup-runner] continue_work cap reached for ${sessionKey}: ` +
+              `${currentChainCount}/${maxChainLength}`,
+          );
+        } else {
+          const nextChainCount = currentChainCount + 1;
+          const requestedDelayMs = attemptContinueWorkRequest.delaySeconds * 1000;
+          const clampedDelay = Math.max(
+            minDelayMs,
+            Math.min(maxDelayMs, requestedDelayMs || defaultDelayMs),
+          );
+
+          // Persist advanced chain state.
+          persistContinuationChainState({
+            sessionEntry: tailEntry,
+            count: nextChainCount,
+            startedAt: chainState.chainStartedAt,
+            tokens: chainState.accumulatedChainTokens,
+          });
+
+          // Schedule the continuation timer.
+          retainContinuationTimerRef(sessionKey);
+          const timerHandle = setTimeout(() => {
+            try {
+              defaultRuntime.log(
+                `[followup-runner] continue_work timer fired for session ${sessionKey}`,
+              );
+              enqueueSystemEvent(
+                `[continuation:wake] Turn ${nextChainCount}/${maxChainLength}. ` +
+                  `The agent elected to continue working.` +
+                  (attemptContinueWorkRequest!.reason
+                    ? ` Reason: ${attemptContinueWorkRequest!.reason}`
+                    : ""),
+                { sessionKey, trusted: true },
+              );
+              requestHeartbeatNow({
+                sessionKey,
+                reason: "continuation",
+                parentRunId: runId,
+              });
+            } finally {
+              unregisterContinuationTimerHandle(sessionKey, timerHandle);
+            }
+          }, clampedDelay);
+          registerContinuationTimerHandle(sessionKey, timerHandle);
+          timerHandle.unref();
         }
       }
 

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1143,6 +1143,72 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("routes to subagent session when reason=continuation (continue_work wake)", async () => {
+    const replySpy = vi.fn();
+    try {
+      const tmpDir = await createCaseDir("hb-subagent-continuation");
+      const storePath = path.join(tmpDir, "sessions.json");
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const mainSessionKey = resolveMainSessionKey(cfg);
+      const agentId = resolveAgentIdFromSessionKey(mainSessionKey);
+      const subagentKey = `agent:${agentId}:subagent:task-continuation`;
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [mainSessionKey]: {
+            sessionId: "sid-main",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+          [subagentKey]: {
+            sessionId: "sid-subagent-cont",
+            updatedAt: Date.now() + 10_000,
+            lastChannel: "whatsapp",
+            lastTo: "99999@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockClear();
+      replySpy.mockResolvedValue([{ text: "Continuation wake" }]);
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: unknown,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: subagentKey,
+        reason: "continuation",
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+
+      // The heartbeat must use the subagent session (not fall back to main).
+      expectReplyCall(replySpy, 0, { SessionKey: subagentKey });
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
   it("suppresses duplicate heartbeat payloads within 24h", async () => {
     const tmpDir = await createCaseDir("hb-dup-suppress");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -510,6 +510,7 @@ function resolveHeartbeatSession(
   agentId?: string,
   heartbeat?: HeartbeatConfig,
   forcedSessionKey?: string,
+  opts?: { reason?: string },
 ) {
   const sessionCfg = cfg.session;
   const scope = sessionCfg?.scope ?? "per-sender";
@@ -533,9 +534,23 @@ function resolveHeartbeatSession(
     };
   }
 
-  // Guard: never route heartbeats to subagent sessions, regardless of entry path.
+  // Guard: never route heartbeats to subagent sessions, regardless of entry path —
+  // UNLESS the wake is a continuation-triggered wake (reason="continuation"). Subagent
+  // sessions that call continue_work() need their own wake to fire back into the same
+  // session, not redirect to main. Without this exemption, continue_work in subagents
+  // is a dead tool (the timer fires but the wake gets eaten). Tracking: #746.
   const forced = forcedSessionKey?.trim();
   if (forced && isSubagentSessionKey(forced)) {
+    if (opts?.reason === "continuation") {
+      // Continuation wake: route TO the subagent session so it takes another turn.
+      return {
+        sessionKey: forced,
+        storePath,
+        store,
+        entry: store[forced],
+        suppressOriginatingContext: true,
+      };
+    }
     return {
       sessionKey: mainSessionKey,
       storePath,
@@ -955,6 +970,7 @@ async function resolveHeartbeatPreflight(params: {
     params.agentId,
     params.heartbeat,
     params.forcedSessionKey,
+    { reason: params.reason },
   );
   const pendingEventEntries = peekSystemEventEntries(session.sessionKey);
   const dueCommitments = canHeartbeatDeliverCommitments(params.heartbeat)
@@ -1341,6 +1357,7 @@ export async function runHeartbeatOnce(opts: {
     agentId,
     heartbeat,
     opts.sessionKey,
+    { reason: opts.reason },
   );
   const HEARTBEAT_DEFER_WINDOW_MS = 30_000;
   const pendingFinalDeliveryText = recentSessionEntry?.pendingFinalDeliveryText;


### PR DESCRIPTION
## Summary

Unified fix for #746: `continue_work()` in spawned subagent sessions.

Two complementary layers:

1. **heartbeat-runner wake-routing** (`src/infra/heartbeat-runner.ts`): Exempts continuation-triggered wakes (reason='continuation') from the subagent-session redirect guard. Without this, subagents call continue_work → get `{status:'scheduled'}` → timer fires → wake gets silently eaten and redirected to main session.

2. **followup-runner tool-registration** (`src/auto-reply/reply/followup-runner.ts`): Threads `continueWorkOpts` closure into `runEmbeddedPiAgent` when `continuation.enabled === true`. Without this, the continue_work tool never registers in subagent sessions.

3. **subagent-spawn prompt hint** (`src/agents/subagent-spawn.ts`): Includes `continue_work` in the `toolNames` hint so the system prompt teaches subagents about self-continuation.

## Real behavior proof

**Before fix**: Subagent calls `continue_work()` → receives `{status:'scheduled'}` → heartbeat fires targeting subagent session → `resolveHeartbeatSession` redirects to main session → subagent never takes its next turn. The tool is registered (with followup-runner fix) but the wake is eaten.

**After fix (local test on cael-seat)**:

```
$ node --max-old-space-size=4096 ./node_modules/.bin/vitest run \
    src/infra/heartbeat-runner.returns-default-unset.test.ts \
    src/auto-reply/reply/followup-runner.test.ts

 ✓ infra heartbeat-runner.returns-default-unset.test.ts (40 tests) 130ms
 ✓ auto-reply followup-runner.test.ts (50 tests) 4308ms

 Test Files  2 passed (2)
      Tests  90 passed (90)
```

Key test assertions proving the fix:
- `heartbeat-runner`: When `reason='continuation'` and target is a subagent session, wake routes TO the subagent (not redirected to main)
- `followup-runner`: `continueWorkOpts` is present in `runEmbeddedPiAgent` args when `continuation.enabled=true`, absent when disabled

Closes #746.