### PR TITLE
fix(subagent): #871 — surface result.error in spawn-rejected journal-line + raise maxChildrenPerAgent default 5 → 20

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1077,7 +1077,9 @@ export async function runSubagentAnnounceFlow(params: {
                 );
               } else {
                 defaultRuntime.log(
-                  `[subagent-chain-hop] Spawn rejected (${spawnResult.status}) from ${params.childSessionKey}: ${chainTask.slice(0, 80)}`,
+                  spawnResult.error
+                    ? `[subagent-chain-hop] Spawn rejected (${spawnResult.status}) from ${params.childSessionKey}: ${chainTask.slice(0, 80)} — ${spawnResult.error}`
+                    : `[subagent-chain-hop] Spawn rejected (${spawnResult.status}) from ${params.childSessionKey}: ${chainTask.slice(0, 80)}`,
                 );
               }
             } catch (err) {
@@ -1234,13 +1236,17 @@ export async function runSubagentAnnounceFlow(params: {
               } else {
                 markPendingDelegateFailed(
                   toolDelegate,
-                  `Tool delegate spawn ${spawnResult.status}: delegation was not accepted.`,
+                  spawnResult.error
+                    ? `Tool delegate spawn ${spawnResult.status}: ${spawnResult.error}`
+                    : `Tool delegate spawn ${spawnResult.status}: delegation was not accepted.`,
                   spawnResult.status === "forbidden"
                     ? "Delegate rejected"
                     : "Delegate spawn failed",
                 );
                 defaultRuntime.log(
-                  `[subagent-chain-hop] Tool delegate spawn rejected (${spawnResult.status}) from ${params.childSessionKey}`,
+                  spawnResult.error
+                    ? `[subagent-chain-hop] Tool delegate spawn rejected (${spawnResult.status}) from ${params.childSessionKey}: ${spawnResult.error}`
+                    : `[subagent-chain-hop] Tool delegate spawn rejected (${spawnResult.status}) from ${params.childSessionKey}`,
                 );
               }
             } catch (err) {

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -211,7 +211,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
       params.emitSessionLifecycleEventMock?.(...args),
     formatThinkingLevels: (levels: string[]) => levels.join(", "),
     normalizeThinkLevel: (level: unknown) => normalizeOptionalString(level),
-    DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT: 5,
+    DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT: 20,
     DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH: 3,
     ADMIN_SCOPE: "operator.admin",
     AGENT_LANE_SUBAGENT: "subagent",

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,7 +2,12 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
-export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5;
+// Raised from 5 → 20 (cure #871): the 5-cap deterministically bit 6+ delegate fanout
+// patterns (PROOFS R-CD-CHAINED-DEPTH-2/Chain-3 at 4896c3129b). 20 gives ~4x headroom
+// over the empirical bite-threshold for prince-fanout patterns while keeping unbounded
+// explosion in check. Users with stricter needs override via
+// `agents.defaults.subagents.maxChildrenPerAgent`.
+export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 20;
 export const DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES = 60;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;

--- a/src/config/config.agent-concurrency-defaults.test.ts
+++ b/src/config/config.agent-concurrency-defaults.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_AGENT_MAX_CONCURRENT,
   DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
+  DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
   DEFAULT_SUBAGENT_MAX_CONCURRENT,
   resolveAgentMaxConcurrent,
   resolveSubagentMaxConcurrent,
@@ -55,5 +56,16 @@ describe("agent concurrency defaults", () => {
     expect(cfg.agents?.defaults?.subagents?.archiveAfterMinutes).toBe(
       DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
     );
+  });
+
+  // cure #871: the maxChildrenPerAgent default deterministically bit 6+ delegate
+  // fanout patterns at the prior value of 5 (PROOFS R-CD-CHAINED-DEPTH-2/Chain-3
+  // at 4896c3129b). 20 gives ~4x headroom over the empirical bite-threshold for
+  // prince-fanout patterns while keeping unbounded explosion in check.
+  it("pins maxChildrenPerAgent default at 20 (cure #871: prince-fanout headroom)", () => {
+    expect(DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT).toBe(20);
+    // Sanity guard: not so high that a misconfigured agent could runaway-fork.
+    // 20 is the figs-aligned canon; anything > 100 should make us pause and ask why.
+    expect(DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT).toBeLessThanOrEqual(100);
   });
 });


### PR DESCRIPTION
Closes #871.

## Two-part cure

### option-A (observability): surface `result.error` in spawn-rejected journal-line

The journal-lines at `src/agents/subagent-announce.ts:1080` (chain-hop case) and `:1243` (tool-delegate case) logged only `spawnResult.status` (e.g. `"forbidden"`) with no hint about which forbidden-shape fired (depth-cap, children-cap, sandbox-cap, agent-policy-cap — all return same status). When prince-fanout patterns hit the cap at 6+ delegates per session, the journal-line gave no diagnostic clue and required a source-walk through `subagent-spawn.ts:1166-1175` to diagnose.

**Now appends `spawnResult.error` when present:**

```
[subagent-chain-hop] Tool delegate spawn rejected (forbidden) from <child-key>: sessions_spawn has reached max active children for this session (5/5)
[subagent-chain-hop] Spawn rejected (forbidden) from <child-key>: <task-preview> — sessions_spawn has reached max active children for this session (5/5)
```

The `markPendingDelegateFailed` reason text also surfaces the error so the bracket-form fallback path carries the same diagnostic. Ternary-conditional preserves existing behavior when `spawnResult.error` is undefined.

### option-D (cap-raise): `DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT` 5 → 20

The 5-cap deterministically bit 6+ delegate fanout patterns. PROOFS row R-CD-CHAINED-DEPTH-2/Chain-3 at SHA `4896c3129b` empirically reproduced this (banked at `karmaterminal/karmaterminal-openclaw-docs:PROOFS/4896c3129b8ec181c107b7dd64ec87a4e46b0943/R-CD-CHAINED-DEPTH-2/Chain-3`).

20 gives ~4x headroom over the empirical bite-threshold (prince-fanout patterns typically hit ~6-10 delegates per session) while keeping unbounded explosion in check (sanity guard pins ≤100 in test). Users with stricter needs override via `agents.defaults.subagents.maxChildrenPerAgent` config field — no schema/zod changes.

## Tests

| File | Change |
|---|---|
| `src/config/config.agent-concurrency-defaults.test.ts` | New pin: default is 20, upper-bound sanity guard ≤100 |
| `src/agents/subagent-spawn.test-helpers.ts` | Mocked default updated 5 → 20 to match real default |

**All existing tests still pass:**
- `subagent-spawn.depth-limits.test.ts` — 7/7 (per-test `maxChildrenPerAgent: N` overrides not touched)
- `subagent-announce.chain-guard.test.ts` — 22/22 (chain-guard observability paths exercised, no regressions)
- `config.agent-concurrency-defaults.test.ts` — 5/5 (4 original + 1 new cure-pin)

`pnpm tsgo:core` GREEN.

## Scope discipline

- No changes to `subagent-spawn.ts` enforcement code (only the message text in journal-lines + the default value).
- No changes to `agents.defaults.subagents.maxChildrenPerAgent` schema or zod-validation.
- No changes to the other three caps in `agent-limits.ts` (`MAX_AGENT_CONCURRENT=4`, `MAX_SUBAGENT_CONCURRENT=8`, `MAX_SPAWN_DEPTH=1`).
- Hot-reloads via existing config-patch path.

## figs canon

2026-06-03 `#sprites-of-thornfield`: figs asked "you think you can handle 871?" + named "20" as the recall-target for the cap.

