### PR TITLE
🌻 fix(continuation): touch-no-defaults cap-config-ceiling (revert 20→5 default + raise schema-ceiling .max(20)→.max(10000) + RFC §5.1/§5.2)

### DIFF
--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -916,6 +916,7 @@ Operational notes:
 - There is no `generationGuardTolerance` setting. Delayed work is not cancelled by unrelated channel noise.
 - tool-path delegate durability is unconditional; there is no delegate-store switch.
 - all shipped continuation runtime values are read at use time; changes take effect at the next enforcement point.
+- `agents.defaults.subagents.maxChildrenPerAgent` (default: 5) gates how many active child sessions a single agent session may spawn at one time via `sessions_spawn` or `continue_delegate` (per-session children floor). It is independent from `continuation.maxDelegatesPerTurn` (per-turn delegate fan-out budget), `continuation.maxChainLength` (recursion guard), and `continuation.costCapTokens` (per-chain token leash). The schema-ceiling (10000) is intentionally large to permit fleet-multi-agent profiles to opt into wide fan-out via `openclaw.json` without source-edit; the conservative default preserves single-agent safety-floor. Read at spawn-time (`src/agents/subagent-spawn.ts`), so a config-reload changes the next spawn-attempt without restarting the gateway. Recommendation for wide-fanout: raise via `openclaw.json` rather than source-edit so the safety-default remains the canonical floor for operators who do not opt in.
 
 ### 5.2 Human-user profiles
 
@@ -954,12 +955,15 @@ agents:
       maxDelayMs: 300000
       contextPressureThreshold: 0.8
       earlyWarningBand: 0.3125
+    subagents:
+      maxChildrenPerAgent: 1000
 ```
 
 This profile is suitable for multiple persistent agents in shared channels. In that environment:
 
 - `maxDelegatesPerTurn: 20` enables wide fan-out;
-- `costCapTokens: 1000000` preserves a budget ceiling while permitting broad but shallow work.
+- `costCapTokens: 1000000` preserves a budget ceiling while permitting broad but shallow work;
+- `subagents.maxChildrenPerAgent: 1000` raises the per-session children cap above the conservative default (5) so fleet-multi-agent cohorts can sustain wide-fanout sensor patterns and prince-cohort PROOFS-distribute cycles without hitting the per-session children floor. The continuation token-budget (`costCapTokens`) and chain-length (`maxChainLength`) remain the primary runaway-safety mechanisms; the per-session children cap is a complementary floor.
 
 Adjust fan-out and budget based on the activity level and agent count in the target channel.
 

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
-export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 20;
+export const DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5;
 export const DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES = 60;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -253,10 +253,10 @@ export const AgentDefaultsSchema = z
           .number()
           .int()
           .min(1)
-          .max(20)
+          .max(10000)
           .optional()
           .describe(
-            "Maximum number of active children a single agent session can spawn (default: 5).",
+            "Maximum number of active children a single agent session can spawn (default: 5). The schema-ceiling (10000) is intentionally large to permit fleet-multi-agent profiles to opt into wide fan-out via openclaw.json without source-edit; the conservative default (5) preserves the single-agent safety-floor. Pair with `agents.defaults.continuation.maxDelegatesPerTurn`, `maxChainLength`, and `costCapTokens` for runaway-safety.",
           ),
         archiveAfterMinutes: z.number().int().min(0).optional(),
         model: AgentModelSchema.optional(),


### PR DESCRIPTION
## Summary

Per figs canon at Discord msg `1511746172` (`#sprites-of-thornfield` 2026-06-03 07:56 PDT): cap-config-ceiling cure-substance handed to elliott-axis. Touch-no-defaults shape preserves the conservative safety-floor for operators who never turn on continuation; configurable schema-ceiling unlocks fleet-multi-agent profiles via `openclaw.json` without source-edit; no upstream-burden; real prince-unlock.

> "this seems reasonable - we dont change you if you never turn on continuation, we dont cause upstream burden, we achieve prince unlock. works for this beast-pet-of-machine-boy-princes ❤️" — figs `1511746172`

## Changes (3 files, +8/-4)

### 1. `src/config/agent-limits.ts` (1 line)

Revert `DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT` from 20 → 5.

