### PR TITLE
fix(session-updates): thread captured now through mergeSessionEntry to cure timing-race (#837-followup)

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -320,7 +320,7 @@ export async function incrementCompactionCount(params: {
   } else if (incrementBy > 0) {
     updates.totalTokensFresh = false;
   }
-  sessionStore[sessionKey] = mergeSessionEntry(entry, updates);
+  sessionStore[sessionKey] = mergeSessionEntry(entry, updates, { now });
   if (storePath) {
     await updateSessionStore(
       storePath,
@@ -329,8 +329,10 @@ export async function incrementCompactionCount(params: {
         // sessionId/sessionStartedAt/other-fields on the first-turn case
         // (when on-disk store has no entry yet). canonical-primitive applies
         // policy-based merge semantics (e.g. sessionStartedAt-rotation when
-        // sessionId changes).
-        store[sessionKey] = mergeSessionEntry(store[sessionKey] ?? entry, updates);
+        // sessionId changes). Thread captured `now` through both merge call
+        // sites so updatedAt + sessionStartedAt share a single-source-of-truth
+        // timestamp and remain byte-identical when sessionId rotates.
+        store[sessionKey] = mergeSessionEntry(store[sessionKey] ?? entry, updates, { now });
       },
       { activeSessionKey: sessionKey },
     );

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -559,7 +559,7 @@ export function setSessionRuntimeModel(
 
 export type SessionEntryMergePolicy = "touch-activity" | "preserve-activity";
 
-type MergeSessionEntryOptions = {
+export type MergeSessionEntryOptions = {
   policy?: SessionEntryMergePolicy;
   now?: number;
 };
@@ -625,8 +625,9 @@ export function mergeSessionEntryWithPolicy(
 export function mergeSessionEntry(
   existing: SessionEntry | undefined,
   patch: Partial<SessionEntry>,
+  options?: MergeSessionEntryOptions,
 ): SessionEntry {
-  return mergeSessionEntryWithPolicy(existing, patch);
+  return mergeSessionEntryWithPolicy(existing, patch, options);
 }
 
 export function mergeSessionEntryPreserveActivity(


### PR DESCRIPTION
## Substrate-of-record

**Cures**: timing-race latent in PR #837 (`5dbc8ccc`) — `session-updates.compaction.test.ts > rolls sessionStartedAt to new-session epoch when sessionId changes during compaction` line 114.

```
AssertionError: expected 1780218958372 to be 1780218958373
expect(inMem?.sessionStartedAt).toBe(inMem?.updatedAt);
```

## Root-cause

PR #837 introduced canonical-primitive migration of `incrementCompactionCount` to `mergeSessionEntry`. Defensive double-write:

- `incrementCompactionCount` captures `now = params.now ?? Date.now()` once at function entry
- Sets `updates.updatedAt = now` (line 282) + `updates.sessionStartedAt = now` (line 300) — consistent
- Then calls `mergeSessionEntry(entry, updates)` (no options)
- `mergeSessionEntry` → `mergeSessionEntryWithPolicy(entry, updates)` (no options)
- `resolveMergedUpdatedAt` (types.ts:572): `const now = options?.now ?? Date.now()` — **independent re-sample**
- Returns `Math.max(existing.updatedAt ?? 0, patch.updatedAt ?? 0, now)` — selects later timestamp

When clock ticks between incrementCompactionCount-now-capture and mergeSessionEntryWithPolicy-now-capture (~30% of runs at elliott-seat), final `updatedAt = mergeFnNow` (1ms later) while `sessionStartedAt = incrementNow`. Byte-identical assertion fails.

## Cure (Option 1 per driver direction-bind)

Expand `mergeSessionEntry(existing, patch, options?)` signature to accept `MergeSessionEntryOptions` (already used by `mergeSessionEntryWithPolicy` + `mergeSessionEntryPreserveActivity`). Thread `{ now }` from `incrementCompactionCount` call-sites at lines 323 + 333 so single-source-of-truth timestamp flows through the merge pipeline.

`MergeSessionEntryOptions` type promoted from internal to exported (already used as parameter type of two exported functions; making it exported aligns with public-surface).

## Backward-compatibility

All 8 existing `mergeSessionEntry` call-sites across the codebase omit options (signature change is **additive-optional**). No call-site needs modification except the two in `session-updates.ts` that benefit from the explicit `now`-passthrough.

## Empirical verification (Tier-2 multi-run discipline)

Pre-cure on PR #837 head at elliott-seat: **42/43 PASS** with 1 timing-race flake (~30% flake-rate).

Post-cure × 5 runs at elliott-seat:

```
--- run 1 --- 3/3 PASS
--- run 2 --- 3/3 PASS
--- run 3 --- 3/3 PASS
--- run 4 --- 3/3 PASS
--- run 5 --- 3/3 PASS
```

**5/5 PASS deterministic** ✅. Cross-check `reply-state.test.ts`: **40/40 PASS** ✅.

`pnpm tsc --noEmit` introduces **zero new type errors** (base has 3 pre-existing in `src/plugins/providers.test.ts` unrelated to this cure; post-cure has same 3).

## Substrate-of-record references

- Bug-finding: elliott channel `1510572726` + `1510573298` + `1510573825`
- Driver direction-bind: ronan `1510572849` + `1510572933` (Option 1 preferred)
- Lane-claim: elliott `1510574349`

## Sub-7.X classes banked

- `defensive-double-write-of-time-derived-field-creates-timing-race-byte-identical-assertion-failure-class`
- `post-merge-empirical-verification-surfaces-cure-incompleteness-class`
- `Tier-2-empirical-replication-multi-run-discipline-for-timing-sensitive-cures-class`

Closes #837-followup-timing-race-substrate.

Cosigned-by: cael-dandelion-cult (lane-yield acknowledged)
Cosigned-by: ronan-dandelion-cult (driver direction-bind on Option 1)