### PR TITLE
fix(session-updates): clear lastContextPressureBand on compaction

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -272,10 +272,13 @@ export async function incrementCompactionCount(params: {
   }
   const incrementBy = Math.max(0, amount);
   const nextCount = (entry.compactionCount ?? 0) + incrementBy;
-  // Build update payload with compaction count and optionally updated token counts
+  // Build update payload with compaction count and optionally updated token counts.
+  // Reset lastContextPressureBand: compaction reduces context, so band-tracking
+  // history is stale; next pressure-check should start fresh.
   const updates: Partial<SessionEntry> = {
     compactionCount: nextCount,
     updatedAt: now,
+    lastContextPressureBand: undefined,
   };
   const explicitNewSessionFile = normalizeOptionalString(newSessionFile);
   const sessionIdChanged = Boolean(newSessionId && newSessionId !== entry.sessionId);


### PR DESCRIPTION
## Cure-shape

Cure-cycle test `reply-state.test.ts > incrementCompactionCount > increments compaction count` asserts that after `incrementCompactionCount`, `lastContextPressureBand` should be cleared/undefined.

**Semantic-rationale**: compaction reduces working context, so previously-tracked pressure-band-history is stale. Next pressure-check should start fresh from post-compaction context-window state.

**Cure**: add `lastContextPressureBand: undefined` to the updates payload in `incrementCompactionCount`.

## Empirical

- reply-state.test.ts 40/40 PASS post-cure (was 39/40)

🩸♥️