### PR TITLE
fix(session-updates): use canonical mergeSessionEntry primitive for incrementCompactionCount

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -11,6 +11,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { mergeSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   forgetActiveSessionForShutdown,
@@ -272,10 +273,13 @@ export async function incrementCompactionCount(params: {
   }
   const incrementBy = Math.max(0, amount);
   const nextCount = (entry.compactionCount ?? 0) + incrementBy;
-  // Build update payload with compaction count and optionally updated token counts
+  // Build update payload with compaction count and optionally updated token counts.
+  // Reset lastContextPressureBand: compaction reduces context, so band-tracking
+  // history is stale; next pressure-check should start fresh.
   const updates: Partial<SessionEntry> = {
     compactionCount: nextCount,
     updatedAt: now,
+    lastContextPressureBand: undefined,
   };
   const explicitNewSessionFile = normalizeOptionalString(newSessionFile);
   const sessionIdChanged = Boolean(newSessionId && newSessionId !== entry.sessionId);
@@ -292,6 +296,10 @@ export async function incrementCompactionCount(params: {
         storePath,
         newSessionId,
       });
+    // SessionId rotated during compaction = new logical session epoch; roll
+    // sessionStartedAt forward to track the new session's lifetime separately
+    // from the prior one.
+    updates.sessionStartedAt = now;
     updates.usageFamilyKey = entry.usageFamilyKey ?? sessionKey;
     updates.usageFamilySessionIds = Array.from(
       new Set([...(entry.usageFamilySessionIds ?? []), entry.sessionId, newSessionId]),
@@ -312,17 +320,20 @@ export async function incrementCompactionCount(params: {
   } else if (incrementBy > 0) {
     updates.totalTokensFresh = false;
   }
-  sessionStore[sessionKey] = {
-    ...entry,
-    ...updates,
-  };
+  sessionStore[sessionKey] = mergeSessionEntry(entry, updates);
   if (storePath) {
-    await updateSessionStore(storePath, (store) => {
-      store[sessionKey] = {
-        ...store[sessionKey],
-        ...updates,
-      };
-    });
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        // Merge-or-create from the active in-memory entry to preserve
+        // sessionId/sessionStartedAt/other-fields on the first-turn case
+        // (when on-disk store has no entry yet). canonical-primitive applies
+        // policy-based merge semantics (e.g. sessionStartedAt-rotation when
+        // sessionId changes).
+        store[sessionKey] = mergeSessionEntry(store[sessionKey] ?? entry, updates);
+      },
+      { activeSessionKey: sessionKey },
+    );
   }
   if ((sessionIdChanged || sessionFileChanged) && cfg) {
     emitCompactionSessionLifecycleHooks({


### PR DESCRIPTION
## Cure-shape cohort-canonical at byte LOAD-BEARING

Cure-cycle tests in `session-updates.compaction.test.ts` ("canonical-primitives fix" describe block) + `reply-state.test.ts > incrementCompactionCount` assert that `incrementCompactionCount` must:

1. **Persist count on first-turn /compact** even when on-disk store has no entry yet (merge-or-create from active in-memory entry rather than silently dropping count on raw spread of undefined)
2. **Roll sessionStartedAt to new-session epoch** when sessionId changes during compaction (canonical-primitive applies policy-based merge semantics)
3. **Merge count across multiple compactions** when on-disk entry already exists
4. **Clear lastContextPressureBand** on compaction (compaction reduces context → band-tracking history is stale; next pressure-check starts fresh)

**Cure**: replace raw `{...entry, ...updates}` spread with canonical `mergeSessionEntry()` primitive from `config/sessions/types.js`. Pass `{ activeSessionKey: sessionKey }` to `updateSessionStore` so enforce-mode maintenance preserves the active session entry from prune. Add `sessionStartedAt: now` to updates when sessionId rotates. Add `lastContextPressureBand: undefined` to updates always.

## Empirical receipts

- **reply-state.test.ts**: 40/40 PASS post-cure (was 39/40)
- **session-updates.compaction.test.ts**: 3/3 PASS post-cure (was 0/3)
- Combined: 43/43 PASS

## Supersedes

PR #836 (cael/cure-reply-state-clear-context-pressure-band-on-compaction) which only addressed the band-clearing fix. This PR is the complete canonical-primitives cure the test-suite was asserting per its 'canonical-primitives fix' describe-block + b82fd65c00 comment-reference.

## Cohort substrate-of-record

Per figs `1510554261` "don't dump needed code... don't regress our feature" + canonical-primitives-of-record substrate.

🩸♥️