### PR TITLE
fix(ci-meta): regenerate tool-display.json for continuation tools

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -965,6 +965,30 @@
         "text",
         "channel"
       ]
+    },
+    "continue_delegate": {
+      "emoji": "🔄",
+      "title": "Continue Delegate",
+      "detailKeys": [
+        "task",
+        "mode",
+        "delaySeconds"
+      ]
+    },
+    "continue_work": {
+      "emoji": "⏩",
+      "title": "Continue Work",
+      "detailKeys": [
+        "reason",
+        "delaySeconds"
+      ]
+    },
+    "request_compaction": {
+      "emoji": "📦",
+      "title": "Request Compaction",
+      "detailKeys": [
+        "reason"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Scope

Sister cure to PR #822 (CI-meta-substrate cure-cycle test additions). Different axis: OpenClawKit Swift-side tool-display snapshot regen.

## Substrate

Cure-cycle #811 + #819 added new continuation tools (`continue_work`, `continue_delegate`, `request_compaction`) to the tool registry. The OpenClawKit Swift-side `tool-display.json` snapshot wasn't regenerated → `pnpm check` `tool-display` sub-check fails:

```
tool-display snapshot is stale:
  apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
run: pnpm tool-display:write
```

## Cure

Mechanical: `pnpm tool-display:write` regenerates the snapshot. Adds 24 lines (3 new tool entries with emoji + title + detailKeys).

## Verification

```
$ pnpm check
[check] summary
   546ms  ok  conflict markers
   ...
   542ms  ok  tool display  ← previously failed
   ...
```

All check-gates green post-regen.

## Identified by

emeric byte-walk on `check-guards` shard at `1510521xxx`.

## Sub-7.X banking

**tool-display-snapshot-not-regenerated-after-tool-registrations-class** — when cure-cycle adds new tools to the registry, the OpenClawKit Swift-side display snapshot needs concurrent regen via `pnpm tool-display:write`. Sister to `ci-meta-substrate-not-updated-with-cure-cycle-test-additions-class` (covered by #822).

## Cohort substrate

Part of cure-cycle Gate-4.5 readiness (`uncurse/20260530/copilot-opus47-1m`). Companion to PR #823 (vitest-scoped-config assertion) + PR #825 (barrel-import-cycle).

PR-into-cure-cycle pattern.