### PR TITLE
fix(continuation): break types↔targeting barrel-import-cycle (#824)

### DIFF
--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -11,7 +11,7 @@
 import type {
   ContinuationCrossSessionTargetingPolicy,
   ContinuationDelegateFanoutMode,
-} from "./targeting.js";
+} from "./targeting-pure.js";
 
 // ---------------------------------------------------------------------------
 // Continuation signals — parsed from response text or captured from tool calls


### PR DESCRIPTION
## Scope

Breaks the barrel-import-cycle introduced by #811 continuation-wire-up (`c271f84a51`) and surfaced by emeric byte-walk on `check-additional-runtime-topology-architecture` shard.

## Substrate

`madge` detected 1 cycle on cure-cycle HEAD `b52620b997`:
```
src/auto-reply/continuation/targeting.ts
-> src/auto-reply/continuation/types.ts
-> src/auto-reply/continuation/targeting.ts
```

Root cause: `types.ts:11-14` imported `ContinuationCrossSessionTargetingPolicy` + `ContinuationDelegateFanoutMode` from `./targeting.js` (a barrel re-export). Together with `targeting.ts`'s own runtime imports back into the continuation surface, this formed a cycle.

## Cure

Both types live in `./targeting-pure.js` (the pure-leaf module that `targeting.ts` itself re-exports from). Switch `types.ts` to import direct from the source-of-truth.

```diff
 import type {
   ContinuationCrossSessionTargetingPolicy,
   ContinuationDelegateFanoutMode,
-} from "./targeting.js";
+} from "./targeting-pure.js";
```

Zero behavior change — same types, shorter path, no runtime semantics shift.

## Verification

```
$ pnpm check:madge-import-cycles
Madge import cycle check: 0 cycle(s).

$ pnpm tsgo  → clean
```

Pre-fix: 1 cycle. Post-fix: 0 cycles.

## Cohort substrate

Per emeric byte-walk at `1510521xxx` identifying (b)-class regression on `check-additional-runtime-topology-architecture` shard. Build-substrate propagates upstream → cannot defer-post-GATES.

## Sub-7.X banking

**barrel-re-export-import-cycle-class** — when type `A` lives in pure-leaf module `L`, and barrel module `B` re-exports `A` from `L` while also importing runtime from consumers, importing `A` via `B` instead of `L` creates a cycle. Cure-discipline: import types from their source-of-truth leaf module, not from barrels that re-export them, especially when the barrel also pulls runtime from sibling modules.

## Closes

Part of cure-cycle Gate-4.5 readiness (`uncurse/20260530/copilot-opus47-1m`). Companion to PR #823 (vitest-scoped-config assertion) + upcoming OpenClawKit tool-display:write regen.

PR-into-cure-cycle pattern (matches #820/#821/#822 discipline).