### PR TITLE
fix(channel-monitor-tests): align forceSenderIsOwnerFalse expectations to elliott a5c0c735cfd impl-flip (#906/#907/#909)

### DIFF
--- a/extensions/discord/src/monitor/monitor.agent-components.test.ts
+++ b/extensions/discord/src/monitor/monitor.agent-components.test.ts
@@ -140,6 +140,7 @@ describe("agent components", () => {
       {
         sessionKey: defaultDmSessionKey,
         contextKey: "discord:agent-button:dm-channel:hello:123456789",
+        forceSenderIsOwnerFalse: true,
       },
     );
     if (params.expectPairingStoreRead) {
@@ -267,6 +268,7 @@ describe("agent components", () => {
       {
         sessionKey: defaultGroupDmSessionKey,
         contextKey: "discord:agent-button:group-dm-channel:hello:123456789",
+        forceSenderIsOwnerFalse: true,
       },
     );
     expect(peekSystemEvents(defaultDmSessionKey)).toStrictEqual([]);
@@ -347,6 +349,7 @@ describe("agent components", () => {
       {
         sessionKey: defaultDmSessionKey,
         contextKey: "discord:agent-select:dm-channel:hello:123456789",
+        forceSenderIsOwnerFalse: true,
       },
     );
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
@@ -370,6 +373,7 @@ describe("agent components", () => {
       {
         sessionKey: defaultDmSessionKey,
         contextKey: "discord:agent-button:dm-channel:hello_cid:123456789",
+        forceSenderIsOwnerFalse: true,
       },
     );
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
@@ -393,6 +397,7 @@ describe("agent components", () => {
       {
         sessionKey: defaultDmSessionKey,
         contextKey: "discord:agent-button:dm-channel:hello%2G:123456789",
+        forceSenderIsOwnerFalse: true,
       },
     );
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();

--- a/extensions/imessage/src/monitor/reaction-system-event.test.ts
+++ b/extensions/imessage/src/monitor/reaction-system-event.test.ts
@@ -33,6 +33,7 @@ describe("enqueueIMessageReactionSystemEvent", () => {
       {
         sessionKey: "agent:main:main",
         contextKey: "imessage:reaction:added:3:lobster-reply-guid:+15555550123:👎",
+        forceSenderIsOwnerFalse: true,
       },
     );
     expect(runtime.log).toHaveBeenCalledWith(

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -1832,6 +1832,7 @@ describe("matrix monitor handler pairing account scope", () => {
       {
         sessionKey: "agent:ops:main",
         contextKey: "matrix:reaction:add:!room:example.org:$msg1:@user:example.org:👍",
+        forceSenderIsOwnerFalse: true,
       },
     );
   });
@@ -1894,6 +1895,7 @@ describe("matrix monitor handler pairing account scope", () => {
       {
         sessionKey: "agent:bound:session-1",
         contextKey: "matrix:reaction:add:!room:example.org:$reply1:@user:example.org:🎯",
+        forceSenderIsOwnerFalse: true,
       },
     );
   });
@@ -1938,6 +1940,7 @@ describe("matrix monitor handler pairing account scope", () => {
       {
         sessionKey: "agent:ops:main",
         contextKey: "matrix:reaction:add:!dm:example.org:$reply1:@user:example.org:🎯",
+        forceSenderIsOwnerFalse: true,
       },
     );
   });
@@ -1976,6 +1979,7 @@ describe("matrix monitor handler pairing account scope", () => {
       {
         sessionKey: "agent:ops:main:thread:$root",
         contextKey: "matrix:reaction:add:!room:example.org:$root:@user:example.org:🧵",
+        forceSenderIsOwnerFalse: true,
       },
     );
   });

--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -173,6 +173,7 @@ describe("matrix approval reactions", () => {
       {
         sessionKey: "agent:main:matrix:channel:!ops:example.org",
         contextKey: "matrix:reaction:add:!ops:example.org:$msg-1:@owner:example.org:👍",
+        forceSenderIsOwnerFalse: true,
       },
     );
   });

--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -886,6 +886,7 @@ describe("createMattermostInteractionHandler", () => {
       {
         sessionKey: "session:thread:root-9",
         contextKey: "mattermost:interaction:post-1:approve",
+        forceSenderIsOwnerFalse: true,
       },
     );
     expect(dispatchButtonClick).toHaveBeenCalledWith({

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -594,6 +594,7 @@ describe("createMSTeamsReplyDispatcher", () => {
     expect(context).toEqual({
       sessionKey: "agent:main:main",
       contextKey: "msteams:delivery-failure:conv",
+      forceSenderIsOwnerFalse: true,
     });
   });
 

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -533,6 +533,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(enqueueSystemEventMock).toHaveBeenCalledWith("reaction added", {
       sessionKey: "agent:main:signal:group:g1",
       contextKey: "signal:reaction:added:1700000000000:+15550001111:+1:g1",
+      forceSenderIsOwnerFalse: true,
     });
   });
 


### PR DESCRIPTION
Cures 15 pre-existing-RED tests across discord+matrix+slack-cluster channel-monitor test files. Same root-cause class as #905 / #908 — Elliott commit `a5c0c735cfd` (Mon Jun 1, "fix(security): flip 23 channel-monitor enqueueSystemEvent callsites to forceSenderIsOwnerFalse: true (Track B for #858)") flipped 23 impl callsites without updating corresponding test-mock expectations. Tests silently RED on both presentation-tip and assembly until frond surfaced them via Layer 1 audit (#902 Section A). PR #914 (frond) set the mechanical cure pattern for slack-only; this PR completes it for the remaining 3 issues.

## Mechanical pattern
Add `forceSenderIsOwnerFalse: true,` to third positional arg of `toHaveBeenCalledWith` expectations on `enqueueSystemEvent` / `reactionQueue` mocks. No impl changes.

## Scope
- **#906** (6 tests): `extensions/discord/src/monitor/monitor.agent-components.test.ts` (5 callsites cover 6 parameterized tests)
- **#907** (5 tests): `extensions/matrix/src/matrix/monitor/{handler,reaction-events}.test.ts`
- **#909** (4 tests): `extensions/{msteams,imessage,mattermost,signal}` test files

## Verification at byte (lothric-seat, base `406fddcc88`)
| Cluster | Before | After |
|---------|--------|-------|
| discord | 6/12 fail | **12/12 PASS** |
| matrix  | 5/120 fail | **120/120 PASS** |
| mixed (msteams/imessage/mattermost/signal) | 4/99 fail | **99/99 PASS** |
| **total** | **15 fail** | **0 fail, 0 regressions** |

## Diff
7 files changed, 14 insertions(+). Test-only.

## Cohort substrate
Closes #906
Closes #907
Closes #909

🌫 silas-dandelion-cult on lothric, 2026-06-03