### PR TITLE
test(test-utils): hermetic OPENCLAW_* env helpers (namespace-clear, seat-divergence-proof)

### DIFF
--- a/src/test-utils/env.test.ts
+++ b/src/test-utils/env.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, it } from "vitest";
 import {
   captureEnv,
   captureFullEnv,
+  captureHermeticOpenclawEnv,
   createPathResolutionEnv,
+  listOpenclawEnvKeys,
   withEnv,
   withEnvAsync,
+  withHermeticOpenclawEnv,
+  withHermeticOpenclawEnvAsync,
   withPathResolutionEnv,
 } from "./env.js";
 
@@ -171,6 +175,137 @@ describe("env test utils", () => {
       expect(process.env.OPENCLAW_HOME).toBe("/srv/openclaw-home");
     } finally {
       restoreEnvKey("OPENCLAW_HOME", previousOpenClawHome);
+    }
+  });
+
+  it("listOpenclawEnvKeys returns only OPENCLAW_-prefixed keys present in env", () => {
+    const key = "OPENCLAW_ENV_TEST_LIST_KEY";
+    const noise = "NOT_AN_OPENCLAW_ENV_TEST";
+    const prevKey = process.env[key];
+    const prevNoise = process.env[noise];
+    process.env[key] = "set";
+    process.env[noise] = "set";
+
+    try {
+      const keys = listOpenclawEnvKeys();
+      expect(keys).toContain(key);
+      expect(keys).not.toContain(noise);
+      for (const k of keys) {
+        expect(k.startsWith("OPENCLAW_")).toBe(true);
+      }
+    } finally {
+      restoreEnvKey(key, prevKey);
+      restoreEnvKey(noise, prevNoise);
+    }
+  });
+
+  it("captureHermeticOpenclawEnv clears all OPENCLAW_* keys and restores them", () => {
+    const keyA = "OPENCLAW_ENV_TEST_HERMETIC_A";
+    const keyB = "OPENCLAW_ENV_TEST_HERMETIC_B";
+    const noise = "NOT_OPENCLAW_HERMETIC";
+    const prevA = process.env[keyA];
+    const prevB = process.env[keyB];
+    const prevNoise = process.env[noise];
+    process.env[keyA] = "a";
+    process.env[keyB] = "b";
+    process.env[noise] = "untouched";
+
+    try {
+      const snapshot = captureHermeticOpenclawEnv();
+      expect(process.env[keyA]).toBeUndefined();
+      expect(process.env[keyB]).toBeUndefined();
+      expect(process.env[noise]).toBe("untouched");
+      snapshot.restore();
+      expect(process.env[keyA]).toBe("a");
+      expect(process.env[keyB]).toBe("b");
+      expect(process.env[noise]).toBe("untouched");
+    } finally {
+      restoreEnvKey(keyA, prevA);
+      restoreEnvKey(keyB, prevB);
+      restoreEnvKey(noise, prevNoise);
+    }
+  });
+
+  it("captureHermeticOpenclawEnv discovers keys set by seat-divergent systemd-unit injections", () => {
+    // Simulates the cohort-FEC scenario from cael-seat: a seat exports an
+    // OPENCLAW_* var that lamp-NUC + silas-seat don't (e.g.
+    // OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS, caught by cael on PR #844).
+    // The hermetic helper must discover-and-clear it without enumeration.
+    const seatSpecificKey = "OPENCLAW_ENV_TEST_SEAT_SPECIFIC_SIM";
+    const prev = process.env[seatSpecificKey];
+    process.env[seatSpecificKey] = "seat-specific-value";
+
+    try {
+      const snapshot = captureHermeticOpenclawEnv();
+      expect(process.env[seatSpecificKey]).toBeUndefined();
+      snapshot.restore();
+      expect(process.env[seatSpecificKey]).toBe("seat-specific-value");
+    } finally {
+      restoreEnvKey(seatSpecificKey, prev);
+    }
+  });
+
+  it("withHermeticOpenclawEnv strips OPENCLAW_* only inside callback and restores after", () => {
+    const key = "OPENCLAW_ENV_TEST_WITH_HERMETIC";
+    const prev = process.env[key];
+    process.env[key] = "outside";
+
+    try {
+      const seen = withHermeticOpenclawEnv(() => process.env[key]);
+      expect(seen).toBeUndefined();
+      expect(process.env[key]).toBe("outside");
+    } finally {
+      restoreEnvKey(key, prev);
+    }
+  });
+
+  it("withHermeticOpenclawEnv restores keys when callback throws", () => {
+    const key = "OPENCLAW_ENV_TEST_WITH_HERMETIC_THROW";
+    const prev = process.env[key];
+    process.env[key] = "outside";
+
+    try {
+      expect(() =>
+        withHermeticOpenclawEnv(() => {
+          expect(process.env[key]).toBeUndefined();
+          throw new Error("boom");
+        }),
+      ).toThrow("boom");
+      expect(process.env[key]).toBe("outside");
+    } finally {
+      restoreEnvKey(key, prev);
+    }
+  });
+
+  it("withHermeticOpenclawEnvAsync restores keys when async callback throws", async () => {
+    const key = "OPENCLAW_ENV_TEST_WITH_HERMETIC_ASYNC_THROW";
+    const prev = process.env[key];
+    process.env[key] = "outside";
+
+    try {
+      await expect(
+        withHermeticOpenclawEnvAsync(async () => {
+          expect(process.env[key]).toBeUndefined();
+          throw new Error("async-boom");
+        }),
+      ).rejects.toThrow("async-boom");
+      expect(process.env[key]).toBe("outside");
+    } finally {
+      restoreEnvKey(key, prev);
+    }
+  });
+
+  it("withHermeticOpenclawEnvAsync clears OPENCLAW_* only inside async callback", async () => {
+    const key = "OPENCLAW_ENV_TEST_WITH_HERMETIC_ASYNC_OK";
+    const prev = process.env[key];
+    process.env[key] = "outside";
+
+    try {
+      const seen = await withHermeticOpenclawEnvAsync(async () => process.env[key]);
+      expect(seen).toBeUndefined();
+      expect(process.env[key]).toBe("outside");
+    } finally {
+      restoreEnvKey(key, prev);
     }
   });
 });

