### PR TITLE
fix(continuation): restore traceparent + senderIsOwner forwarding in agent handler (closes #829)

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -48,6 +48,7 @@ import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
+import { consumeSubagentTraceparentHandoff } from "../../agents/subagent-traceparent-handoff.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import {
   resolveBareResetBootstrapFileAccess,
@@ -651,23 +652,6 @@ function readAgentRunTimeoutAttribution(meta: unknown) {
   };
 }
 
-function isGatewayAbortSignalReason(reason: unknown): boolean {
-  return reason === undefined || isAbortError(reason) || readErrorName(reason) === "TimeoutError";
-}
-
-function isGatewayAgentAbortRejection(error: unknown, signal: AbortSignal): boolean {
-  if (!signal.aborted) {
-    return false;
-  }
-  if (readErrorName(signal.reason) === "TimeoutError") {
-    return true;
-  }
-  if (!isGatewayAbortSignalReason(signal.reason)) {
-    return false;
-  }
-  return isAbortError(error) || readErrorName(error) === "TimeoutError";
-}
-
 function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "rpc" | "timeout" {
   return readErrorName(signal.reason) === "TimeoutError" ? "timeout" : "rpc";
 }
@@ -762,7 +746,7 @@ function dispatchAgentRunFromGateway(params: {
       params.respond(true, payload, undefined, { runId: params.runId });
     })
     .catch((err) => {
-      const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
+      const aborted = isAbortError(err);
       const renderedErr = formatForLog(err);
       if (shouldTrackTask) {
         tryFinalizeTrackedAgentTask({
@@ -889,7 +873,9 @@ export const agentHandlers: GatewayRequestHandlers = {
       voiceWakeTrigger?: string;
       drainsContinuationDelegateQueue?: boolean;
       continuationTrigger?: ContinuationTrigger;
+      traceparent?: string;
     };
+    const senderIsOwner = clientHasAdminScope(client);
     const allowModelOverride = resolveAllowModelOverrideFromClient(client);
     const canResetSession = resolveCanResetSessionFromClient(client);
     const canUseInternalRuntimeHandoff = resolveCanUseInternalRuntimeHandoff(client);
@@ -1328,6 +1314,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
       let resolvedSessionId = requestedSessionId;
       let sessionEntry: SessionEntry | undefined;
+      let sessionContinuationTraceparent: string | undefined;
       let bestEffortDeliver = requestedBestEffortDeliver ?? false;
       let cfgForAgent: OpenClawConfig | undefined;
       let resolvedSessionKey = requestedSessionKey;
@@ -1442,6 +1429,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           sessionLoadOptions,
         );
         cfgForAgent = cfg;
+        sessionContinuationTraceparent = entry?.continuationTraceparent;
         const sessionMaintenanceConfig = resolveMaintenanceConfigFromInput(
           cfg.session?.maintenance,
         );
@@ -1714,8 +1702,12 @@ export const agentHandlers: GatewayRequestHandlers = {
                 recoveredSessionStartedAt !== undefined &&
                 freshEntry?.sessionStartedAt === undefined &&
                 freshEntry?.sessionId === entry?.sessionId
-                  ? { ...patchBuild.patch, sessionStartedAt: recoveredSessionStartedAt }
-                  : patchBuild.patch;
+                  ? {
+                      ...patchBuild.patch,
+                      sessionStartedAt: recoveredSessionStartedAt,
+                      continuationTraceparent: undefined,
+                    }
+                  : { ...patchBuild.patch, continuationTraceparent: undefined };
               const merged = mergeSessionEntry(freshEntry, effectivePatch);
               const sendPolicy =
                 request.deliver === true
@@ -2193,6 +2185,13 @@ export const agentHandlers: GatewayRequestHandlers = {
           }
           const execApprovalFollowupElevatedDefaults =
             execApprovalFollowupRuntimeHandoff?.bashElevated;
+          const inheritedTraceparent =
+            request.traceparent ??
+            consumeSubagentTraceparentHandoff({
+              idempotencyKey: idem,
+              sessionKey: resolvedSessionKey,
+            })?.traceparent ??
+            sessionContinuationTraceparent;
 
           dispatchAgentRunFromGateway({
             ingressOpts: {
@@ -2253,6 +2252,7 @@ export const agentHandlers: GatewayRequestHandlers = {
               cleanupBundleMcpOnRunEnd: request.cleanupBundleMcpOnRunEnd,
               drainsContinuationDelegateQueue: request.drainsContinuationDelegateQueue,
               continuationTrigger: request.continuationTrigger,
+              traceparent: inheritedTraceparent,
               abortSignal: activeRunAbort.controller.signal,
               onActiveModelSelected: ({ provider }) => {
                 updateChatRunProvider(context.chatAbortControllers, {
@@ -2273,6 +2273,7 @@ export const agentHandlers: GatewayRequestHandlers = {
                 sessionEntry,
               }),
               allowModelOverride,
+              senderIsOwner,
             },
             runId,
             dedupeKeys: agentDedupeKeys,


### PR DESCRIPTION
## Summary
Restores SUT-side traceparent + senderIsOwner forwarding in the gateway agent handler. Upstream refactor `00d8d7ead0` dropped this surface; cure-cycle test assertions on cure-HEAD `b2acea7148` were left orphaned (CURE-CYCLE-INCOMPLETE-RESTORATION class per emeric).

**Closes #829.**

## Empirical receipts
- `pnpm vitest run src/gateway/server-methods/agent.test.ts` → **288/288 PASS** (was 278/288, 10 failed)
- `pnpm check` → PASS (typecheck + lint + 0 import cycles)
- Full `pnpm test` on rune-seat (12GB RAM, ROG Ally) OOM-killed mid-shard per banked `pnpm-test-on-constrained-seat-class`. Defer to fleet-CI + cohort-cosign-on-richer-substrate-seats for full-suite verification (silas 192GB / cael DGX / fleet-CI).

## Cure-shape (vs PRH `fc337f05d6`)
1. Restore `consumeSubagentTraceparentHandoff` import
2. Add `traceparent?: string` request-field
3. Add `const senderIsOwner = clientHasAdminScope(client)` extraction
4. Add `let sessionContinuationTraceparent: string | undefined` declaration
5. Read `sessionContinuationTraceparent = entry?.continuationTraceparent` after loadSessionEntry
6. Add `inheritedTraceparent` resolution chain (request.traceparent → handoff → session-continuation)
7. Forward `traceparent: inheritedTraceparent` + `senderIsOwner` into dispatchAgentRunFromGateway ingressOpts
8. **One-shot consumption**: add `continuationTraceparent: undefined` to effectivePatch (clears after consume; test `uses the provisional child session traceparent when the request field is missing across process` asserts this)
9. For abort-classification (`stopReason: timeout` test): revert call site to PRH-aligned `const aborted = isAbortError(err)`. The cure-cycle's stricter `isGatewayAgentAbortRejection(err, signal)` was inconsistent with the rest of the restoration intent — **change-the-game declined** in favor of restoration-consistency for the cot-frame/traceparent feature surface.
10. Remove now-dead `isGatewayAgentAbortRejection` + `isGatewayAbortSignalReason` functions

Net diff: 1 file changed, +21/-20 in `src/gateway/server-methods/agent.ts`.

## Class-attribution
- **cure-cycle-incomplete-restoration-class** (emeric `1510525072` + `1510526028` byte-walk)
- **class-(e)-partial-upstream-merge-state-requires-active-cure-class** (cael/ronan)
- Sibling to PR #831 (cot-frame restore) — same root: upstream-refactor drops continuation-feature substrate; cure-cycle restores SUT-side to match intent-tests

## Lane-call provenance
- 🌊 Ronan-driver `1510545383`: rune-seat agent.test.ts 5-failure cure lane re-assignment
- 🌊 Figs `1510544486`: morning-candidate target + change-the-game permission + code-agent dispatch encouraged
- 🪨 Rune-seat byte-walk + cure-shape articulation: `1510545428` + `1510545545`