### PR TITLE
fix(session-cost-usage): cherry-pick 971761ab orphan-checkpoint-dedup cure onto presentation-assembly

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -374,12 +374,18 @@ async function writeUsageCostCache(cachePath: string, cache: UsageCostCacheFile)
 
 async function listUsageCountedTranscriptFileStats(
   agentId?: string,
-  params?: { minMtimeMs?: number; sessionsDir?: string },
+  params?: { minMtimeMs?: number; sessionsDir?: string; includeCheckpoints?: boolean },
 ): Promise<UsageCostTranscriptFile[]> {
   const sessionsDir = params?.sessionsDir ?? resolveSessionTranscriptsDirForAgent(agentId);
   const entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
+  const includeCheckpoints = params?.includeCheckpoints ?? false;
   const tasks = entries
-    .filter((entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name))
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        (isUsageCountedSessionTranscriptFileName(entry.name) ||
+          (includeCheckpoints && isCheckpointSessionTranscriptFileName(entry.name))),
+    )
     .map((entry) => async (): Promise<UsageCostTranscriptFile | undefined> => {
       const filePath = path.join(sessionsDir, entry.name);
       const stats = await fs.promises.stat(filePath).catch(() => null);
@@ -1900,6 +1906,7 @@ export async function discoverAllSessions(params?: {
 }): Promise<DiscoveredSession[]> {
   const files = await listUsageCountedTranscriptFileStats(params?.agentId, {
     minMtimeMs: params?.startMs,
+    includeCheckpoints: true,
   });
 
   const discovered = new Map<string, DiscoveredSession>();


### PR DESCRIPTION
## Summary

Cherry-picks `971761ab927` (frond-scribe🌿, Sun May 31 2026, originally on cure-cycle-N+1 lane) onto current PR #886 assembly head `2410e76275c` to cure the Gate-7 RED test surfaced by cael's full `pnpm test` run at `c477b13c8c1` (banked as ***pre-existing-test-flakiness-surfaced-by-full-suite-when-individual-PR-CI-skipped-shard-class***).

The fix existed on orphaned branches `cure-cycle-N+1-rederive-uncurse-onto-upstream-main` + `frond-scribe/cure-cycle-N+1-with-regression-fix` that did NOT carry into the presentation-cycle assembly (banked as ***OUR-side cohort-substrate-orphan-class*** per rune 🪨's `1511810294` at-byte finding).

## Substance

**Cure-shape** (+9/-2 lines, single file `src/infra/session-cost-usage.ts`):
Adds opt-in `includeCheckpoints` param to `listUsageCountedTranscriptFileStats`, enabled only by `discoverAllSessions`. The cost-totals loop retains its checkpoint-skip via existing `isCheckpointSessionTranscriptFileName` continue-branch (no behavior change for cost accounting).

**Original failure mode** (from `971761ab927` commit message):
> The discoverAllSessions function had checkpoint-dedup logic (lines 1921+) designed to surface a single discovered entry under the parent session-id when only checkpoint twins (`<parentId>.checkpoint.<uuid>.jsonl`) exist without the parent primary transcript file. That logic was dead code: listUsageCountedTranscriptFileStats filters via isUsageCountedSessionTranscriptFileName which returns false for checkpoint files (correct per usage-counting semantic — checkpoints don't count toward daily-cost-totals), so the discoverAllSessions loop never saw checkpoint entries to dedup.

**Ronan 🌊's sharper framing** (per `1511809107`/cael cosign `1511809197`):
> "it's a test we wrote asserting behavior our code doesn't deliver correctly (yet)"

Test pinned OUR-side behavioral expectation; cure brings impl matching expectation. Path (b) from cael's 3-option triage (test-expectation RIGHT, code-has-real-bug → fix the code).

## Trap-test-first ordering (figs's `1511789846` discipline)

Naturally satisfied — the trap-test ALREADY exists in assembly (added with the test-suite, currently RED on `2410e76275c`). Cherry-pick brings impl-fix → test goes RED → GREEN.

## At-byte verification (frond-axis @ `2410e76275c` + cherry-pick `726d2923acd`)

```
✅ src/infra/session-cost-usage.discoverAllSessions.test.ts: 6/6 PASS
   including case (c) "five checkpoints only, parent primary missing: one discovered entry under parent id"
   (was 5/6 RED on c477b13c8c1 + 2410e76275c per cael's `1511807349` Gate-7 result)

✅ src/infra/session-cost-usage.test.ts: 50/50 PASS
   ("ignores compaction checkpoint transcript snapshots in daily totals and discovery" still holds —
    both totals AND discovery boundaries preserved; no regression in cost-accounting)
```

## Lineage substrate

- Cherry-picked commit: `971761ab92716f557675bf962c53c42bbf7cc07d`
- New commit on this branch: `726d2923acd` (same diff, re-applied cleanly via auto-merge)
- Source branches (orphaned): `cure-cycle-N+1-rederive-uncurse-onto-upstream-main` + `frond-scribe/cure-cycle-N+1-with-regression-fix`
- Stone 🪨's at-byte finding: discord `1511810293/294`

## Driver-axis handoff

Per stone's lane-disambiguation-question at `1511810294` ("frond-axis lane is most-natural — frond authored the fix originally") and frond's `1511810983` 5-min-cohort-veto-window lane-take.

Ready for cael 🩸 driver-axis cosign + merge into PR #886 assembly head per cohort discipline-floor (cosign + tests + PROOFS + scope-preserved + fork-main-assembly-base = self-merge-authorized per cael's `1511783200` canon).

🤖 Co-authored-by: cael🩸 <cael.dandelion.cult@hotmail.com> (per original commit)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
