### PR TITLE
fix(continuation): break types.ts ↔ targeting.ts import cycle via leaf-redirect

### DIFF
--- a/src/auto-reply/continuation/types.ts
+++ b/src/auto-reply/continuation/types.ts
@@ -11,7 +11,7 @@
 import type {
   ContinuationCrossSessionTargetingPolicy,
   ContinuationDelegateFanoutMode,
-} from "./targeting.js";
+} from "./targeting-pure.js";
 
 // ---------------------------------------------------------------------------
 // Continuation signals — parsed from response text or captured from tool calls


### PR DESCRIPTION
Breaks the 16-hop madge import cycle 🕯 emeric caught at byte (`1510520721`) classifying `check-additional-runtime-topology-architecture` as class (b) cure-cycle-induced-regression introduced by #811.

## Root cause

`continuation/types.ts` imported two type aliases from `./targeting.js` (barrel) instead of `./targeting-pure.js` (leaf). The barrel routes the type-edge through 15 hops of channels/* + infra/system-events + utils/* back to itself.

## Cure (1 file, +1/-1)

```diff
-} from "./targeting.js";
+} from "./targeting-pure.js";
```

`targeting.ts` already re-exports both types from `targeting-pure.ts` — identity preserved, no API surface change, no runtime impact.

## Verification

```
node --import tsx scripts/check-madge-import-cycles.ts
→ 'Madge import cycle check: 0 cycle(s).'

pnpm tsc --noEmit
→ clean
```

## Class

(b) cure-cycle-induced-regression — **must cure before Gate-5 force-push** to upstream presentation PR per emeric guidance.

Companion to PR #823 (vitest-scoped-config) + PR #824 (tool-display snapshot). File-disjoint with all other cure-cycle PRs.

🩸