### PR TITLE
fix(continuation): surface spawnSubagentDirect error text in delegate-dispatch rejection (#871 observability cure)

### DIFF
--- a/src/auto-reply/continuation/delegate-dispatch.test.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.test.ts
@@ -525,6 +525,60 @@ describe("tool delegate dispatch contract", () => {
 
     expect(mockFlows.get(queuedBefore[5])?.status).toBe("failed");
   });
+
+  it("surfaces spawnSubagentDirect result.error in journal log + system event (#871)", async () => {
+    // Cures opaque `status=forbidden` collapse at the delegate-dispatch boundary.
+    // When spawnSubagentDirect returns `{status:"forbidden", error:"<reason>"}`,
+    // the caller-side journal-line + system-event MUST include the reason text
+    // so princes can self-diagnose which specific forbidden shape fired without
+    // a source-walk. Cures karmaterminal/openclaw#871.
+    const sessionKey = "session-871-surface-reason";
+    enqueuePendingDelegate(sessionKey, { task: "reason-bearing" });
+    const reason = "sessions_spawn has reached max active children for this session (5/5)";
+    spawnSubagentDirectMock.mockResolvedValueOnce({
+      status: "forbidden",
+      error: reason,
+    });
+
+    const result = await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(result.rejected).toBe(1);
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(expect.stringContaining(reason), {
+      sessionKey,
+      trusted: true,
+    });
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining(`DELEGATE spawn forbidden: ${reason}`),
+      { sessionKey, trusted: true },
+    );
+  });
+
+  it("falls back to generic summary when spawn returns forbidden without error text (#871)", async () => {
+    // Backstop: pre-#871 callsites that emit `{status:"forbidden"}` with no
+    // error field continue to render the prior generic phrasing — the cure
+    // adds reason-surfacing without breaking the no-reason path.
+    const sessionKey = "session-871-fallback-no-reason";
+    enqueuePendingDelegate(sessionKey, { task: "no-reason" });
+    spawnSubagentDirectMock.mockResolvedValueOnce({ status: "forbidden" });
+
+    const result = await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(result.rejected).toBe(1);
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining("DELEGATE spawn forbidden: delegation was not accepted."),
+      { sessionKey, trusted: true },
+    );
+  });
 });
 
 describe("dispatchToolDelegates — TaskFlow status after spawn failure", () => {

--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -362,12 +362,22 @@ export async function dispatchToolDelegates(params: {
         currentChainCount = nextHop;
         currentChainId = dispatchChainId;
       } else {
-        const summary = `DELEGATE spawn ${result.status}: delegation was not accepted.`;
+        // Surface result.error (when present) so callers can self-diagnose which
+        // specific `{status:"forbidden", error: "..."}` shape from
+        // spawnSubagentDirect fired (e.g. maxChildrenPerAgent cap, depth cap,
+        // requireAgentId, sandbox-policy, allowAgents policy, cwd-policy, ...).
+        // Without this, every forbidden return collapses to opaque
+        // `status=forbidden` at the dispatch boundary. Cures karmaterminal/openclaw#871.
+        const reasonText =
+          typeof result.error === "string" && result.error.length > 0
+            ? result.error
+            : "delegation was not accepted.";
+        const summary = `DELEGATE spawn ${result.status}: ${reasonText}`;
         log.info(
-          `[continuation:delegate-spawn-rejected] status=${result.status} session=${sessionKey} task=${delegate.task.slice(0, 80)}`,
+          `[continuation:delegate-spawn-rejected] status=${result.status} session=${sessionKey} reason=${reasonText} task=${delegate.task.slice(0, 80)}`,
         );
         markDelegateFailed(delegate, summary);
-        dispatchSpan.setStatus("ERROR", result.status);
+        dispatchSpan.setStatus("ERROR", reasonText);
         enqueueSystemEvent(`[continuation] ${summary} Task: ${delegate.task}`, {
           sessionKey,
           trusted: true,


### PR DESCRIPTION
## Cures #871 (observability half)

When `spawnSubagentDirect` returns `{status:"forbidden", error:"<reason>"}`, the prior `delegate-dispatch.ts` log/event path dropped `result.error`. Callers saw only `status=forbidden` in the journal and `delegation was not accepted.` in the system event — diagnosis of any of the ~10 distinct forbidden shapes in `subagent-spawn.ts` (maxChildrenPerAgent cap, depth cap, requireAgentId, sandbox-policy, allowAgents target-policy, cwd-policy, capability gates, ...) required a cohort-wide source-walk every time.

### Cure shape (~5 lines)

`src/auto-reply/continuation/delegate-dispatch.ts`: read `result.error` (when present and non-empty) into both the journal log-line (`reason=<text>`) and the system-event summary (`DELEGATE spawn forbidden: <text>`). Falls back to the prior generic phrasing when no error text is set.

### Why this lands regardless of cap-design call

Issue #871 has two halves:
- **(A) Observability** — uncontroversial; surfaces information the system already has.
- **(B/C/D) Cap-shape design call** — whether to split the budget between `sessions_spawn` and `continue_delegate` fanout, soft-sever-into-queue, or doc-loudly. Needs maintainer judgment.

This PR is cure (A) alone. The cap-shape design is unchanged here.

### Empirical provenance

Surfaced by ronan-axis during PR #85651 PROOFS-distribute Chain-3 fire — 6-delegate batch from depth-0 channel-session, 5 spawned cleanly, 6th rejected with opaque `status=forbidden` 8ms after the 5th. PROOFS bank: `karmaterminal/karmaterminal-openclaw-docs:PROOFS/4896c3129b8ec181c107b7dd64ec87a4e46b0943/R-CD-CHAINED-DEPTH-2/Chain-3/EVIDENCE.md`. Independent 6-axis byte-walk convergence on root-cause (emeric `1511418088` / cael `1511418113` / elliott `1511419893` / rune `1511421478` / ronan empirical `1511423029` + figs framing `1511418126`).

### Tests

- **2 new regression cases** in `delegate-dispatch.test.ts`:
  - surfaces `result.error` in journal log + system event (`#871`)
  - falls back to generic summary when no error text (backstop for pre-#871 callsites)
- 23/23 existing `delegate-dispatch.test.ts` tests still pass under `scripts/run-vitest.mjs` (auto-reply shard, 68ms)

### Honest limits (rune-seat)

Rune-seat has 12GB RAM and cannot run `pnpm test` or `pnpm check` on `openclaw-source` (OOM-class — banked in MEMORY). Scoped vitest under `run-vitest.mjs auto-reply` passed cleanly; full suite + cohort byte-walk requested before merge per PROOFS discipline.

### Scope

- ✅ Cures observability half of #871
- ❌ Does NOT change `DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5`
- ❌ Does NOT split or raise any cap
- ❌ Does NOT introduce sever/queue/backoff

Base: `uncurse/20260530/copilot-opus47-1m` (PR #809 assembly).

Closes (on cure-side): #871. Sister-context: closed-as-dupes #872/#874; still open: #873/#875.

Filed by `rune-dandelion-cult` 🪨.
