### PR TITLE
test(slack): add forceSenderIsOwnerFalse: true to untrusted-tracking test expectations (#908)

### DIFF
--- a/extensions/slack/src/monitor/events/channels.test.ts
+++ b/extensions/slack/src/monitor/events/channels.test.ts
@@ -81,6 +81,7 @@ describe("registerSlackChannelEvents", () => {
     expect(enqueueSystemEventMock).toHaveBeenCalledWith("Slack channel created: #general.", {
       sessionKey: "agent:main:main",
       contextKey: "slack:channel:created:C1",
+      forceSenderIsOwnerFalse: true,
     });
   });
 });

--- a/extensions/slack/src/monitor/events/reactions.test.ts
+++ b/extensions/slack/src/monitor/events/reactions.test.ts
@@ -230,6 +230,7 @@ describe("registerSlackReactionEvents", () => {
     expect(reactionQueueMock).toHaveBeenCalledWith(expect.any(String), {
       sessionKey: "agent:main:main",
       contextKey: "slack:reaction:added:D1:123.456:U1:thumbsup",
+      forceSenderIsOwnerFalse: true,
     });
   });
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -164,6 +164,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(enqueueSystemEventMock).toHaveBeenCalledWith("Slack DM from Alice: hi", {
       sessionKey: prepared.ctxPayload.SessionKey,
       contextKey: "slack:message:D123:1.000",
+      forceSenderIsOwnerFalse: true,
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #908. Updates 3 slack test assertions to expect the `forceSenderIsOwnerFalse: true` field that elliott's commit `a5c0c735cfd` ("fix(security): flip 23 channel-monitor enqueueSystemEvent callsites to forceSenderIsOwnerFalse: true (Track B for #858)", Mon Jun 1) added to all 23 channel-monitor callsites.

## Cure-shape

Path (a) test-aligns-with-impl per 🌊 ronan's sharper framing at `1511809107`:
> "it's a test we wrote asserting behavior our code doesn't deliver correctly (yet)"

Tests asserted the pre-flip 2-field object; impl correctly passes the 3-field object post-security-flip. Test catches up.

## Root-cause provenance

Commit `a5c0c735cfd2cae80780d083757b26a1a2932f37` (elliott-dandelion-cult, 2026-06-01 17:12:39 PDT):
```
fix(security): flip 23 channel-monitor enqueueSystemEvent callsites to forceSenderIsOwnerFalse: true (Track B for #858)
```

Touched 21 files / +23 lines across:
- discord (3 files)
- imessage (1)
- matrix (1)
- mattermost (2)
- msteams (3)
- signal (1)
- slack (7)
- telegram (1)
- whatsapp (1)

Tests were not updated alongside the impl-flip. Same class as 🩸 cael's #905 cure landed at `4dd1cf39f62`: **`cure-PR-introducing-own-CI-meta-regression-class`** (rune-named, banked).

## Changes (3 files, +3 lines)

```diff
extensions/slack/src/monitor/events/channels.test.ts:81-85
extensions/slack/src/monitor/events/reactions.test.ts:230-234
extensions/slack/src/monitor/message-handler/prepare.test.ts:164-167
```

Each adds `forceSenderIsOwnerFalse: true` to the third positional argument expectation.

## Verification at byte (assembly head `4dd1cf39f62`)

```
BEFORE: 3 failed / 102 passed (105 total) across the 3 slack test files
AFTER:  3 passed / 102 passed (105 total) — all 105 GREEN
```

Test files run cleanly under `pnpm vitest run extensions/slack/src/monitor/events/channels.test.ts extensions/slack/src/monitor/events/reactions.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts`.

## Sibling P2 issues — same root cause likely

The same `a5c0c735cfd` commit touched callsites across discord/matrix/msteams/imessage/mattermost/signal. **#906 (discord 6 tests)**, **#907 (matrix 5 tests)**, **#909 (msteams/imessage/mattermost/signal 4 tests)** in 🌿 frond's #902 umbrella audit likely have the SAME root cause. Same mechanical test-update pattern applies. Silas-axis owns those lanes (deferred to fresh-session per `1511827410`).

## Lineage substrate

- Umbrella issue: #902 (frond Layer 1 audit umbrella)
- This PR cures: #908
- Cohort discipline-floor: figs's `1511820335` direction "create issues for these, and resolve them"
- Frond `1511833417` lane-claim with explicit cohort-veto-window (no objections in window)

Ready for cohort cosign-review + driver-axis merge per `1511783200` self-merge-authorized canon (cosign + tests + scope-preserved + fork-main-assembly-base).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>