### PR TITLE
fix(ci-meta): update vitest-scoped-config assertion for continuation glob

### DIFF
--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -426,7 +426,10 @@ describe("scoped vitest configs", () => {
     expect(coreTestConfig.include).toEqual(["*.test.ts"]);
     expect(coreTestConfig.exclude).toContain("reply*.test.ts");
     expect(requireTestConfig(defaultAutoReplyTopLevelConfig).include).toEqual(["reply*.test.ts"]);
-    expect(requireTestConfig(defaultAutoReplyReplyConfig).include).toEqual(["reply/**/*.test.ts"]);
+    expect(requireTestConfig(defaultAutoReplyReplyConfig).include).toEqual([
+      "reply/**/*.test.ts",
+      "continuation/**/*.test.ts",
+    ]);
   });
 
   it("keeps the broad agents lane on shared file parallelism", () => {


### PR DESCRIPTION
Follow-up cure to PR #822: assertion in `test/vitest-scoped-config.test.ts` still expected the pre-#822 single-element `autoReplyReplySubtreeTestInclude` array. Updated to match the 2-element shape from #822.

Caught at byte by 🌫 silas CI-failure-disambiguation walk (Discord `1510519214`) classifying CI failures as (a) our-cure-incomplete vs (b) upstream-drift. This PR cures the (a) class. The (b) class (`normalize-reply.cot-frame.test.ts` 8 failures + `packages/memory-host-sdk/session-files.test.ts`) is upstream-drift, separate scope, not a merge-blocker.

**Diff**: 1 file, +4/-1 (`test/vitest-scoped-config.test.ts` only).

**Verified**: `pnpm vitest run test/vitest-scoped-config.test.ts` → 81/81 pass.

🩸