### PR TITLE
feat(continuation): restore continue_work() in subagent sessions (#746) — P0 cherry-pick

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -3686,3 +3686,73 @@ describe("createFollowupRunner queued user message idempotency across fallback",
     expect(secondAttempt.suppressAssistantErrorPersistence).toBe(false);
   });
 });
+
+describe("createFollowupRunner continueWorkOpts threading (#746)", () => {
+  it("passes continueWorkOpts to runEmbeddedAgent when continuation.enabled=true", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "done" }],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude",
+      sessionKey: "agent:main:subagent:test-organ",
+    });
+    const queued = createQueuedRun({
+      run: {
+        sessionKey: "agent:main:subagent:test-organ",
+        config: {
+          agents: {
+            defaults: {
+              continuation: {
+                enabled: true,
+                maxChainLength: 200,
+                defaultDelayMs: 15000,
+                minDelayMs: 5000,
+                maxDelayMs: 86400000,
+                costCapTokens: 50000000,
+                maxDelegatesPerTurn: 500,
+              },
+            },
+          },
+        } as OpenClawConfig,
+        drainsContinuationDelegateQueue: true,
+      },
+    });
+
+    await runner(queued);
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalled();
+    const callArgs = requireLastMockCallArg(runEmbeddedAgentMock, "runEmbeddedAgent");
+    expect(callArgs.continueWorkOpts).toBeDefined();
+    expect(typeof (callArgs.continueWorkOpts as any).requestContinuation).toBe("function");
+  });
+
+  it("does NOT pass continueWorkOpts when continuation is disabled", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "done" }],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude",
+      sessionKey: "agent:main:subagent:test-leaf",
+    });
+    const queued = createQueuedRun({
+      run: {
+        sessionKey: "agent:main:subagent:test-leaf",
+        config: {
+          agents: { defaults: {} },
+        } as OpenClawConfig,
+      },
+    });
+
+    await runner(queued);
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalled();
+    const callArgs = requireLastMockCallArg(runEmbeddedAgentMock, "runEmbeddedAgent");
+    expect(callArgs.continueWorkOpts).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -25,9 +25,17 @@ import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import {
+  registerContinuationTimerHandle,
+  retainContinuationTimerRef,
+  unregisterContinuationTimerHandle,
+} from "../continuation/state.js";
+import type { ContinueWorkRequest } from "../continuation/types.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
@@ -680,6 +688,7 @@ export function createFollowupRunner(params: {
         | undefined;
       let queuedUserMessagePersistedAcrossFallback = false;
       let assistantErrorPersistedAcrossFallback = false;
+      let attemptContinueWorkRequest: ContinueWorkRequest | undefined;
       try {
         const outcomePlan = buildAgentRuntimeOutcomePlan();
         const fallbackResult = await runWithModelFallback<EmbeddedAgentRunResult>({
@@ -945,6 +954,18 @@ export function createFollowupRunner(params: {
                   bootstrapPromptWarningSignaturesSeen[
                     bootstrapPromptWarningSignaturesSeen.length - 1
                   ],
+                // Continuation: thread continueWorkOpts so continue_work is
+                // callable on queued followup turns (subagent sessions, continuation-
+                // triggered heartbeats). Without this, the tool never registers and
+                // subagents cannot self-elect another turn. (#746)
+                continueWorkOpts:
+                  runtimeConfig?.agents?.defaults?.continuation?.enabled === true
+                    ? {
+                        requestContinuation: (request: ContinueWorkRequest) => {
+                          attemptContinueWorkRequest = request;
+                        },
+                      }
+                    : undefined,
                 toolProgressDetail,
                 shouldEmitToolResult: shouldEmitToolResultProgress,
                 shouldEmitToolOutput: shouldEmitToolOutputProgress,
@@ -1047,6 +1068,171 @@ export function createFollowupRunner(params: {
       }
 
       await drainProgressDeliveries();
+
+      // Consume and dispatch continue_delegate queue enqueued during this
+      // followup turn. Parallels the main-session dispatch in agent-runner.ts:
+      // without this, delegates queued by continue_work-triggered heartbeats
+      // (or any followup turn) stay in the queue until the NEXT inbound
+      // message arrives to trigger the main-session dispatch. RFC §3.2.
+      if (runtimeConfig?.agents?.defaults?.continuation?.enabled === true && sessionKey) {
+        const [
+          { dispatchToolDelegates },
+          { resolveLiveContinuationRuntimeConfig },
+          { loadContinuationChainState, persistContinuationChainState },
+          { updateSessionStore, resolveSessionStoreEntry },
+        ] = await Promise.all([
+          import("../continuation/delegate-dispatch.js"),
+          import("../continuation/config.js"),
+          import("../continuation/state.js"),
+          import("../../config/sessions/store.js"),
+        ]);
+        const tailUsage = runResult.meta?.agentMeta?.usage;
+        const turnTokens = (tailUsage?.input ?? 0) + (tailUsage?.output ?? 0);
+        const tailEntry = (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
+        const chainState = loadContinuationChainState(tailEntry, turnTokens);
+        const dispatchResult = await dispatchToolDelegates({
+          sessionKey,
+          chainState,
+          ctx: {
+            sessionKey,
+            agentChannel: queued.originatingChannel ?? undefined,
+            agentAccountId: queued.originatingAccountId ?? undefined,
+            agentTo: queued.originatingTo ?? undefined,
+            agentThreadId: queued.originatingThreadId ?? undefined,
+          },
+          maxChainLength: resolveLiveContinuationRuntimeConfig(runtimeConfig).maxChainLength,
+          // Hedge re-arm must see fresh chain state.
+          loadFreshChainState: () => loadContinuationChainState(tailEntry, 0),
+        });
+        // Persist the advanced chain state back to the session
+        // entry after dispatch. Without this the followup-path counter never
+        // advances and `maxChainLength` enforcement breaks across hops.
+        //
+        // Persist even when `dispatched === 0`. The chainState
+        // returned from `dispatchToolDelegates` carries the fresh
+        // `accumulatedChainTokens` from `loadContinuationChainState(tailEntry,
+        // turnTokens)` regardless of whether any delegate spawned. Guarding on
+        // `dispatched > 0` drops the token total on followup-only chains
+        // (delayed-only delegates, all-deferred dispatches, or pure
+        // continue_work turns), causing token-budget drift across hops.
+        if (dispatchResult && tailEntry) {
+          persistContinuationChainState({
+            sessionEntry: tailEntry,
+            count: dispatchResult.chainState.currentChainCount,
+            startedAt: dispatchResult.chainState.chainStartedAt,
+            tokens: dispatchResult.chainState.accumulatedChainTokens,
+          });
+          // The in-memory mutation above is orphaned for disk. The followup
+          // path's only durable writer is `persistRunSessionUsage`
+          // → `updateSessionStoreEntry`, which `loadSessionStore(...,
+          // skipCache: true)` and patches usage fields only —
+          // `continuationChain*` is not in that patch shape. Without an
+          // explicit `updateSessionStore` call the followup-only token chain
+          // never reaches disk; cost-cap and `maxChainLength` enforcement
+          // see stale values across cache eviction or gateway restart.
+          //
+          // Mirror agent-runner's explicit `updateSessionStore` with
+          // `resolveSessionStoreEntry`
+          // legacy-key cleanup so the chain fields land alongside the
+          // disk-canonical entry.
+          if (storePath && sessionKey) {
+            try {
+              await updateSessionStore(storePath, (store) => {
+                const resolved = resolveSessionStoreEntry({ store, sessionKey });
+                if (resolved.existing) {
+                  store[resolved.normalizedKey] = {
+                    ...resolved.existing,
+                    continuationChainCount: dispatchResult.chainState.currentChainCount,
+                    continuationChainStartedAt: dispatchResult.chainState.chainStartedAt,
+                    continuationChainTokens: dispatchResult.chainState.accumulatedChainTokens,
+                  };
+                  for (const legacyKey of resolved.legacyKeys) {
+                    delete store[legacyKey];
+                  }
+                }
+              });
+            } catch (err) {
+              // Mirror agent-runner.ts's defensive log: persistence failure
+              // must not break the followup reply itself.
+              defaultRuntime.error?.(
+                `[followup-runner] failed to persist continuation chain state for ${sessionKey}: ${String(err)}`,
+              );
+            }
+          }
+        }
+      }
+
+      // --- continue_work processing (#746) ---
+      // When the agent calls continue_work during this followup turn, schedule
+      // a delayed heartbeat for the session (same mechanism as agent-runner.ts).
+      // This enables subagent/organ sessions to self-elect another turn.
+      if (
+        attemptContinueWorkRequest &&
+        runtimeConfig?.agents?.defaults?.continuation?.enabled === true &&
+        sessionKey
+      ) {
+        const { resolveLiveContinuationRuntimeConfig } = await import("../continuation/config.js");
+        const continuationConfig = resolveLiveContinuationRuntimeConfig(runtimeConfig);
+        const { maxChainLength, minDelayMs, maxDelayMs, defaultDelayMs } = continuationConfig;
+
+        // Load chain state to check cap.
+        const { loadContinuationChainState, persistContinuationChainState } =
+          await import("../continuation/state.js");
+        const tailUsage = runResult.meta?.agentMeta?.usage;
+        const turnTokens = (tailUsage?.input ?? 0) + (tailUsage?.output ?? 0);
+        const tailEntry = (sessionKey ? sessionStore?.[sessionKey] : undefined) ?? sessionEntry;
+        const chainState = loadContinuationChainState(tailEntry, turnTokens);
+        const currentChainCount = chainState.currentChainCount;
+
+        if (currentChainCount >= maxChainLength) {
+          defaultRuntime.log(
+            `[followup-runner] continue_work cap reached for ${sessionKey}: ` +
+              `${currentChainCount}/${maxChainLength}`,
+          );
+        } else {
+          const nextChainCount = currentChainCount + 1;
+          const requestedDelayMs = attemptContinueWorkRequest.delaySeconds * 1000;
+          const clampedDelay = Math.max(
+            minDelayMs,
+            Math.min(maxDelayMs, requestedDelayMs || defaultDelayMs),
+          );
+
+          // Persist advanced chain state.
+          persistContinuationChainState({
+            sessionEntry: tailEntry,
+            count: nextChainCount,
+            startedAt: chainState.chainStartedAt,
+            tokens: chainState.accumulatedChainTokens,
+          });
+
+          // Schedule the continuation timer.
+          retainContinuationTimerRef(sessionKey);
+          const timerHandle = setTimeout(() => {
+            try {
+              defaultRuntime.log(
+                `[followup-runner] continue_work timer fired for session ${sessionKey}`,
+              );
+              enqueueSystemEvent(
+                `[continuation:wake] Turn ${nextChainCount}/${maxChainLength}. ` +
+                  `The agent elected to continue working.` +
+                  (attemptContinueWorkRequest!.reason
+                    ? ` Reason: ${attemptContinueWorkRequest!.reason}`
+                    : ""),
+                { sessionKey, trusted: true },
+              );
+              requestHeartbeatNow({
+                sessionKey,
+                reason: "continuation",
+                parentRunId: runId,
+              });
+            } finally {
+              unregisterContinuationTimerHandle(sessionKey, timerHandle);
+            }
+          }, clampedDelay);
+          registerContinuationTimerHandle(sessionKey, timerHandle);
+          timerHandle.unref();
+        }
+      }
 
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;


### PR DESCRIPTION
## P0: figs /tableflip-essential

Cherry-picks the #746 cure from `cael/continuation-tools-natural-reach` (PR #759, commit `583903b422`, merged 2026-05-22). This fix was **lost** when PR #714 was closed without absorbing into the assembly.

### Empirical proof of the gap

Silas-seat fired a `continue_delegate` proof-test this round. Spawned subagent reported: **`CONTINUE_WORK NOT AVAILABLE`**. The system-prompt teaches `continue_work` to subagents (`subagent-spawn.ts:1458`) but the tool-registration gate at `openclaw-tools.ts:592` evaluates false because `continueWorkOpts` was never supplied.

### What this PR does

1. **followup-runner.ts**: Threads `continueWorkOpts` closure into `runEmbeddedAgent` when `continuation.enabled === true`. This is the path that handles subagent continuation-triggered turns.
2. **followup-runner.ts**: Adds delegate-dispatch drain + continuation-timer logic post-run so delegates queued by continue_work-triggered subagent turns get dispatched.
3. **followup-runner.test.ts**: 2 regression tests pinning `continueWorkOpts` presence when enabled / absence when disabled.

### What's NOT in this PR

- `requestCompactionOpts` threading (references `pi-embedded-runner/compact.queued.js` which was removed during cure-cycle module-rename). Can restore when module-path is available.
- `attempt-execution.ts:649` initial-spawn-path wiring (separate concern for turn-1; this covers turn-2+ via followup-runner)

### Provenance

- Original fix: Ronan, commit `583903b422` on `cael/746-continue-work-subagents`
- PROOF: `karmaterminal-openclaw-docs/PROOFS/0849551642/R-CW-DELEGATE-SELF-CONTINUATION/`
- Empirical re-verification of gap: Silas proof-test this round (subagent returned CONTINUE_WORK NOT AVAILABLE)
- figs /tableflip-essential: msg `1511740580`

Closes #746 (followup-runner path). Note: `attempt-execution.ts:649` (turn-1 path) may still need separate wiring for turn-1 availability.