### PR TITLE
fix(ci-meta): regenerate tool-display snapshot for cure-cycle continuation tools

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -965,6 +965,30 @@
         "text",
         "channel"
       ]
+    },
+    "continue_delegate": {
+      "emoji": "🔄",
+      "title": "Continue Delegate",
+      "detailKeys": [
+        "task",
+        "mode",
+        "delaySeconds"
+      ]
+    },
+    "continue_work": {
+      "emoji": "⏩",
+      "title": "Continue Work",
+      "detailKeys": [
+        "reason",
+        "delaySeconds"
+      ]
+    },
+    "request_compaction": {
+      "emoji": "📦",
+      "title": "Request Compaction",
+      "detailKeys": [
+        "reason"
+      ]
     }
   }
 }


### PR DESCRIPTION
Follow-up CI-meta cure caught by 🕯 emeric CI-failure-disambiguation walk (`1510520669`).

PRs #811 (continuation wire-up) + #819 (checkContextPressure) registered new continuation tools but the OpenClawKit Swift-side `tool-display.json` snapshot wasn't regenerated → `check-guards` CI failure.

**Diff**: 1 file, +24/-0 (`apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json` — auto-regenerated by `pnpm tool-display:write`).

**Verified**: `node --import tsx scripts/tool-display.ts --check` → 'tool-display snapshot is up to date'.

**Class**: (a) CI-meta-substrate-not-updated-with-cure-cycle-additions-class — same family as PR #822 cures, different axis (OpenClawKit-snapshot vs shard-plan/lint-allowlist/vitest-config).

Companion to PR #823 (vitest-scoped-config assertion follow-up). File-disjoint with all other cure-cycle PRs.

🩸