### PR TITLE
fix(continuation): honor totalTokensFresh + resolve context-window via canonical pipeline in request_compaction gate (#817)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.context-usage.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.context-usage.test.ts
@@ -1,0 +1,273 @@
+/**
+ * #817 regression: computeRequestCompactionContextUsage must
+ *   (a) honor the totalTokensFresh freshness contract, returning null when
+ *       the prior turn could not compute a fresh totalTokens snapshot, and
+ *   (b) resolve the context-window denominator via the canonical pipeline
+ *       (session-entry → cfg/provider/model) instead of the prior
+ *       hardcoded `?? 200_000` fallback that misreports utilization on any
+ *       non-200K model.
+ *
+ * Both null-return branches map to request-compaction-tool.ts:209's
+ * [request_compaction:context-unknown] rejection path, so the request_compaction
+ * gate refuses rather than misfires on stale or unresolvable inputs.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+
+const state = vi.hoisted(() => ({
+  resolveContextTokensForModelMock:
+    vi.fn<
+      (params: {
+        cfg?: unknown;
+        provider?: string;
+        model?: string;
+        contextTokensOverride?: number;
+        fallbackContextTokens?: number;
+        allowAsyncLoad?: boolean;
+      }) => number | undefined
+    >(),
+}));
+
+vi.mock("../../agents/context.js", () => ({
+  resolveContextTokensForModel: (
+    params: Parameters<typeof state.resolveContextTokensForModelMock>[0],
+  ) => state.resolveContextTokensForModelMock(params),
+}));
+
+async function getComputeRequestCompactionContextUsage() {
+  return (await import("./agent-runner-execution.js")).computeRequestCompactionContextUsage;
+}
+
+function makeEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "session-id-default",
+    updatedAt: 1,
+    ...overrides,
+  } as SessionEntry;
+}
+
+const PROVIDER = "anthropic";
+const MODEL = "claude-sonnet-4.6";
+const CFG = { runtime: { id: "cfg-test" } } as never;
+
+beforeEach(() => {
+  state.resolveContextTokensForModelMock.mockReset();
+});
+
+describe("computeRequestCompactionContextUsage: freshness contract (#817 axis a)", () => {
+  it("returns null when totalTokensFresh is explicitly false (known-stale)", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+    state.resolveContextTokensForModelMock.mockReturnValue(200_000);
+
+    const result = compute({
+      entry: makeEntry({ totalTokens: 100_000, totalTokensFresh: false, contextTokens: 200_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+
+    expect(result).toBeNull();
+    // The freshness short-circuit happens BEFORE context-window resolution, so
+    // resolveContextTokensForModel must not be called in this path.
+    expect(state.resolveContextTokensForModelMock).not.toHaveBeenCalled();
+  });
+
+  it("computes the ratio when totalTokensFresh is true", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+
+    const result = compute({
+      entry: makeEntry({ totalTokens: 150_000, totalTokensFresh: true, contextTokens: 200_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+
+    expect(result).toBeCloseTo(0.75, 5);
+  });
+
+  it("computes the ratio when totalTokensFresh is undefined (treated as fresh)", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+
+    const result = compute({
+      entry: makeEntry({ totalTokens: 100_000, contextTokens: 200_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+
+    expect(result).toBeCloseTo(0.5, 5);
+  });
+
+  it("returns null when totalTokens is missing (entry has no usage snapshot yet)", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+
+    const result = compute({
+      entry: makeEntry({ contextTokens: 200_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when entry itself is undefined (no active session)", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+
+    const result = compute({
+      entry: undefined,
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("computeRequestCompactionContextUsage: context-window resolution (#817 axis b)", () => {
+  it("prefers entry.contextTokens over the model-resolution fallback when populated", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+    // If resolveContextTokensForModel were called erroneously, the test would
+    // pick up its 999_999 return value instead of the session-entry's 100_000.
+    state.resolveContextTokensForModelMock.mockReturnValue(999_999);
+
+    const result = compute({
+      entry: makeEntry({ totalTokens: 50_000, contextTokens: 100_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+
+    expect(result).toBeCloseTo(0.5, 5);
+    expect(state.resolveContextTokensForModelMock).not.toHaveBeenCalled();
+  });
+
+  it("falls through to resolveContextTokensForModel when entry.contextTokens is undefined", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+    state.resolveContextTokensForModelMock.mockReturnValue(128_000);
+
+    const result = compute({
+      entry: makeEntry({ totalTokens: 32_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+
+    expect(result).toBeCloseTo(0.25, 5);
+    expect(state.resolveContextTokensForModelMock).toHaveBeenCalledTimes(1);
+    const arg = state.resolveContextTokensForModelMock.mock.calls[0]?.[0];
+    expect(arg).toMatchObject({
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+      allowAsyncLoad: false,
+    });
+  });
+
+  it("returns null when resolveContextTokensForModel returns undefined (unknown model)", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+    state.resolveContextTokensForModelMock.mockReturnValue(undefined);
+
+    const result = compute({
+      entry: makeEntry({ totalTokens: 50_000 }),
+      cfg: CFG,
+      provider: "unknown-provider",
+      model: "unknown-model",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when resolveContextTokensForModel returns 0 or negative", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+    state.resolveContextTokensForModelMock.mockReturnValue(0);
+
+    const zeroResult = compute({
+      entry: makeEntry({ totalTokens: 50_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+    expect(zeroResult).toBeNull();
+
+    state.resolveContextTokensForModelMock.mockReturnValue(-1);
+    const negResult = compute({
+      entry: makeEntry({ totalTokens: 50_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+    expect(negResult).toBeNull();
+  });
+});
+
+describe("computeRequestCompactionContextUsage: model-size matrix (#817 anti-hardcode-200K)", () => {
+  // Same totalTokens, different real model context-windows — the OLD code's
+  // `?? 200_000` hardcode would have reported 0.7 for every row (since
+  // entry.contextTokens absent forced the fallback). Threading the real
+  // window through resolveContextTokensForModel produces correct ratios.
+  const TOTAL_TOKENS = 140_000;
+  const cases: Array<{ name: string; modelWindow: number; expectedRatio: number }> = [
+    {
+      name: "100K context model (under-fired at 200K hardcode)",
+      modelWindow: 100_000,
+      expectedRatio: 1.4,
+    },
+    {
+      name: "200K context model (matches the prior hardcode coincidentally)",
+      modelWindow: 200_000,
+      expectedRatio: 0.7,
+    },
+    { name: "256K context model", modelWindow: 256_000, expectedRatio: 140_000 / 256_000 },
+    {
+      name: "1M context model (over-fired at 200K hardcode)",
+      modelWindow: 1_000_000,
+      expectedRatio: 0.14,
+    },
+  ];
+
+  it.each(cases)("$name → ratio=$expectedRatio", async ({ modelWindow, expectedRatio }) => {
+    const compute = await getComputeRequestCompactionContextUsage();
+    state.resolveContextTokensForModelMock.mockReturnValue(modelWindow);
+
+    const result = compute({
+      entry: makeEntry({ totalTokens: TOTAL_TOKENS }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+
+    expect(result).toBeCloseTo(expectedRatio, 5);
+  });
+});
+
+describe("computeRequestCompactionContextUsage: signature contract for the consumer", () => {
+  // request-compaction-tool.ts:98 types getContextUsage as `() => number | null`
+  // and explicitly branches on `=== null` at :209. These tests anchor the
+  // narrow return-shape so a future refactor cannot silently widen it.
+  it("returns number when both freshness + window resolve cleanly", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+    const result = compute({
+      entry: makeEntry({ totalTokens: 10_000, contextTokens: 100_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+    expect(typeof result).toBe("number");
+  });
+
+  it("returns null (not undefined, not 0) when context cannot be resolved", async () => {
+    const compute = await getComputeRequestCompactionContextUsage();
+    state.resolveContextTokensForModelMock.mockReturnValue(undefined);
+    const result = compute({
+      entry: makeEntry({ totalTokens: 10_000 }),
+      cfg: CFG,
+      provider: PROVIDER,
+      model: MODEL,
+    });
+    expect(result).toBeNull();
+    expect(result).not.toBe(0);
+    expect(result).not.toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -54,6 +54,7 @@ import { resolveOpenAIRuntimeProvider } from "../../agents/openai-routing.js";
 import { buildAgentRuntimeOutcomePlan } from "../../agents/runtime-plan/build.js";
 import type { ContinueWorkRequest } from "../../agents/tools/continue-work-tool.js";
 import {
+  resolveFreshSessionTotalTokens,
   resolveGroupSessionKey,
   resolveSessionStoreEntry,
   resolveSessionTranscriptPath,
@@ -232,6 +233,52 @@ export async function releaseQueuedCompactionTolerant(
       `[request_compaction:post-compaction-release-failed] session=${params.sessionKey ?? "none"} reason=${reason}`,
     );
   }
+}
+
+// Computes the context-usage ratio supplied to request-compaction-tool's
+// MIN_CONTEXT_THRESHOLD gate (request-compaction-tool.ts:208-228). Returns
+// null in two cases that both map to the consumer's [request_compaction:
+// context-unknown] rejection path (request-compaction-tool.ts:209):
+//   - totalTokens is missing, invalid, or known-stale (totalTokensFresh=false)
+//   - the context-window denominator cannot be resolved for this provider/model
+// Returning null is preferable to a synthetic ratio because the consumer
+// already distinguishes "unknown" from "below-threshold" with separate
+// rejection codes and operator-facing reasons (#817).
+export function computeRequestCompactionContextUsage(params: {
+  entry: SessionEntry | undefined;
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+  model: string;
+}): number | null {
+  // Honor the canonical freshness contract: when the prior turn could not
+  // compute a fresh totalTokens snapshot (set in session-store.ts:253,280),
+  // the value is explicitly known-stale and consumers must refuse to use it
+  // for context-utilization gates. Matches the pattern in status-message.ts:
+  // 689-694 and sessions.ts:430-431 (#817).
+  const freshTotalTokens = resolveFreshSessionTotalTokens(params.entry);
+  if (freshTotalTokens === undefined) {
+    return null;
+  }
+  // Resolve the context-window denominator via the canonical pipeline
+  // (session-entry → cfg/provider/model lookup) instead of a hardcoded 200K
+  // fallback. The 200K hardcode misreports utilization on 100K context
+  // models (under-fire) and 1M context models (over-fire). No other
+  // production caller in the codebase uses a ?? 200_000 shortcut here;
+  // they all route through resolveContextTokensForModel /
+  // resolveContextWindowInfo (#817).
+  const sessionWindow = params.entry?.contextTokens;
+  const contextWindow =
+    sessionWindow ??
+    resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: params.model,
+      allowAsyncLoad: false,
+    });
+  if (typeof contextWindow !== "number" || contextWindow <= 0) {
+    return null;
+  }
+  return freshTotalTokens / contextWindow;
 }
 
 type AgentTurnTimingSpan = {
@@ -2420,15 +2467,13 @@ export async function runAgentTurnWithFallback(params: {
                       runtimeConfig?.agents?.defaults?.continuation?.enabled === true
                         ? {
                             sessionId: params.followupRun.run.sessionId,
-                            getContextUsage: () => {
-                              const entry = params.getActiveSessionEntry();
-                              const totalTokens =
-                                (entry as { totalTokens?: number } | undefined)?.totalTokens ?? 0;
-                              const contextWindow =
-                                (entry as { contextTokens?: number } | undefined)?.contextTokens ??
-                                200_000;
-                              return contextWindow > 0 ? totalTokens / contextWindow : 0;
-                            },
+                            getContextUsage: () =>
+                              computeRequestCompactionContextUsage({
+                                entry: params.getActiveSessionEntry(),
+                                cfg: params.followupRun.run.config,
+                                provider,
+                                model,
+                              }),
                             triggerCompaction: async (request) => {
                               attemptCompactionTraceparent = request.traceparent;
                               try {


### PR DESCRIPTION
## Summary

The `getContextUsage` closure passed to `request_compaction` in `src/auto-reply/reply/agent-runner-execution.ts:2404-2412` (before this change) had **two axis-distinct bugs** that both feed into the `MIN_CONTEXT_THRESHOLD = 0.7` gate at `src/agents/tools/request-compaction-tool.ts:208-228` and produce spurious compaction triggers or refusals on the non-200K context-window models in our model matrix.

### Axis (a) — `totalTokensFresh` flag ignored

The closure read `entry.totalTokens` without checking `entry.totalTokensFresh`. Every other consumer in the codebase that uses `totalTokens` for utilization gates **explicitly checks the freshness flag**:
- `src/status/status-message.ts:689-694`: `allowTranscriptContextUsage = entry?.totalTokensFresh !== false`
- `src/commands/sessions.ts:430-431`: same pattern

When `totalTokensFresh === false` (set in `src/agents/command/session-store.ts:253,280` when the prior turn could not compute a fresh snapshot), the value is **explicitly known-stale**, yet `MIN_CONTEXT_THRESHOLD` would treat it as authoritative and either fire or skip based on whichever stale number the entry happens to hold.

### Axis (b) — hardcoded 200K context-window fallback

The closure used `?? 200_000` as the denominator when `entry.contextTokens` was not yet populated (early/recovery states before `SessionEntry.contextTokens` is set at run start by `resolveContextWindowInfo`). Effect on non-200K models:
- **100K-context model**: 70K context → reports 35% used → **UNDER-fires** compaction
- **1M-context model**: 200K context → reports 100% used → **OVER-fires** compaction

**No other production caller uses a `?? 200_000` shortcut** — every other consumer routes through `resolveContextWindowInfo` (5+ call sites under `src/agents/`) which carries a properly-configured default per model.

## Fix shape

Extract `computeRequestCompactionContextUsage` sibling helper to `releaseQueuedCompactionCompletion` (`agent-runner-execution.ts:217+`), and reduce the closure call-site (`agent-runner-execution.ts:2451`) to a boring helper invocation. The helper:

1. **Uses the canonical `resolveFreshSessionTotalTokens`** (`src/config/sessions/types.ts:651`) which encapsulates "valid totalTokens AND fresh"; returns `undefined` for missing/invalid/stale. We map that `undefined` to `null`, which:
   - Matches the consumer's already-declared `getContextUsage: () => number | null` signature (`request-compaction-tool.ts:98`)
   - Triggers the explicit `[request_compaction:context-unknown]` rejection branch at `request-compaction-tool.ts:209` — distinct rejection code + operator-facing reason from the below-threshold case

2. **Resolves the context-window denominator via session-entry → cfg/provider/model** (using `resolveContextTokensForModel`, already imported at `agent-runner-execution.ts:27`, with `allowAsyncLoad: false` to keep the closure sync). Same `null`-rejection for unresolvable windows so the gate refuses rather than misfires.

The widened return type (`number` → `number | null`) **matches the consumer's already-declared signature**; the previous closure was strictly narrower than the consumer expected, so this change makes the producer side honor a contract that was always there.

## Scope alignment

This is **our PR's plumbing** — the `getContextUsage` closure + the `request_compaction` tool both live ONLY on PR #85651 (continuation-feature) substrate. Verified at byte: closure absent on `upstream/main`, present on PRH `fc337f05d643` lines 2365-2371 + cohort HEAD `0b7e6050ad` lines 2404-2412. The `totalTokensFresh` flag + `resolveContextTokensForModel` helper ARE pre-existing openclaw infra; we're just teaching our new closure to honor existing conventions instead of inventing a non-conformant shortcut. In-scope for the cure-cycle PR.

## Origin

Surfaced by frond-scribe scribe-class code-review-agent walk of PR #809 candidate `f426d9dbbf` at Discord byte `1510488947`. Not flagged by codex review or cael-opus-4.8 7-axis review. **Separate axis from codex-6 findings**: bounded-knowledge-class / freshness-flag-honoring vs the integration-completeness-gaps-from-per-file-extraction family.

## Diff

```
 src/auto-reply/reply/agent-runner-execution.context-usage.test.ts | 273 ++++++++++++++++++++
 src/auto-reply/reply/agent-runner-execution.ts                    |  63 +++++++++++++++++--
 2 files changed, 327 insertions(+), 9 deletions(-)
```

## Verification

**Behavior addressed**: `getContextUsage` closure ignoring `totalTokensFresh` freshness flag AND using a hardcoded 200K context-window fallback, causing the `request_compaction` MIN_CONTEXT_THRESHOLD gate to misfire (under-fire / over-fire / fire on stale snapshots) on any model whose real context window isn't 200K and on any session where the prior turn couldn't compute a fresh snapshot.

**Real environment tested**: local cohort cure-cycle worktree at HEAD `0b7e6050ad`, Node v25.9.0, pnpm v11.2.2 (per repo defaults).

**Exact steps or command run after this patch**:

```
pnpm install --frozen-lockfile
pnpm test src/auto-reply/reply/agent-runner-execution.context-usage.test.ts
pnpm test src/auto-reply/reply/agent-runner-execution.release-queued-compaction.test.ts
pnpm tsgo
pnpm check:test-types
pnpm check:changed
npx oxfmt --check src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.context-usage.test.ts
```

**Evidence after fix**:
- `pnpm test ...context-usage.test.ts` → Test Files 1 passed (1), Tests 15 passed (15)
- `pnpm test ...release-queued-compaction.test.ts` → Test Files 1 passed (1), Tests 8 passed (8) (no regression from the `resolveFreshSessionTotalTokens` import-add)
- `pnpm tsgo` → exit 0 (production typecheck clean)
- `pnpm check:test-types` → exit 0 (test typecheck clean)
- `pnpm check:changed` → exit 0 (lint + typecheck + import-cycles + guard-checks all green)
- `oxfmt --check` on touched files → "All matched files use the correct format."

**Observed result after fix**: The new 15-test `computeRequestCompactionContextUsage` test file passes across 4 describe blocks:

- freshness contract (axis a): 5 tests covering `totalTokensFresh === false`, `true`, `undefined`, `totalTokens` missing, `entry` undefined
- context-window resolution (axis b): 4 tests covering session-window-preference, model-resolution-fallback, undefined model-window, 0/negative model-window
- model-size matrix (anti-hardcode-200K): 4 table-driven cases — 100K (was under-fired), 200K (coincidentally-matches), 256K, 1M (was over-fired); all produce the correct ratio with the new pipeline
- signature contract: 2 tests anchoring the `number | null` return shape

**What was not tested**: full `pnpm test` suite (only the targeted colocated files fired); live `request_compaction` integration with a real provider on a non-200K-context model; `bash scripts/prepush-ci.sh` upstream-CI-mirror (Gate 3g) — that gate fires at the cure-cycle PR-presentation force-push window, not at PR-into-cure-cycle merge.

## References

- Issue: #817
- Cure-cycle PR (base): #809 — branch `uncurse/20260530/copilot-opus47-1m` at HEAD `0b7e6050ad`
- Sibling PR for #816: #820 (same surface family — `agent-runner-execution.ts` request_compaction plumbing — but axis-distinct fix)
- Cohort surface: Discord byte `1510488947` (initial finding) → `1510497896+` (figs scope-correction confirming in-PR scope)
