### PR TITLE
fix(continuation): surface SpawnSubagentResult.error in 3 sister rejection paths (#871 followup, 3-site scope)

### DIFF
--- a/src/agents/subagent-announce.spawn-reject-obs.test.ts
+++ b/src/agents/subagent-announce.spawn-reject-obs.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Regression-pin tests for `surface spawnResult.error in subagent-announce
+ * sister rejection paths` cure (PR #889 / Closes #871 followup).
+ *
+ * Pins observability contracts at two rejection sites in
+ * `src/agents/subagent-announce.ts`:
+ *
+ *   1. Chain-delegate (bracket) rejection-path (~line 1079)
+ *      - log line includes `reason=<text>` with `spawnResult.error` when present
+ *      - log line falls back to `reason=no reason given` when absent
+ *
+ *   2. Tool-delegate sister rejection-path (~line 1244)
+ *      - log line includes `reason=<text>` with `spawnResult.error` when present
+ *      - `markPendingDelegateFailed` summary surfaces real reason text
+ *      - Both fall back to `delegation was not accepted.` when error absent
+ *
+ * Without these contracts pinned, a regression that reverts the rejection-
+ * obs cure would re-introduce opaque `Spawn rejected (forbidden)` /
+ * `Tool delegate spawn rejected (forbidden)` log lines + the hard-coded
+ * `delegation was not accepted.` system-event text — leaving the cohort
+ * unable to disambiguate which forbidden-shape fired (cap, depth, agent-id
+ * policy, sandbox policy, allowAgents target-policy, cwd policy, capability
+ * gate, etc).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks that DO intercept the SUT (non-barrel modules) ---
+
+vi.mock("./subagent-announce.runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  readSessionMessagesAsync: vi.fn(async () => []),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (request: Record<string, unknown>) => {
+    if (request.method === "chat.history") {
+      return { messages: [] };
+    }
+    return {};
+  }),
+}));
+
+vi.mock("./subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 1,
+}));
+
+vi.mock("./embedded-agent.js", () => ({
+  isEmbeddedAgentRunActive: () => false,
+  queueEmbeddedAgentMessage: () => false,
+  waitForEmbeddedAgentRunEnd: async () => true,
+}));
+
+vi.mock("./subagent-announce.registry.runtime.js", () => ({
+  countActiveDescendantRuns: () => 0,
+  countPendingDescendantRuns: () => 0,
+  countPendingDescendantRunsExcludingRun: () => 0,
+  isSubagentSessionRunActive: () => true,
+  listSubagentRunsForRequester: () => [],
+  replaceSubagentRunAfterSteer: () => true,
+  resolveRequesterForChildSession: () => null,
+  shouldIgnorePostCompletionAnnounceForSession: () => false,
+}));
+
+vi.mock("../auto-reply/continuation/state.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../auto-reply/continuation/state.js")>()),
+  registerContinuationTimerHandle: vi.fn(),
+  retainContinuationTimerRef: vi.fn(),
+  releaseContinuationTimerRef: vi.fn(),
+  unregisterContinuationTimerHandle: vi.fn(),
+}));
+
+vi.mock("../auto-reply/continuation-delegate-store.js", () => ({
+  consumePendingDelegates: vi.fn(() => []),
+  markPendingDelegateFailed: vi.fn(),
+}));
+
+import {
+  consumePendingDelegates,
+  markPendingDelegateFailed,
+} from "../auto-reply/continuation-delegate-store.js";
+import { setRuntimeConfigSnapshot, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { resolveStorePath } from "../config/sessions.js";
+import { defaultRuntime } from "../runtime.js";
+import { runSubagentAnnounceFlow } from "./subagent-announce.js";
+import * as subagentSpawn from "./subagent-spawn.js";
+
+type AnnounceFlowParams = Parameters<typeof runSubagentAnnounceFlow>[0];
+
+function makeConfig() {
+  return {
+    session: { mainKey: "main", scope: "per-sender" as const },
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: true,
+          maxChainLength: 10,
+          costCapTokens: 500_000,
+          minDelayMs: 0,
+          maxDelayMs: 0,
+          crossSessionTargeting: "disabled" as const,
+        },
+      },
+    },
+  };
+}
+
+function writeSessionStore(data: Record<string, unknown>) {
+  const storePath = resolveStorePath(undefined, { agentId: "main" });
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.writeFileSync(storePath, JSON.stringify(data), "utf8");
+}
+
+function buildChainDelegateParams(): AnnounceFlowParams {
+  return {
+    childSessionKey: "agent:main:subagent:shard-reject-chain",
+    childRunId: "run-reject-chain",
+    requesterSessionKey: "agent:main:discord:dm:test-reject",
+    requesterDisplayKey: "test-reject",
+    task: "[continuation:chain-hop:1] Delegated task: do research",
+    roundOneReply: "Research result.\n[[CONTINUE_DELEGATE: continue next step]]",
+    timeoutMs: 30_000,
+    cleanup: "delete",
+    outcome: { status: "ok" as const },
+    silentAnnounce: true,
+    wakeOnReturn: true,
+  };
+}
+
+function buildToolDelegateParams(): AnnounceFlowParams {
+  return {
+    childSessionKey: "agent:main:subagent:shard-reject-tool",
+    childRunId: "run-reject-tool",
+    requesterSessionKey: "agent:main:discord:dm:test-reject-tool",
+    requesterDisplayKey: "test-reject-tool",
+    task: "[continuation:chain-hop:1] Tool-delegated from sub-agent (depth 1): do research",
+    roundOneReply: "Research complete.",
+    timeoutMs: 30_000,
+    cleanup: "delete",
+    outcome: { status: "ok" as const },
+    silentAnnounce: true,
+    wakeOnReturn: true,
+  };
+}
+
+const mockedConsumePendingDelegates = vi.mocked(consumePendingDelegates);
+const mockedMarkPendingDelegateFailed = vi.mocked(markPendingDelegateFailed);
+
+describe("subagent-announce chain-delegate rejection observability (PR #889 / #871 followup)", () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writeSessionStore({});
+    setRuntimeConfigSnapshot(makeConfig() as any);
+    spawnSpy = vi.spyOn(subagentSpawn, "spawnSubagentDirect");
+    logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    mockedConsumePendingDelegates.mockReturnValue([]);
+    mockedMarkPendingDelegateFailed.mockClear();
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    logSpy.mockRestore();
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("surfaces spawnResult.error in `reason=...` log line when error present", async () => {
+    const REASON = "child cap exceeded for sandbox policy";
+    spawnSpy.mockResolvedValue({ status: "forbidden", error: REASON });
+
+    await runSubagentAnnounceFlow(buildChainDelegateParams());
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const rejectionLogs = logSpy.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .filter((m: string) => m.includes("[subagent-chain-hop] Spawn rejected"));
+    expect(rejectionLogs).toHaveLength(1);
+    expect(rejectionLogs[0]).toContain("reason=" + REASON);
+    expect(rejectionLogs[0]).toContain("(forbidden)");
+  });
+
+  it("falls back to `reason=no reason given` when spawnResult.error is absent", async () => {
+    spawnSpy.mockResolvedValue({ status: "forbidden" });
+
+    await runSubagentAnnounceFlow(buildChainDelegateParams());
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const rejectionLogs = logSpy.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .filter((m: string) => m.includes("[subagent-chain-hop] Spawn rejected"));
+    expect(rejectionLogs).toHaveLength(1);
+    expect(rejectionLogs[0]).toContain("reason=no reason given");
+  });
+});
+
+describe("subagent-announce tool-delegate rejection observability (PR #889 / #871 followup)", () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writeSessionStore({});
+    setRuntimeConfigSnapshot(makeConfig() as any);
+    spawnSpy = vi.spyOn(subagentSpawn, "spawnSubagentDirect");
+    logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    mockedConsumePendingDelegates.mockReset().mockReturnValue([]);
+    mockedMarkPendingDelegateFailed.mockClear();
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    logSpy.mockRestore();
+    mockedConsumePendingDelegates.mockReturnValue([]);
+    mockedMarkPendingDelegateFailed.mockClear();
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("surfaces spawnResult.error in `reason=...` log + markPendingDelegateFailed summary when present", async () => {
+    const REASON = "tool-delegate depth cap exceeded";
+    mockedConsumePendingDelegates.mockReturnValue([{ task: "tool task to reject" }]);
+    spawnSpy.mockResolvedValue({ status: "forbidden", error: REASON });
+
+    await runSubagentAnnounceFlow(buildToolDelegateParams());
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+
+    const rejectionLogs = logSpy.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .filter((m: string) => m.includes("[subagent-chain-hop] Tool delegate spawn rejected"));
+    expect(rejectionLogs).toHaveLength(1);
+    expect(rejectionLogs[0]).toContain("reason=" + REASON);
+    expect(rejectionLogs[0]).toContain("(forbidden)");
+
+    expect(mockedMarkPendingDelegateFailed).toHaveBeenCalledTimes(1);
+    const summaryArg = String(mockedMarkPendingDelegateFailed.mock.calls[0][1]);
+    expect(summaryArg).toContain(REASON);
+    expect(summaryArg).toContain("forbidden");
+    // Reason text must replace the canned "delegation was not accepted." string
+    expect(summaryArg).not.toContain("delegation was not accepted.");
+    expect(mockedMarkPendingDelegateFailed.mock.calls[0][2]).toBe("Delegate rejected");
+  });
+
+  it("falls back to `delegation was not accepted.` when spawnResult.error is absent", async () => {
+    mockedConsumePendingDelegates.mockReturnValue([{ task: "tool task no reason" }]);
+    spawnSpy.mockResolvedValue({ status: "forbidden" });
+
+    await runSubagentAnnounceFlow(buildToolDelegateParams());
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+
+    const rejectionLogs = logSpy.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .filter((m: string) => m.includes("[subagent-chain-hop] Tool delegate spawn rejected"));
+    expect(rejectionLogs).toHaveLength(1);
+    expect(rejectionLogs[0]).toContain("reason=delegation was not accepted.");
+
+    expect(mockedMarkPendingDelegateFailed).toHaveBeenCalledTimes(1);
+    const summaryArg = String(mockedMarkPendingDelegateFailed.mock.calls[0][1]);
+    expect(summaryArg).toContain("delegation was not accepted.");
+    expect(mockedMarkPendingDelegateFailed.mock.calls[0][2]).toBe("Delegate rejected");
+  });
+});

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1076,8 +1076,9 @@ export async function runSubagentAnnounceFlow(params: {
                     : `[subagent-chain-hop] Spawned chain delegate (${nextChainHop}/${maxChainLength}) from ${params.childSessionKey}: ${chainTask.slice(0, 80)}`,
                 );
               } else {
+                const reasonText = spawnResult.error ?? "no reason given";
                 defaultRuntime.log(
-                  `[subagent-chain-hop] Spawn rejected (${spawnResult.status}) from ${params.childSessionKey}: ${chainTask.slice(0, 80)}`,
+                  `[subagent-chain-hop] Spawn rejected (${spawnResult.status}) from ${params.childSessionKey} reason=${reasonText}: ${chainTask.slice(0, 80)}`,
                 );
               }
             } catch (err) {
@@ -1232,15 +1233,16 @@ export async function runSubagentAnnounceFlow(params: {
                   `[subagent-chain-hop] Tool delegate (${nextToolHop}/${toolMaxChainLength}) from ${params.childSessionKey}: ${toolDelegate.task.slice(0, 80)}`,
                 );
               } else {
+                const toolReasonText = spawnResult.error ?? "delegation was not accepted.";
                 markPendingDelegateFailed(
                   toolDelegate,
-                  `Tool delegate spawn ${spawnResult.status}: delegation was not accepted.`,
+                  `Tool delegate spawn ${spawnResult.status}: ${toolReasonText}`,
                   spawnResult.status === "forbidden"
                     ? "Delegate rejected"
                     : "Delegate spawn failed",
                 );
                 defaultRuntime.log(
-                  `[subagent-chain-hop] Tool delegate spawn rejected (${spawnResult.status}) from ${params.childSessionKey}`,
+                  `[subagent-chain-hop] Tool delegate spawn rejected (${spawnResult.status}) from ${params.childSessionKey} reason=${toolReasonText}`,
                 );
               }
             } catch (err) {

--- a/src/auto-reply/reply/agent-runner.continuation-delegate-reject-obs.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-delegate-reject-obs.test.ts
@@ -1,0 +1,416 @@
+// Integration test pinning the runner-side `continuation.delegate.fire` span
+// emission contract at the timer-callback seam before reservation lookup.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as embeddedRunTesting,
+  abortEmbeddedAgentRun,
+  isEmbeddedAgentRunActive,
+} from "../../agents/embedded-agent-runner/runs.js";
+import { createContinueDelegateTool } from "../../agents/tools/continue-delegate-tool.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  resetContinuationTracer,
+  setContinuationTracer,
+  type Span,
+  type SpanAttributes,
+  type SpanStatus,
+  type StartSpanOptions,
+  type Tracer,
+} from "../../infra/continuation-tracer.js";
+import {
+  clearMemoryPluginState,
+  registerMemoryFlushPlanResolver,
+} from "../../plugins/memory-state.js";
+import {
+  clearDelayedContinuationReservations,
+  enqueuePendingDelegate,
+} from "../continuation/delegate-store.js";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { __testing as replyRunRegistryTesting } from "./reply-run-registry.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+void registerMemoryFlushPlanResolver;
+
+const runEmbeddedAgentMock = vi.fn();
+const runCliAgentMock = vi.fn();
+const runWithModelFallbackMock = vi.fn();
+const runtimeErrorMock = vi.fn();
+const abortEmbeddedAgentRunMock = vi.fn();
+const clearSessionQueuesMock = vi.fn();
+const refreshQueuedFollowupSessionMock = vi.fn();
+const compactState = vi.hoisted(() => ({
+  compactEmbeddedAgentSessionMock: vi.fn(),
+}));
+const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
+const spawnSubagentDirectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: (params: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => runWithModelFallbackMock(params),
+  isFallbackSummaryError: (err: unknown) =>
+    err instanceof Error &&
+    err.name === "FallbackSummaryError" &&
+    Array.isArray((err as { attempts?: unknown[] }).attempts),
+}));
+
+vi.mock("../../agents/model-auth.js", () => ({
+  resolveModelAuthMode: () => "api-key",
+}));
+
+vi.mock("../../agents/embedded-agent.js", () => ({
+  compactEmbeddedAgentSession: (params: unknown) =>
+    compactState.compactEmbeddedAgentSessionMock(params),
+  queueEmbeddedAgentMessage: vi.fn().mockReturnValue(false),
+  runEmbeddedAgent: (params: unknown) => runEmbeddedAgentMock(params),
+  abortEmbeddedAgentRun: (sessionId: string) => {
+    abortEmbeddedAgentRunMock(sessionId);
+    return abortEmbeddedAgentRun(sessionId);
+  },
+  isEmbeddedAgentRunActive: (sessionId: string) => isEmbeddedAgentRunActive(sessionId),
+}));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: (...args: unknown[]) => runCliAgentMock(...args),
+}));
+
+vi.mock("../../agents/subagent-spawn.js", () => ({
+  SUBAGENT_SPAWN_MODES: ["run", "session"],
+  SUBAGENT_SPAWN_SANDBOX_MODES: ["inherit", "require"],
+  SUBAGENT_SPAWN_CONTEXT_MODES: ["isolated", "fork"],
+  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: (...args: unknown[]) => runtimeErrorMock(...args),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
+}));
+
+vi.mock("./queue.js", () => ({
+  enqueueFollowupRun: vi.fn(),
+  scheduleFollowupDrain: vi.fn(),
+  clearSessionQueues: (...args: unknown[]) => clearSessionQueuesMock(...args),
+  refreshQueuedFollowupSession: (...args: unknown[]) => refreshQueuedFollowupSessionMock(...args),
+}));
+
+vi.mock("../../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: async ({ config }: { config: unknown }) => ({
+    resolvedConfig: config,
+    diagnostics: [],
+  }),
+}));
+
+vi.mock("../../utils/provider-utils.js", () => ({
+  isReasoningTagProvider: (provider: string | undefined | null) =>
+    provider === "google" || provider === "google-gemini-cli",
+}));
+
+const loadCronStoreMock = vi.fn();
+vi.mock("../../cron/store.js", () => ({
+  loadCronStore: (...args: unknown[]) => loadCronStoreMock(...args),
+  resolveCronStorePath: (storePath?: string) => storePath ?? "/tmp/openclaw-cron-store.json",
+}));
+
+vi.mock("../../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    resolveSession: () => ({ kind: "none" }),
+    cancelSession: async () => {},
+  }),
+}));
+
+vi.mock("../../agents/subagent-registry.js", () => ({
+  getLatestSubagentRunByChildSessionKey: () => null,
+  listSubagentRunsForController: () => [],
+  markSubagentRunTerminated: () => 0,
+}));
+
+import { runReplyAgent } from "./agent-runner.js";
+
+type RunWithModelFallbackParams = {
+  provider: string;
+  model: string;
+  run: (provider: string, model: string) => Promise<unknown>;
+};
+
+type RecordedSpan = {
+  name: string;
+  attributes: SpanAttributes;
+  traceparent: string | undefined;
+  status: SpanStatus | undefined;
+  ended: boolean;
+};
+
+function createRecordingTracer(): { tracer: Tracer; spans: RecordedSpan[] } {
+  const spans: RecordedSpan[] = [];
+  const tracer: Tracer = {
+    startSpan(name: string, opts?: StartSpanOptions): Span {
+      const rec: RecordedSpan = {
+        name,
+        attributes: { ...opts?.attributes },
+        traceparent: opts?.traceparent,
+        status: undefined,
+        ended: false,
+      };
+      spans.push(rec);
+      const span: Span = {
+        setAttributes(attrs: SpanAttributes): void {
+          Object.assign(rec.attributes, attrs);
+        },
+        setStatus(status: SpanStatus, _message?: string): void {
+          rec.status = status;
+        },
+        recordException(_err: unknown): void {
+          // unused
+        },
+        end(): void {
+          rec.ended = true;
+        },
+      };
+      return span;
+    },
+  };
+  return { tracer, spans };
+}
+
+beforeEach(() => {
+  embeddedRunTesting.resetActiveEmbeddedRuns();
+  replyRunRegistryTesting.resetReplyRunRegistry();
+  runEmbeddedAgentMock.mockClear();
+  runCliAgentMock.mockClear();
+  runWithModelFallbackMock.mockClear();
+  runtimeErrorMock.mockClear();
+  abortEmbeddedAgentRunMock.mockClear();
+  compactState.compactEmbeddedAgentSessionMock.mockReset();
+  compactState.compactEmbeddedAgentSessionMock.mockResolvedValue({
+    compacted: false,
+    reason: "test-preflight-disabled",
+  });
+  clearSessionQueuesMock.mockReset();
+  clearSessionQueuesMock.mockReturnValue({ followupCleared: 0, laneCleared: 0, keys: [] });
+  refreshQueuedFollowupSessionMock.mockReset();
+  refreshQueuedFollowupSessionMock.mockResolvedValue(undefined);
+  loadCronStoreMock.mockClear();
+  loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+  requestHeartbeatNowMock.mockReset();
+  spawnSubagentDirectMock.mockReset().mockResolvedValue({
+    status: "accepted",
+    childSessionKey: "agent:main:subagent:spawned",
+    runId: "run-spawned",
+  });
+  runWithModelFallbackMock.mockImplementation(
+    async ({ provider, model, run }: RunWithModelFallbackParams) => ({
+      result: await run(provider, model),
+      provider,
+      model,
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearRuntimeConfigSnapshot();
+  clearMemoryPluginState();
+  replyRunRegistryTesting.resetReplyRunRegistry();
+  embeddedRunTesting.resetActiveEmbeddedRuns();
+  resetContinuationTracer();
+});
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function createContinuationRun(params?: {
+  sessionKey?: string;
+  config?: Record<string, unknown>;
+  sessionEntry?: SessionEntry;
+}) {
+  const sessionKey = params?.sessionKey ?? "continuation-delegate-fire-span";
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: "discord",
+    OriginatingTo: "channel:1",
+    AccountId: "primary",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+  const sessionEntry =
+    params?.sessionEntry ??
+    ({
+      sessionId: "session",
+      updatedAt: Date.now(),
+    } satisfies SessionEntry);
+  const followupRun = {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey,
+      messageProvider: "discord",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config:
+        params?.config ??
+        ({
+          agents: {
+            defaults: {
+              continuation: {
+                enabled: true,
+                minDelayMs: 0,
+                maxDelayMs: 5_000,
+                defaultDelayMs: 1_000,
+                maxChainLength: 4,
+                maxDelegatesPerTurn: 4,
+              },
+            },
+          },
+        } satisfies Record<string, unknown>),
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+
+  return { sessionKey, sessionEntry, typing, sessionCtx, resolvedQueue, followupRun };
+}
+
+async function runDelegateTurn(
+  run: ReturnType<typeof createContinuationRun>,
+  sessionStore: Record<string, SessionEntry>,
+): Promise<unknown> {
+  setRuntimeConfigSnapshot(run.followupRun.run.config);
+  return runReplyAgent({
+    commandBody: "hello",
+    followupRun: run.followupRun,
+    queueKey: run.sessionKey,
+    resolvedQueue: run.resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    isStreaming: false,
+    typing: run.typing,
+    sessionCtx: run.sessionCtx,
+    sessionEntry: run.sessionEntry,
+    sessionStore,
+    sessionKey: run.sessionKey,
+    defaultModel: "anthropic/claude-opus-4-6",
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: "instant",
+  });
+}
+
+describe("runReplyAgent :: continuation-delegate rejection observability (PR #889 / #871 followup)", () => {
+  // Pins the contract that the agent-runner-side `doSpawn` (`agent-runner.ts:~2751-2758`)
+  // surfaces `spawnResult.error` into BOTH the rejection log line AND the
+  // `[continuation]` system-event text. Sister-site to the two
+  // `subagent-announce.ts` rejection-paths already cured by the same PR.
+  //
+  // Without this contract pinned, a regression that reverts the cure would
+  // re-introduce the opaque `DELEGATE spawn rejected (forbidden) for session
+  // <key>` log line + the hard-coded `delegation was not accepted.`
+  // system-event text — leaving the cohort unable to disambiguate which
+  // forbidden-shape fired (cap, depth, agent-id policy, sandbox policy,
+  // allowAgents target-policy, cwd policy, capability gate, etc).
+
+  it("surfaces spawnResult.error into log + system event when error present (bracket-delegate immediate path)", async () => {
+    const { tracer } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    const REASON = "child cap exceeded for sandbox policy";
+    spawnSubagentDirectMock.mockReset().mockResolvedValueOnce({
+      status: "forbidden",
+      error: REASON,
+    });
+
+    const sessionKey = "continuation-delegate-reject-with-reason";
+    const run = createContinuationRun({ sessionKey });
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [
+        {
+          text: "Reply\n[[CONTINUE_DELEGATE: do task that will be rejected]]",
+        },
+      ],
+      meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+    });
+
+    const { drainSystemEventEntries } = await import("../../infra/system-events.js");
+    drainSystemEventEntries(sessionKey);
+
+    await runDelegateTurn(run, { [sessionKey]: run.sessionEntry });
+
+    // Bracket-delegate spawn was attempted exactly once, returned forbidden.
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+
+    // System event surfaces real reason text (substring on full event body).
+    const entries = drainSystemEventEntries(sessionKey);
+    const rejectionEvent = entries.find((e) => e.text.includes("DELEGATE spawn forbidden"));
+    expect(
+      rejectionEvent,
+      `expected [continuation] DELEGATE spawn forbidden event, got entries: ${entries.map((e) => e.text).join(" | ")}`,
+    ).toBeDefined();
+    expect(rejectionEvent!.text).toContain(REASON);
+    // The canned fallback "delegation was not accepted." MUST be replaced by
+    // real reason text when spawnResult.error is present.
+    expect(
+      rejectionEvent!.text.startsWith(
+        "[continuation] DELEGATE spawn forbidden: delegation was not accepted.",
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back to `delegation was not accepted.` when spawnResult.error is absent (bracket-delegate immediate path)", async () => {
+    const { tracer } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    spawnSubagentDirectMock.mockReset().mockResolvedValueOnce({
+      status: "forbidden",
+    });
+
+    const sessionKey = "continuation-delegate-reject-no-reason";
+    const run = createContinuationRun({ sessionKey });
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [
+        {
+          text: "Reply\n[[CONTINUE_DELEGATE: do task that will be rejected]]",
+        },
+      ],
+      meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+    });
+
+    const { drainSystemEventEntries } = await import("../../infra/system-events.js");
+    drainSystemEventEntries(sessionKey);
+
+    await runDelegateTurn(run, { [sessionKey]: run.sessionEntry });
+
+    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+
+    const entries = drainSystemEventEntries(sessionKey);
+    const rejectionEvent = entries.find((e) => e.text.includes("DELEGATE spawn forbidden"));
+    expect(rejectionEvent).toBeDefined();
+    expect(rejectionEvent!.text).toContain("delegation was not accepted.");
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2748,12 +2748,13 @@ export async function runReplyAgent(replyParams: {
                   );
                   return true;
                 }
+                const reasonText = spawnResult.error ?? "delegation was not accepted.";
                 defaultRuntime.log(
-                  `DELEGATE spawn rejected (${spawnResult.status}) for session ${sessionKey}`,
+                  `DELEGATE spawn rejected (${spawnResult.status}) for session ${sessionKey} reason=${reasonText}`,
                 );
-                dispatchSpan?.setStatus("ERROR", spawnResult.status);
+                dispatchSpan?.setStatus("ERROR", reasonText);
                 enqueueSystemEvent(
-                  `[continuation] DELEGATE spawn ${spawnResult.status}: delegation was not accepted. Use sessions_spawn manually. Original task: ${task}`,
+                  `[continuation] DELEGATE spawn ${spawnResult.status}: ${reasonText} Use sessions_spawn manually. Original task: ${task}`,
                   { sessionKey, trusted: true },
                 );
                 return false;


### PR DESCRIPTION
Closes karmaterminal/openclaw#871

3-site obs-cure completing PR #877's canonical-site work. Surfaces `spawnResult.error` (when present, with canonical fallback) into BOTH the rejection log line AND the dispatching-session-visible system-event / markPendingDelegateFailed summary at every continuation/delegate spawn-rejection seam.

## Sister sites cured

### Site 1 — Bracket chain-delegate at announce-time
- **File**: `src/agents/subagent-announce.ts:~1079` (`doChainSpawn` inside `runSubagentAnnounceFlow`)
- **Pre-cure**: `[subagent-chain-hop] Spawn rejected (${status}) from ${childSessionKey}` — opaque
- **Post-cure**: adds `reason=${spawnResult.error ?? "no reason given"}` to log line

### Site 2 — Tool-delegate at announce-time
- **File**: `src/agents/subagent-announce.ts:~1240` (`doToolChainSpawn` inside `runSubagentAnnounceFlow`)
- **Pre-cure**: opaque log + `markPendingDelegateFailed("...delegation was not accepted.")` hardcoded
- **Post-cure**: adds `reason=${spawnResult.error ?? "delegation was not accepted."}` to BOTH the log line AND the markPendingDelegateFailed summary

### Site 3 — Continuation-delegate at agent-runner doSpawn
- **File**: `src/auto-reply/reply/agent-runner.ts:~2748-2761` (`doSpawn` inside `runReplyAgent`)
- **Pre-cure**: opaque `DELEGATE spawn rejected (${status}) for session ${sessionKey}` log + hardcoded `[continuation] DELEGATE spawn ${status}: delegation was not accepted.` system-event
- **Post-cure**: threads `spawnResult.error` into the log line, the `dispatchSpan.setStatus("ERROR", reasonText)` trace attribute, AND the `[continuation]` system-event text

## Regression-pin tests (6 total, 2 per site)

### `src/agents/subagent-announce.spawn-reject-obs.test.ts` (NEW, 4 tests)
- Site 1: surfaces `spawnResult.error` in `reason=...` log line when present
- Site 1: falls back to `reason=no reason given` when error absent
- Site 2: surfaces `spawnResult.error` in log + `markPendingDelegateFailed` summary when present
- Site 2: falls back to `delegation was not accepted.` when error absent

### `src/auto-reply/reply/agent-runner.continuation-delegate-reject-obs.test.ts` (NEW, 2 tests)
- Site 3: surfaces `spawnResult.error` into log + system-event when present (bracket-delegate immediate path)
- Site 3: falls back to `delegation was not accepted.` when error absent

## Tested

- `vitest run subagent-announce.spawn-reject-obs.test.ts + agent-runner.continuation-delegate-reject-obs.test.ts` → 10/10 pass (4 + 4 across agents-core + agents-support projects, 2 auto-reply)
- `vitest run` on broader neighborhood (continuation, chain-guard, fire-span, delegate-dispatch, continuation-drain, subagent-announce) → 136/136 pass across 13 test files, 0 regressions
- `tsgo --noEmit` clean on the 3 touched files (no new TS errors; pre-existing unrelated `config/io.ts` + `secrets/config-io.ts` errors not caused by this PR)

## Linked PROOF doc

karmaterminal/karmaterminal-openclaw-docs#91 — full 3-site evidence corpus:
- Gap evidence (pre-cure log + system-event opacity, byte-quoted from `683e309118`)
- Post-cure shape for each site (byte-quoted from PR HEAD)
- Proof procedure for cohort manual verification
- Test-run receipts

## Provenance

- 🌧 Rune `1511746594` byte-walk surfaced Site 3
- 🌻 Elliott `1511728744` byte-walk surfaced Sites 1+2 (cured in lamp's `58da7b408a`)
- 🕯 figs `1511763538` testing-discipline directive (regression-pin tests floor)
- 🕯 figs `1511746478` scope-discipline (continuation-feature-scope only)
- Pre-claim channel-line hygiene: lamp `1511748561` + `1511760986` + `1511763755`

## Discipline floor

- `gh auth` identity: `emeric-dandelion-cult` (NOT shared `karmafeast`) per figs's `1511728437` correction
- Self-assigned with labels `continuation,P2,bug` per cohort discipline
- Scope-extension commit lands on top of lamp's `58da7b408a` (NOT a rewrite)