### PR TITLE
fix(codex-ext): complete provider-test mock + auth-bridge accept codex-cli alias

### DIFF
--- a/extensions/codex/provider.test.ts
+++ b/extensions/codex/provider.test.ts
@@ -26,6 +26,8 @@ function createFakeCodexClient(): CodexAppServerClient {
     initialize: vi.fn(async () => undefined),
     request: vi.fn(async () => ({ data: [] })),
     addCloseHandler: vi.fn(() => () => undefined),
+    setActiveSharedLeaseCountProviderForUnscopedNotifications: vi.fn(),
+    getActiveSharedLeaseCountForUnscopedNotifications: vi.fn(() => undefined),
     close: vi.fn(),
   } as unknown as CodexAppServerClient;
 }

--- a/src/agents/provider-auth-aliases.ts
+++ b/src/agents/provider-auth-aliases.ts
@@ -27,6 +27,7 @@ type ProviderAuthAliasCandidate = {
 
 const RETIRED_PROVIDER_AUTH_ALIASES: Readonly<Record<string, string>> = {
   [["openai", "codex"].join("-")]: "openai",
+  [["codex", "cli"].join("-")]: "openai",
 };
 
 const PROVIDER_AUTH_ALIAS_ORIGIN_PRIORITY: Readonly<Record<PluginOrigin, number>> = {


### PR DESCRIPTION
## Cure-shape

**Cures 3 codex-ext failures across 2 files**:

1. **provider.test.ts**: `createFakeCodexClient()` missing `setActiveSharedLeaseCountProviderForUnscopedNotifications` mock-stub; SUT calls it via shared-client wiring path. Cure: add missing method-stubs as no-op vi.fn() mocks.

2. **auth-bridge.test.ts × 2**: Tests use `provider: "codex-cli"` as legacy-alias; SUT rejected because not in `RETIRED_PROVIDER_AUTH_ALIASES`. Cure: add `codex-cli` → `openai` mapping (matches existing `openai-codex` → `openai` pattern).

## Empirical

- provider.test.ts: 16/16 PASS post-cure (was 15/16)
- auth-bridge.test.ts: 43/43 PASS post-cure (was 41/43)

🩸♥️