### PR TITLE
fix(continuation): isolate post-compaction release errors from compaction-outcome signal (#816)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.release-queued-compaction.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.release-queued-compaction.test.ts
@@ -61,6 +61,10 @@ async function getReleaseQueuedCompactionCompletion() {
   return (await import("./agent-runner-execution.js")).releaseQueuedCompactionCompletion;
 }
 
+async function getReleaseQueuedCompactionTolerant() {
+  return (await import("./agent-runner-execution.js")).releaseQueuedCompactionTolerant;
+}
+
 function makeSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
   return {
     sessionId: "session-id-default",
@@ -415,5 +419,158 @@ describe("releaseQueuedCompactionCompletion: happy-path dispatch (branch 4)", ()
     // resolved.existing was undefined, so refreshedSessionEntry falls back to
     // the original (pre-resolve) sessionEntry. This guards the `??` chain.
     expect(dispatchArg.sessionEntry).toBe(initialSessionEntry);
+  });
+});
+
+/**
+ * #816 regression: releaseQueuedCompactionTolerant must isolate release-side
+ * failures from the caller's compaction-outcome signal.
+ *
+ * compactEmbeddedAgentSession has already mutated session-snapshot truth on
+ * disk before release runs. If release throws and that throw flips the
+ * caller's outcome to `{ ok: false, compacted: false }`, the agent retries
+ * compaction on an already-compacted session — double-compaction risk.
+ *
+ * These tests force the downstream deps of releaseQueuedCompactionCompletion
+ * (incrementRunCompactionCount, dispatchPostCompactionDelegates, span emit)
+ * to throw. The tolerant wrapper must swallow + logVerbose + not re-throw.
+ */
+describe("releaseQueuedCompactionTolerant: error-isolation guard (#816)", () => {
+  it("resolves silently when the underlying release succeeds (happy-path passthrough)", async () => {
+    const tolerant = await getReleaseQueuedCompactionTolerant();
+    const sessionEntry = makeSessionEntry();
+    const activeSessionStore: Record<string, SessionEntry> = { [SESSION_KEY]: sessionEntry };
+
+    state.incrementRunCompactionCountMock.mockResolvedValue(1);
+    state.resolveSessionStoreEntryMock.mockReturnValue({
+      existing: sessionEntry,
+      legacyKeys: [],
+      normalizedKey: SESSION_KEY,
+    });
+    state.dispatchPostCompactionDelegatesMock.mockResolvedValue({ queuedDelegates: 0 });
+
+    await expect(
+      tolerant({
+        activeSessionStore,
+        compactionResult: { ok: true, compacted: true },
+        followupRun: makeFollowupRun(),
+        getActiveSessionEntry: () => sessionEntry,
+        sessionKey: SESSION_KEY,
+        storePath: STORE_PATH,
+        traceparent: TRACEPARENT,
+      }),
+    ).resolves.toBeUndefined();
+
+    // Success-path must NOT emit a release-failed verbose log.
+    const failedLogs = state.logVerboseMock.mock.calls.filter((call) =>
+      String(call[0]).includes("[request_compaction:post-compaction-release-failed]"),
+    );
+    expect(failedLogs).toHaveLength(0);
+    // Sanity: the underlying release did fire its happy-path deps.
+    expect(state.incrementRunCompactionCountMock).toHaveBeenCalledTimes(1);
+    expect(state.dispatchPostCompactionDelegatesMock).toHaveBeenCalledTimes(1);
+    expect(state.emitContinuationCompactionReleasedSpanMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows Error thrown by incrementRunCompactionCount and logs the reason", async () => {
+    const tolerant = await getReleaseQueuedCompactionTolerant();
+    const sessionEntry = makeSessionEntry();
+    const activeSessionStore: Record<string, SessionEntry> = { [SESSION_KEY]: sessionEntry };
+
+    state.incrementRunCompactionCountMock.mockRejectedValue(new Error("session-store I/O failure"));
+
+    await expect(
+      tolerant({
+        activeSessionStore,
+        compactionResult: { ok: true, compacted: true },
+        followupRun: makeFollowupRun(),
+        getActiveSessionEntry: () => sessionEntry,
+        sessionKey: SESSION_KEY,
+        storePath: STORE_PATH,
+        traceparent: TRACEPARENT,
+      }),
+    ).resolves.toBeUndefined();
+
+    // Outer cleanup short-circuits at the increment throw; dispatch + span
+    // never run, but the tolerant wrapper must not re-throw.
+    expect(state.dispatchPostCompactionDelegatesMock).not.toHaveBeenCalled();
+    expect(state.emitContinuationCompactionReleasedSpanMock).not.toHaveBeenCalled();
+
+    const failedLogs = state.logVerboseMock.mock.calls.filter((call) =>
+      String(call[0]).includes("[request_compaction:post-compaction-release-failed]"),
+    );
+    expect(failedLogs).toHaveLength(1);
+    const msg = failedLogs[0]?.[0] as string;
+    expect(msg).toContain(`session=${SESSION_KEY}`);
+    expect(msg).toContain("reason=session-store I/O failure");
+  });
+
+  it("swallows Error thrown by dispatchPostCompactionDelegates and logs the reason", async () => {
+    const tolerant = await getReleaseQueuedCompactionTolerant();
+    const sessionEntry = makeSessionEntry();
+    const activeSessionStore: Record<string, SessionEntry> = { [SESSION_KEY]: sessionEntry };
+
+    state.incrementRunCompactionCountMock.mockResolvedValue(1);
+    state.resolveSessionStoreEntryMock.mockReturnValue({
+      existing: sessionEntry,
+      legacyKeys: [],
+      normalizedKey: SESSION_KEY,
+    });
+    state.dispatchPostCompactionDelegatesMock.mockRejectedValue(
+      new Error("delegate dispatch crashed"),
+    );
+
+    await expect(
+      tolerant({
+        activeSessionStore,
+        compactionResult: { ok: true, compacted: true },
+        followupRun: makeFollowupRun(),
+        getActiveSessionEntry: () => sessionEntry,
+        sessionKey: SESSION_KEY,
+        storePath: STORE_PATH,
+        traceparent: TRACEPARENT,
+      }),
+    ).resolves.toBeUndefined();
+
+    // increment succeeded, dispatch threw, span never ran.
+    expect(state.incrementRunCompactionCountMock).toHaveBeenCalledTimes(1);
+    expect(state.emitContinuationCompactionReleasedSpanMock).not.toHaveBeenCalled();
+
+    const failedLogs = state.logVerboseMock.mock.calls.filter((call) =>
+      String(call[0]).includes("[request_compaction:post-compaction-release-failed]"),
+    );
+    expect(failedLogs).toHaveLength(1);
+    const msg = failedLogs[0]?.[0] as string;
+    expect(msg).toContain("reason=delegate dispatch crashed");
+  });
+
+  it("coerces non-Error throws via String() so the verbose log still carries a reason", async () => {
+    const tolerant = await getReleaseQueuedCompactionTolerant();
+    const sessionEntry = makeSessionEntry();
+    const activeSessionStore: Record<string, SessionEntry> = { [SESSION_KEY]: sessionEntry };
+
+    // exercising non-Error throws on purpose (verifies String() coercion)
+    state.incrementRunCompactionCountMock.mockImplementation(() => {
+      throw "raw-string-thrown-by-store";
+    });
+
+    await expect(
+      tolerant({
+        activeSessionStore,
+        compactionResult: { ok: true, compacted: true },
+        followupRun: makeFollowupRun(),
+        getActiveSessionEntry: () => sessionEntry,
+        sessionKey: SESSION_KEY,
+        storePath: STORE_PATH,
+        traceparent: TRACEPARENT,
+      }),
+    ).resolves.toBeUndefined();
+
+    const failedLogs = state.logVerboseMock.mock.calls.filter((call) =>
+      String(call[0]).includes("[request_compaction:post-compaction-release-failed]"),
+    );
+    expect(failedLogs).toHaveLength(1);
+    const msg = failedLogs[0]?.[0] as string;
+    expect(msg).toContain("reason=raw-string-thrown-by-store");
   });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -215,6 +215,25 @@ export async function releaseQueuedCompactionCompletion(params: {
   });
 }
 
+// Wraps releaseQueuedCompactionCompletion so post-compaction cleanup
+// errors (count-write / delegate dispatch / tracer emit) never flip the
+// caller's compaction-outcome signal. compactEmbeddedAgentSession has
+// already mutated session-snapshot truth on disk before we get here; if
+// release throws and the caller sees `{ ok: false, compacted: false }`,
+// the agent retries compaction on an already-compacted session (#816).
+export async function releaseQueuedCompactionTolerant(
+  params: Parameters<typeof releaseQueuedCompactionCompletion>[0],
+): Promise<void> {
+  try {
+    await releaseQueuedCompactionCompletion(params);
+  } catch (releaseErr) {
+    const reason = releaseErr instanceof Error ? releaseErr.message : String(releaseErr);
+    logVerbose(
+      `[request_compaction:post-compaction-release-failed] session=${params.sessionKey ?? "none"} reason=${reason}`,
+    );
+  }
+}
+
 type AgentTurnTimingSpan = {
   name: string;
   durationMs: number;
@@ -2436,7 +2455,7 @@ export async function runAgentTurnWithFallback(params: {
                                   traceparent: request.traceparent,
                                 });
                                 if (result.ok && result.compacted) {
-                                  await releaseQueuedCompactionCompletion({
+                                  await releaseQueuedCompactionTolerant({
                                     activeSessionStore: params.activeSessionStore,
                                     compactionResult: result,
                                     followupRun: params.followupRun,


### PR DESCRIPTION
## Summary

The `triggerCompaction` closure in `src/auto-reply/reply/agent-runner-execution.ts:2455` was awaiting `releaseQueuedCompactionCompletion` **inside the same try-block** that wraps `compactEmbeddedAgentSession`. Any throw from release-side cleanup (count-write / delegate dispatch / tracer emit / dynamic imports inside the helper) was caught by the outer catch at `:2473`, flipping the closure's return to `{ ok: false, compacted: false }` — even though the session **was** compacted on disk.

The consumer at `src/agents/tools/request-compaction-tool.ts:286-311` then routes to `notifyFailure`, telling the agent compaction failed. After the 5-min rate-limit window the agent may compact AGAIN — **double-compaction on an already-compacted session**, with cascade: compaction-count divergence between session-store and on-disk reality, post-compaction delegates not drained, agent flying blind on retry signals.

### Fix shape

Extract `releaseQueuedCompactionTolerant` sibling helper after `releaseQueuedCompactionCompletion:216` that wraps the release call in its own try/catch. On throw the wrapper:
- emits `logVerbose("[request_compaction:post-compaction-release-failed] session=... reason=...")` (coerces non-Error throws via `String()`)
- does **NOT** re-throw, so the closure's compaction-outcome signal stays aligned with what `compactEmbeddedAgentSession` actually returned

Closure call-site at `:2455` swaps `releaseQueuedCompactionCompletion(...)` → `releaseQueuedCompactionTolerant(...)` (one-line change). Outer try around `compactEmbeddedAgentSession` stays — compact-side throws DO indicate the compaction did not happen; flipping outcome there is correct.

### Scope alignment

This is **our PR's plumbing** — the `triggerCompaction` closure + `releaseQueuedCompactionCompletion` + the `request_compaction` tool all live ONLY on PR #85651 (continuation-feature) substrate (verified at byte: 0 hits on `upstream/main`, 2 hits on PRH `fc337f05d643`). Fixing this is in-scope for the cure-cycle PR, not a separate openclaw-patch slipped in.

### Origin

Surfaced by frond-scribe scribe-class code-review-agent walk of PR #809 candidate `f426d9dbbf` at Discord byte `1510488947`. Not flagged by codex review or cael-opus-4.8 7-axis review. **Separate axis from codex-6 findings**: error-handling-scope-class vs the integration-completeness-gaps-from-per-file-extraction family.

## Diff

```
 src/auto-reply/reply/agent-runner-execution.release-queued-compaction.test.ts | 157 +++++++++++++++++++++
 src/auto-reply/reply/agent-runner-execution.ts                                |  21 ++-
 2 files changed, 177 insertions(+), 1 deletion(-)
```

## Verification

**Behavior addressed**: `triggerCompaction` closure misreporting successful compaction as failure when post-compaction release-side cleanup throws, leading to potential double-compaction on already-compacted sessions.

**Real environment tested**: local cohort cure-cycle worktree at HEAD `0b7e6050ad`, Node v25.9.0, pnpm v11.2.2 (per repo defaults).

**Exact steps or command run after this patch**:

```
pnpm install --frozen-lockfile
pnpm test src/auto-reply/reply/agent-runner-execution.release-queued-compaction.test.ts
pnpm tsgo
pnpm check:test-types
pnpm check:changed
npx oxfmt --check src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.release-queued-compaction.test.ts
```

**Evidence after fix**:
- `pnpm test ...release-queued-compaction.test.ts` → Test Files 1 passed (1), Tests 12 passed (12) — 8 pre-existing + 4 new #816 regression
- `pnpm tsgo` → exit 0 (production typecheck clean)
- `pnpm check:test-types` → exit 0 (test typecheck clean)
- `pnpm check:changed` → exit 0 (lint + typecheck + import-cycles + guard-checks all green)
- `oxfmt --check` on touched files → "All matched files use the correct format."

**Observed result after fix**: The new 4-test `releaseQueuedCompactionTolerant: error-isolation guard (#816)` describe block passes:
- happy-path: release succeeds, no failure-log fires, all downstream deps observed
- increment throws Error: tolerant resolves without throw, failure-log carries `session=main reason=session-store I/O failure`
- dispatch throws Error: tolerant resolves without throw, failure-log carries `reason=delegate dispatch crashed`, span emit never reached
- non-Error throw (raw string): tolerant coerces via `String()`, failure-log carries `reason=raw-string-thrown-by-store`

**What was not tested**: full `pnpm test` suite (only the targeted colocated file fired); full `pnpm check` umbrella vs `check:changed` incremental; live request_compaction integration with a real provider; `bash scripts/prepush-ci.sh` upstream-CI-mirror (Gate 3g) — that gate fires at the cure-cycle PR-presentation force-push window, not at PR-into-cure-cycle merge.

## References

- Issue: #816
- Cure-cycle PR (base): #809 — branch `uncurse/20260530/copilot-opus47-1m` at HEAD `0b7e6050ad`
- Cohort surface: Discord byte `1510488947` (initial finding) → `1510497896+` (figs scope-correction confirming in-PR scope)
- Sibling PR for #817 coming next (separate by issue per cohort discipline)