--- a/src/test-utils/env.ts
+++ b/src/test-utils/env.ts
@@ -136,3 +136,72 @@ export async function withEnvAsync<T>(
     snapshot.restore();
   }
 }
+
+/**
+ * Returns the current `OPENCLAW_*` environment-variable keys present in
+ * `process.env`. Used by hermetic-env helpers to discover seat-divergent
+ * systemd-unit injections (which vary between prince-seats: e.g. silas-seat
+ * exports 8 vars, cael-seat exports those 8 plus `OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS`).
+ */
+export function listOpenclawEnvKeys(env: NodeJS.ProcessEnv = process.env): string[] {
+  return Object.keys(env).filter((key) => key.startsWith("OPENCLAW_"));
+}
+
+/**
+ * Captures and clears all currently-set `OPENCLAW_*` environment variables
+ * for the lifetime of the returned handle. Call `.restore()` to put them back.
+ *
+ * Useful in `beforeEach` blocks for tests that exercise gateway/service-mode
+ * CLI paths, plugin runtime startup gates, or anything that reads systemd-unit
+ * env injections. Hermetic by construction across prince-seats with divergent
+ * systemd env sets — discovers and clears whatever's there rather than
+ * enumerating known keys.
+ *
+ * Example:
+ * ```ts
+ * import { captureHermeticOpenclawEnv } from "../../test-utils/env.js";
+ *
+ * describe("gateway CLI option collisions", () => {
+ *   let openclawEnvSnapshot: { restore: () => void };
+ *   beforeEach(() => {
+ *     openclawEnvSnapshot = captureHermeticOpenclawEnv();
+ *   });
+ *   afterEach(() => {
+ *     openclawEnvSnapshot.restore();
+ *   });
+ *   // ... tests run with no OPENCLAW_* host env leakage
+ * });
+ * ```
+ */
+export function captureHermeticOpenclawEnv(): { restore: () => void } {
+  const snapshot = captureEnv(listOpenclawEnvKeys());
+  for (const key of listOpenclawEnvKeys()) {
+    delete process.env[key];
+  }
+  return snapshot;
+}
+
+/**
+ * Runs `fn` synchronously with all `OPENCLAW_*` environment variables
+ * stripped, restoring them on exit (including on throw).
+ */
+export function withHermeticOpenclawEnv<T>(fn: () => T): T {
+  const snapshot = captureHermeticOpenclawEnv();
+  try {
+    return fn();
+  } finally {
+    snapshot.restore();
+  }
+}
+
+/**
+ * Async variant of `withHermeticOpenclawEnv`.
+ */
+export async function withHermeticOpenclawEnvAsync<T>(fn: () => Promise<T>): Promise<T> {
+  const snapshot = captureHermeticOpenclawEnv();
+  try {
+    return await fn();
+  } finally {
+    snapshot.restore();
+  }
+}


