### PR TITLE
fix: restore upstream faithfulness for #935

### DIFF
--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -16,11 +16,11 @@ import {
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
 } from "../../logging/diagnostic-run-activity.js";
-import { getDiagnosticSessionState } from "../../logging/diagnostic-session-state.js";
 import {
   diagnosticLogger as diag,
   logMessageQueued,
   logSessionStateChange,
+  updateDiagnosticSessionFile,
 } from "../../logging/diagnostic.js";
 import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
 import {
@@ -767,11 +767,7 @@ export function updateActiveEmbeddedRunSessionFile(
   }
   clearActiveRunSessionFiles(sessionId);
   setActiveRunSessionFile(sessionFile, sessionId);
-  // Sync the rotated session-file into diagnostic state so heartbeat-recovery
-  // observes the current path rather than the pre-rotation one.
-  if (sessionFile) {
-    getDiagnosticSessionState({ sessionId, sessionFile });
-  }
+  updateDiagnosticSessionFile({ sessionId, sessionFile });
 }
 
 export function clearActiveEmbeddedRun(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -77,6 +77,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { defaultRuntime } from "../../runtime.js";
+import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import {
   isMarkdownCapableMessageChannel,
   resolveMessageChannel,
@@ -1676,6 +1677,9 @@ export async function runAgentTurnWithFallback(params: {
           ...runnableRun,
           config: runtimeConfig,
         };
+  const preserveUserFacingSessionState = shouldPreserveUserFacingSessionStateForInputProvenance(
+    effectiveRun.inputProvenance,
+  );
   const resolveRunForFallbackCandidate = (provider: string, model: string): FollowupRun["run"] => {
     const probe = effectiveRun.autoFallbackPrimaryProbe;
     const isPrimaryProbeCandidate = probe && provider === probe.provider && model === probe.model;
@@ -1895,6 +1899,7 @@ export async function runAgentTurnWithFallback(params: {
     if (
       !params.sessionKey ||
       !params.activeSessionStore ||
+      preserveUserFacingSessionState ||
       (provider === effectiveRun.provider && model === effectiveRun.model)
     ) {
       return undefined;
@@ -2006,6 +2011,9 @@ export async function runAgentTurnWithFallback(params: {
     provider: string;
     model: string;
   }): Promise<void> => {
+    if (preserveUserFacingSessionState) {
+      return;
+    }
     const probe = effectiveRun.autoFallbackPrimaryProbe;
     if (!probe) {
       return;

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1005,6 +1005,15 @@ export function logSessionStateChange(
   markActivity();
 }
 
+export function updateDiagnosticSessionFile(params: SessionRef) {
+  if (!areDiagnosticsEnabledForProcess()) {
+    return;
+  }
+  const state = getDiagnosticSessionState(params);
+  state.sessionFile = params.sessionFile?.trim() || undefined;
+  markActivity();
+}
+
 export function markDiagnosticSessionProgress(params: SessionRef) {
   if (!areDiagnosticsEnabledForProcess()) {
     return;


### PR DESCRIPTION
## Summary

- Restores upstream `preserveUserFacingSessionState` guard wiring in `src/auto-reply/reply/agent-runner-execution.ts` for fallback persistence/probe clearing.
- Restores upstream diagnostic session-file liveness path via `updateDiagnosticSessionFile`, including the `markActivity()` call, and wires `updateActiveEmbeddedRunSessionFile` back through it.
- Leaves the cleared `.trim() || undefined` normalization path untouched, per #935.

Refs #935

## Verification

- `pnpm test src/auto-reply/reply/agent-runner-execution.test.ts src/agents/embedded-agent-runner/runs.test.ts src/logging/diagnostic.test.ts -- --reporter=verbose`
- `pnpm tsgo`
- `pnpm build`

## Review

- `.agents/skills/autoreview/scripts/autoreview --mode local` was attempted twice with the default Codex engine, but both attempts failed before review due to local Codex auth (`refresh_token_reused` / expired token). No autoreview findings were produced.
