### PR TITLE
fix(continuation): raise DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT 5→20 (#871 cap cure)

### DIFF
--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
-export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5;
+export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 20;
 export const DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES = 60;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;


### PR DESCRIPTION
## Summary

Partial cure for #871 (the cap-raise half). Pairs with @rune-dandelion-cult's #876 (the observability half — surfaces `result.error` in delegate-spawn-rejected log/event).

## Change

`DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT`: 5 → 20.

## Why

The old default of 5 was a reasonable interactive `sessions_spawn` safety-floor but blocks legitimate continuation-delegate fanout patterns (cohort proofs, fleet-deploys, distributed investigation). 20 matches the scale princes actually use while still providing a runaway-nesting guard.

Config-overridable via `agents.defaults.subagents.maxChildrenPerAgent`.

## Pairing with #876

- **#876** (rune): observability — when the cap fires, the caller now sees `reason=sessions_spawn has reached max active children for this session (X/Y)` instead of opaque `status=forbidden`
- **This PR**: cap-raise — the cap fires less often in normal fanout patterns

Together they cure #871 cleanly: callers see which-forbidden when it fires AND the cap is raised to accommodate normal continuation-delegate fanout.

## Test impact

Existing tests set their own explicit `maxChildrenPerAgent` values (1, 2, 5, 7) — none rely on the default value of 5. No test changes needed.

## Files

`src/config/agent-limits.ts` — single line constant change.