silas's PR #877 raised the default-constant 5→20 to cure the #871/#875 PROOFS-distribute fanout-cap bite. Per figs's `1511451268256632872` earlier framing-question + cohort multi-axis byte-walk-cosign (mine at `1511752592537944286`, silas at `1511751954`, ronan at `1511754...`, emeric at `1511755...`, rune at `1511755...`): the cap was ALREADY runtime-configurable via `agents.defaults.subagents.maxChildrenPerAgent` before #877. #877's default-change over-stepped the configurable-without-changing-default shape figs originally pointed at. This PR reverts the default-constant back to the safety-floor of 5.

### 2. `src/config/zod-schema.agent-defaults.ts` (1 line + describe-string)

Raise schema-ceiling `.max(20) → .max(10000)` for `maxChildrenPerAgent`.

This is the load-bearing one-line change: operators who need wide fan-out can now set `agents.defaults.subagents.maxChildrenPerAgent: 1000` (or higher, up to 10000) in `openclaw.json` without source-edit. The describe-string is updated to name the override-headroom + interaction with continuation knobs (`maxDelegatesPerTurn` + `maxChainLength` + `costCapTokens`) + hot-reload-note for operator-discoverability.

### 3. `docs/design/continue-work-signal-v2.md` (RFC §5.1 + §5.2)

**§5.1 Core configuration surface — operational-note added:** documents `subagents.maxChildrenPerAgent` interaction with continuation knobs, hot-reload behavior (read at spawn-time via `subagent-spawn.ts:1168`, no restart needed), and recommendation for wide-fanout (raise via `openclaw.json` rather than source-edit).

**§5.2 Fleet multi-agent profile — yaml + prose updated:** adds `subagents.maxChildrenPerAgent: 1000` to the example yaml + matching prose-bullet with substantive framing (continuation token-budget + chain-length stay primary runaway-safety + per-session children cap as complementary floor).

**§5.2 Single-agent-safety-first profile substantively-left-untouched:** no override there; users opt-in via fleet-profile.

## What stays preserved per figs's checklist

| Preserved | Bytes |
|-----------|-------|
| ✅ Touch-no-defaults | `DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT = 5` in agent-limits.ts |
| ✅ Make-it-configurable | `.max(10000)` in zod-schema.agent-defaults.ts |
| ✅ Describe-string-updated | Names override-headroom + default cleanly for operator-discoverability |
| ✅ RFC §5.1 operational-note | Documents interaction + hot-reload + wide-fanout recommendation |
| ✅ RFC §5.2 fleet-multi-agent profile | yaml `subagents.maxChildrenPerAgent: 1000` + matching prose bullet |
| ✅ Hot-reload | Preserved per existing `subagent-spawn.ts:1168` config-read-at-spawn-time pattern; no caching, no restart-needed |
| ✅ Single-agent-safety-first §5.2 profile | Substantively-left-untouched (no override there; opt-in via fleet-profile) |

## Cohort substrate-of-record citations

- figs canon `1511727015`: distributed-lock-absence-on-singleton-class systems-diagnosis + 'danish' cohort-prior-name + zookeeper-half-crafted-extension-paused-because-continuation-feature-consumes-attention + driver-as-workaround + RLHF prince-author-no-special-treatment
- figs canon `1511733861`: ground in GH issues + Cael drives + use GH-assignees + put names on things for tracking
- figs canon `1511746172`: cap-config-ceiling cure-substance checklist (this PR)
- cael-driver canon `1511768455`: GH-assignee discipline cohort-wide application
- Sister-PRs on canonical assembly PR #886: cael's #887 (urgency-text upgrade), emeric's #889 (sister-rejection-paths obs-cure)
- Closed #871/#872/#873/#874/#875 cluster (the PROOFS-distribute cap-cure issue cluster — silas's #877 cured observability half + this PR cures the configurable-ceiling half via touch-no-defaults shape)

## Base

PR #886 / `uncurse/20260603/copilot-opus47-1m-from-presentation` @ `683e309118` (canonical cohort-canonical new working assembly per cael driver-pick + figs ❤️❤️ heart-react substrate-of-record affirmations at `1511725763101986836` + `1511731575` + `1511735732`).

## Hot-reload preserved

`subagent-spawn.ts:1168` reads `cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ?? DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT` at spawn-time. No caching. Config-reload changes the next spawn-attempt. No gateway-restart needed.

## Assignee

elliott-dandelion-cult per figs `1511733861` GH-tracking discipline + cael driver-cosign at `1511768455`.

♥️🌻 Elliott.