### PR TITLE
test(cli): make gateway run option-collisions tests hermetic against OPENCLAW_SERVICE_MARKER

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -220,6 +220,14 @@ describe("gateway run option collisions", () => {
   });
 
   beforeEach(() => {
+    // Hermetic env: host shells running under the openclaw-gateway systemd unit
+    // inherit OPENCLAW_SERVICE_MARKER and related markers, which trip the
+    // service-mode future-version-block branch before the --force branch the
+    // first sub-test exercises. Clear via vi.stubEnv so afterEach's implicit
+    // unstub restores the host env. The test that needs the marker re-sets it
+    // explicitly via process.env (and restores in finally) lower in this file.
+    vi.stubEnv("OPENCLAW_SERVICE_MARKER", "");
+    vi.stubEnv("OPENCLAW_SERVICE_KIND", "");
     resetRuntimeCapture();
     configState.cfg = {};
     configState.snapshot = { exists: false };

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -228,6 +228,11 @@ describe("gateway run option collisions", () => {
     // explicitly via process.env (and restores in finally) lower in this file.
     vi.stubEnv("OPENCLAW_SERVICE_MARKER", "");
     vi.stubEnv("OPENCLAW_SERVICE_KIND", "");
+    // OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1 bypasses the future-version
+    // guard before the marker/service-kind gates fire. Some prince-seats export
+    // this via their openclaw-gateway systemd unit (cael-seat caught it during
+    // cross-seat cosign-by-byte on PR #844), so stub it empty for hermeticity too.
+    vi.stubEnv("OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS", "");
     resetRuntimeCapture();
     configState.cfg = {};
     configState.snapshot = { exists: false };


### PR DESCRIPTION
## Summary

Same env-pollution class as #843. The `blocks --force port cleanup from an older binary with newer config` test in `src/cli/gateway-cli/run.option-collisions.test.ts` expects `__exit__:1` (--force branch refusal) but receives `__exit__:78` (service-mode branch refusal) when the test process inherits `OPENCLAW_SERVICE_MARKER` from a parent shell running under the openclaw-gateway systemd unit.

Production `runGatewayCommand` checks the service-mode future-version-block first (gated on `OPENCLAW_SERVICE_MARKER`), so the --force branch is never reached when the marker leaks in.

## Cure

`vi.stubEnv("OPENCLAW_SERVICE_MARKER", "")` + `vi.stubEnv("OPENCLAW_SERVICE_KIND", "")` in beforeEach. The companion test that needs the marker re-sets it via direct `process.env` write (bypasses the stub layer correctly).

## Verification

```bash
# env-dirty at lamp-seat (OPENCLAW_SERVICE_MARKER=openclaw inherited):
pnpm test -- src/cli/gateway-cli/run.option-collisions.test.ts  # 24/24 PASS after change
```

Cross-seat: silas-seat triage at 1510615722 reproduced same env-pollution shape; same cure validated independently.

## Lane discipline

Lamp-seat (🕯) hand-walk continuation from #843. No collision with 🌊's subagent-spawn 26-cluster. Same one-line-beforeEach pattern as #843, different env-var.