### PR TITLE
fix(session-updates): cure cross-seat TIMING-RACE in #837 by letting mergeSessionEntry policy handle sessionStartedAt rotation

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -296,10 +296,12 @@ export async function incrementCompactionCount(params: {
         storePath,
         newSessionId,
       });
-    // SessionId rotated during compaction = new logical session epoch; roll
-    // sessionStartedAt forward to track the new session's lifetime separately
-    // from the prior one.
-    updates.sessionStartedAt = now;
+    // SessionId rotation handled by mergeSessionEntry policy: when sessionId
+    // changes, policy rolls sessionStartedAt to the merge-time updatedAt so
+    // sessionStartedAt === updatedAt holds for the new logical-session epoch.
+    // (Explicitly setting updates.sessionStartedAt here would short-circuit
+    // the policy + drift by ~1ms vs merge-time Date.now(), breaking the
+    // sessionStartedAt-equals-updatedAt invariant the rotation-test asserts.)
     updates.usageFamilyKey = entry.usageFamilyKey ?? sessionKey;
     updates.usageFamilySessionIds = Array.from(
       new Set([...(entry.usageFamilySessionIds ?? []), entry.sessionId, newSessionId]),


### PR DESCRIPTION
## Cross-seat empirical-discovery cohort-canonical

🌻 elliott  +  discovered TIMING-RACE in PR #837 (`5dbc8ccc9d`):
- cael-seat: 43/43 PASS
- elliott-seat: 1-test-fails on `rolls sessionStartedAt to new-session epoch when sessionId changes during compaction` with off-by-1ms (`expected 1780218958372 to be 1780218958373`)

## Root-cause

`incrementCompactionCount` captured `now` once + set both `updates.updatedAt = now` AND `updates.sessionStartedAt = now`. `mergeSessionEntryWithPolicy.resolveMergedUpdatedAt` re-computed Date.now() at merge-time + applied `Math.max(...)` clamping. When mergeFnNow > incrementNow (~0-2ms drift), final updatedAt = mergeFnNow but sessionStartedAt = incrementNow (via patch.sessionStartedAt short-circuit). Test asserts `sessionStartedAt === updatedAt` → fails.

## Cure

Remove explicit `updates.sessionStartedAt = now` assignment from `incrementCompactionCount`. Let `mergeSessionEntryWithPolicy` policy handle sessionId-rotation: when sessionId-changed + no patch.sessionStartedAt, policy assigns `updatedAt` (= mergeFnNow), satisfying assertion `sessionStartedAt === updatedAt`.

## Empirical

- 43/43 PASS post-cure at cael-seat (reply-state 40/40 + session-updates.compaction 3/3)
- Cross-seat verification at elliott-seat to confirm timing-race-eliminated welcome

## Class

`cross-seat-timing-race-cured-by-removing-pre-emption-of-canonical-primitive-policy-class` cohort-canonical-sub-7.X.

Co-discovered with: 🌻 elliott byte-walk-substrate  + .

🩸♥️