### PR TITLE
test(voice-call): make plugin tests hermetic against OPENCLAW_CLI host env

### DIFF
--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -210,6 +210,11 @@ async function registerVoiceCallCli(
 
 describe("voice-call plugin", () => {
   beforeEach(() => {
+    // Hermetic env: tests assume a non-CLI-only process so service.start() runs the
+    // runtime path. Host envs that export OPENCLAW_CLI=1 (e.g. running under the
+    // openclaw-gateway systemd unit) otherwise short-circuit isCliOnlyProcess()
+    // and falsely fail mock-call assertions. Cleared in afterEach via vi.unstubAllEnvs.
+    vi.stubEnv("OPENCLAW_CLI", "");
     noopLogger.info.mockClear();
     noopLogger.warn.mockClear();
     noopLogger.error.mockClear();


### PR DESCRIPTION
## Summary

Four `extensions/voice-call/index.test.ts` tests fail spuriously when the test process inherits `OPENCLAW_CLI=1` from a parent shell (e.g. running pnpm test under the openclaw-gateway systemd unit). `isCliOnlyProcess()` returns true, `service.start()` short-circuits, and the runtime mocks are never invoked.

## Failing tests at HEAD 1c25e84e55 (env-dirty)
- does not block service startup while runtime exposure initializes
- creates a fresh shared runtime after service stop
- does not log a startup error when provider setup is incomplete
- registers Twilio configs with SecretRef auth tokens

## Cure
Add vi.stubEnv(OPENCLAW_CLI, empty) to beforeEach. The two existing tests that need OPENCLAW_CLI=1 re-stub it explicitly; afterEach already calls vi.unstubAllEnvs.

## Verification
- env-dirty: 38/38 PASS after change (was 34/38)
- env-clean: 38/38 PASS after change (was 38/38)

Lamp-seat lane, no collision with 🌊's subagent-spawn 26-cluster.