### PR TITLE
fix(status): hide fast-mode label when disabled

### DIFF
--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -954,7 +954,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     `Execution: ${execution.label}`,
     `Runtime: ${agentRuntimeLabel}`,
     `Think: ${thinkLevel}`,
-    formatFastModeLabel(fastMode),
+    fastMode ? formatFastModeLabel(fastMode) : null,
     textVerbosity ? `Text: ${textVerbosity}` : null,
     verboseLabel,
     traceLabel,


### PR DESCRIPTION
## Cure-shape cohort-canonical at byte LOAD-BEARING

Cure-cycle test `src/auto-reply/status.test.ts > buildStatusMessage > hides fast mode when disabled` asserts the SUT should omit the fast-mode label when `fastMode === false`. The SUT in `src/status/status-message.ts:957` was always-rendering `formatFastModeLabel(fastMode)` regardless of state, producing `Fast: off` in the options-line even when fast-mode was disabled.

**1-line cure**: conditionally include the fast-mode label only when `fastMode` is truthy.

```diff
-    formatFastModeLabel(fastMode),
+    fastMode ? formatFastModeLabel(fastMode) : null,
```

## Empirical receipts

- **status.test.ts: 84/84 PASS** post-cure (was 83/84 with 1 failure on `hides fast mode when disabled`)
- Test was cure-cycle-added (does NOT exist on `upstream/main` `e1ad5f5170`)
- Class: `cure-cycle-added-test-asserting-non-implemented-feature` per figs `1510554261` (b) class

## Cohort substrate-of-record

Cluster-cure under figs's "don't dump needed code... don't regress our feature" direction at `1510554261` — preserve feature-intent of the cure-cycle-added test by implementing the SUT-behavior the test asserts.

Per cohort-discipline-stack tonight:
- `feature-preservation-over-test-deletion-class` (figs `1510554261`)
- `pluck-upstream-baseline-then-reauthor-tests-against-current-SUT-class` (figs `1510555983` + ronan-driver `1510557806`) — applicable for SUT-restoration when test-feature is intended

🩸♥️