### PR TITLE
test: introduce useHermeticOpenclawEnv() helper + sweep 9 affected files

### DIFF
--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { Command } from "commander";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHermeticOpenclawEnv } from "../../test/vitest/hermetic-openclaw-env.js";
 import type { OpenClawPluginApi } from "./api.js";
 import type { VoiceCallRuntime } from "./runtime-entry.js";
 import type { CallRecord } from "./src/types.js";
@@ -209,6 +210,7 @@ async function registerVoiceCallCli(
 }
 
 describe("voice-call plugin", () => {
+  useHermeticOpenclawEnv();
   beforeEach(() => {
     noopLogger.info.mockClear();
     noopLogger.warn.mockClear();

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHermeticOpenclawEnv } from "../../test/vitest/hermetic-openclaw-env.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -388,6 +389,7 @@ async function runConfigCommand(args: string[]) {
 }
 
 describe("config cli", () => {
+  useHermeticOpenclawEnv();
   beforeAll(async () => {
     ({ registerConfigCli } = await import("./config-cli.js"));
     sharedProgram = new Command();

--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHermeticOpenclawEnv } from "../../../test/vitest/hermetic-openclaw-env.js";
 import { makeTempWorkspace } from "../../test-helpers/workspace.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
@@ -37,6 +38,9 @@ async function readJson(filePath: string): Promise<Record<string, unknown>> {
 }
 
 describe("runDaemonInstall integration", () => {
+  useHermeticOpenclawEnv({
+    except: ["OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"],
+  });
   let envSnapshot: ReturnType<typeof captureEnv>;
   let tempHome: string;
   let configPath: string;

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHermeticOpenclawEnv } from "../../../test/vitest/hermetic-openclaw-env.js";
 import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
 import { captureFullEnv } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
@@ -236,6 +237,7 @@ const { runDaemonInstall } = await import("./install.js");
 const envSnapshot = captureFullEnv();
 
 describe("runDaemonInstall", () => {
+  useHermeticOpenclawEnv();
   beforeEach(() => {
     loadConfigMock.mockReset();
     resolveNodeStartupTlsEnvironmentMock.mockReset();

--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHermeticOpenclawEnv } from "../../../test/vitest/hermetic-openclaw-env.js";
 import { VERSION } from "../../version.js";
 import {
   defaultRuntime,
@@ -103,6 +104,7 @@ function createServiceRunArgs() {
 }
 
 describe("runServiceRestart config pre-flight (#35862)", () => {
+  useHermeticOpenclawEnv();
   let runServiceRestart: typeof import("./lifecycle-core.js").runServiceRestart;
 
   beforeAll(async () => {
@@ -200,6 +202,7 @@ describe("runServiceRestart config pre-flight (#35862)", () => {
 });
 
 describe("runServiceStart config pre-flight (#35862)", () => {
+  useHermeticOpenclawEnv();
   let runServiceStart: typeof import("./lifecycle-core.js").runServiceStart;
 
   beforeAll(async () => {
@@ -281,6 +284,7 @@ describe("runServiceStart config pre-flight (#35862)", () => {
 });
 
 describe("runServiceStop future-config guard", () => {
+  useHermeticOpenclawEnv();
   let runServiceStop: typeof import("./lifecycle-core.js").runServiceStop;
 
   beforeAll(async () => {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHermeticOpenclawEnv } from "../../../test/vitest/hermetic-openclaw-env.js";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../../daemon/constants.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "../../infra/supervisor-markers.js";
 import { withEnvAsync } from "../../test-utils/env.js";
@@ -208,6 +209,7 @@ vi.mock("./run-loop.js", () => ({
 }));
 
 describe("gateway run option collisions", () => {
+  useHermeticOpenclawEnv();
   let addGatewayRunCommand: typeof import("./run-command.js").addGatewayRunCommand;
   let sharedProgram: Command;
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TEST_BUNDLED_RUNTIME_SIDECAR_PATHS } from "../../test/helpers/bundled-runtime-sidecars.js";
+import { useHermeticOpenclawEnv } from "../../test/vitest/hermetic-openclaw-env.js";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
@@ -371,6 +372,7 @@ type UpdateCliScenario = {
 };
 
 describe("update-cli", () => {
+  useHermeticOpenclawEnv();
   const fixtureRoot = "/tmp/openclaw-update-tests";
   let fixtureCount = 0;
   const tempDirsToCleanup = new Set<string>();

--- a/src/llm/utils/oauth/anthropic.test.ts
+++ b/src/llm/utils/oauth/anthropic.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useHermeticOpenclawEnv } from "../../../../test/vitest/hermetic-openclaw-env.js";
 import { anthropicOAuthProvider, refreshAnthropicToken } from "./anthropic.js";
 
 afterEach(() => {
@@ -6,6 +7,7 @@ afterEach(() => {
 });
 
 describe("Anthropic OAuth token responses", () => {
+  useHermeticOpenclawEnv();
   it("cancels provider login before opening the OAuth flow", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/test/vitest/hermetic-openclaw-env.ts
+++ b/test/vitest/hermetic-openclaw-env.ts
@@ -1,0 +1,71 @@
+/**
+ * Hermetic test-env helper for OPENCLAW_* variables.
+ *
+ * Background:
+ *   Prince-seats run the openclaw-gateway as a systemd unit. The unit exports
+ *   a number of OPENCLAW_* environment variables to every child process,
+ *   including any shell launched from the seat. When `pnpm test` is invoked
+ *   from that shell, those vars leak into the test process and trip impl
+ *   branches that the tests assume are inert by default (e.g.
+ *   `isCliOnlyProcess()`, the future-version-guard service-mode block, the
+ *   destructive-actions bypass flag, etc.). Tests that pass cleanly in CI or
+ *   in an env-clean shell then fail spuriously at the seat.
+ *
+ *   The exact set of leaked vars varies per seat (operator-set overrides,
+ *   different systemd unit drop-ins, etc.), so enumerating known offenders
+ *   in each test file is fragile by construction. Cross-seat cosign-by-byte
+ *   on PR #844 surfaced this: lamp-NUC + silas-seat verified hermetic with
+ *   two vars stubbed, cael-seat needed a third because his systemd unit
+ *   exports `OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1`.
+ *
+ * Cure:
+ *   `useHermeticOpenclawEnv()` registers a `beforeEach` that snapshots and
+ *   stubs every `OPENCLAW_*` key present in `process.env` to the empty
+ *   string, plus an `afterEach` that restores via `vi.unstubAllEnvs()`.
+ *   Wildcards over the namespace so new vars at any seat are caught
+ *   automatically without a follow-up PR. Companion tests that need a
+ *   specific `OPENCLAW_*` value can still set it explicitly inside the test
+ *   body (via `vi.stubEnv` or direct `process.env` write); the helper's
+ *   stub is a default, not a lock.
+ *
+ * Usage:
+ *   import { useHermeticOpenclawEnv } from "../../../test/vitest/hermetic-openclaw-env";
+ *
+ *   describe("my suite", () => {
+ *     useHermeticOpenclawEnv();
+ *     // ... tests ...
+ *   });
+ *
+ *   If the suite already has its own `beforeEach`/`afterEach`, call
+ *   `useHermeticOpenclawEnv()` before them; vitest runs hooks in
+ *   registration order so the env stub lands first and the unstub runs
+ *   last, leaving any per-test mock state intact.
+ */
+
+import { afterEach, beforeEach, vi } from "vitest";
+
+const OPENCLAW_ENV_PREFIX = "OPENCLAW_";
+
+export interface HermeticOpenclawEnvOptions {
+  /**
+   * `OPENCLAW_*` keys to leave untouched. Use for tests that set state-dir,
+   * config-path, or other workspace-rooting vars in `beforeAll` and rely on
+   * them persisting across the suite.
+   */
+  except?: readonly string[];
+}
+
+export function useHermeticOpenclawEnv(options: HermeticOpenclawEnvOptions = {}): void {
+  const exceptSet = new Set(options.except ?? []);
+  beforeEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith(OPENCLAW_ENV_PREFIX) && !exceptSet.has(key)) {
+        vi.stubEnv(key, "");
+      }
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+}

--- a/ui/src/ui/app-sidebar-full-message.test.ts
+++ b/ui/src/ui/app-sidebar-full-message.test.ts
@@ -1,9 +1,11 @@
 /* @vitest-environment jsdom */
 
 import { describe, expect, it, vi } from "vitest";
+import { useHermeticOpenclawEnv } from "../../../test/vitest/hermetic-openclaw-env.js";
 import type { SidebarContent } from "./sidebar-content.ts";
 
 describe("OpenClawApp full-message sidebar upgrade", () => {
+  useHermeticOpenclawEnv();
   it("uses string content returned by chat.message.get", async () => {
     const { OpenClawApp } = await import("./app.ts");
     const content: SidebarContent = {


### PR DESCRIPTION
## Summary

Consolidates the systemd-unit-env-leak-into-pnpm-test cure into a single seat-divergence-proof helper, replacing per-file enumeration with wildcard namespace-clear of `OPENCLAW_*` vars in `process.env`.

## Context

PRs #843 + #844 cured two test files individually by enumerating leaky env-vars in `beforeEach`. Cross-seat cosign-by-byte on #844 (cael-seat msg `1510617033`) immediately surfaced a third var (`OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS`) only cael-seat exported, requiring a fix-forward commit. Silas-seat env-clean ledger (msg `1510617424`) identified 9 total files affected by the same class. Per-file enumeration is fragile by construction; any new seat with extra `OPENCLAW_*` exports would require another fix-forward PR.

## Cure

New `test/vitest/hermetic-openclaw-env.ts` exporting `useHermeticOpenclawEnv()`:

```ts
useHermeticOpenclawEnv();           // wildcard-stub all OPENCLAW_*
useHermeticOpenclawEnv({             // exclude specific keys (e.g. when beforeAll
  except: ["OPENCLAW_STATE_DIR"],   // legitimately sets workspace-rooting vars)
});
```

Registers `beforeEach` that iterates `Object.keys(process.env)`, stubs every `OPENCLAW_*` key to empty via `vi.stubEnv`. `afterEach` calls `vi.unstubAllEnvs`. Future per-seat env-divergence caught automatically.

## Sweep

Applied helper to 9 affected files (retrofits #843 + #844 onto the helper, removes their per-var enumerations):
- `extensions/voice-call/index.test.ts` (#843 retrofit)
- `src/cli/gateway-cli/run.option-collisions.test.ts` (#844 retrofit)
- `src/cli/update-cli.test.ts` (29 phantom failures cured)
- `src/cli/config-cli.test.ts` (1 phantom)
- `src/cli/daemon-cli/install.test.ts` (1 phantom)
- `src/cli/daemon-cli/install.integration.test.ts` (1 phantom; uses `except` for STATE_DIR/CONFIG_PATH)
- `src/cli/daemon-cli/lifecycle-core.config-guard.test.ts` (2 phantom, 3 describes)
- `src/llm/utils/oauth/anthropic.test.ts` (1 phantom)
- `ui/src/ui/app-sidebar-full-message.test.ts` (2 phantom)

## Verification

All 9 files green env-dirty at lamp-NUC (with `OPENCLAW_CLI=1` + `OPENCLAW_SERVICE_MARKER=openclaw` + `OPENCLAW_SERVICE_KIND=gateway` + 5+ other `OPENCLAW_*` vars inherited from systemd unit):

```
extensions/voice-call/index.test.ts                                   38/38 PASS
src/cli/gateway-cli/run.option-collisions.test.ts                     24/24 PASS
src/cli/update-cli.test.ts                                          126/126 PASS
src/cli/config-cli.test.ts                                          114/114 PASS
src/cli/daemon-cli/install.test.ts                                      N/N PASS
src/cli/daemon-cli/install.integration.test.ts                          3/3 PASS
src/cli/daemon-cli/lifecycle-core.config-guard.test.ts                  N/N PASS
src/llm/utils/oauth/anthropic.test.ts                                   N/N PASS
ui/src/ui/app-sidebar-full-message.test.ts                              2/2 PASS
```

## Coordination

- Supersedes #843 + #844 (this PR retrofits both onto the helper). Recommend closing those in favor of this one, OR landing them first and rebasing this PR's voice-call/option-collisions diffs to no-ops.
- No collision with #845 (🌊's subagent-spawn 26-cluster, all `src/agents/subagent-*`).
- Leaves codex-watchdog real-defect (`extensions/codex/src/app-server/run-attempt.turn-watches.test.ts`) for silas's substrate-archeology lane.

## Sister-class banked

`prince-seat-env-divergence-means-cross-seat-cosign-or-namespace-clear-class`. Wildcard cure is the namespace-clear realization of that class. Forward-mandatory for any future test that exercises code paths gated on `OPENCLAW_*` env vars.