### PR TITLE
fix(continuation): surface result.error in delegate-spawn-rejected log + system-event (closes #871)

### DIFF
--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -362,12 +362,13 @@ export async function dispatchToolDelegates(params: {
         currentChainCount = nextHop;
         currentChainId = dispatchChainId;
       } else {
-        const summary = `DELEGATE spawn ${result.status}: delegation was not accepted.`;
+        const reasonText = result.error ?? "delegation was not accepted.";
+        const summary = `DELEGATE spawn ${result.status}: ${reasonText}`;
         log.info(
-          `[continuation:delegate-spawn-rejected] status=${result.status} session=${sessionKey} task=${delegate.task.slice(0, 80)}`,
+          `[continuation:delegate-spawn-rejected] status=${result.status} session=${sessionKey} reason=${reasonText} task=${delegate.task.slice(0, 80)}`,
         );
         markDelegateFailed(delegate, summary);
-        dispatchSpan.setStatus("ERROR", result.status);
+        dispatchSpan.setStatus("ERROR", reasonText);
         enqueueSystemEvent(`[continuation] ${summary} Task: ${delegate.task}`, {
           sessionKey,
           trusted: true,


### PR DESCRIPTION
## Cure (1) from issue #871 — observability fix

The delegate-dispatch rejection path at `src/auto-reply/continuation/delegate-dispatch.ts:365` dropped `result.error` from the log-line and system-event, making all forbidden-class rejections appear as opaque `status=forbidden` with no explanation.

Every `{status:"forbidden", error: ...}` shape in `subagent-spawn.ts` (~10 distinct forbidden returns: maxChildrenPerAgent cap, depth cap, sandbox policy, allowAgents target-policy, cwd-policy, capability gates, etc.) now self-reports at byte without further code changes.

### Change
- `result.error ?? "delegation was not accepted."` as `reasonText`
- Used in log-line (`reason=...`), span-status, and system-event summary
- 1 file, +4/-3 lines

### What's NOT in this PR
- Cap-shape cure (split budget, queue-overflow, raise cap) — needs design pick per issue #871 cure (2) options
- Test — the change is pure observability (log/event string); existing dispatch tests pass unchanged

### Provenance
Surfaced at byte by ronan-axis during PR #85651 PROOFS Chain-3 distributed coverage. Root-cause source-walk by emeric + cael converging. Cohort-canonical.

Closes #871.