### PR TITLE
fix(continuation): surface delegate-spawn rejection reason + raise maxChildrenPerAgent 5→20 (#871)

### DIFF
--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -362,12 +362,13 @@ export async function dispatchToolDelegates(params: {
         currentChainCount = nextHop;
         currentChainId = dispatchChainId;
       } else {
-        const summary = `DELEGATE spawn ${result.status}: delegation was not accepted.`;
+        const reasonText = result.error ?? "delegation was not accepted.";
+        const summary = `DELEGATE spawn ${result.status}: ${reasonText}`;
         log.info(
-          `[continuation:delegate-spawn-rejected] status=${result.status} session=${sessionKey} task=${delegate.task.slice(0, 80)}`,
+          `[continuation:delegate-spawn-rejected] status=${result.status} session=${sessionKey} reason=${reasonText} task=${delegate.task.slice(0, 80)}`,
         );
         markDelegateFailed(delegate, summary);
-        dispatchSpan.setStatus("ERROR", result.status);
+        dispatchSpan.setStatus("ERROR", reasonText);
         enqueueSystemEvent(`[continuation] ${summary} Task: ${delegate.task}`, {
           sessionKey,
           trusted: true,
@@ -563,10 +564,10 @@ export async function dispatchStagedPostCompactionDelegates(
         continue;
       }
       postCompactionLog.warn(
-        `[continuation:post-compaction-spawn-rejected] status=${spawnResult.status} session=${sessionKey} task=${delegate.task.slice(0, 80)}`,
+        `[continuation:post-compaction-spawn-rejected] status=${spawnResult.status} session=${sessionKey} reason=${spawnResult.error ?? "not accepted"} task=${delegate.task.slice(0, 80)}`,
       );
       enqueueSystemEvent(
-        `[continuation] Post-compaction delegate spawn ${spawnResult.status}: delegation was not accepted. Task: ${delegate.task}`,
+        `[continuation] Post-compaction delegate spawn ${spawnResult.status}: ${spawnResult.error ?? "delegation was not accepted."}. Task: ${delegate.task}`,
         { sessionKey, trusted: true },
       );
       failed++;

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
-export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5;
+export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 20;
 export const DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES = 60;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;


### PR DESCRIPTION
## Summary

Closes #871. Two-cure fix for opaque delegate-fanout rejection:

### Cure 1 — Observability

`delegate-dispatch.ts` now includes `result.error` in:
- The rejection log-line (`reason=...`)
- The OTel span status
- The system-event summary that the caller session sees

Covers both normal dispatch and post-compaction dispatch paths. All ~10 distinct `{status:"forbidden", error:...}` shapes in `subagent-spawn.ts` now self-report at byte without any other code change.

Before: `DELEGATE spawn forbidden: delegation was not accepted.`
After: `DELEGATE spawn forbidden: sessions_spawn has reached max active children for this session (5/5)`

### Cure 2 — Cap raise

`DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT`: 5 → 20.

The old default of 5 was a reasonable interactive `sessions_spawn` safety-floor but blocks legitimate continuation-delegate fanout patterns (cohort proofs, fleet-deploys, distributed investigation). 20 matches the scale princes actually use while still providing a runaway-nesting guard.

Config-overridable via `agents.defaults.subagents.maxChildrenPerAgent`.

### Files changed

- `src/auto-reply/continuation/delegate-dispatch.ts` — surface `result.error`
- `src/config/agent-limits.ts` — raise default constant

### Test impact

Existing tests set their own explicit `maxChildrenPerAgent` values (1, 2, 5, 7) — none rely on the default. No test changes needed.