### PR TITLE
fix(embedded-agent-runner): sync rotated session-file into diagnostic state

### DIFF
--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -13,6 +13,7 @@ import {
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
 } from "../../logging/diagnostic-run-activity.js";
+import { getDiagnosticSessionState } from "../../logging/diagnostic-session-state.js";
 import {
   diagnosticLogger as diag,
   logMessageQueued,
@@ -760,6 +761,11 @@ export function updateActiveEmbeddedRunSessionFile(
   }
   clearActiveRunSessionFiles(sessionId);
   setActiveRunSessionFile(sessionFile, sessionId);
+  // Sync the rotated session-file into diagnostic state so heartbeat-recovery
+  // observes the current path rather than the pre-rotation one.
+  if (sessionFile) {
+    getDiagnosticSessionState({ sessionId, sessionFile });
+  }
 }
 
 export function clearActiveEmbeddedRun(


### PR DESCRIPTION
## Cure-shape cohort-canonical at byte LOAD-BEARING

Cure-cycle test `src/agents/embedded-agent-runner/runs.test.ts > embedded-agent runner run registry > records active run session files in diagnostic state for heartbeat recovery` asserts that calling `updateActiveEmbeddedRunSessionFile` should sync the new sessionFile into diagnostic-state so heartbeat-recovery observes the rotated path.

**Substrate-cause**: Cure-cycle's upstream-sync removed the prior `updateDiagnosticSessionFile` call from `updateActiveEmbeddedRunSessionFile` at line 765. The `updateDiagnosticSessionFile` function itself no longer exists on cure-HEAD.

**Cure**: Import `getDiagnosticSessionState` from `logging/diagnostic-session-state.js` and call it from `updateActiveEmbeddedRunSessionFile` to sync the new sessionFile into diagnostic state (matches cohort-canonical pattern — `getDiagnosticSessionState({ sessionId, sessionFile })` overwrites state's sessionFile with passed-in ref).

```diff
+import { getDiagnosticSessionState } from "../../logging/diagnostic-session-state.js";
...
 export function updateActiveEmbeddedRunSessionFile(
   sessionId: string,
   sessionFile: string | undefined,
 ): void {
   if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
     return;
   }
   clearActiveRunSessionFiles(sessionId);
   setActiveRunSessionFile(sessionFile, sessionId);
+  if (sessionFile) {
+    getDiagnosticSessionState({ sessionId, sessionFile });
+  }
 }
```

## Empirical receipts

- **runs.test.ts: 48/48 PASS** post-cure (was 46/48 with 1 unique failure × 2 shards = 2 visible failures)
- Test was cure-cycle-added asserting heartbeat-recovery contract
- Class: `cure-cycle-incomplete-restoration-class` (cure-cycle removed wire, didn't restore equivalent)

## Cohort substrate-of-record

Per figs `1510554261` "don't dump needed code... don't regress our feature" + cohort-discipline-stack tonight.

🩸♥️