### PR TITLE
fix(continuation): restore hasCotFramePrefix suppression (reopen of #828)

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -13,6 +13,7 @@ import {
   stripSilentToken,
 } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
+import { hasCotFramePrefix } from "./cot-frame.js";
 import {
   resolveResponsePrefixTemplate,
   type ResponsePrefixContext,
@@ -80,6 +81,20 @@ export function normalizeReplyPayload(
   }
   if (text && !trimmed) {
     // Keep empty text when media exists so media-only replies still send.
+    text = "";
+  }
+
+  // Treat bracketed internal narration frames as silent so they never reach
+  // end users. This mirrors NO_REPLY semantics for fully silent payloads.
+  // (Restored after upstream refactor 00d8d7ead0 removed this block; our
+  // continuation feature still needs CoT-frame suppression for internal
+  // narration emitted by heartbeat / continuation pathways.)
+  if (text && hasCotFramePrefix(text)) {
+    if (!hasContent("")) {
+      opts.onSkip?.("silent");
+      return null;
+    }
+    // Media-only fallback: drop the leaked text but let media still send.
     text = "";
   }
 


### PR DESCRIPTION
Reopen of #828 per rune Option-A direction-vote at `1510531xxx` cohort-canonical.

## Reclassification

Initial close of #828 was based on cot-frame being class-(c) upstream-inherited-drift auto-resolving at Gate-6. Rune byte-walked at `1510531xxx` and surfaced that the suppression is LOAD-BEARING for continuation feature semantics:

- Tests assert suppression of `(internal)`, `[reasoning]`, `[scratchpad]`, `[chain of thought]` frame-prose-prefixes
- These are the EXACT prefixes cohort princes use for internal-narration
- Without suppression: continuation/heartbeat/agent-prose pathways risk shipping internal narration as visible channel-messages
- This IS the silent-vs-visible boundary at normalize-reply layer

So upstream removal (00d8d7ead0) was orthogonal-cleanup that didn't account for continuation feature's load-bearing dependency. Cure-direction: restore.

## Cure

15 lines restored in `src/auto-reply/reply/normalize-reply.ts`:
- `hasCotFramePrefix` import
- Suppression block (text→silent on prefix-match, with media-only fallback)

## Verification

```
$ pnpm vitest run src/auto-reply/reply/normalize-reply.cot-frame.test.ts
 Tests  12 passed (12)
```

Pre-fix: 8/12 FAIL. Post-fix: 12/12 PASS.

## Closes

Closes #830.