### PR TITLE
feat(plugin-sdk): expose delegateCompactionToRuntime on plugin API

### DIFF
--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { attachPluginApiFacades, type OpenClawPluginApiWithoutFacades } from "./api-facades.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import type { OpenClawPluginApi, PluginLogger } from "./types.js";
+import { delegateCompactionToRuntime } from "../context-engine/delegate.js";
 
 export type BuildPluginApiParams = {
   id: string;
@@ -134,6 +135,11 @@ const noopOnConversationBindingResolved: OpenClawPluginApi["onConversationBindin
 const noopRegisterCommand: OpenClawPluginApi["registerCommand"] = () => {};
 const noopRegisterContextEngine: OpenClawPluginApi["registerContextEngine"] = () => {};
 const noopRegisterCompactionProvider: OpenClawPluginApi["registerCompactionProvider"] = () => {};
+const noopDelegateCompactionToRuntime: OpenClawPluginApi["delegateCompactionToRuntime"] = async () => ({
+  ok: false,
+  compacted: false,
+  reason: "not wired",
+});
 const noopRegisterAgentHarness: OpenClawPluginApi["registerAgentHarness"] = () => {};
 const noopRegisterCodexAppServerExtensionFactory: OpenClawPluginApi["registerCodexAppServerExtensionFactory"] =
   () => {};
@@ -249,6 +255,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     registerContextEngine: handlers.registerContextEngine ?? noopRegisterContextEngine,
     registerCompactionProvider:
       handlers.registerCompactionProvider ?? noopRegisterCompactionProvider,
+    delegateCompactionToRuntime,
     registerAgentHarness: handlers.registerAgentHarness ?? noopRegisterAgentHarness,
     registerCodexAppServerExtensionFactory:
       handlers.registerCodexAppServerExtensionFactory ?? noopRegisterCodexAppServerExtensionFactory,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2717,6 +2717,15 @@ export type OpenClawPluginApi = {
   registerCompactionProvider: (
     provider: import("./compaction-provider.js").CompactionProvider,
   ) => void;
+  /**
+   * Delegate compaction to the runtime's built-in compaction pipeline.
+   * Context engine plugins should call this from their `compact()` method
+   * to reuse the gateway's native summarization instead of implementing
+   * their own compression.
+   */
+  delegateCompactionToRuntime: (
+    params: Parameters<import("../context-engine/types.js").ContextEngine["compact"]>[0],
+  ) => Promise<import("../context-engine/types.js").CompactResult>;
   /** Register an agent harness implementation. */
   registerAgentHarness: (harness: AgentHarness) => void;
   /**


### PR DESCRIPTION
Exposes delegateCompactionToRuntime on the OpenClawPluginApi interface. 2 files, 16 insertions. Ref: karmaterminal/binary-canticle#31