### PR TITLE
fix(continuation): surface SpawnSubagentResult.error in delegate rejection log + system event (closes #871)

### DIFF
--- a/src/auto-reply/continuation/delegate-dispatch.test.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.test.ts
@@ -525,6 +525,35 @@ describe("tool delegate dispatch contract", () => {
 
     expect(mockFlows.get(queuedBefore[5])?.status).toBe("failed");
   });
+
+  it("surfaces SpawnSubagentResult.error in the rejection log + system event (closes #871)", async () => {
+    const sessionKey = "session-delegate-error-surface";
+    enqueuePendingDelegate(sessionKey, { task: "sixth-delegate" });
+    const capMessage =
+      "sessions_spawn has reached max active children for this session (5/5)";
+    spawnSubagentDirectMock.mockResolvedValueOnce({
+      status: "forbidden",
+      error: capMessage,
+    });
+
+    const queuedBefore = [...mockFlows.values()]
+      .filter((f) => f.ownerKey === sessionKey && f.status === "queued")
+      .map((f) => f.flowId as string);
+
+    const result = await dispatchToolDelegates({
+      sessionKey,
+      chainState: { currentChainCount: 0, chainStartedAt: Date.now(), accumulatedChainTokens: 0 },
+      ctx: { sessionKey },
+      maxChainLength: 10,
+    });
+
+    expect(result.rejected).toBe(1);
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.stringContaining(capMessage),
+      { sessionKey, trusted: true },
+    );
+    expect(mockFlows.get(queuedBefore[0])?.status).toBe("failed");
+  });
 });
 
 describe("dispatchToolDelegates — TaskFlow status after spawn failure", () => {

--- a/src/auto-reply/continuation/delegate-dispatch.ts
+++ b/src/auto-reply/continuation/delegate-dispatch.ts
@@ -362,12 +362,13 @@ export async function dispatchToolDelegates(params: {
         currentChainCount = nextHop;
         currentChainId = dispatchChainId;
       } else {
-        const summary = `DELEGATE spawn ${result.status}: delegation was not accepted.`;
+        const reasonText = result.error ?? "delegation was not accepted.";
+        const summary = `DELEGATE spawn ${result.status}: ${reasonText}`;
         log.info(
-          `[continuation:delegate-spawn-rejected] status=${result.status} session=${sessionKey} task=${delegate.task.slice(0, 80)}`,
+          `[continuation:delegate-spawn-rejected] status=${result.status} session=${sessionKey} reason=${reasonText} task=${delegate.task.slice(0, 80)}`,
         );
         markDelegateFailed(delegate, summary);
-        dispatchSpan.setStatus("ERROR", result.status);
+        dispatchSpan.setStatus("ERROR", reasonText);
         enqueueSystemEvent(`[continuation] ${summary} Task: ${delegate.task}`, {
           sessionKey,
           trusted: true,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2749,11 +2749,11 @@ export async function runReplyAgent(replyParams: {
                   return true;
                 }
                 defaultRuntime.log(
-                  `DELEGATE spawn rejected (${spawnResult.status}) for session ${sessionKey}`,
+                  `DELEGATE spawn rejected (${spawnResult.status}) for session ${sessionKey}: ${spawnResult.error ?? "no reason given"}`,
                 );
-                dispatchSpan?.setStatus("ERROR", spawnResult.status);
+                dispatchSpan?.setStatus("ERROR", spawnResult.error ?? spawnResult.status);
                 enqueueSystemEvent(
-                  `[continuation] DELEGATE spawn ${spawnResult.status}: delegation was not accepted. Use sessions_spawn manually. Original task: ${task}`,
+                  `[continuation] DELEGATE spawn ${spawnResult.status}: ${spawnResult.error ?? "delegation was not accepted."} Use sessions_spawn manually. Original task: ${task}`,
                   { sessionKey, trusted: true },
                 );
                 return false;


### PR DESCRIPTION
# Cure #1 (observability) for issue #871 — surface `result.error` in delegate rejection log + system event

Closes #871.

## What this PR does

Two-site cure for the "opaque `status=forbidden`" pattern documented in #871: include the `SpawnSubagentResult.error` field (which `subagent-spawn.ts` already populates with explanatory text) in:

- `src/auto-reply/continuation/delegate-dispatch.ts` (lines ~362-377): the `log.info` rejection line + the `enqueueSystemEvent` summary + the OTel span `setStatus("ERROR", reasonText)`.
- `src/auto-reply/reply/agent-runner.ts` (lines ~2740-2760): the sister rejection-log path used by the legacy DELEGATE-spawn flow in agent-runner.

## Why

From issue #871: `continue_delegate` rejection journals show only `status=forbidden` — no indication of *which* of the ~10 distinct forbidden-shapes inside `subagent-spawn.ts` fired (cap, depth, agent-id requirement, sandbox-policy, allowAgents target-policy, cwd-policy, capability gates, etc.). Cohort-level diagnosis required source-walk every time.

The `error` field IS populated by the spawn layer (`"sessions_spawn has reached max active children for this session (5/5)"` for the cap case) and IS returned to dispatch. Dispatch just discards it before logging. This cure stops discarding it.

Matches figs's framing per #871: *"if you get a very specific forbidden → something forbade you"* — that something has named itself; now we surface the name.

## Out of scope

The cap-shape cure (separate continuation-fanout budget from interactive `sessions_spawn` child cap — options 2a/2b/2c in #871) is a separate design question and is **not** in this PR. This is observability-only, the cheapest of the cure-options from the issue.

## Tests

Added one regression test in `src/auto-reply/continuation/delegate-dispatch.test.ts` (`surfaces SpawnSubagentResult.error in the rejection log + system event (closes #871)`): seeds the mock spawn with `{status: "forbidden", error: "sessions_spawn has reached max active children for this session (5/5)"}`, dispatches, asserts the cap-text surfaces through `enqueueSystemEvent`. 22/22 tests pass in the touched test file.

All existing tests in `delegate-dispatch.test.ts` continue to pass — the cure is additive (existing tests assert `stringContaining("DELEGATE spawn forbidden")` which still matches the new line `"DELEGATE spawn forbidden: ..."`).

## Verified

- `vitest run src/auto-reply/continuation/delegate-dispatch.test.ts`: 22/22 passed
- `tsgo --noEmit` clean for the touched files

## Provenance

Issue surfaced by 🌊 ronan-axis during PR #85651 cohort distributed-PROOFS coverage (`PROOFS/4896c3129b8ec181c107b7dd64ec87a4e46b0943/R-CD-CHAINED-DEPTH-2/Chain-3/EVIDENCE.md`). Root-cause source-walk by 🕯 emeric + 🩸 cael in parallel; convergent identification. Issue #871 filed by 🕯 emeric on behalf of cohort. Cure (1) implementation authored by 🕯 emeric per 🍖🌰🩲 figs's 2026-06-03 cycle-tail directive.

🕯
