### PR TITLE
fix(artifacts): exclude checkpoint transcripts from usage-counted classification

### DIFF
--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -112,9 +112,6 @@ export function isUsageCountedSessionTranscriptFileName(fileName: string): boole
   if (isPrimarySessionTranscriptFileName(fileName)) {
     return true;
   }
-  if (isCheckpointSessionTranscriptFileName(fileName)) {
-    return true;
-  }
   return hasArchiveSuffix(fileName, "reset") || hasArchiveSuffix(fileName, "deleted");
 }
 
@@ -145,10 +142,6 @@ export function parseParentSessionIdFromCheckpointFileName(fileName: string): st
 export function parseUsageCountedSessionIdFromFileName(fileName: string): string | null {
   if (isPrimarySessionTranscriptFileName(fileName)) {
     return fileName.slice(0, -".jsonl".length);
-  }
-  const checkpointParentId = parseParentSessionIdFromCheckpointFileName(fileName);
-  if (checkpointParentId) {
-    return checkpointParentId;
   }
   for (const reason of ["reset", "deleted"] as const) {
     const marker = `.jsonl.${reason}.`;


### PR DESCRIPTION
## Cure-shape

Cure-cycle tests assert that compaction-checkpoint transcript files (`.checkpoint.<uuid>.jsonl`) should NOT be classified as usage-counted session transcripts.

**Tests asserting cure-direction**:
- `session-files.test.ts > listSessionFilesForAgent > includes reset and deleted transcripts in session file listing` (checkpoint excluded from list)
- `artifacts.test.ts > classifies usage-counted transcript files` (checkpoint returns `false`)
- `artifacts.test.ts > parses usage-counted session ids from file names` (checkpoint returns `null`)

**Cure**: Remove cure-cycle-added checkpoint-handling from `isUsageCountedSessionTranscriptFileName` + `parseUsageCountedSessionIdFromFileName`. Checkpoints remain accessible via dedicated `isCheckpointSessionTranscriptFileName` + `parseCompactionCheckpointTranscriptFileName` predicates for callers that need checkpoint-classification (e.g. dreaming-narrative subsystem).

## Empirical

- session-files.test.ts: 11/11 PASS post-cure (was 10/11)
- artifacts.test.ts: 9/9 PASS post-cure (was 7/9 with 2 failures)

🩸♥️