### PR TITLE
fix(config): revert maxChildrenPerAgent default to 5, raise schema ceiling to 10000 (figs direction)

### DIFF
--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
-export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 20;
+export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5;
 export const DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES = 60;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -253,10 +253,10 @@ export const AgentDefaultsSchema = z
           .number()
           .int()
           .min(1)
-          .max(20)
+          .max(10000)
           .optional()
           .describe(
-            "Maximum number of active children a single agent session can spawn (default: 5).",
+            "Maximum number of active children a single agent session can spawn (default: 5). Override in openclaw.json to permit wide continuation-delegate fanout patterns.",
           ),
         archiveAfterMinutes: z.number().int().min(0).optional(),
         model: AgentModelSchema.optional(),


### PR DESCRIPTION
## Per figs direction 2026-06-03 (quoting yesterday's approved approach)

```
✅ Touch-no-defaults: const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5 substantively-left-untouched
✅ Make-it-configurable: schema-ceiling .max(20) → .max(10000) permits operators to set up-to-10000 via openclaw.json (~1 line)
✅ Describe-string-updated: names override-headroom + default cleanly for operator-discoverability
```

### What this does
1. **Reverts constant** `DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT` from 20 → **5** (undoing #877's raise)
2. **Raises schema ceiling** from `.max(20)` → `.max(10000)` so operators can opt-in via `agents.defaults.subagents.maxChildrenPerAgent` in openclaw.json
3. **Updates describe-string** to name the override path for discoverability

### Why
#877 raised the constant 5→20 — universal effect on every seat without override. figs's approved direction was the inverse: leave the default safe for upstream/new-installs, let operators opt-in to wide fanout via config.

Princes needing wide continuation-delegate fanout (PROOFS-distribute patterns, cohort parallel-work) set their own config value. Default stays conservative.

### Files
- `src/config/agent-limits.ts` — constant revert 20→5
- `src/config/zod-schema.agent-defaults.ts` — schema ceiling 20→10000 + describe-string update

Closes the direction-mismatch from this round. Pairs with #877's observability cure (result.error surfacing) which remains correct and unaffected.

Self-assigned: ronan-dandelion-cult.