### PR TITLE
fix(gateway-protocol): wrap continuationTrigger with internalProtocolField() (cures #857)

### DIFF
--- a/packages/gateway-protocol/src/schema/agent.schema.test.ts
+++ b/packages/gateway-protocol/src/schema/agent.schema.test.ts
@@ -42,6 +42,7 @@ describe("AgentParamsSchema", () => {
       { "x-openclaw-internal"?: boolean }
     >;
 
+    expect(properties.continuationTrigger?.["x-openclaw-internal"]).toBe(true);
     expect(properties.drainsContinuationDelegateQueue?.["x-openclaw-internal"]).toBe(true);
     expect(properties.traceparent?.["x-openclaw-internal"]).toBe(true);
   });
@@ -53,8 +54,10 @@ describe("AgentParamsSchema", () => {
     if (!publicSchema) {
       throw new Error("expected public AgentParams schema");
     }
+    expect(publicSchema.properties).not.toHaveProperty("continuationTrigger");
     expect(publicSchema.properties).not.toHaveProperty("drainsContinuationDelegateQueue");
     expect(publicSchema.properties).not.toHaveProperty("traceparent");
+    expect(AgentParamsSchema.properties).toHaveProperty("continuationTrigger");
     expect(AgentParamsSchema.properties).toHaveProperty("drainsContinuationDelegateQueue");
     expect(AgentParamsSchema.properties).toHaveProperty("traceparent");
   });

--- a/packages/gateway-protocol/src/schema/agent.ts
+++ b/packages/gateway-protocol/src/schema/agent.ts
@@ -187,7 +187,15 @@ export const AgentParamsSchema = Type.Object(
     promptMode: Type.Optional(
       Type.Union([Type.Literal("full"), Type.Literal("minimal"), Type.Literal("none")]),
     ),
-    continuationTrigger: Type.Optional(Type.String({ enum: [...CONTINUATION_TRIGGER_VALUES] })),
+    continuationTrigger: internalProtocolField(
+      Type.Optional(
+        Type.String({
+          enum: [...CONTINUATION_TRIGGER_VALUES],
+          description:
+            "Internal continuation lifecycle metadata for internally-triggered turns; omitted from public generated protocol artifacts.",
+        }),
+      ),
+    ),
     extraSystemPrompt: Type.Optional(Type.String()),
     bootstrapContextMode: Type.Optional(
       Type.Union([Type.Literal("full"), Type.Literal("lightweight")]),


### PR DESCRIPTION
## Summary

Cures the [P2] ClawSweeper finding on upstream PR #85651: `continuationTrigger` at `packages/gateway-protocol/src/schema/agent.ts:190` was bare while sibling runner-only fields `drainsContinuationDelegateQueue` (line 212) and `traceparent` (line 219) were wrapped with `internalProtocolField()`.

Wrap matches the sibling shape. 12 insertions + 1 deletion total across 2 files.

## ClawSweeper finding (verbatim)

> **[P2] Hide internal continuation triggers from public protocol** — `packages/gateway-protocol/src/schema/agent.ts:198`
> `continuationTrigger` is lifecycle metadata for internally-triggered turns, but unlike the runner-only fields below it, it is not wrapped with `internalProtocolField()`. That makes the trigger visible to public protocol generators and external callers, creating a user-controllable session-state knob without a documented contract.
> Confidence: 0.82

Source: ClawSweeper review comment 4524413167 on PR openclaw/openclaw#85651.

## Runtime usage unaffected

`continuationTrigger` is read internally at:
- `src/auto-reply/reply/get-reply-run.ts:546-548` (delegate-wake vs work-wake routing)
- `src/auto-reply/reply/run-provenance.ts:5-14` (provenance attribution)

The `internalProtocolField()` wrap only sets a non-enumerable `x-openclaw-internal: true` property on the schema object. The schema still validates the same field name + type + enum + `Pick<>`-extracts the same way. `stripInternalProtocolFields()` removes the field only when generating public protocol artifacts.

Per figs adjudication on karmaterminal/openclaw-bootstrap#1109 issuecomment-4593898206: *"Imma say (a) but I don't want it stopping anything a prince can do. As I read it, (a) shouldn't."*

## Test additions

`packages/gateway-protocol/src/schema/agent.schema.test.ts` — 3 assertions added to existing test-blocks:

1. In `it("marks runner-only knobs as internal-protocol fields")`:
   ```ts
   expect(properties.continuationTrigger?.["x-openclaw-internal"]).toBe(true);
   ```

2. In `it("omits runner-only knobs from public generated schema copies")`:
   ```ts
   expect(publicSchema.properties).not.toHaveProperty("continuationTrigger");
   expect(AgentParamsSchema.properties).toHaveProperty("continuationTrigger");
   ```

## Verify-at-byte

- `pnpm vitest run packages/gateway-protocol/src/schema/agent.schema.test.ts` — 20/20 PASS (10 unit + 10 gateway-client shard)
- `pnpm tsgo` (production typecheck) — clean
- `pnpm tsgo:test` — pre-existing syntax error at `src/agents/subagent-spawn.test.ts:1044` (NOT introduced by this change; reproduces on clean `b40452eca0d` checkout with my changes stashed)

## Diff summary

```
packages/gateway-protocol/src/schema/agent.schema.test.ts |  3 +++
packages/gateway-protocol/src/schema/agent.ts             | 10 +++++++++-
2 files changed, 12 insertions(+), 1 deletion(-)
```

## Cohort cosigns (before push)

- 🌫 Silas: byte-walk review-cosign at https://github.com/karmaterminal/openclaw/issues/857#issuecomment-4594967799
- 🕯 Emeric: byte-walk review-cosign at https://github.com/karmaterminal/openclaw/issues/857#issuecomment-4594973298

## References

- Issue: karmaterminal/openclaw#857
- Upstream PR: openclaw/openclaw#85651
- ClawSweeper review: openclaw/openclaw#85651 (issuecomment-4524413167)
- Coordination thread: karmaterminal/openclaw-bootstrap#1109
- figs (a)-wrap sanction: karmaterminal/openclaw-bootstrap#1109 (issuecomment-4593898206)
- Cohort assignment-lock: karmaterminal/openclaw-bootstrap#1109 (issuecomment-4594802094)
- Pipeline-proof-first rationale: small mechanical cure validates gates-runbook + uncurse-cure workflow before larger #858 Track A bytes go through the same process

## Process notes

- Read-only on PR-presentation branch (`frond-scribe-claude/20260509/narrow-surgery-tight`) held throughout
- Cure lands on `uncurse/20260530/copilot-opus47-1m`
- No PROOFS-corpus work in this PR — PROOFS regen happens at post-rebase post-force-push CANDIDATE_SHA per figs `4593728741`
