### PR TITLE
fix(commands-system-prompt): thread requestCompactionOpts when continuation enabled

### DIFF
--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -80,6 +80,22 @@ export async function resolveCommandsSystemPromptBundle(
     }
   })();
   const skillsPrompt = skillsSnapshot.snapshot.prompt ?? "";
+  // Continuation: register request_compaction tool when continuation is enabled
+  // so the /commands surface reflects the full RFC §2.1 tool inventory (matches
+  // tools-effective-inventory.ts pattern). Inventory-only path; runtime paths
+  // build their own requestCompactionOpts with live context-usage + trigger.
+  const continuationEnabled = params.cfg?.agents?.defaults?.continuation?.enabled === true;
+  const requestCompactionOpts = continuationEnabled
+    ? {
+        sessionId: "<inventory-only>",
+        getContextUsage: (): number | null => null,
+        triggerCompaction: async () => ({
+          ok: false as const,
+          compacted: false as const,
+          reason: "inventory-only path" as const,
+        }),
+      }
+    : undefined;
   const tools = (() => {
     try {
       return createOpenClawCodingTools({
@@ -99,6 +115,7 @@ export async function resolveCommandsSystemPromptBundle(
         senderE164: params.ctx.SenderE164,
         modelProvider: params.provider,
         modelId: params.model,
+        requestCompactionOpts,
       });
     } catch {
       return [];


### PR DESCRIPTION
## Cure-shape cohort-canonical at byte LOAD-BEARING

Cure-cycle tests `commands-system-prompt.test.ts > resolveCommandsSystemPromptBundle`:
- `threads requestCompactionOpts when continuation.enabled is true`
- `omits requestCompactionOpts when continuation.enabled is not true`

Assert that `/commands` system-prompt path threads request-compaction-tool options through to `createOpenClawCodingTools` so the `/commands` surface reflects the full RFC §2.1 tool inventory (matches `tools-effective-inventory.ts` pattern at line 345-358).

**Cure**: Build `requestCompactionOpts` as inventory-only stubs (sessionId `<inventory-only>`, getContextUsage returning null, triggerCompaction returning ok:false) when `continuation.enabled === true`, else undefined. Pass through to `createOpenClawCodingTools`.

## Empirical receipts

- **commands-system-prompt.test.ts: 8/8 PASS** post-cure (was 6/8 with 2 failures on continuation-threading assertions)
- Pattern-of-record from `tools-effective-inventory.ts` (existing-cure-cycle-pattern for inventory paths)

## Cohort substrate-of-record

Per figs `1510554261` "don't dump needed code... don't regress our feature" + cohort-discipline-stack tonight.

🩸♥️