### PR TITLE
feat: thread request compaction focus

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -736,6 +736,7 @@ export async function runAgentAttempt(params: {
               provider: embeddedAgentProvider,
               model: params.modelOverride,
               authProfileId,
+              customInstructions: request.customInstructions,
               trigger: request.trigger,
               diagId: request.diagId,
               traceparent: request.traceparent,

--- a/src/agents/compaction-attribution.ts
+++ b/src/agents/compaction-attribution.ts
@@ -7,6 +7,7 @@ export type RequestCompactionInvocation = {
   diagId: string;
   trigger: "volitional";
   reason: string;
+  customInstructions?: string;
   contextUsage: number;
   requestedAtMs: number;
   traceparent?: string;

--- a/src/agents/tools/request-compaction-tool.callsite-threading.test.ts
+++ b/src/agents/tools/request-compaction-tool.callsite-threading.test.ts
@@ -21,6 +21,7 @@ import {
   runWithDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
+import type { RequestCompactionInvocation } from "../compaction-attribution.js";
 import {
   _resetGuardState,
   _resetVolitionalCounts,
@@ -41,6 +42,7 @@ interface CapturedCompactParams {
   provider: string;
   model: string;
   authProfileId?: string;
+  customInstructions?: string;
 }
 
 const REQUEST_COMPACTION_SESSION_KEY = "agent:main:discord:channel:request-compaction-trace";
@@ -124,8 +126,10 @@ function buildTriggerCompactionClosure(
     provider: string; // The persisted primary provider
     authProfileId?: string;
   },
-): () => Promise<{ ok: boolean; compacted: boolean; reason?: string }> {
-  return async () => {
+): (
+  request?: Pick<RequestCompactionInvocation, "customInstructions">,
+) => Promise<{ ok: boolean; compacted: boolean; reason?: string }> {
+  return async (request = {}) => {
     try {
       // Inline the import pattern from the call sites
       const { compactEmbeddedAgentSession } =
@@ -152,6 +156,7 @@ function buildTriggerCompactionClosure(
         provider: innerProvider,
         model: innerModel,
         authProfileId: compactionAuthProfileId,
+        customInstructions: request.customInstructions,
       });
 
       return {
@@ -279,6 +284,29 @@ describe("call-site threading: provider/model passthrough", () => {
       provider: "anthropic",
       model: "claude-opus-4",
       authProfileId: "profile-full",
+      customInstructions: undefined,
+    });
+  });
+
+  it("passes request focus through to compact customInstructions", async () => {
+    const run = {
+      sessionId: "session-focus",
+      sessionKey: "agent:main:matrix:channel:room",
+      sessionFile: "/data/sessions/focus.jsonl",
+      workspaceDir: "/home/user/workspace",
+      messageProvider: "matrix",
+      provider: "anthropic",
+      authProfileId: "profile-focus",
+    };
+
+    const triggerCompaction = buildTriggerCompactionClosure("anthropic", "claude-opus-4", run);
+    await triggerCompaction({
+      customInstructions: "preserve the b683 fix-spec and the open path-b question",
+    });
+
+    expect(capturedCompactCalls[0]).toMatchObject({
+      sessionId: "session-focus",
+      customInstructions: "preserve the b683 fix-spec and the open path-b question",
     });
   });
 });

--- a/src/agents/tools/request-compaction-tool.test.ts
+++ b/src/agents/tools/request-compaction-tool.test.ts
@@ -341,6 +341,26 @@ describe("request_compaction tool", () => {
     });
   });
 
+  it("threads focus to the compaction customInstructions slot", async () => {
+    const tool = makeTool();
+    const result = await executeTool(tool, {
+      reason: "thermal evacuation complete",
+      focus: "preserve the b683 fix-spec and the open path-b question",
+    });
+    await flushBackgroundCompaction();
+
+    expect(result).toMatchObject({
+      status: "compaction_requested",
+      reason: "thermal evacuation complete",
+    });
+    expect(mockTriggerCompaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "thermal evacuation complete",
+        customInstructions: "preserve the b683 fix-spec and the open path-b question",
+      }),
+    );
+  });
+
   it("keeps traceparent absent when the optional carrier is omitted", async () => {
     const tool = makeTool();
 

--- a/src/agents/tools/request-compaction-tool.ts
+++ b/src/agents/tools/request-compaction-tool.ts
@@ -68,6 +68,14 @@ const RequestCompactionToolSchema = Type.Object({
       "Example: 'context pressure at 92%, working state evacuated to memory files and 2 post-compaction delegates staged.'",
     maxLength: 1024,
   }),
+  focus: Type.Optional(
+    Type.String({
+      description:
+        "Optional instructions that steer what the compaction summary should preserve. " +
+        "Use this to name load-bearing facts, decisions, files, or open questions the summarizer must keep.",
+      maxLength: 4096,
+    }),
+  ),
   traceparent: Type.Optional(
     Type.String({
       description:
@@ -186,6 +194,7 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
       }
 
       const reasonText = readStringParam(params, "reason", { required: true }).slice(0, 1024);
+      const focusText = readStringParam(params, "focus")?.slice(0, 4096);
       const traceparentRaw = readStringParam(params, "traceparent");
       const explicitTraceparent =
         traceparentRaw !== undefined ? normalizeDiagnosticTraceparent(traceparentRaw) : undefined;
@@ -264,6 +273,7 @@ export function createRequestCompactionTool(opts: RequestCompactionToolOpts): An
         diagId,
         trigger: "volitional",
         reason: reasonText,
+        ...(focusText ? { customInstructions: focusText } : {}),
         contextUsage,
         requestedAtMs: now,
         ...traceContextFields,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2597,6 +2597,7 @@ export async function runAgentTurnWithFallback(params: {
                                   provider,
                                   model,
                                   authProfileId: compactionAuthProfileId,
+                                  customInstructions: request.customInstructions,
                                   trigger: request.trigger,
                                   diagId: request.diagId,
                                   traceparent: request.traceparent,


### PR DESCRIPTION
## Summary

What problem does this PR solve?

Adds a model-facing `focus` parameter to `request_compaction` so volitional compaction can steer the existing summarizer focus path.

Why does this matter now?

Issue #938 notes that `reason` is diagnostic-only while `/compact` can already feed `customInstructions`; agents need the same focused-summary path when requesting compaction themselves.

What is the intended outcome?

`request_compaction({ reason, focus })` keeps `reason` unchanged for diagnostics and forwards `focus` to the existing `customInstructions` compaction slot.

What is intentionally out of scope?

No new summarizer behavior, no change to `reason`, no config or migration changes.

What does success look like?

Absent `focus` preserves existing behavior; present `focus` reaches `compactEmbeddedAgentSession.customInstructions`.

What should reviewers focus on?

The additive schema field and pass-through from request payload to both request-compaction compaction call sites.

## Linked context

Which issue does this close?

Closes #938

Which issues, PRs, or discussions are related?

Related #938

Was this requested by a maintainer or owner?

Requested in WO-938.md for the #938 continuation lane.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `request_compaction` can now steer compaction summaries through the same `customInstructions` slot as `/compact`.
- Real environment tested: Local OpenClaw source checkout.
- Exact steps or command run after this patch: `pnpm test src/agents/tools/request-compaction-tool.test.ts src/agents/tools/request-compaction-tool.callsite-threading.test.ts src/agents/tools/request-compaction-tool.volitional-threading.test.ts src/agents/tools/request-compaction-tool.classifier-emission.test.ts src/agents/command/attempt-execution.request-compaction-opts.test.ts src/auto-reply/reply/commands-compact.test.ts src/agents/compaction.test.ts src/plugins/compaction-provider.test.ts`; `pnpm tsgo`; `pnpm build`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Targeted tests passed 3 Vitest shards / 124 tests; `pnpm tsgo` exited 0; `pnpm build` exited 0.
- Observed result after fix: New regression tests confirm `focus` becomes `customInstructions` on the request payload and reaches the compact invocation path.
- What was not tested: No live agent/provider run; this is a small additive tool-schema and local compaction plumbing change.
- Proof limitations or environment constraints: Local mocked/unit coverage, typecheck, and build only.
- Before evidence (optional but encouraged): Issue #938 byte-grounding shows the previous schema only accepted `reason`, which did not feed `customInstructions`.

## Tests and validation

Which commands did you run?

`pnpm test src/agents/tools/request-compaction-tool.test.ts src/agents/tools/request-compaction-tool.callsite-threading.test.ts src/agents/tools/request-compaction-tool.volitional-threading.test.ts src/agents/tools/request-compaction-tool.classifier-emission.test.ts src/agents/command/attempt-execution.request-compaction-opts.test.ts src/auto-reply/reply/commands-compact.test.ts src/agents/compaction.test.ts src/plugins/compaction-provider.test.ts`

`pnpm tsgo`

`pnpm build`

What regression coverage was added or updated?

Added request-compaction coverage proving `focus` is converted to `customInstructions`, plus call-site coverage proving that value reaches the compact invocation params.

What failed before this fix, if known?

A `focus` argument was not part of the schema/payload and could not reach the summarizer steering slot.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, additively: `request_compaction` accepts optional `focus`.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Tool schema growth for model-facing `request_compaction`.

How is that risk mitigated?

The field is optional, capped, and only feeds the existing compaction `customInstructions` slot already used by `/compact`.

## Current review state

What is the next action?

Draft PR ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review.

Which bot or reviewer comments were addressed?

None yet.
