### PR TITLE
fix(gateway): restore #83962 timeout-classifier + 3 regression tests dropped in cure-cycle (closes #851)

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -3317,16 +3317,24 @@ describe("gateway agent handler", () => {
       primeMainAgentRun();
       const abortError = new Error("This operation was aborted");
       abortError.name = "AbortError";
-      mocks.agentCommand.mockRejectedValueOnce(abortError);
       const context = makeContext();
+      const runId = "task-registry-agent-run-abort-error";
+      // Abort the run's chat controller before the rejection bubbles so
+      // isGatewayAgentAbortRejection sees signal.aborted=true. Without this
+      // setup the test cannot distinguish operator-aborted runs from raw
+      // AbortError rejections that originate inside the agent itself.
+      mocks.agentCommand.mockImplementationOnce(() => {
+        context.chatAbortControllers.get(runId)?.controller.abort();
+        return Promise.reject(abortError);
+      });
 
       await invokeAgent(
         {
           message: "background cli task",
           sessionKey: "agent:main:main",
-          idempotencyKey: "task-registry-agent-run-abort-error",
+          idempotencyKey: runId,
         },
-        { context, reqId: "task-registry-agent-run-abort-error" },
+        { context, reqId: runId },
       );
 
       await waitForAssertion(() => {
@@ -3342,7 +3350,143 @@ describe("gateway agent handler", () => {
             runId: "task-registry-agent-run-abort-error",
             status: "timeout",
             summary: "aborted",
+            stopReason: "rpc",
           },
+        );
+      });
+    });
+  });
+
+  it("classifies timeout async gateway agent rejections as timed out", async () => {
+    await withTempDir({ prefix: "openclaw-gateway-agent-task-timeout-error-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      primeMainAgentRun();
+      const timeoutError = new Error("chat run timed out");
+      timeoutError.name = "TimeoutError";
+      const context = makeContext();
+      const runId = "task-registry-agent-run-timeout-error";
+      mocks.agentCommand.mockImplementationOnce(() => {
+        context.chatAbortControllers.get(runId)?.controller.abort(timeoutError);
+        return Promise.reject(timeoutError);
+      });
+
+      await invokeAgent(
+        {
+          message: "background cli task",
+          sessionKey: "agent:main:main",
+          idempotencyKey: runId,
+        },
+        { context, reqId: runId },
+      );
+
+      await waitForAssertion(() => {
+        expectRecordFields(findTaskByRunId("task-registry-agent-run-timeout-error"), {
+          runtime: "cli",
+          childSessionKey: "agent:main:main",
+          status: "timed_out",
+          error: "TimeoutError: chat run timed out",
+        });
+        expectRecordFields(
+          context.dedupe.get("agent:task-registry-agent-run-timeout-error")?.payload,
+          {
+            runId: "task-registry-agent-run-timeout-error",
+            status: "timeout",
+            summary: "aborted",
+            stopReason: "timeout",
+          },
+        );
+      });
+    });
+  });
+
+  it("classifies wrapped rejections after gateway timeout as timed out", async () => {
+    await withTempDir(
+      { prefix: "openclaw-gateway-agent-task-wrapped-timeout-error-" },
+      async (root) => {
+        process.env.OPENCLAW_STATE_DIR = root;
+        resetTaskRegistryForTests();
+        primeMainAgentRun();
+        const timeoutReason = new Error("chat run timed out");
+        timeoutReason.name = "TimeoutError";
+        const wrappedError = new Error("fallback result classified terminal abort");
+        wrappedError.name = "FailoverError";
+        const context = makeContext();
+        const runId = "task-registry-agent-run-wrapped-timeout-error";
+        mocks.agentCommand.mockImplementationOnce(() => {
+          context.chatAbortControllers.get(runId)?.controller.abort(timeoutReason);
+          return Promise.reject(wrappedError);
+        });
+
+        await invokeAgent(
+          {
+            message: "background cli task",
+            sessionKey: "agent:main:main",
+            idempotencyKey: runId,
+          },
+          { context, reqId: runId },
+        );
+
+        await waitForAssertion(() => {
+          expectRecordFields(findTaskByRunId("task-registry-agent-run-wrapped-timeout-error"), {
+            runtime: "cli",
+            childSessionKey: "agent:main:main",
+            status: "timed_out",
+            error: "FailoverError: fallback result classified terminal abort",
+          });
+          expectRecordFields(
+            context.dedupe.get("agent:task-registry-agent-run-wrapped-timeout-error")?.payload,
+            {
+              runId: "task-registry-agent-run-wrapped-timeout-error",
+              status: "timeout",
+              summary: "aborted",
+              stopReason: "timeout",
+            },
+          );
+          expect(
+            context.dedupe.get("agent:task-registry-agent-run-wrapped-timeout-error")?.ok,
+          ).toBe(true);
+        });
+      },
+    );
+  });
+
+  it("does not hide provider timeout async gateway agent rejections", async () => {
+    await withTempDir({ prefix: "openclaw-gateway-agent-task-provider-timeout-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      primeMainAgentRun();
+      const providerError = new Error("provider request timed out");
+      providerError.name = "TimeoutError";
+      mocks.agentCommand.mockRejectedValueOnce(providerError);
+      const context = makeContext();
+
+      await invokeAgent(
+        {
+          message: "background cli task",
+          sessionKey: "agent:main:main",
+          idempotencyKey: "task-registry-agent-run-provider-timeout",
+        },
+        { context, reqId: "task-registry-agent-run-provider-timeout" },
+      );
+
+      await waitForAssertion(() => {
+        expectRecordFields(findTaskByRunId("task-registry-agent-run-provider-timeout"), {
+          runtime: "cli",
+          childSessionKey: "agent:main:main",
+          status: "timed_out",
+          error: "TimeoutError: provider request timed out",
+        });
+        expectRecordFields(
+          context.dedupe.get("agent:task-registry-agent-run-provider-timeout")?.payload,
+          {
+            runId: "task-registry-agent-run-provider-timeout",
+            status: "error",
+            summary: "TimeoutError: provider request timed out",
+          },
+        );
+        expect(context.dedupe.get("agent:task-registry-agent-run-provider-timeout")?.ok).toBe(
+          false,
         );
       });
     });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -834,6 +834,23 @@ function readAgentRunTimeoutAttribution(meta: unknown) {
   };
 }
 
+function isGatewayAbortSignalReason(reason: unknown): boolean {
+  return reason === undefined || isAbortError(reason) || readErrorName(reason) === "TimeoutError";
+}
+
+function isGatewayAgentAbortRejection(error: unknown, signal: AbortSignal): boolean {
+  if (!signal.aborted) {
+    return false;
+  }
+  if (readErrorName(signal.reason) === "TimeoutError") {
+    return true;
+  }
+  if (!isGatewayAbortSignalReason(signal.reason)) {
+    return false;
+  }
+  return isAbortError(error) || readErrorName(error) === "TimeoutError";
+}
+
 function resolveGatewayAgentAbortStopReason(signal: AbortSignal): "rpc" | "timeout" {
   return readErrorName(signal.reason) === "TimeoutError" ? "timeout" : "rpc";
 }
@@ -927,7 +944,11 @@ function dispatchAgentRunFromGateway(params: {
       params.respond(true, payload, undefined, { runId: params.runId });
     })
     .catch((err) => {
-      const aborted = isAbortError(err);
+      // Restored from upstream b4f69286fd (closes openclaw/openclaw#83962): match
+      // TimeoutError and signal.reason TimeoutError shapes so timed-out runs
+      // classify as timeout (not error) and keep dedupe.ok true. isAbortError
+      // alone matches only name="AbortError" and misses both shapes.
+      const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
       const renderedErr = formatForLog(err);
       if (shouldTrackTask) {
         tryFinalizeTrackedAgentTask({


### PR DESCRIPTION
## What

Restores upstream `b4f69286fd` (closes openclaw/openclaw#83962, "fix(gateway): stop chat timeout fallback cascade") on top of PR #809 head, plus re-adds the 3 regression tests cohort commit `f426d9dbbf` deleted.

## Why

Surfaced via copilot built-in `code-review` agent walking PR #809 head `fd703e5816` (frond-scribe-copilot dispatch 2026-05-31 ~16:32 PDT). See https://github.com/karmaterminal/openclaw/pull/809#issuecomment-4588603447 for full byte-walk.

PR #809 cure-cycle commit `5252c9ac66` swapped:
```ts
// upstream b4f69286fd (closes openclaw/openclaw#83962):
const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);

// cure-cycle reverted to:
const aborted = isAbortError(err);
```

`isAbortError` matches only `err.name === "AbortError"`. Does not catch `TimeoutError` or `signal.reason.name === "TimeoutError"`.

### Net effect (before this PR)

| Field | Should be | Was (broken) |
|---|---|---|
| `aborted` | `true` | `false` |
| `payload.status` | `"timeout"` | `"error"` |
| `payload.stopReason` | populated | not populated |
| `payload.timeoutPhase` | `"gateway_draining"` | not set |
| `respond(aborted, ...)` | client sees completed-with-timeout | client sees failed |
| `dedupe.entry.ok` | `true` | `false` → allows incorrect retries on same timeout |

CI invisible because cohort commit `f426d9dbbf` removed the 3 upstream regression tests for this exact behavior.

## Changes

**`src/gateway/server-methods/agent.ts`**:
- Add `isGatewayAbortSignalReason` + `isGatewayAgentAbortRejection` helpers (siblings of existing `resolveGatewayAgentAbortStopReason` which already exists in PR #809 at line 837)
- Swap classifier on the `.catch((err) => ...)` handler back to `isGatewayAgentAbortRejection(err, signal)`
- Inline comment naming the upstream commit + bug class so future cure-cycles don't silently re-revert

**`src/gateway/server-methods/agent.test.ts`**:
- Updated existing `classifies aborted async gateway agent rejections as timed out` test: use `mockImplementationOnce` that aborts the controller before rejecting (so `signal.aborted=true` at classify time) + assert `stopReason: "rpc"`
- Restored 3 deleted upstream regression cases:
  - `classifies timeout async gateway agent rejections as timed out`
  - `classifies wrapped rejections after gateway timeout as timed out`
  - `does not hide provider timeout async gateway agent rejections`

## Verification

- `pnpm tsgo` exit 0 (production typecheck clean)
- `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts` → **148/148 pass** (including the 4 timeout-classifier cases — 1 updated, 3 new)
- Wider Gate 3 batch deferred to cael's existing cure-cycle gate sweeps

## Behavior addressed
Gateway agent runs aborted via timeout now classified correctly as timeout (not error). Client UX restored. dedupe.ok stays true so timed-out runs aren't incorrectly retried.

## Real environment tested
Local node scripts/run-vitest.mjs on `frond-scribe/cure-pr809-restore-83962-timeout-classifier` branch HEAD against frond-scribe-copilot dev host.

## Exact steps or command run after this patch
```bash
cd ~/flesh_beast_best_beast/source/openclaw
git fetch origin frond-scribe/cure-pr809-restore-83962-timeout-classifier
git checkout origin/frond-scribe/cure-pr809-restore-83962-timeout-classifier
pnpm tsgo
node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts
```

## Evidence after fix
- tsgo exit 0
- 148/148 vitest tests pass; the 4 timeout-classifier cases:
  - `classifies aborted async gateway agent rejections as timed out` ✓ stopReason=rpc
  - `classifies timeout async gateway agent rejections as timed out` ✓ stopReason=timeout
  - `classifies wrapped rejections after gateway timeout as timed out` ✓ dedupe.ok=true
  - `does not hide provider timeout async gateway agent rejections` ✓ status=error preserved

## Observed result after fix
Runs aborted via TimeoutError now flow through the timeout payload branch (status=timeout, stopReason populated from signal.reason, dedupe.ok=true). Provider-side TimeoutError without a signal-abort still surfaces as error (no hiding).

## What was not tested
- Full repo `pnpm test` sweep (deferred to cael's wider Gate 3 cure-cycle batch)
- Crabbox / live gateway integration (proof-shape: the upstream tests are already integration-level — they exercise the `dispatchAgentRunFromGateway` catch path end-to-end via `invokeAgent` + abort controller)
- E2E Discord/Telegram roundtrip (not needed for this classifier-only change)

## Discipline-class banked

`silent-revert-of-upstream-bug-fix-with-also-deleted-regression-tests-class` — when a cure-cycle commit modifies behavior in code touched by recent upstream fixes, must preserve the fix OR document trade-away with a covering test. Especially watch cure-cycle commits that ALSO remove regression tests — those are the invisible-in-CI failure mode.

New cohort review-tool `upstream-divergence-walker.agent.md` (in karmaterminal/frond-scribe at `b71c2fb1b2`) built to catch this class automatically going forward.

## Related

- karmaterminal/openclaw#809 cure-cycle assembly singleton (this PR proposes update)
- karmaterminal/openclaw#848 Gate-progression tracker
- karmaterminal/openclaw#851 cure-tracking issue
- karmaterminal/openclaw/pull/809#issuecomment-4588603447 original code-review finding
- openclaw/openclaw#83962 upstream issue (timeout-cascade)

Co-authored-by: Val Alexander <bunsthedev@gmail.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