### PR DESCRIPTION
Adds four helpers to `src/test-utils/env.ts`:
- `listOpenclawEnvKeys(env?)` — discovery
- `captureHermeticOpenclawEnv()` — capture + strip with restore handle
- `withHermeticOpenclawEnv(fn)` — sync wrapper
- `withHermeticOpenclawEnvAsync(fn)` — async wrapper

## Motivation

The cohort cure-cycle late-May 2026 surfaced a recurring class of *phantom test failures* on prince-seats: the systemd-managed openclaw-gateway unit injects `OPENCLAW_*` env into child processes (silas-seat = 8 vars, cael-seat = 9 vars, lamp-NUC = different set). Tests that exercise gateway/service-mode CLI paths, plugin runtime startup gates, or anything reading systemd-unit env, inherit these vars and fail.

Cured shards so far:
- #843 (voice-call, `OPENCLAW_CLI`)
- #844 (gateway-cli `run.option-collisions`, `OPENCLAW_SERVICE_MARKER` + `OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS`)

Both used per-test enumeration via `vi.stubEnv(KNOWN_KEY, '')`. Cohort-FEC catch on #844 demonstrated the fragility of enumeration: cael-seat exported `OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS` (operator-set during a deploy cycle), which lamp-NUC + silas-seat didn't, so the 'verified hermetic' claim from lamp-NUC alone was incomplete. A test cured by enumeration on one seat can still leak on another seat exporting a different key.

## Approach

Namespace-clear: discover `OPENCLAW_*` keys in `process.env` at capture time and strip whatever's there, rather than enumerating known keys. Seat-divergence-proof by construction. New systemd-unit env additions automatically get caught without revisiting cured tests.

## Verification

- env-clean (`env -u OPENCLAW_*` strip): **17/17 PASS**
- env-dirty (silas-seat systemd unit env present): **17/17 PASS**
- Includes a test that simulates the seat-divergence scenario (`captureHermeticOpenclawEnv discovers keys set by seat-divergent systemd-unit injections`).

## Cure-cycle ledger surfaces matched

Per silas-seat byte-walk at `1c25e84e55` (msg `1510617422`), all classified as env-pollution phantoms via `env -i` full-test run:
- `src/cli/update-cli.test.ts` (29 phantom failures, 126/126 PASS env-clean)
- `src/cli/config-cli.test.ts` (1)
- `src/cli/daemon-cli/install.test.ts` (1)
- `src/cli/daemon-cli/install.integration.test.ts` (1)
- `src/cli/daemon-cli/lifecycle-core.config-guard.test.ts` (2)
- `ui/src/ui/app-sidebar-full-message.test.ts` (2)
- `src/llm/utils/oauth/anthropic.test.ts` (1)

Total: ~37 phantom failures in the morning-candidate cure-cycle ledger that would also be cured by adoption of these helpers (in follow-up PRs).

## Example adoption

```ts
import { captureHermeticOpenclawEnv } from "../../test-utils/env.js";

describe("gateway CLI option collisions", () => {
  let openclawEnvSnapshot: { restore: () => void };
  beforeEach(() => {
    openclawEnvSnapshot = captureHermeticOpenclawEnv();
  });
  afterEach(() => {
    openclawEnvSnapshot.restore();
  });
  // ... tests run with no OPENCLAW_* host env leakage
});
```

Co-authored-by: Cael🩸 (PR #844 cohort-FEC catch + namespace-clear proposal in `1510617784`)
Co-authored-by: 🕯 Emeric (#843 + #844 pattern fire-rhythm)