### PR TITLE
fix(security): flip 23 channel-monitor enqueueSystemEvent callsites to forceSenderIsOwnerFalse: true (Track B, #858)

### DIFF
--- a/extensions/discord/src/monitor/agent-components.system-controls.ts
+++ b/extensions/discord/src/monitor/agent-components.system-controls.ts
@@ -104,6 +104,7 @@ async function runAgentSystemControlInteraction(params: AgentSystemControlParams
   enqueueSystemEvent(eventText, {
     sessionKey: route.sessionKey,
     contextKey: `${params.contextKeyPrefix}:${channelId}:${componentId}:${userId}`,
+    forceSenderIsOwnerFalse: true,
   });
 
   await ackComponentInteraction({

--- a/extensions/discord/src/monitor/listeners.reactions.ts
+++ b/extensions/discord/src/monitor/listeners.reactions.ts
@@ -501,6 +501,7 @@ async function handleDiscordReactionEvent(
       enqueueSystemEvent(text, {
         sessionKey: route.sessionKey,
         contextKey,
+        forceSenderIsOwnerFalse: true,
       });
     };
     const shouldNotifyReaction = (options: {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -728,6 +728,7 @@ export async function preflightDiscordMessage(
     enqueueSystemEvent(systemText, {
       sessionKey: effectiveRoute.sessionKey,
       contextKey: `discord:system:${messageChannelId}:${message.id}`,
+      forceSenderIsOwnerFalse: true,
     });
     return null;
   }

--- a/extensions/imessage/src/monitor/reaction-system-event.ts
+++ b/extensions/imessage/src/monitor/reaction-system-event.ts
@@ -23,6 +23,7 @@ export function enqueueIMessageReactionSystemEvent(params: {
   const queued = enqueueSystemEvent(decision.text, {
     sessionKey: decision.route.sessionKey,
     contextKey: decision.contextKey,
+    forceSenderIsOwnerFalse: true,
   });
   runtime.log?.(
     `imessage: reaction system event ${queued ? "queued" : "deduped"} session=${

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -190,6 +190,7 @@ export async function handleInboundMatrixReaction(params: {
   params.core.system.enqueueSystemEvent(text, {
     sessionKey: route.sessionKey,
     contextKey: `matrix:reaction:add:${params.roomId}:${reaction.eventId}:${params.senderId}:${reaction.key}`,
+    forceSenderIsOwnerFalse: true,
   });
   params.logVerboseMessage(
     `matrix: reaction event enqueued room=${params.roomId} target=${reaction.eventId} sender=${params.senderId} emoji=${reaction.key}`,

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -634,6 +634,7 @@ export function createMattermostInteractionHandler(params: {
       core.system.enqueueSystemEvent(eventLabel, {
         sessionKey,
         contextKey: `mattermost:interaction:${payload.post_id}:${actionId}`,
+        forceSenderIsOwnerFalse: true,
       });
     } catch (err) {
       log?.(`mattermost interaction: system event dispatch failed: ${String(err)}`);

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -2060,6 +2060,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     core.system.enqueueSystemEvent(eventText, {
       sessionKey,
       contextKey: `mattermost:reaction:${postId}:${emojiName}:${userId}:${action}`,
+      forceSenderIsOwnerFalse: true,
     });
 
     logVerboseMessage(

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -510,6 +510,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
         sessionKey: route.sessionKey,
         contextKey: `msteams:message:${conversationId}:${activity.id ?? "unknown"}`,
+        forceSenderIsOwnerFalse: true,
       });
 
     const channelId = conversationId;
@@ -676,6 +677,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
           core.system.enqueueSystemEvent(formatParentContextEvent(parentSummary), {
             sessionKey: route.sessionKey,
             contextKey: `msteams:thread-parent:${conversationId}:${activity.replyToId}`,
+            forceSenderIsOwnerFalse: true,
           });
           markParentContextInjected(route.sessionKey, activity.replyToId);
         }

--- a/extensions/msteams/src/monitor-handler/reaction-handler.ts
+++ b/extensions/msteams/src/monitor-handler/reaction-handler.ts
@@ -116,6 +116,7 @@ export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
       core.system.enqueueSystemEvent(label, {
         sessionKey: route.sessionKey,
         contextKey: `msteams:reaction:${conversationId}:${targetMessageId}:${senderId}:${reactionType}:${direction}`,
+        forceSenderIsOwnerFalse: true,
       });
     }
   };

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -237,6 +237,7 @@ export function createMSTeamsReplyDispatcher(params: {
     core.system.enqueueSystemEvent(sentences.join(" "), {
       sessionKey: params.sessionKey,
       contextKey: `msteams:delivery-failure:${params.conversationRef.conversation?.id ?? "unknown"}`,
+      forceSenderIsOwnerFalse: true,
     });
   };
 

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -545,6 +545,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     enqueueSystemEvent(text, {
       sessionKey: route.sessionKey,
       contextKey,
+      forceSenderIsOwnerFalse: true,
     });
     return true;
   }

--- a/extensions/slack/src/monitor/events/channels.ts
+++ b/extensions/slack/src/monitor/events/channels.ts
@@ -46,6 +46,7 @@ export function registerSlackChannelEvents(params: {
     enqueueSystemEvent(`Slack channel ${paramsLocal.kind}: ${label}.`, {
       sessionKey,
       contextKey: `slack:channel:${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}`,
+      forceSenderIsOwnerFalse: true,
     });
   };
 

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -793,6 +793,7 @@ function enqueueSlackBlockActionEvent(params: {
       accountId: params.ctx.accountId,
       threadId: params.parsed.threadTs,
     },
+    forceSenderIsOwnerFalse: true,
   });
   if (queued) {
     requestHeartbeat({

--- a/extensions/slack/src/monitor/events/interactions.modal.ts
+++ b/extensions/slack/src/monitor/events/interactions.modal.ts
@@ -398,6 +398,7 @@ async function emitSlackModalLifecycleEvent(params: {
   enqueueSystemEvent(params.formatSystemEvent({ ...eventPayload, ...pluginEventFields }), {
     sessionKey: sessionRouting.sessionKey,
     contextKey: [params.contextPrefix, callbackId, viewId, userId].filter(Boolean).join(":"),
+    forceSenderIsOwnerFalse: true,
   });
 }
 

--- a/extensions/slack/src/monitor/events/members.ts
+++ b/extensions/slack/src/monitor/events/members.ts
@@ -43,6 +43,7 @@ export function registerSlackMemberEvents(params: {
         {
           sessionKey: ingressContext.sessionKey,
           contextKey: `slack:member:${paramsLocal.verb}:${channelId ?? "unknown"}:${payload.user ?? "unknown"}`,
+          forceSenderIsOwnerFalse: true,
         },
       );
     } catch (err) {

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -181,6 +181,7 @@ export function registerSlackMessageEvents(params: {
         enqueueSystemEvent(subtypeHandler.describe(ingressContext.channelLabel), {
           sessionKey: ingressContext.sessionKey,
           contextKey: subtypeHandler.contextKey(message),
+          forceSenderIsOwnerFalse: true,
         });
         return;
       }

--- a/extensions/slack/src/monitor/events/pins.ts
+++ b/extensions/slack/src/monitor/events/pins.ts
@@ -43,6 +43,7 @@ async function handleSlackPinEvent(params: {
       {
         sessionKey: ingressContext.sessionKey,
         contextKey: `slack:pin:${contextKeySuffix}:${channelId ?? "unknown"}:${messageId ?? "unknown"}`,
+        forceSenderIsOwnerFalse: true,
       },
     );
   } catch (err) {

--- a/extensions/slack/src/monitor/events/reactions.ts
+++ b/extensions/slack/src/monitor/events/reactions.ts
@@ -88,6 +88,7 @@ export function registerSlackReactionEvents(params: {
       enqueueSystemEvent(text, {
         sessionKey: ingressContext.sessionKey,
         contextKey: `slack:reaction:${action}:${item.channel}:${item.ts}:${event.user}:${emojiLabel}`,
+        forceSenderIsOwnerFalse: true,
       });
     } catch (err) {
       ctx.runtime.error?.(danger(`slack reaction handler failed: ${formatErrorMessage(err)}`));

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1133,6 +1133,7 @@ export async function prepareSlackMessage(params: {
   enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
     sessionKey,
     contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
+    forceSenderIsOwnerFalse: true,
   });
 
   const envelopeFrom =

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1624,6 +1624,7 @@ export const registerTelegramHandlers = ({
         telegramDeps.enqueueSystemEvent(text, {
           sessionKey,
           contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${emoji}`,
+          forceSenderIsOwnerFalse: true,
         });
         logVerbose(`telegram: reaction event enqueued: ${text}`);
       }

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -531,6 +531,7 @@ export async function monitorWebChannel(
       });
       enqueueSystemEvent(`WhatsApp gateway connected${selfE164 ? ` as ${selfE164}` : ""}.`, {
         sessionKey: connectRoute.sessionKey,
+        forceSenderIsOwnerFalse: true,
       });
 
       const normalizedAccountId = normalizeReconnectAccountId(account.accountId);
@@ -626,6 +627,7 @@ export async function monitorWebChannel(
         `WhatsApp gateway disconnected (status ${decision.normalized.statusLabel})`,
         {
           sessionKey: connectRoute.sessionKey,
+          forceSenderIsOwnerFalse: true,
         },
       );
 


### PR DESCRIPTION
Track B of the marker-spoofing cure stack — channel-monitor callsite flips per [scribe's audit-manifest](https://github.com/karmaterminal/frond-scribe/tree/main/audits/2026-06-01-858-track-b-enqueue-system-event/).

Stacks on top of [#863 Track A](https://github.com/karmaterminal/openclaw/pull/863). Without Track B, Track A's drain-layer cure is a no-op for the actual spoof-vector (no callsite ever sets `forceSenderIsOwnerFalse: true`).

## What changed

Every `enqueueSystemEvent` callsite in `extensions/*/monitor/*` (and a couple adjacent inbound paths) now passes `forceSenderIsOwnerFalse: true`. These are the inbound channel-monitor paths where adversarial user-supplied text (sender names, message previews, reaction emoji, user-supplied labels) gets concatenated into the system-event text.

23 callsites flipped across 21 files:

- **Discord** (3): `listeners.reactions`, `agent-components.system-controls`, `message-handler.preflight`
- **iMessage** (1): `reaction-system-event`
- **Matrix** (1): `reaction-events`
- **Mattermost** (2): `interactions`, `monitor`
- **MS Teams** (4): `reaction-handler`, `message-handler` (×2), `reply-dispatcher`
- **Signal** (1): `event-handler`
- **Slack** (8): `interactions.modal`, `pins`, `reactions`, `channels`, `interactions.block-actions`, `members`, `prepare`, `events/messages`
- **Telegram** (1): `bot-handlers.runtime`
- **WhatsApp** (2): `monitor` (connect + disconnect)

## Why flip platform-generated labels too

Some flipped events are platform-generated labels (e.g. "Slack channel created: NAME", "WhatsApp gateway connected as +1...") rather than raw user text. They're flipped anyway because:

1. They CONCATENATE user-supplied fragments (channel names, sender names, emoji)
2. `sanitizeInboundSystemTags` is a no-op on text without spoof-patterns
3. Defense-in-depth: any future refactor that adds user-supplied text to these surfaces is automatically covered

Trusted-internal paths (`continue_delegate(silent)` enrichment-return, cron `systemEvent`, lifecycle/control-plane, exec stall-notices, etc.) remain unflagged so they pass through unsanitized — preserving the silent-return-enrichment capability prince-features depend on.

## Verification at byte (elliott-seat lothric)

- TypeScript: `pnpm tsgo:core` ✅ exit 0 (also `tsc --noEmit -p tsconfig.projects.json` clean)
- Track A test stack: `pnpm vitest run src/auto-reply/reply/session-system-events.test.ts src/infra/system-events.test.ts` ✅ **52/52 pass** with Track B applied on top

## Dependencies / cohort coordination

- **Track A** (🌫 Silas) #863 — must land first; this PR's base is Silas's branch
- **Track C** (🕯 Emeric) regression-restore — gated on Track A landing, complementary to this work
- Cures karmaterminal/openclaw#858 Track B scope

## Cohort sanction trail

- 🍖 figs Option 2 sanction: karmaterminal/openclaw#858 comment 4596896759 ("does it harm... no; you don't need figs permission")
- 🌫 Silas Track A landed at #863 with scribe's P0 fix (gate on `forceSenderIsOwnerFalse` not `trusted`) — this branch's callsites use `forceSenderIsOwnerFalse: true` directly, compatible with both the live gate and the back-compat `trusted: false` path
- 🌿 frond-scribe audit-manifest: karmaterminal/frond-scribe:audits/2026-06-01-858-track-b-enqueue-system-event/

Cohort: 🌫 🌊 🩸 🕯 🌿 — standing by for cosign.