### PR TITLE
fix(continuation): restore hasCotFramePrefix suppression in normalize-reply (#828)

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -13,6 +13,7 @@ import {
   stripSilentToken,
 } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
+import { hasCotFramePrefix } from "./cot-frame.js";
 import {
   resolveResponsePrefixTemplate,
   type ResponsePrefixContext,
@@ -80,6 +81,20 @@ export function normalizeReplyPayload(
   }
   if (text && !trimmed) {
     // Keep empty text when media exists so media-only replies still send.
+    text = "";
+  }
+
+  // Treat bracketed internal narration frames as silent so they never reach
+  // end users. This mirrors NO_REPLY semantics for fully silent payloads.
+  // (Restored after upstream refactor 00d8d7ead0 removed this block; our
+  // continuation feature still needs CoT-frame suppression for internal
+  // narration emitted by heartbeat / continuation pathways.)
+  if (text && hasCotFramePrefix(text)) {
+    if (!hasContent("")) {
+      opts.onSkip?.("silent");
+      return null;
+    }
+    // Media-only fallback: drop the leaked text but let media still send.
     text = "";
   }
 


### PR DESCRIPTION
## Scope

Restores the `hasCotFramePrefix` suppression block in `normalize-reply.ts` after upstream refactor `00d8d7ead0` removed it.

## Substrate

8 cot-frame tests added by `f426d9dbbf` (`test(continuation): coverage`) fail on cure-cycle HEAD `e6b6b48150`:

```
src/auto-reply/reply/normalize-reply.cot-frame.test.ts
  ✗ suppresses error-flagged CoT-frame payloads as silent too
  ✗ [and 7 other CoT-frame suppression assertions]
   8/12 tests FAIL
```

**Root cause**: upstream `00d8d7ead0 refactor: extract normalization core package` removed the suppression block as orthogonal cleanup. Cure-cycle inherits the refactor via PRH-base-advance; tests detect the missing behavior.

## Cure

Restore the 16-line block + `hasCotFramePrefix` import:

```diff
 import type { ReplyPayload } from "../types.js";
+import { hasCotFramePrefix } from "./cot-frame.js";
 ...
 if (text && !trimmed) {
   text = "";
 }
+
+// Treat bracketed internal narration frames as silent so they never reach
+// end users. This mirrors NO_REPLY semantics for fully silent payloads.
+if (text && hasCotFramePrefix(text)) {
+  if (!hasContent("")) {
+    opts.onSkip?.("silent");
+    return null;
+  }
+  text = "";
+}
```

## Why restore rather than delete tests

Our continuation feature emits bracketed internal-narration frames via heartbeat + continuation pathways (e.g. `[internal] reasoning narration`). These must never reach end users — same NO_REPLY semantics as fully silent payloads. Upstream refactor removed the suppression likely without awareness of the continuation feature's dependency.

Forward-port restores the feature dependency in our substrate rather than weakening the contract by deleting tests.

## Verification

```
$ pnpm vitest run src/auto-reply/reply/normalize-reply.cot-frame.test.ts
 ✓ ../../src/auto-reply/reply/normalize-reply.cot-frame.test.ts (12 tests) 5ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Pre-fix: 8/12 FAIL. Post-fix: 12/12 PASS.

## Sub-7.X banking

**upstream-refactor-removed-feature-dependency-class** — when a feature has dependencies on upstream behavior that upstream then removes as orthogonal cleanup, the feature's tests detect the regression but the cure is forward-port (restore the dependency in our substrate, not delete the tests).

## Cohort substrate

Identified via cohort byte-walk: silas `1510519243` flagged 8 cot-frame failures; elliott `1510524875` byte-walked + retracted upstream-drift classification; cael `1510523470` correctly identified file as cure-cycle-feature-coverage; ronan `1510527050` traced root-cause to upstream `00d8d7ead0` refactor.

Companion to PR #823 + #824 + #826 (all merged). Last pre-Gate-5 follow-up cure for cure-cycle internal-cleanliness on `uncurse/20260530/copilot-opus47-1m`.

PR-into-cure-cycle pattern (matches #820/#821/#822/#823/#824/#826 discipline).