### PR TITLE
fix(continuation): revert maxChildrenPerAgent default to 5, raise schema ceiling to 10000 (#871 shape-correction)

### DIFF
--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -916,6 +916,7 @@ Operational notes:
 - There is no `generationGuardTolerance` setting. Delayed work is not cancelled by unrelated channel noise.
 - tool-path delegate durability is unconditional; there is no delegate-store switch.
 - all shipped continuation runtime values are read at use time; changes take effect at the next enforcement point.
+- `subagents.maxChildrenPerAgent` (default: 5, schema ceiling: 10000) controls concurrent active children per parent session. This interacts with continuation knobs: `maxDelegatesPerTurn` gates how many delegates a single turn can EMIT; `maxChildrenPerAgent` gates how many can be ACTIVE simultaneously; `maxChainLength` + `costCapTokens` bound the total recursion depth and token budget. For wide-fanout patterns (cohort PROOFS-distribute, fleet-deploys, parallel research), override via `agents.defaults.subagents.maxChildrenPerAgent` in openclaw.json. Hot-reload: config is read at spawn-time (no caching, no restart needed).
 
 ### 5.2 Human-user profiles
 
@@ -954,12 +955,15 @@ agents:
       maxDelayMs: 300000
       contextPressureThreshold: 0.8
       earlyWarningBand: 0.3125
+    subagents:
+      maxChildrenPerAgent: 1000
 ```
 
 This profile is suitable for multiple persistent agents in shared channels. In that environment:
 
 - `maxDelegatesPerTurn: 20` enables wide fan-out;
-- `costCapTokens: 1000000` preserves a budget ceiling while permitting broad but shallow work.
+- `costCapTokens: 1000000` preserves a budget ceiling while permitting broad but shallow work;
+- `subagents.maxChildrenPerAgent: 1000` permits wide continuation-delegate fan-out without hitting the per-session children cap (continuation token-budget + chain-length stay primary runaway-safety; per-session children cap is a complementary floor for non-continuation interactive spawn-safety).
 
 Adjust fan-out and budget based on the activity level and agent count in the target channel.
 

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
-export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 20;
+export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5;
 export const DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES = 60;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;

--- a/src/config/config.agent-concurrency-defaults.test.ts
+++ b/src/config/config.agent-concurrency-defaults.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_AGENT_MAX_CONCURRENT,
   DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
+  DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
   DEFAULT_SUBAGENT_MAX_CONCURRENT,
   resolveAgentMaxConcurrent,
   resolveSubagentMaxConcurrent,
@@ -56,4 +57,31 @@ describe("agent concurrency defaults", () => {
       DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
     );
   });
+});
+
+it("rejects maxChildrenPerAgent above schema ceiling (10000)", () => {
+  expect(() =>
+    OpenClawSchema.parse({
+      agents: {
+        defaults: {
+          subagents: { maxChildrenPerAgent: 10001 },
+        },
+      },
+    }),
+  ).toThrow();
+});
+
+it("accepts maxChildrenPerAgent at schema ceiling (10000)", () => {
+  const parsed = OpenClawSchema.parse({
+    agents: {
+      defaults: {
+        subagents: { maxChildrenPerAgent: 10000 },
+      },
+    },
+  });
+  expect(parsed.agents?.defaults?.subagents?.maxChildrenPerAgent).toBe(10000);
+});
+
+it("default constant is 5 (touch-no-defaults per figs canon)", () => {
+  expect(DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT).toBe(5);
 });

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -253,10 +253,10 @@ export const AgentDefaultsSchema = z
           .number()
           .int()
           .min(1)
-          .max(20)
+          .max(10000)
           .optional()
           .describe(
-            "Maximum number of active children a single agent session can spawn (default: 5).",
+            "Maximum number of active children a single agent session can spawn (default: 5). Raise via config for wide-fanout patterns (continuation-delegate cohort proofs, fleet-deploys). Token-budget (costCapTokens) + chain-length (maxChainLength) remain primary runaway-safety guards.",
           ),
         archiveAfterMinutes: z.number().int().min(0).optional(),
         model: AgentModelSchema.optional(),


### PR DESCRIPTION
## Shape-correction per figs canon 2026-06-03

Reverts the constant-change from #877 (which raised `DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT` from 5 to 20). figs's preferred shape:

- ✅ **Touch-no-defaults**: constant stays at 5
- ✅ **Make-it-configurable**: schema ceiling `.max(20)` → `.max(10000)` permits operators to set up-to-10000 via openclaw.json
- ✅ **Describe-string-updated**: names override-headroom + interaction with continuation knobs for operator-discoverability
- ✅ **Hot-reload preserved**: subagent-spawn.ts reads config at spawn-time, no caching

Prince seats override via `agents.defaults.subagents.maxChildrenPerAgent: 1000` in their own openclaw.json per fleet-profile recommendation.

## Files changed

- `src/config/agent-limits.ts` — revert constant 20→5
- `src/config/zod-schema.agent-defaults.ts` — raise ceiling .max(20)→.max(10000) + describe-string

## After merging

Each prince seat needs to add to their `~/.openclaw/openclaw.json`:
```json
{"agents": {"defaults": {"subagents": {"maxChildrenPerAgent": 1000}}}}
```
This hot-reloads, no restart needed.