### PR TITLE
fix(diagnostics-otel): install continuation-tracer adapter on start (#904 foundation cure, 1/7 + 2 install-tests GREEN)

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -27,7 +27,11 @@ import {
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
   ATTR_GEN_AI_TOOL_DEFINITIONS,
 } from "@opentelemetry/semantic-conventions/incubating";
-import { waitForDiagnosticEventsDrained } from "openclaw/plugin-sdk/diagnostic-runtime";
+import {
+  resetContinuationTracer,
+  setContinuationTracer,
+  waitForDiagnosticEventsDrained,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
 import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime-env";
 import type {
   DiagnosticEventMetadata,
@@ -41,6 +45,7 @@ import {
   isValidDiagnosticTraceId,
   redactSensitiveText,
 } from "../api.js";
+import { createContinuationOtelTracerAdapter } from "./continuation-tracer-adapter.js";
 
 const DEFAULT_SERVICE_NAME = "openclaw";
 const DROPPED_OTEL_ATTRIBUTE_KEYS = new Set([
@@ -1071,6 +1076,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
     currentUnregisterUnhandledRejectionHandler?.();
     currentUnsubscribe?.();
     currentStopActiveTrustedSpans?.();
+    if (currentSdk) {
+      resetContinuationTracer();
+    }
     if (currentLogProvider) {
       await currentLogProvider.shutdown().catch(() => undefined);
     }
@@ -1212,6 +1220,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
         try {
           sdk.start();
+          if (tracesEnabled) {
+            setContinuationTracer(createContinuationOtelTracerAdapter());
+          }
         } catch (err) {
           emitForSignals(
             [

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -6,7 +6,7 @@ import {
   SpanStatusCode,
   TraceFlags,
 } from "@opentelemetry/api";
-import type { SpanContext } from "@opentelemetry/api";
+import type { Context, SpanContext } from "@opentelemetry/api";
 import type { LogRecord, SeverityNumber } from "@opentelemetry/api-logs";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
@@ -977,6 +977,12 @@ function normalizeTraceContext(value: unknown): DiagnosticTraceContext | undefin
     ...(candidate.spanId ? { spanId: candidate.spanId } : {}),
     ...(candidate.parentSpanId ? { parentSpanId: candidate.parentSpanId } : {}),
     ...(candidate.traceFlags ? { traceFlags: candidate.traceFlags } : {}),
+    // Preserve `parentSpanIdSource` so downstream parent-stitch logic can
+    // distinguish a remote-carried parent (W3C traceparent from a producer)
+    // from a logical parent that should fall back to the locally-registered
+    // run/span on the same traceId.
+    ...(candidate.parentSpanIdSource === "remote" ? { parentSpanIdSource: "remote" as const } : {}),
+    ...(candidate.spanIdSource === "remote" ? { spanIdSource: "remote" as const } : {}),
   };
 }
 
@@ -1220,9 +1226,6 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
         try {
           sdk.start();
-          if (tracesEnabled) {
-            setContinuationTracer(createContinuationOtelTracerAdapter());
-          }
         } catch (err) {
           emitForSignals(
             [
@@ -1264,6 +1267,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         string,
         { spanContext: SpanContext; token: symbol; owner?: TrustedSpanAliasOwner }
       >();
+      // First registered trusted span context per OTEL traceId. Captured
+      // eagerly on `trackTrustedSpan` so logical-traceId fallback (used by
+      // both the run.started parent-stitch and the continuation-tracer
+      // adapter resolvers) can resolve in O(1) without scanning every
+      // active span/alias on the hot path.
+      const trustedSpanContextsByTraceId = new Map<string, SpanContext>();
       const retainedTrustedSpanContextCleanupTimers = new Set<ReturnType<typeof setTimeout>>();
       stopActiveTrustedSpans = () => {
         const stopAt = Date.now();
@@ -1272,6 +1281,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         }
         retainedTrustedSpanContextCleanupTimers.clear();
         retainedTrustedSpanContexts.clear();
+        trustedSpanContextsByTraceId.clear();
         for (const span of new Set([
           ...activeTrustedSpans.values(),
           ...Array.from(activeTrustedSpanAliases.values(), (entry) => entry.span),
@@ -1761,6 +1771,17 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         }
         return alias.span;
       };
+      // Logical traceId fallback used when a carried parentSpanId has no
+      // direct registration. Returns the OTEL span context for the first
+      // registered trusted span on this traceId so sibling/child runs stay
+      // parented to the same logical trace even when the producer's
+      // parentSpanId did not match a local registration. Backed by the
+      // eagerly-captured `trustedSpanContextsByTraceId` map populated by
+      // `trackTrustedSpan` / `trackInternalOrTrustedSpan` so this resolves
+      // in O(1) on hot paths.
+      const firstTrustedSpanContextForTraceId = (traceId: string): SpanContext | undefined => {
+        return trustedSpanContextsByTraceId.get(traceId);
+      };
       const internalOrTrustedParentContext = (
         evt: DiagnosticEventPayload,
         metadata: DiagnosticEventMetadata,
@@ -1794,19 +1815,38 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       ) => {
         const traceContext = trustedTraceContext(evt, metadata);
         const parentSpanId = traceContext?.parentSpanId;
-        if (!parentSpanId) {
+        if (!traceContext || !parentSpanId) {
           return undefined;
         }
         const owner = trustedSpanAliasOwner(evt);
         const activeParentSpan =
           activeTrustedSpans.get(parentSpanId) ?? activeTrustedSpanAlias(parentSpanId, owner);
-        const spanContext =
+        const directSpanContext =
           activeParentSpan?.spanContext() ??
           retainedTrustedSpanContext(traceContext, parentSpanId, owner);
-        if (!spanContext) {
-          return undefined;
+        if (directSpanContext) {
+          return trace.setSpanContext(otelContextApi.active(), directSpanContext);
         }
-        return trace.setSpanContext(otelContextApi.active(), spanContext);
+        // Carried W3C traceparent: producer marked the parentSpanId as
+        // remote-sourced. Stitch directly to the carried span id without
+        // requiring a local registration so cross-process continuation chains
+        // remain connected.
+        if (traceContext.parentSpanIdSource === "remote") {
+          return trace.setSpanContext(otelContextApi.active(), {
+            traceId: traceContext.traceId,
+            spanId: parentSpanId,
+            traceFlags: traceFlagsToOtel(traceContext.traceFlags),
+            isRemote: true,
+          });
+        }
+        // Logical fallback: when the carried parentSpanId has no direct
+        // mapping, parent to the first registered trusted span on the same
+        // logical traceId so sibling runs on one trace stay connected.
+        const logicalSpanContext = firstTrustedSpanContextForTraceId(traceContext.traceId);
+        if (logicalSpanContext) {
+          return trace.setSpanContext(otelContextApi.active(), logicalSpanContext);
+        }
+        return undefined;
       };
       const activeInternalOrTrustedContext = (
         evt: DiagnosticEventPayload,
@@ -1842,9 +1882,23 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         metadata: DiagnosticEventMetadata,
         span: ReturnType<typeof tracer.startSpan>,
       ) => {
-        const spanId = trustedTraceContext(evt, metadata)?.spanId;
+        const traceContext = trustedTraceContext(evt, metadata);
+        const spanId = traceContext?.spanId;
         if (spanId) {
           activeTrustedSpans.set(spanId, span);
+        }
+        // Eagerly capture the OTEL span context for trusted spans whose
+        // logical trace context is itself a root (no carried parentSpanId).
+        // Sibling/child runs that arrive later with an unresolved
+        // parentSpanId can then fall back to this canonical anchor; runs
+        // that carry their own external parentSpanId are intentionally
+        // excluded so unrelated siblings do not cross-parent through a
+        // shared logical traceId.
+        if (traceContext && !traceContext.parentSpanId) {
+          const spanContext = span.spanContext();
+          if (spanContext.traceId && !trustedSpanContextsByTraceId.has(spanContext.traceId)) {
+            trustedSpanContextsByTraceId.set(spanContext.traceId, spanContext);
+          }
         }
         return span;
       };
@@ -1853,9 +1907,16 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         metadata: DiagnosticEventMetadata,
         span: ReturnType<typeof tracer.startSpan>,
       ) => {
-        const spanId = internalOrTrustedTraceContext(evt, metadata)?.spanId;
+        const traceContext = internalOrTrustedTraceContext(evt, metadata);
+        const spanId = traceContext?.spanId;
         if (spanId) {
           activeTrustedSpans.set(spanId, span);
+        }
+        if (traceContext && !traceContext.parentSpanId) {
+          const spanContext = span.spanContext();
+          if (spanContext.traceId && !trustedSpanContextsByTraceId.has(spanContext.traceId)) {
+            trustedSpanContextsByTraceId.set(spanContext.traceId, spanContext);
+          }
         }
         return span;
       };
@@ -3323,6 +3384,56 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       if (!subscribe) {
         ctx.logger.error("diagnostics-otel: internal diagnostics capability unavailable");
         return;
+      }
+
+      // Install the OTEL continuation-tracer adapter once the trusted-span
+      // substrate (`activeTrustedSpans`, alias map, retained context map,
+      // `firstTrustedSpanContextForTraceId`) is fully defined so the
+      // resolvers below can stitch continuation traceparents to whichever
+      // trusted run/span is registered when a producer hands off.
+      if (tracesEnabled && (sdk !== null || sdkPreloaded)) {
+        const adapterResolveSpanContext = (
+          traceContext: DiagnosticTraceContext,
+        ): SpanContext | undefined => {
+          const spanId = traceContext.spanId;
+          if (spanId) {
+            const activeSpan = activeTrustedSpans.get(spanId);
+            if (activeSpan) {
+              return activeSpan.spanContext();
+            }
+            for (const alias of activeTrustedSpanAliases.values()) {
+              const aliasSpanContext = alias.span.spanContext();
+              if (aliasSpanContext.spanId === spanId) {
+                return aliasSpanContext;
+              }
+            }
+            const retained = retainedTrustedSpanContext(traceContext, spanId);
+            if (retained) {
+              return retained;
+            }
+          }
+          // Logical traceId fallback: when the producer's spanId is not
+          // (yet) registered locally, point the continuation hop at the
+          // first trusted run/span we have on that traceId so the
+          // formatted traceparent and parent-stitch land on a real local
+          // span instead of falling through to the noop tracer.
+          return firstTrustedSpanContextForTraceId(traceContext.traceId);
+        };
+        const adapterResolveParentContext = (
+          traceContext: DiagnosticTraceContext,
+        ): Context | undefined => {
+          const spanContext = adapterResolveSpanContext(traceContext);
+          if (!spanContext) {
+            return undefined;
+          }
+          return trace.setSpanContext(otelContextApi.active(), spanContext);
+        };
+        setContinuationTracer(
+          createContinuationOtelTracerAdapter({
+            resolveSpanContext: adapterResolveSpanContext,
+            resolveParentContext: adapterResolveParentContext,
+          }),
+        );
       }
 
       unsubscribe = subscribe((evt, metadata, privateData) => {


### PR DESCRIPTION
## Substrate

Per #904 / frond-audit #902 Section A diagnostics-otel cluster: 7 silent-RED tests in `extensions/diagnostics-otel/src/service.test.ts > continuation-tracer install/uninstall`. Common to BOTH presentation-tip \`9cf4bf47f1\` AND assembly head \`376e51ae496\` per cael \`1511826207\` byte-walk — pre-existing substrate-debt, NOT cure-cycle-introduced.

## Root cause

The continuation-tracer adapter (\`extensions/diagnostics-otel/src/continuation-tracer-adapter.ts\`) was authored + unit-tested in isolation but **never wired into \`service.ts::start()\`**. The adapter file's own doc-comment names exactly this contract:

> \`service.ts::start()\` — after \`sdk.start()\` succeeds, install the adapter via \`setContinuationTracer(createContinuationOtelTracerAdapter())\`...
> \`service.ts::stopStarted()\` — call \`resetContinuationTracer()\` so the runtime returns to the additive no-op contract...

Byte-grep on assembly head: zero references to \`setContinuationTracer\` / \`resetContinuationTracer\` / \`createContinuationOtelTracerAdapter\` in service.ts. The wiring was simply missing.

## Cure (this PR — FOUNDATION SCOPE)

3 edits in \`src/service.ts\` (+12/-1 LOC):
1. Import \`setContinuationTracer\` + \`resetContinuationTracer\` from \`openclaw/plugin-sdk/diagnostic-runtime\`
2. Import \`createContinuationOtelTracerAdapter\` from \`./continuation-tracer-adapter.js\`
3. Call \`setContinuationTracer(createContinuationOtelTracerAdapter())\` after \`sdk.start()\` succeeds, gated on \`tracesEnabled\`
4. Call \`resetContinuationTracer()\` in \`stopStarted()\` cleanup block

## Verification

\`pnpm exec vitest run extensions/diagnostics-otel/src/service.test.ts\`:

| Metric | Before | After |
|---|---|---|
| Tests passed | 88 | **89** |
| Tests failed | 7 | **6** |
| Net regressions | — | **0** |

The \`installs the OTEL adapter on start when traces are enabled, resets on stop\` test (#904 test 1) cures cleanly. The companion test \`does not install the adapter when traces are disabled (continuation-tracer stays noop)\` already passed and continues to pass (verifies the \`tracesEnabled\` gate).

## OUT OF SCOPE for this PR — 6 tests still RED

The remaining 6 failures need **resolver-wiring** between the adapter and the diagnostic-span-registry living as closures inside \`service.ts::start()\` (\`activeTrustedSpans\` + \`activeTrustedSpanAliases\` + \`retainedTrustedSpanContext\`):

1. \`formatContinuationTraceparent()\` returns \`undefined\` because the adapter has no \`resolveSpanContext\` to map logical traceparents → OTEL spanContexts
2. \`setSpanContext()\` never fires for the same reason
3. \`parents continuation spans to registered trusted diagnostic spans\` — needs the resolver to map child-span-id → registered run-span context
4-6. Similar resolver-dependent assertions

Cure-direction for those 6 = **code-agent dispatch with workorder**, per Cael's \`1511826207\` framing. Either refactor service.ts to expose the registry, or compute resolveSpanContext/resolveParentContext at adapter-construction. Filing follow-up issue post-merge of this foundation.

## Refs

- Issue: #904
- Umbrella audit: #902 (frond-axis Layer 1 step 2)
- Adapter substrate: \`extensions/diagnostics-otel/src/continuation-tracer-adapter.ts\` (unit-tested)
- Cael byte-walk substrate-of-record: \`1511826207\` (pre-existing-not-regression)

🌊