### PR TITLE
Re-absorb upstream drift to verified-consistent tip (06e8a74) — fixes shrinkwrap

### DIFF
--- a/docs/tools/parallel-search.md
+++ b/docs/tools/parallel-search.md
@@ -1,17 +1,36 @@
 ---
 summary: "Parallel Search -- LLM-optimized dense excerpts from web sources"
 read_when:
-  - You want to use Parallel for web_search
-  - You need a PARALLEL_API_KEY
+  - You want web search without an API key
+  - You want Parallel's paid Search API
   - You want dense excerpts ranked for LLM context efficiency
 title: "Parallel search"
 ---
 
-OpenClaw supports [Parallel](https://parallel.ai/) as a `web_search` provider.
-Parallel returns ranked, LLM-optimized dense excerpts from a web index
-purpose-built for AI agents.
+OpenClaw bundles two [Parallel](https://parallel.ai/) `web_search` providers:
 
-## Get an API key
+- **Parallel Search (Free)** (`parallel-free`) -- Parallel's free
+  [Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp). Requires no
+  account or API key. OpenClaw selects it automatically when no other web search
+  provider is configured, so `web_search` works without setup.
+- **Parallel Search** (`parallel`) -- Parallel's paid Search API. Requires a
+  `PARALLEL_API_KEY` and offers higher rate limits and objective tuning.
+
+Both return ranked, LLM-optimized excerpts from a web index built for AI agents.
+Set `tools.web.search.provider` to `parallel-free` or `parallel` to choose one
+explicitly.
+
+<Note>
+  OpenAI Responses models use OpenAI's native web search when
+  `tools.web.search.provider` is unset, so they bypass the Parallel providers.
+  Set `tools.web.search.provider` to `parallel-free` or `parallel` to route them
+  through Parallel.
+</Note>
+
+## API key (paid provider)
+
+`parallel-free` requires no setup. The paid `parallel` provider needs an API
+key:
 
 <Steps>
   <Step title="Create an account">
@@ -59,6 +78,9 @@ For a gateway install, put it in `~/.openclaw/.env`.
 
 ## Base URL override
 
+The base URL override applies to the paid `parallel` provider only. The free
+`parallel-free` provider always uses `https://search.parallel.ai/mcp`.
+
 Set `plugins.entries.parallel.config.webSearch.baseUrl` when Parallel requests
 should go through a compatible proxy or alternate Parallel endpoint (for
 example, the Cloudflare AI Gateway). OpenClaw normalizes bare hosts by
@@ -88,9 +110,11 @@ Results to return (1-40).
 </ParamField>
 
 <ParamField path="session_id" type="string">
-Optional Parallel session id (max 1000 chars). Pass the `sessionId` from a
-previous Parallel result on follow-up searches that are part of the same task
-so Parallel can group related calls and improve subsequent results.
+Optional Parallel session id (max 1000 chars on `parallel`; the free
+`parallel-free` Search MCP caps it at 100). Pass the `sessionId` from a previous
+Parallel result on follow-up searches that are part of the same task so Parallel
+can group related calls and improve subsequent results. An id past the limit is
+dropped and a fresh one is generated.
 </ParamField>
 
 <ParamField path="client_model" type="string">
@@ -119,6 +143,9 @@ alias.
   when switching between providers; Parallel on its own defaults to 10
 - Results are cached for 15 minutes by default (configurable via
   `cacheTtlMinutes`)
+- The free `parallel-free` provider accepts the same parameters. It applies
+  `count` client-side and generates a `session_id` per call when one is not
+  supplied.
 
 ## Related
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -85,7 +85,10 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
     Search via a signed-in local Ollama host or the hosted Ollama API.
   </Card>
   <Card title="Parallel" icon="layer-group" href="/tools/parallel-search">
-    LLM-optimized dense excerpts from a web index purpose-built for AI agents.
+    Paid Parallel Search API (`PARALLEL_API_KEY`); higher rate limits and objective tuning.
+  </Card>
+  <Card title="Parallel Search (Free)" icon="layer-group" href="/tools/parallel-search">
+    Zero-config default. Parallel's free Search MCP, with LLM-optimized dense excerpts and no API key.
   </Card>
   <Card title="Perplexity" icon="search" href="/tools/perplexity-search">
     Structured results with content extraction controls and domain filtering.
@@ -100,21 +103,22 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 
 ### Provider comparison
 
-| Provider                                  | Result style                                                   | Filters                                          | API key                                                                                 |
-| ----------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| [Brave](/tools/brave-search)              | Structured snippets                                            | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                                                                         |
-| [DuckDuckGo](/tools/duckduckgo-search)    | Structured snippets                                            | --                                               | None (key-free)                                                                         |
-| [Exa](/tools/exa-search)                  | Structured + extracted                                         | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                                                                           |
-| [Firecrawl](/tools/firecrawl)             | Structured snippets                                            | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                                                     |
-| [Gemini](/tools/gemini-search)            | AI-synthesized + citations                                     | --                                               | `GEMINI_API_KEY`                                                                        |
-| [Grok](/tools/grok-search)                | AI-synthesized + citations                                     | --                                               | xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey`              |
-| [Kimi](/tools/kimi-search)                | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
-| [MiniMax Search](/tools/minimax-search)   | Structured snippets                                            | Region (`global` / `cn`)                         | `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN`              |
-| [Ollama Web Search](/tools/ollama-search) | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
-| [Parallel](/tools/parallel-search)        | Dense excerpts ranked for LLM context                          | --                                               | `PARALLEL_API_KEY`                                                                      |
-| [Perplexity](/tools/perplexity-search)    | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
-| [SearXNG](/tools/searxng-search)          | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
-| [Tavily](/tools/tavily)                   | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
+| Provider                                         | Result style                                                   | Filters                                          | API key                                                                                 |
+| ------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| [Brave](/tools/brave-search)                     | Structured snippets                                            | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                                                                         |
+| [DuckDuckGo](/tools/duckduckgo-search)           | Structured snippets                                            | --                                               | None (key-free)                                                                         |
+| [Exa](/tools/exa-search)                         | Structured + extracted                                         | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                                                                           |
+| [Firecrawl](/tools/firecrawl)                    | Structured snippets                                            | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                                                     |
+| [Gemini](/tools/gemini-search)                   | AI-synthesized + citations                                     | --                                               | `GEMINI_API_KEY`                                                                        |
+| [Grok](/tools/grok-search)                       | AI-synthesized + citations                                     | --                                               | xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey`              |
+| [Kimi](/tools/kimi-search)                       | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
+| [MiniMax Search](/tools/minimax-search)          | Structured snippets                                            | Region (`global` / `cn`)                         | `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN`              |
+| [Ollama Web Search](/tools/ollama-search)        | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
+| [Parallel](/tools/parallel-search)               | Dense excerpts ranked for LLM context                          | --                                               | `PARALLEL_API_KEY` (paid)                                                               |
+| [Parallel Search (Free)](/tools/parallel-search) | Dense excerpts ranked for LLM context                          | --                                               | None (free Search MCP)                                                                  |
+| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
+| [SearXNG](/tools/searxng-search)                 | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
+| [Tavily](/tools/tavily)                          | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
 
 ## Auto-detection
 
@@ -188,16 +192,22 @@ API-backed providers first:
 7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
-10. **Parallel** -- `PARALLEL_API_KEY` or `plugins.entries.parallel.config.webSearch.apiKey`; optional `plugins.entries.parallel.config.webSearch.baseUrl` overrides the Parallel endpoint (order 75)
+10. **Parallel** -- paid Parallel Search API via `PARALLEL_API_KEY` or `plugins.entries.parallel.config.webSearch.apiKey`; optional `plugins.entries.parallel.config.webSearch.baseUrl` overrides the endpoint (order 75)
 
 Key-free fallbacks after that:
 
-11. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
-12. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
-13. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
+11. **Parallel Search (Free)** -- the zero-config default: works with no account or API key via Parallel's free hosted [Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) (order 76)
+12. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
+13. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
+14. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
 
-If no provider is detected, it falls back to Brave (you will get a missing-key
-error prompting you to configure one).
+When no API-backed provider is configured, OpenClaw defaults to **Parallel
+Search (Free)**, so `web_search` works without an API key.
+
+OpenAI Responses models are an exception: while `tools.web.search.provider` is
+unset, they use OpenAI's native web search instead of the managed providers
+above. Set `tools.web.search.provider` to `parallel-free` (or another provider)
+to route them through the managed path.
 
 <Note>
   All provider key fields support SecretRef objects. Plugin-scoped SecretRefs

--- a/extensions/acpx/doctor-contract-api.ts
+++ b/extensions/acpx/doctor-contract-api.ts
@@ -124,7 +124,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         .map((entry) => normalizeAcpxProcessLease(entry.value))
         .filter(
           (lease): lease is AcpxProcessLease =>
-            Boolean(lease) && (lease.state === "open" || lease.state === "closing"),
+            lease !== undefined && (lease.state === "open" || lease.state === "closing"),
         );
       const leaseGatewayIds = new Set(openLeases.map((lease) => lease.gatewayInstanceId));
       const onlyLeaseGatewayId = leaseGatewayIds.size === 1 ? [...leaseGatewayIds][0] : null;

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -567,6 +567,16 @@
     },
     {
       "endpointClass": "google-vertex",
+      "hosts": ["aiplatform.eu.rep.googleapis.com"],
+      "googleVertexRegion": "eu"
+    },
+    {
+      "endpointClass": "google-vertex",
+      "hosts": ["aiplatform.us.rep.googleapis.com"],
+      "googleVertexRegion": "us"
+    },
+    {
+      "endpointClass": "google-vertex",
       "hostSuffixes": ["-aiplatform.googleapis.com"],
       "googleVertexRegionHostSuffix": "-aiplatform.googleapis.com"
     }

--- a/extensions/google/provider-policy.ts
+++ b/extensions/google/provider-policy.ts
@@ -41,10 +41,18 @@ function stripUrlUserInfo(url: URL): void {
 
 const GOOGLE_VERTEX_HOST = "aiplatform.googleapis.com";
 const GOOGLE_VERTEX_REGION_HOST_SUFFIX = "-aiplatform.googleapis.com";
+const GOOGLE_VERTEX_MULTI_REGION_HOSTS = new Set([
+  "aiplatform.eu.rep.googleapis.com",
+  "aiplatform.us.rep.googleapis.com",
+]);
 
 export function isGoogleVertexHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
-  return normalized === GOOGLE_VERTEX_HOST || normalized.endsWith(GOOGLE_VERTEX_REGION_HOST_SUFFIX);
+  return (
+    normalized === GOOGLE_VERTEX_HOST ||
+    normalized.endsWith(GOOGLE_VERTEX_REGION_HOST_SUFFIX) ||
+    GOOGLE_VERTEX_MULTI_REGION_HOSTS.has(normalized)
+  );
 }
 
 export function isGoogleVertexBaseUrl(baseUrl?: string | null): boolean {

--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -235,8 +235,12 @@ async function runGeminiSearch(params: {
       const groundingChunks =
         groundingMetadata === undefined
           ? []
-          : isRecord(groundingMetadata) && Array.isArray(groundingMetadata.groundingChunks)
-            ? groundingMetadata.groundingChunks
+          : isRecord(groundingMetadata)
+            ? groundingMetadata.groundingChunks === undefined
+              ? []
+              : Array.isArray(groundingMetadata.groundingChunks)
+                ? groundingMetadata.groundingChunks
+                : undefined
             : undefined;
       if (!groundingChunks) {
         throwMalformedGeminiResponse();

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -356,7 +356,7 @@ function resolveGoogleVertexLocation(options: GoogleTransportOptions | undefined
   return location;
 }
 
-function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: string): string {
+export function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: string): string {
   const configured = normalizeOptionalString(model.baseUrl);
   if (configured && !configured.includes("{location}")) {
     try {
@@ -371,6 +371,12 @@ function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: st
   }
   if (location === "global") {
     return "https://aiplatform.googleapis.com";
+  }
+  // Multi-region locations (eu, us) use the dedicated .rep.googleapis.com host
+  // with the location embedded in the host, matching @google/genai SDK behavior.
+  // A regional prefix (eu-aiplatform.googleapis.com) returns an HTML 404.
+  if (location === "eu" || location === "us") {
+    return `https://aiplatform.${location}.rep.googleapis.com`;
   }
   return `https://${location}-aiplatform.googleapis.com`;
 }

--- a/extensions/google/vertex-multi-region-host.test.ts
+++ b/extensions/google/vertex-multi-region-host.test.ts
@@ -1,0 +1,68 @@
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import { isGoogleVertexHostname } from "./provider-policy.js";
+import { resolveGoogleVertexBaseOrigin } from "./transport-stream.js";
+
+// Minimal Vertex model whose baseUrl carries the {location} template, so the
+// base-origin resolver falls through to location-based host construction
+// (the configured-baseUrl early return only fires for a literal host).
+function buildModel(overrides: Partial<Model<"google-vertex">> = {}): Model<"google-vertex"> {
+  return {
+    id: "gemini-3.5-flash",
+    name: "Gemini 3.5 Flash",
+    api: "google-vertex",
+    provider: "google-vertex",
+    baseUrl: "https://{location}-aiplatform.googleapis.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 8192,
+    ...overrides,
+  };
+}
+
+describe("Google Vertex multi-region host construction", () => {
+  const model = buildModel();
+
+  it("routes the eu multi-region to the dedicated .rep.googleapis.com host", () => {
+    expect(resolveGoogleVertexBaseOrigin(model, "eu")).toBe(
+      "https://aiplatform.eu.rep.googleapis.com",
+    );
+  });
+
+  it("routes the us multi-region to the dedicated .rep.googleapis.com host", () => {
+    expect(resolveGoogleVertexBaseOrigin(model, "us")).toBe(
+      "https://aiplatform.us.rep.googleapis.com",
+    );
+  });
+
+  it("keeps the unprefixed host for the global location", () => {
+    expect(resolveGoogleVertexBaseOrigin(model, "global")).toBe(
+      "https://aiplatform.googleapis.com",
+    );
+  });
+
+  it("keeps the regional prefix for normal regions", () => {
+    expect(resolveGoogleVertexBaseOrigin(model, "europe-west1")).toBe(
+      "https://europe-west1-aiplatform.googleapis.com",
+    );
+  });
+});
+
+describe("Google Vertex hostname recognition", () => {
+  it("recognizes the multi-region rep host as a Vertex host", () => {
+    expect(isGoogleVertexHostname("aiplatform.eu.rep.googleapis.com")).toBe(true);
+    expect(isGoogleVertexHostname("aiplatform.us.rep.googleapis.com")).toBe(true);
+  });
+
+  it("does not classify unrelated rep hosts as Vertex hosts", () => {
+    expect(isGoogleVertexHostname("discoveryengine.eu.rep.googleapis.com")).toBe(false);
+    expect(isGoogleVertexHostname("not-aiplatform.eu.rep.googleapis.com")).toBe(false);
+  });
+
+  it("still recognizes the unprefixed and regional Vertex hosts", () => {
+    expect(isGoogleVertexHostname("aiplatform.googleapis.com")).toBe(true);
+    expect(isGoogleVertexHostname("europe-west1-aiplatform.googleapis.com")).toBe(true);
+  });
+});

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -195,6 +195,54 @@ describe("google web search provider", () => {
     );
   });
 
+  it("accepts Gemini success JSON with empty grounding metadata", async () => {
+    vi.stubGlobal(
+      "fetch",
+      withFetchPreconnect(
+        vi.fn(() =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                candidates: [
+                  {
+                    content: { parts: [{ text: "Today's date is Sunday, June 7, 2026." }] },
+                    groundingMetadata: {},
+                  },
+                ],
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+    const provider = createGeminiWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: "AIza-plugin-test",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: { provider: "gemini" },
+    });
+
+    const result = await tool?.execute({ query: "current date today" });
+
+    expect(result).toMatchObject({
+      citations: [],
+      model: "gemini-2.5-flash",
+      provider: "gemini",
+    });
+    expect(String(result?.content)).toContain("Today's date is Sunday, June 7, 2026.");
+  });
+
   it("reports malformed Gemini API JSON with a stable provider error", async () => {
     vi.stubGlobal(
       "fetch",

--- a/extensions/memory-core/api.ts
+++ b/extensions/memory-core/api.ts
@@ -14,6 +14,7 @@ export { previewGroundedRemMarkdown } from "./src/rem-evidence.js";
 export { filterRecallEntriesWithinLookback } from "./src/dreaming-phases.js";
 export { previewRemHarness } from "./src/rem-harness.js";
 export type { PreviewRemHarnessOptions, PreviewRemHarnessResult } from "./src/rem-harness.js";
+export { configureMemoryCoreDreamingState } from "./src/dreaming-state.js";
 export {
   buildDreamingShadowTrialReport,
   defaultDreamingShadowTrialReportPath,

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1,0 +1,261 @@
+// Memory Core tests cover doctor migration of legacy dreaming state.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type {
+  OpenKeyedStoreOptions,
+  PluginDoctorStateMigrationContext,
+} from "openclaw/plugin-sdk/runtime-doctor";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { stateMigrations } from "./doctor-contract-api.js";
+import { testing as dreamingTesting } from "./src/dreaming-phases.js";
+import {
+  configureMemoryCoreDreamingState,
+  resetMemoryCoreDreamingStateForTests,
+} from "./src/dreaming-state.js";
+import { testing as shortTermTesting } from "./src/short-term-promotion.js";
+
+function createDoctorContext(env: NodeJS.ProcessEnv): PluginDoctorStateMigrationContext {
+  return {
+    openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
+      return createPluginStateKeyedStoreForTests<T>("memory-core", {
+        ...options,
+        env: options.env ?? env,
+      });
+    },
+  };
+}
+
+describe("memory-core doctor dreaming migration", () => {
+  let rootDir = "";
+  let workspaceDir = "";
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    resetPluginStateStoreForTests();
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-core-doctor-"));
+    workspaceDir = path.join(rootDir, "workspace");
+    await fs.mkdir(path.join(workspaceDir, "memory", ".dreams"), { recursive: true });
+    env = { ...process.env, OPENCLAW_STATE_DIR: path.join(rootDir, "state") };
+  });
+
+  afterEach(async () => {
+    resetMemoryCoreDreamingStateForTests();
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  function context(): PluginDoctorStateMigrationContext {
+    return createDoctorContext(env);
+  }
+
+  function migrationParams(
+    config: unknown = {
+      agents: {
+        list: [{ id: "main", workspace: workspaceDir }],
+      },
+    },
+  ) {
+    return {
+      config,
+      env,
+      stateDir: path.join(rootDir, "state"),
+      oauthDir: path.join(rootDir, "oauth"),
+      context: context(),
+    };
+  }
+
+  it("imports persistent legacy dreaming state and ignores transient locks", async () => {
+    const dreamsDir = path.join(workspaceDir, "memory", ".dreams");
+    const dailyPath = path.join(dreamsDir, "daily-ingestion.json");
+    const sessionPath = path.join(dreamsDir, "session-ingestion.json");
+    const recallPath = path.join(dreamsDir, "short-term-recall.json");
+    const phasePath = path.join(dreamsDir, "phase-signals.json");
+    const lockPath = path.join(dreamsDir, "short-term-promotion.lock");
+
+    await fs.writeFile(
+      dailyPath,
+      JSON.stringify({
+        version: 1,
+        files: {
+          "memory/2026-04-05.md": {
+            size: 42,
+            mtimeMs: 1,
+            contentHash: "daily-hash",
+            ingestedAt: "2026-04-05T10:00:00.000Z",
+          },
+        },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      sessionPath,
+      JSON.stringify({
+        version: 1,
+        files: {
+          "main/session.jsonl": {
+            size: 91,
+            mtimeMs: 2,
+            lineCount: 3,
+            lastContentLine: 3,
+            contentHash: "session-hash",
+            ingestedAt: "2026-04-05T11:00:00.000Z",
+          },
+        },
+        seenMessages: {
+          "main/session.jsonl": ["seen-a", "seen-b"],
+        },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      recallPath,
+      JSON.stringify({
+        version: 1,
+        updatedAt: "2026-04-05T12:00:00.000Z",
+        entries: {
+          "memory:memory/2026-04-05.md:1:1": {
+            key: "memory:memory/2026-04-05.md:1:1",
+            path: "memory/2026-04-05.md",
+            startLine: 1,
+            endLine: 1,
+            source: "memory",
+            snippet: "Move backups to S3 Glacier.",
+            recallCount: 1,
+            totalScore: 0.9,
+            maxScore: 0.9,
+            firstRecalledAt: "2026-04-05T12:00:00.000Z",
+            lastRecalledAt: "2026-04-05T12:00:00.000Z",
+            queryHashes: ["hash-a"],
+          },
+        },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      phasePath,
+      JSON.stringify({
+        version: 1,
+        updatedAt: "2026-04-05T13:00:00.000Z",
+        entries: {
+          "memory:memory/2026-04-05.md:1:1": {
+            key: "memory:memory/2026-04-05.md:1:1",
+            lightHits: 1,
+            remHits: 2,
+            lastLightAt: "2026-04-05T12:00:00.000Z",
+            lastRemAt: "2026-04-05T13:00:00.000Z",
+          },
+        },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(lockPath, `${process.pid}:${Date.now()}\n`, "utf8");
+
+    const migration = stateMigrations[0];
+    const preview = await migration.detectLegacyState(migrationParams());
+    expect(preview?.preview).toEqual([
+      expect.stringContaining("Memory Core daily ingestion"),
+      expect.stringContaining("Memory Core session ingestion"),
+      expect.stringContaining("Memory Core short-term recall"),
+      expect.stringContaining("Memory Core phase signals"),
+    ]);
+    expect(preview?.preview.join("\n")).not.toContain("short-term-promotion.lock");
+
+    const result = await migration.migrateLegacyState(migrationParams());
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated Memory Core daily ingestion -> SQLite plugin state (1 row(s))",
+      expect.stringContaining("Archived Memory Core daily ingestion legacy source"),
+      "Migrated Memory Core session ingestion -> SQLite plugin state (2 row(s))",
+      expect.stringContaining("Archived Memory Core session ingestion legacy source"),
+      "Migrated Memory Core short-term recall -> SQLite plugin state (1 row(s))",
+      expect.stringContaining("Archived Memory Core short-term recall legacy source"),
+      "Migrated Memory Core phase signals -> SQLite plugin state (1 row(s))",
+      expect.stringContaining("Archived Memory Core phase signals legacy source"),
+    ]);
+
+    configureMemoryCoreDreamingState(context().openPluginStateKeyedStore);
+    await expect(fs.access(`${dailyPath}.migrated`)).resolves.toBeUndefined();
+    await expect(fs.access(`${sessionPath}.migrated`)).resolves.toBeUndefined();
+    await expect(fs.access(`${recallPath}.migrated`)).resolves.toBeUndefined();
+    await expect(fs.access(`${phasePath}.migrated`)).resolves.toBeUndefined();
+    await expect(fs.access(lockPath)).resolves.toBeUndefined();
+
+    const daily = await dreamingTesting.readDailyIngestionState(workspaceDir);
+    expect(daily.files["memory/2026-04-05.md"]?.mtimeMs).toBe(1);
+    const session = await dreamingTesting.readSessionIngestionState(workspaceDir);
+    expect(session.files["main/session.jsonl"]?.contentHash).toBe("session-hash");
+    expect(session.seenMessages["main/session.jsonl"]).toEqual(["seen-a", "seen-b"]);
+    const recall = await shortTermTesting.readRecallStore(workspaceDir, "2026-04-05T12:00:00.000Z");
+    expect(recall.entries["memory:memory/2026-04-05.md:1:1"]?.conceptTags).toContain("glacier");
+    const phase = await shortTermTesting.readPhaseSignalStore(
+      workspaceDir,
+      "2026-04-05T13:00:00.000Z",
+    );
+    expect(phase.entries["memory:memory/2026-04-05.md:1:1"]?.remHits).toBe(2);
+  });
+
+  it("leaves invalid legacy JSON in place", async () => {
+    const recallPath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
+    await fs.writeFile(recallPath, "{", "utf8");
+
+    const result = await stateMigrations[0].migrateLegacyState(migrationParams());
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("Skipped Memory Core short-term recall import"),
+    ]);
+    await expect(fs.access(recallPath)).resolves.toBeUndefined();
+    await expect(fs.access(`${recallPath}.migrated`)).rejects.toThrow();
+    configureMemoryCoreDreamingState(context().openPluginStateKeyedStore);
+    const recall = await shortTermTesting.readRecallStore(workspaceDir, new Date().toISOString());
+    expect(recall.entries).toEqual({});
+  });
+
+  it("uses migration env when resolving default workspaces", async () => {
+    env = { ...env, OPENCLAW_WORKSPACE_DIR: workspaceDir };
+    const recallPath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
+    await fs.writeFile(
+      recallPath,
+      JSON.stringify({
+        version: 1,
+        updatedAt: "2026-04-05T12:00:00.000Z",
+        entries: {
+          "memory:memory/2026-04-05.md:1:1": {
+            key: "memory:memory/2026-04-05.md:1:1",
+            path: "memory/2026-04-05.md",
+            startLine: 1,
+            endLine: 1,
+            source: "memory",
+            snippet: "Move backups to S3 Glacier.",
+            recallCount: 1,
+            totalScore: 0.9,
+            maxScore: 0.9,
+            firstRecalledAt: "2026-04-05T12:00:00.000Z",
+            lastRecalledAt: "2026-04-05T12:00:00.000Z",
+            queryHashes: ["hash-a"],
+          },
+        },
+      }),
+      "utf8",
+    );
+    const config = { agents: { list: [{ id: "main", default: true }] } };
+
+    const preview = await stateMigrations[0].detectLegacyState(migrationParams(config));
+    expect(preview?.preview).toEqual([expect.stringContaining("Memory Core short-term recall")]);
+
+    const result = await stateMigrations[0].migrateLegacyState(migrationParams(config));
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated Memory Core short-term recall -> SQLite plugin state (1 row(s))",
+      expect.stringContaining("Archived Memory Core short-term recall legacy source"),
+    ]);
+    configureMemoryCoreDreamingState(context().openPluginStateKeyedStore);
+    const recall = await shortTermTesting.readRecallStore(workspaceDir, "2026-04-05T12:00:00.000Z");
+    expect(recall.entries["memory:memory/2026-04-05.md:1:1"]?.conceptTags).toContain("glacier");
+  });
+});

--- a/extensions/memory-core/doctor-contract-api.ts
+++ b/extensions/memory-core/doctor-contract-api.ts
@@ -1,0 +1,270 @@
+// Memory Core doctor contract migrates shipped workspace dreaming state.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveMemoryDreamingWorkspaces } from "openclaw/plugin-sdk/memory-core-host-status";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  DAILY_INGESTION_STATE_RELATIVE_PATH,
+  SESSION_INGESTION_STATE_RELATIVE_PATH,
+  normalizeDailyIngestionState,
+  normalizeSessionIngestionState,
+} from "./src/dreaming-phases.js";
+import {
+  DREAMING_DAILY_INGESTION_NAMESPACE,
+  DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+  DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+  SESSION_SEEN_HASHES_PER_CHUNK,
+  SHORT_TERM_META_NAMESPACE,
+  SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
+  SHORT_TERM_RECALL_NAMESPACE,
+  configureMemoryCoreDreamingState,
+  readMemoryCoreWorkspaceEntries,
+  writeMemoryCoreWorkspaceEntries,
+  writeMemoryCoreWorkspaceEntry,
+} from "./src/dreaming-state.js";
+import {
+  SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH,
+  SHORT_TERM_STORE_RELATIVE_PATH,
+  normalizeShortTermPhaseSignalStore,
+  normalizeShortTermRecallStore,
+} from "./src/short-term-promotion.js";
+
+type LegacySource = {
+  workspaceDir: string;
+  label: string;
+  filePath: string;
+};
+
+function resolveConfiguredWorkspaces(config: unknown, env: NodeJS.ProcessEnv): string[] {
+  return resolveMemoryDreamingWorkspaces(
+    config as Parameters<typeof resolveMemoryDreamingWorkspaces>[0],
+    { env },
+  ).map((entry) => entry.workspaceDir);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonFile(filePath: string): Promise<unknown | null> {
+  return JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+}
+
+async function archiveLegacySource(params: {
+  filePath: string;
+  label: string;
+  changes: string[];
+  warnings: string[];
+}): Promise<void> {
+  const archivedPath = `${params.filePath}.migrated`;
+  if (await fileExists(archivedPath)) {
+    params.warnings.push(
+      `Left migrated Memory Core ${params.label} source in place because ${archivedPath} already exists`,
+    );
+    return;
+  }
+  try {
+    await fs.rename(params.filePath, archivedPath);
+    params.changes.push(`Archived Memory Core ${params.label} legacy source -> ${archivedPath}`);
+  } catch (err) {
+    params.warnings.push(
+      `Failed archiving Memory Core ${params.label} legacy source: ${String(err)}`,
+    );
+  }
+}
+
+async function collectLegacySources(
+  config: unknown,
+  env: NodeJS.ProcessEnv,
+): Promise<LegacySource[]> {
+  const sources: LegacySource[] = [];
+  for (const workspaceDir of resolveConfiguredWorkspaces(config, env)) {
+    const candidates = [
+      { label: "daily ingestion", relativePath: DAILY_INGESTION_STATE_RELATIVE_PATH },
+      { label: "session ingestion", relativePath: SESSION_INGESTION_STATE_RELATIVE_PATH },
+      { label: "short-term recall", relativePath: SHORT_TERM_STORE_RELATIVE_PATH },
+      { label: "phase signals", relativePath: SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH },
+    ];
+    for (const candidate of candidates) {
+      const filePath = path.join(workspaceDir, candidate.relativePath);
+      if (await fileExists(filePath)) {
+        sources.push({ workspaceDir, label: candidate.label, filePath });
+      }
+    }
+  }
+  return sources;
+}
+
+async function workspaceHasRows(namespace: string, workspaceDir: string): Promise<boolean> {
+  return (await readMemoryCoreWorkspaceEntries({ namespace, workspaceDir })).length > 0;
+}
+
+async function migrateDailyIngestion(source: LegacySource): Promise<number> {
+  const state = normalizeDailyIngestionState(await readJsonFile(source.filePath));
+  await writeMemoryCoreWorkspaceEntries({
+    namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
+    workspaceDir: source.workspaceDir,
+    entries: Object.entries(state.files).map(([key, value]) => ({ key, value })),
+  });
+  return Object.keys(state.files).length;
+}
+
+async function migrateSessionIngestion(source: LegacySource): Promise<number> {
+  const state = normalizeSessionIngestionState(await readJsonFile(source.filePath));
+  const seenEntries = Object.entries(state.seenMessages).flatMap(([scope, hashes]) =>
+    Array.from(
+      { length: Math.ceil(hashes.length / SESSION_SEEN_HASHES_PER_CHUNK) },
+      (_, index) => ({
+        key: `${scope}:${index}`,
+        value: {
+          scope,
+          index,
+          hashes: hashes.slice(
+            index * SESSION_SEEN_HASHES_PER_CHUNK,
+            (index + 1) * SESSION_SEEN_HASHES_PER_CHUNK,
+          ),
+        },
+      }),
+    ),
+  );
+  await Promise.all([
+    writeMemoryCoreWorkspaceEntries({
+      namespace: DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+      workspaceDir: source.workspaceDir,
+      entries: Object.entries(state.files).map(([key, value]) => ({ key, value })),
+    }),
+    writeMemoryCoreWorkspaceEntries({
+      namespace: DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+      workspaceDir: source.workspaceDir,
+      entries: seenEntries,
+    }),
+  ]);
+  return Object.keys(state.files).length + Object.keys(state.seenMessages).length;
+}
+
+async function migrateShortTermRecall(source: LegacySource): Promise<number> {
+  const nowIso = new Date().toISOString();
+  const state = normalizeShortTermRecallStore(await readJsonFile(source.filePath), nowIso);
+  await Promise.all([
+    writeMemoryCoreWorkspaceEntries({
+      namespace: SHORT_TERM_RECALL_NAMESPACE,
+      workspaceDir: source.workspaceDir,
+      entries: Object.entries(state.entries).map(([key, value]) => ({ key, value })),
+    }),
+    writeMemoryCoreWorkspaceEntry({
+      namespace: SHORT_TERM_META_NAMESPACE,
+      workspaceDir: source.workspaceDir,
+      key: "recall",
+      value: { updatedAt: state.updatedAt },
+    }),
+  ]);
+  return Object.keys(state.entries).length;
+}
+
+async function migratePhaseSignals(source: LegacySource): Promise<number> {
+  const nowIso = new Date().toISOString();
+  const state = normalizeShortTermPhaseSignalStore(await readJsonFile(source.filePath), nowIso);
+  await Promise.all([
+    writeMemoryCoreWorkspaceEntries({
+      namespace: SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
+      workspaceDir: source.workspaceDir,
+      entries: Object.entries(state.entries).map(([key, value]) => ({ key, value })),
+    }),
+    writeMemoryCoreWorkspaceEntry({
+      namespace: SHORT_TERM_META_NAMESPACE,
+      workspaceDir: source.workspaceDir,
+      key: "phase",
+      value: { updatedAt: state.updatedAt },
+    }),
+  ]);
+  return Object.keys(state.entries).length;
+}
+
+function targetNamespacesForSource(label: string): string[] {
+  if (label === "daily ingestion") {
+    return [DREAMING_DAILY_INGESTION_NAMESPACE];
+  }
+  if (label === "session ingestion") {
+    return [DREAMING_SESSION_INGESTION_FILES_NAMESPACE, DREAMING_SESSION_INGESTION_SEEN_NAMESPACE];
+  }
+  if (label === "short-term recall") {
+    return [SHORT_TERM_RECALL_NAMESPACE];
+  }
+  return [SHORT_TERM_PHASE_SIGNAL_NAMESPACE];
+}
+
+async function migrateSource(source: LegacySource): Promise<number> {
+  if (source.label === "daily ingestion") {
+    return await migrateDailyIngestion(source);
+  }
+  if (source.label === "session ingestion") {
+    return await migrateSessionIngestion(source);
+  }
+  if (source.label === "short-term recall") {
+    return await migrateShortTermRecall(source);
+  }
+  return await migratePhaseSignals(source);
+}
+
+export const stateMigrations: PluginDoctorStateMigration[] = [
+  {
+    id: "memory-core-dreams-json-to-sqlite",
+    label: "Memory Core dreaming state",
+    async detectLegacyState(params) {
+      configureMemoryCoreDreamingState(params.context.openPluginStateKeyedStore);
+      const sources = await collectLegacySources(params.config, params.env);
+      if (sources.length === 0) {
+        return null;
+      }
+      return {
+        preview: sources.map(
+          (source) => `- Memory Core ${source.label}: ${source.filePath} -> SQLite plugin state`,
+        ),
+      };
+    },
+    async migrateLegacyState(params) {
+      configureMemoryCoreDreamingState(params.context.openPluginStateKeyedStore);
+      const changes: string[] = [];
+      const warnings: string[] = [];
+      for (const source of await collectLegacySources(params.config, params.env)) {
+        const targetHasRows = (
+          await Promise.all(
+            targetNamespacesForSource(source.label).map((namespace) =>
+              workspaceHasRows(namespace, source.workspaceDir),
+            ),
+          )
+        ).some(Boolean);
+        if (targetHasRows) {
+          warnings.push(
+            `Skipped Memory Core ${source.label} import for ${source.workspaceDir} because SQLite rows already exist; left legacy source in place`,
+          );
+          continue;
+        }
+        let imported: number;
+        try {
+          imported = await migrateSource(source);
+        } catch (err) {
+          warnings.push(
+            `Skipped Memory Core ${source.label} import for ${source.workspaceDir} because the legacy source could not be imported: ${String(err)}`,
+          );
+          continue;
+        }
+        changes.push(
+          `Migrated Memory Core ${source.label} -> SQLite plugin state (${imported} row(s))`,
+        );
+        await archiveLegacySource({
+          filePath: source.filePath,
+          label: source.label,
+          changes,
+          warnings,
+        });
+      }
+      return { changes, warnings };
+    },
+  },
+];

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -12,7 +12,9 @@ import {
   type AnyAgentTool,
   type OpenClawPluginToolContext,
 } from "openclaw/plugin-sdk/plugin-entry";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { TSchema } from "typebox";
+import { configureMemoryCoreDreamingState } from "./src/dreaming-state.js";
 import { registerShortTermPromotionDreaming } from "./src/dreaming.js";
 import { buildMemoryFlushPlan } from "./src/flush-plan.js";
 import { registerBuiltInMemoryEmbeddingProviders } from "./src/memory/provider-adapters.js";
@@ -178,6 +180,9 @@ export default definePluginEntry({
   description: "File-backed memory search tools and CLI",
   kind: "memory",
   register(api) {
+    configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
+      api.runtime.state.openKeyedStore<T>(options),
+    );
     registerBuiltInMemoryEmbeddingProviders(api);
     registerShortTermPromotionDreaming(api);
     api.registerMemoryCapability({

--- a/extensions/memory-core/runtime-api.ts
+++ b/extensions/memory-core/runtime-api.ts
@@ -17,8 +17,10 @@ export {
 export { checkQmdBinaryAvailability } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 export { hasConfiguredMemorySecretInput } from "openclaw/plugin-sdk/memory-core-host-secret";
 export { auditDreamingArtifacts, repairDreamingArtifacts } from "./src/dreaming-repair.js";
+export { configureMemoryCoreDreamingState } from "./src/dreaming-state.js";
 export {
   auditShortTermPromotionArtifacts,
+  loadShortTermPromotionDreamingStats,
   removeGroundedShortTermCandidates,
   repairShortTermPromotionArtifacts,
 } from "./src/short-term-promotion.js";
@@ -29,5 +31,7 @@ export type {
 } from "./src/dreaming-repair.js";
 export type {
   RepairShortTermPromotionArtifactsResult,
+  ShortTermDreamingStats,
+  ShortTermDreamingStatsEntry,
   ShortTermAuditSummary,
 } from "./src/short-term-promotion.js";

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -10,7 +10,15 @@ import {
   spyRuntimeLogs,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { readShortTermRecallEntries, recordShortTermRecalls } from "./short-term-promotion.js";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+} from "./dreaming-state.js";
+import {
+  readShortTermRecallEntries,
+  recordShortTermRecalls,
+  testing as shortTermTesting,
+} from "./short-term-promotion.js";
 
 const getMemorySearchManager = vi.hoisted(() => vi.fn());
 const getRuntimeConfig = vi.hoisted(() => vi.fn(() => ({})));
@@ -73,6 +81,7 @@ let workspaceCaseId = 0;
 let qmdCaseId = 0;
 
 beforeAll(async () => {
+  await configureMemoryCoreDreamingStateForTests();
   ({ registerMemoryCli } = await import("./cli.js"));
   ({ defaultRuntime, isVerbose, setVerbose } =
     await import("openclaw/plugin-sdk/memory-core-host-runtime-cli"));
@@ -104,6 +113,7 @@ afterAll(async () => {
     return;
   }
   await fs.rm(fixtureRoot, { recursive: true, force: true });
+  resetMemoryCoreDreamingStateForTests();
 });
 
 describe("memory cli", () => {
@@ -702,42 +712,33 @@ describe("memory cli", () => {
 
   it("repairs invalid recall metadata and stale locks with status --fix", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
-      await fs.writeFile(
-        storePath,
-        JSON.stringify(
-          {
-            version: 1,
-            updatedAt: "2026-04-04T00:00:00.000Z",
-            entries: {
-              good: {
-                key: "good",
-                path: "memory/2026-04-03.md",
-                startLine: 1,
-                endLine: 2,
-                source: "memory",
-                snippet: "QMD router cache note",
-                recallCount: 1,
-                totalScore: 0.8,
-                maxScore: 0.8,
-                firstRecalledAt: "2026-04-04T00:00:00.000Z",
-                lastRecalledAt: "2026-04-04T00:00:00.000Z",
-                queryHashes: ["a"],
-              },
-              bad: {
-                path: "",
-              },
-            },
+      await shortTermTesting.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: {
+          good: {
+            key: "good",
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 2,
+            source: "memory",
+            snippet: "QMD router cache note",
+            recallCount: 1,
+            totalScore: 0.8,
+            maxScore: 0.8,
+            firstRecalledAt: "2026-04-04T00:00:00.000Z",
+            lastRecalledAt: "2026-04-04T00:00:00.000Z",
+            queryHashes: ["a"],
           },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
-      const lockPath = path.join(workspaceDir, "memory", ".dreams", "short-term-promotion.lock");
-      await fs.writeFile(lockPath, "999999:0\n", "utf-8");
-      const staleMtime = new Date(Date.now() - 120_000);
-      await fs.utimes(lockPath, staleMtime, staleMtime);
+          bad: {
+            path: "",
+          },
+        },
+      });
+      await shortTermTesting.writeShortTermLock(workspaceDir, {
+        owner: "999999:0",
+        acquiredAt: Date.now() - 120_000,
+      });
 
       const close = vi.fn(async () => {});
       mockManager({
@@ -750,8 +751,8 @@ describe("memory cli", () => {
       await runMemoryCli(["status", "--fix"]);
 
       expectLogged(log, "Repair: rewrote store");
-      await expectPathMissing(lockPath);
-      const repaired = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      const audit = await shortTermTesting.readRecallStore(workspaceDir, new Date().toISOString());
+      const repaired = audit as {
         entries: Record<string, { conceptTags?: string[] }>;
       };
       expect(repaired.entries.good?.conceptTags).toContain("router");
@@ -761,8 +762,15 @@ describe("memory cli", () => {
 
   it("shows the fix hint only before --fix has been run", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
-      await fs.writeFile(storePath, " \n", "utf-8");
+      await shortTermTesting.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: {
+          bad: {
+            path: "",
+          },
+        },
+      });
 
       const close = vi.fn(async () => {});
       mockManager({
@@ -2054,32 +2062,11 @@ describe("memory cli", () => {
 
       await runMemoryCli(["search", "glacier", "--json"]);
 
-      const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
-      const storeRaw = await waitFor(async () => await fs.readFile(storePath, "utf-8"));
-      const store = JSON.parse(storeRaw) as {
-        entries?: Record<
-          string,
-          {
-            key: string;
-            path: string;
-            startLine: number;
-            endLine: number;
-            source: string;
-            snippet: string;
-            recallCount: number;
-            dailyCount: number;
-            groundedCount: number;
-            totalScore: number;
-            maxScore: number;
-            firstRecalledAt: string;
-            lastRecalledAt: string;
-            queryHashes: string[];
-            recallDays: string[];
-            conceptTags: string[];
-          }
-        >;
-      };
-      const entries = Object.values(store.entries ?? {});
+      const entries = await waitFor(async () => {
+        const recalled = await readShortTermRecallEntries({ workspaceDir });
+        expect(recalled).toHaveLength(1);
+        return recalled;
+      });
       expect(entries).toHaveLength(1);
       const entry = entries[0];
       if (!entry) {
@@ -2160,9 +2147,7 @@ describe("memory cli", () => {
       }
       expect(payload.results).toHaveLength(1);
       expect(payload.results[0]?.path).toBe("memory/2026-04-03.md");
-      await expectPathMissing(
-        path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json"),
-      );
+      expect(await readShortTermRecallEntries({ workspaceDir })).toHaveLength(0);
       expect(close).toHaveBeenCalled();
     });
   });

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -21,7 +21,7 @@ import { previewRemHarness } from "./rem-harness.js";
 import {
   rankShortTermPromotionCandidates,
   recordShortTermRecalls,
-  resolveShortTermPhaseSignalStorePath,
+  testing as shortTermTesting,
   type ShortTermRecallEntry,
 } from "./short-term-promotion.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
@@ -572,9 +572,8 @@ describe("memory-core dreaming phases", () => {
       ([target]) => typeof target === "string" && target === dailyPath,
     ).length;
     expect(dailyReadCount).toBeLessThanOrEqual(1);
-    await expect(
-      fs.access(path.join(workspaceDir, "memory", ".dreams", "daily-ingestion.json")),
-    ).resolves.toBeUndefined();
+    const dailyIngestion = await testing.readDailyIngestionState(workspaceDir);
+    expect(Object.keys(dailyIngestion.files)).toHaveLength(1);
   });
 
   it("ingests recent daily memory files even before recall traffic exists", async () => {
@@ -902,9 +901,8 @@ describe("memory-core dreaming phases", () => {
 
     expect(transcriptReadCount).toBeLessThanOrEqual(1);
 
-    await expect(
-      fs.access(path.join(workspaceDir, "memory", ".dreams", "session-ingestion.json")),
-    ).resolves.toBeUndefined();
+    const sessionIngestion = await testing.readSessionIngestionState(workspaceDir);
+    expect(Object.keys(sessionIngestion.files)).toContain("main:sessions/main/dreaming-main.jsonl");
     await expect(
       fs.access(path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-05.txt")),
     ).resolves.toBeUndefined();
@@ -1174,21 +1172,7 @@ describe("memory-core dreaming phases", () => {
       path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-05.txt"),
     );
 
-    const sessionIngestion = JSON.parse(
-      await fs.readFile(
-        path.join(workspaceDir, "memory", ".dreams", "session-ingestion.json"),
-        "utf-8",
-      ),
-    ) as {
-      files: Record<
-        string,
-        {
-          lineCount: number;
-          lastContentLine: number;
-          contentHash: string;
-        }
-      >;
-    };
+    const sessionIngestion = await testing.readSessionIngestionState(workspaceDir);
     expect(Object.keys(sessionIngestion.files)).toHaveLength(1);
     const ingestionEntry = requireFirstIngestionEntry(sessionIngestion);
     expect(ingestionEntry.lineCount).toBe(0);
@@ -1284,21 +1268,7 @@ describe("memory-core dreaming phases", () => {
       path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-05.txt"),
     );
 
-    const sessionIngestion = JSON.parse(
-      await fs.readFile(
-        path.join(workspaceDir, "memory", ".dreams", "session-ingestion.json"),
-        "utf-8",
-      ),
-    ) as {
-      files: Record<
-        string,
-        {
-          lineCount: number;
-          lastContentLine: number;
-          contentHash: string;
-        }
-      >;
-    };
+    const sessionIngestion = await testing.readSessionIngestionState(workspaceDir);
     expect(Object.keys(sessionIngestion.files)).toHaveLength(1);
     const ingestionEntry = requireFirstIngestionEntry(sessionIngestion);
     expect(ingestionEntry.lineCount).toBe(0);
@@ -1391,21 +1361,7 @@ describe("memory-core dreaming phases", () => {
       path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-05.txt"),
     );
 
-    const sessionIngestion = JSON.parse(
-      await fs.readFile(
-        path.join(workspaceDir, "memory", ".dreams", "session-ingestion.json"),
-        "utf-8",
-      ),
-    ) as {
-      files: Record<
-        string,
-        {
-          lineCount: number;
-          lastContentLine: number;
-          contentHash: string;
-        }
-      >;
-    };
+    const sessionIngestion = await testing.readSessionIngestionState(workspaceDir);
     const ingestionEntry = requireFirstIngestionEntry(sessionIngestion);
     expect(ingestionEntry.lineCount).toBe(0);
     expect(ingestionEntry.lastContentLine).toBe(0);
@@ -2529,10 +2485,10 @@ describe("memory-core dreaming phases", () => {
     const reinforcedCandidate = requireCandidateByKey(reinforced, baseline[0].key);
     expect(reinforcedCandidate.score).toBeGreaterThan(baselineScore);
 
-    const phaseSignalPath = resolveShortTermPhaseSignalStorePath(workspaceDir);
-    const phaseSignalStore = JSON.parse(await fs.readFile(phaseSignalPath, "utf-8")) as {
-      entries: Record<string, { lightHits: number; remHits: number }>;
-    };
+    const phaseSignalStore = await shortTermTesting.readPhaseSignalStore(
+      workspaceDir,
+      new Date().toISOString(),
+    );
     const baselineSignals = phaseSignalStore.entries[baseline[0].key];
     expect(baselineSignals?.lightHits).toBe(1);
     expect(baselineSignals?.remHits).toBe(1);
@@ -2614,10 +2570,10 @@ describe("memory-core dreaming phases", () => {
       });
     });
 
-    const phaseSignalPath = resolveShortTermPhaseSignalStorePath(workspaceDir);
-    const phaseSignalStore = JSON.parse(await fs.readFile(phaseSignalPath, "utf-8")) as {
-      entries: Record<string, { remHits: number }>;
-    };
+    const phaseSignalStore = await shortTermTesting.readPhaseSignalStore(
+      workspaceDir,
+      new Date().toISOString(),
+    );
     expect(phaseSignalStore.entries[liveKey]?.remHits).toBe(1);
     expect(phaseSignalStore.entries[staleKey]).toBeUndefined();
 

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -19,7 +19,7 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { appendRegularFile, privateFileStore } from "openclaw/plugin-sdk/security-runtime";
+import { appendRegularFile } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
 import {
@@ -28,6 +28,14 @@ import {
   runDetachedDreamNarrative,
 } from "./dreaming-narrative.js";
 import { asRecord, formatErrorMessage, normalizeTrimmedString } from "./dreaming-shared.js";
+import {
+  DREAMING_DAILY_INGESTION_NAMESPACE,
+  DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+  DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+  SESSION_SEEN_HASHES_PER_CHUNK,
+  readMemoryCoreWorkspaceEntries,
+  writeMemoryCoreWorkspaceEntries,
+} from "./dreaming-state.js";
 import { textSimilarity as snippetSimilarity } from "./memory/tokenize.js";
 import {
   filterLiveShortTermRecallEntries,
@@ -80,12 +88,16 @@ const LIGHT_SLEEP_EVENT_TEXT = "__openclaw_memory_core_light_sleep__";
 const REM_SLEEP_EVENT_TEXT = "__openclaw_memory_core_rem_sleep__";
 const MEMORY_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const DAILY_MEMORY_FILENAME_RE = /^(\d{4}-\d{2}-\d{2})(?:-[^/]+)?\.md$/i;
-const DAILY_INGESTION_STATE_RELATIVE_PATH = path.join("memory", ".dreams", "daily-ingestion.json");
+export const DAILY_INGESTION_STATE_RELATIVE_PATH = path.join(
+  "memory",
+  ".dreams",
+  "daily-ingestion.json",
+);
 const DAILY_INGESTION_SCORE = 0.62;
 const DAILY_INGESTION_MAX_SNIPPET_CHARS = 280;
 const DAILY_INGESTION_MIN_SNIPPET_CHARS = 8;
 const DAILY_INGESTION_MAX_CHUNK_LINES = 4;
-const SESSION_INGESTION_STATE_RELATIVE_PATH = path.join(
+export const SESSION_INGESTION_STATE_RELATIVE_PATH = path.join(
   "memory",
   ".dreams",
   "session-ingestion.json",
@@ -438,7 +450,7 @@ type DailyIngestionState = {
   files: Record<string, DailyIngestionFileState>;
 };
 
-function normalizeDailyIngestionState(raw: unknown): DailyIngestionState {
+export function normalizeDailyIngestionState(raw: unknown): DailyIngestionState {
   const record = asRecord(raw);
   const filesRaw = asRecord(record?.files);
   if (!filesRaw) {
@@ -480,24 +492,24 @@ function normalizeMemoryDay(value: unknown): string | undefined {
 }
 
 async function readDailyIngestionState(workspaceDir: string): Promise<DailyIngestionState> {
-  try {
-    return normalizeDailyIngestionState(
-      await privateFileStore(workspaceDir).readJsonIfExists(DAILY_INGESTION_STATE_RELATIVE_PATH),
-    );
-  } catch (err) {
-    if (err instanceof SyntaxError) {
-      return { version: 1, files: {} };
-    }
-    throw err;
-  }
+  const entries = await readMemoryCoreWorkspaceEntries<DailyIngestionFileState>({
+    namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
+    workspaceDir,
+  });
+  return normalizeDailyIngestionState({
+    version: 1,
+    files: Object.fromEntries(entries.map((entry) => [entry.key, entry.value])),
+  });
 }
 
 async function writeDailyIngestionState(
   workspaceDir: string,
   state: DailyIngestionState,
 ): Promise<void> {
-  await privateFileStore(workspaceDir).writeJson(DAILY_INGESTION_STATE_RELATIVE_PATH, state, {
-    trailingNewline: true,
+  await writeMemoryCoreWorkspaceEntries({
+    namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
+    workspaceDir,
+    entries: Object.entries(state.files).map(([key, value]) => ({ key, value })),
   });
 }
 
@@ -532,7 +544,7 @@ function normalizeWorkspaceKey(workspaceDir: string): string {
   return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 }
 
-function normalizeSessionIngestionState(raw: unknown): SessionIngestionState {
+export function normalizeSessionIngestionState(raw: unknown): SessionIngestionState {
   const record = asRecord(raw);
   const filesRaw = asRecord(record?.files);
   const files: Record<string, SessionIngestionFileState> = {};
@@ -583,25 +595,67 @@ function normalizeSessionIngestionState(raw: unknown): SessionIngestionState {
 }
 
 async function readSessionIngestionState(workspaceDir: string): Promise<SessionIngestionState> {
-  try {
-    return normalizeSessionIngestionState(
-      await privateFileStore(workspaceDir).readJsonIfExists(SESSION_INGESTION_STATE_RELATIVE_PATH),
-    );
-  } catch (err) {
-    if (err instanceof SyntaxError) {
-      return { version: 3, files: {}, seenMessages: {} };
+  const [fileEntries, seenChunks] = await Promise.all([
+    readMemoryCoreWorkspaceEntries<SessionIngestionFileState>({
+      namespace: DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+      workspaceDir,
+    }),
+    readMemoryCoreWorkspaceEntries<{ scope: string; index: number; hashes: string[] }>({
+      namespace: DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+      workspaceDir,
+    }),
+  ]);
+  const seenMessages: Record<string, string[]> = {};
+  const chunksByScope = new Map<string, Array<{ index: number; hashes: string[] }>>();
+  for (const chunk of seenChunks) {
+    const scope = chunk.value.scope.trim();
+    if (!scope) {
+      continue;
     }
-    throw err;
+    const chunks = chunksByScope.get(scope) ?? [];
+    chunks.push({ index: chunk.value.index, hashes: chunk.value.hashes });
+    chunksByScope.set(scope, chunks);
   }
+  for (const [scope, chunks] of chunksByScope) {
+    seenMessages[scope] = chunks
+      .toSorted((a, b) => a.index - b.index)
+      .flatMap((chunk) => chunk.hashes);
+  }
+  return normalizeSessionIngestionState({
+    version: 3,
+    files: Object.fromEntries(fileEntries.map((entry) => [entry.key, entry.value])),
+    seenMessages,
+  });
 }
 
 async function writeSessionIngestionState(
   workspaceDir: string,
   state: SessionIngestionState,
 ): Promise<void> {
-  await privateFileStore(workspaceDir).writeJson(SESSION_INGESTION_STATE_RELATIVE_PATH, state, {
-    trailingNewline: true,
-  });
+  const seenEntries = Object.entries(state.seenMessages).flatMap(([scope, hashes]) =>
+    Array.from({ length: Math.ceil(hashes.length / SESSION_SEEN_HASHES_PER_CHUNK) }, (_, index) => {
+      const chunkHashes = hashes.slice(
+        index * SESSION_SEEN_HASHES_PER_CHUNK,
+        (index + 1) * SESSION_SEEN_HASHES_PER_CHUNK,
+      );
+      return {
+        key: `${scope}:${index}`,
+        value: { scope, index, hashes: chunkHashes },
+      };
+    }),
+  );
+  await Promise.all([
+    writeMemoryCoreWorkspaceEntries({
+      namespace: DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+      workspaceDir,
+      entries: Object.entries(state.files).map(([key, value]) => ({ key, value })),
+    }),
+    writeMemoryCoreWorkspaceEntries({
+      namespace: DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+      workspaceDir,
+      entries: seenEntries,
+    }),
+  ]);
 }
 
 function trimTrackedSessionScopes(
@@ -1889,6 +1943,8 @@ async function runPhaseIfTriggered(
 export const testing = {
   runPhaseIfTriggered,
   previewRemDreaming,
+  readDailyIngestionState,
+  readSessionIngestionState,
   // Exposed for the #80613 regression test that exercises CJK-aware dedupe.
   dedupeEntries,
   constants: {

--- a/extensions/memory-core/src/dreaming-repair.test.ts
+++ b/extensions/memory-core/src/dreaming-repair.test.ts
@@ -2,10 +2,26 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { auditDreamingArtifacts, repairDreamingArtifacts } from "./dreaming-repair.js";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+  DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+  readMemoryCoreWorkspaceEntries,
+  resetMemoryCoreDreamingStateForTests,
+  writeMemoryCoreWorkspaceEntries,
+} from "./dreaming-state.js";
 
 const tempDirs: string[] = [];
+
+beforeAll(async () => {
+  await configureMemoryCoreDreamingStateForTests();
+});
+
+afterAll(() => {
+  resetMemoryCoreDreamingStateForTests();
+});
 
 async function createWorkspace(): Promise<string> {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "dreaming-repair-test-"));
@@ -147,5 +163,55 @@ describe("dreaming artifact repair", () => {
     expect(
       archivedEntries.filter((entry) => entry.startsWith("session-ingestion.json.")),
     ).not.toEqual([]);
+  });
+
+  it("clears sqlite session ingestion state when archiving session corpus", async () => {
+    const workspaceDir = await createWorkspace();
+    const sessionCorpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+    await fs.mkdir(sessionCorpusDir, { recursive: true });
+    await fs.writeFile(path.join(sessionCorpusDir, "2026-04-11.txt"), "corpus\n", "utf-8");
+    await Promise.all([
+      writeMemoryCoreWorkspaceEntries({
+        namespace: DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+        workspaceDir,
+        entries: [
+          {
+            key: "main/session.jsonl",
+            value: {
+              lastSize: 120,
+              lastMtimeMs: 1_000,
+              lastContentHash: "hash",
+              cursorLine: 42,
+            },
+          },
+        ],
+      }),
+      writeMemoryCoreWorkspaceEntries({
+        namespace: DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+        workspaceDir,
+        entries: [
+          {
+            key: "main:0",
+            value: { scope: "main", index: 0, hashes: ["message-hash"] },
+          },
+        ],
+      }),
+    ]);
+
+    const repair = await repairDreamingArtifacts({ workspaceDir });
+
+    expect(repair.archivedSessionCorpus).toBe(true);
+    await expect(
+      readMemoryCoreWorkspaceEntries({
+        namespace: DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+        workspaceDir,
+      }),
+    ).resolves.toEqual([]);
+    await expect(
+      readMemoryCoreWorkspaceEntries({
+        namespace: DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+        workspaceDir,
+      }),
+    ).resolves.toEqual([]);
   });
 });

--- a/extensions/memory-core/src/dreaming-repair.ts
+++ b/extensions/memory-core/src/dreaming-repair.ts
@@ -3,6 +3,11 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
+import {
+  clearMemoryCoreWorkspaceNamespace,
+  DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+  DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+} from "./dreaming-state.js";
 
 type DreamingArtifactsAuditIssue = {
   severity: "warn" | "error";
@@ -123,6 +128,19 @@ async function moveToArchive(params: {
   const destination = path.join(params.archiveDir, `${baseName}.${randomUUID()}`);
   await fs.rename(params.targetPath, destination);
   return destination;
+}
+
+async function clearSessionIngestionState(workspaceDir: string): Promise<void> {
+  await Promise.all([
+    clearMemoryCoreWorkspaceNamespace({
+      namespace: DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
+      workspaceDir,
+    }),
+    clearMemoryCoreWorkspaceNamespace({
+      namespace: DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+      workspaceDir,
+    }),
+  ]);
 }
 
 export async function auditDreamingArtifacts(params: {
@@ -256,6 +274,18 @@ export async function repairDreamingArtifacts(params: {
   if (sessionIngestionDestination) {
     archivedSessionIngestion = true;
     archivedPaths.push(sessionIngestionDestination);
+  }
+
+  if (sessionCorpusDestination || sessionIngestionDestination) {
+    try {
+      await clearSessionIngestionState(workspaceDir);
+    } catch (err) {
+      warnings.push(
+        `Failed clearing dreaming session-ingestion SQLite state: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
   }
 
   if (params.archiveDiary) {

--- a/extensions/memory-core/src/dreaming-state.ts
+++ b/extensions/memory-core/src/dreaming-state.ts
@@ -1,0 +1,170 @@
+// Memory Core dreaming state lives in SQLite-backed plugin state.
+import { createHash } from "node:crypto";
+import path from "node:path";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+
+export const MEMORY_CORE_PLUGIN_ID = "memory-core";
+export const DREAMING_DAILY_INGESTION_NAMESPACE = "dreaming-daily-ingestion";
+export const DREAMING_SESSION_INGESTION_FILES_NAMESPACE = "dreaming-session-ingestion-files";
+export const DREAMING_SESSION_INGESTION_SEEN_NAMESPACE = "dreaming-session-ingestion-seen";
+export const SHORT_TERM_RECALL_NAMESPACE = "short-term-recall";
+export const SHORT_TERM_PHASE_SIGNAL_NAMESPACE = "short-term-phase-signals";
+export const SHORT_TERM_META_NAMESPACE = "short-term-meta";
+export const SHORT_TERM_LOCK_NAMESPACE = "short-term-locks";
+
+export const DREAMING_WORKSPACE_STATE_MAX_ENTRIES = 50_000;
+export const SHORT_TERM_LOCK_MAX_ENTRIES = 4_096;
+export const SESSION_SEEN_HASHES_PER_CHUNK = 512;
+
+export type MemoryCoreOpenKeyedStore = <T>(
+  options: OpenKeyedStoreOptions,
+) => PluginStateKeyedStore<T>;
+
+type WorkspaceValue<T> = {
+  version: 1;
+  workspaceKey: string;
+  workspaceDir: string;
+  key: string;
+  value: T;
+};
+
+let configuredOpenKeyedStore: MemoryCoreOpenKeyedStore | undefined;
+
+export function configureMemoryCoreDreamingState(openKeyedStore: MemoryCoreOpenKeyedStore): void {
+  configuredOpenKeyedStore = openKeyedStore;
+}
+
+export async function configureMemoryCoreDreamingStateForTests(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const { createPluginStateKeyedStoreForTests } =
+    await import("openclaw/plugin-sdk/plugin-state-test-runtime");
+  const testEnv = { ...env };
+  configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateKeyedStoreForTests<T>(MEMORY_CORE_PLUGIN_ID, { ...options, env: testEnv }),
+  );
+}
+
+export function resetMemoryCoreDreamingStateForTests(): void {
+  configuredOpenKeyedStore = undefined;
+}
+
+export function openMemoryCoreStateStore<T>(
+  options: OpenKeyedStoreOptions,
+): PluginStateKeyedStore<T> {
+  if (!configuredOpenKeyedStore) {
+    throw new Error("memory-core dreaming SQLite state store is not configured");
+  }
+  return configuredOpenKeyedStore<T>(options);
+}
+
+export function normalizeMemoryCoreWorkspaceKey(workspaceDir: string): string {
+  const resolved = path.resolve(workspaceDir).replace(/\\/g, "/");
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+export function memoryCoreWorkspaceStateKey(workspaceDir: string): string {
+  return createHash("sha256").update(normalizeMemoryCoreWorkspaceKey(workspaceDir)).digest("hex");
+}
+
+export function memoryCoreWorkspaceEntryKey(workspaceDir: string, logicalKey: string): string {
+  const workspaceKey = memoryCoreWorkspaceStateKey(workspaceDir);
+  const itemKey = createHash("sha256").update(logicalKey).digest("hex");
+  return `${workspaceKey}:${itemKey}`;
+}
+
+export function memoryCoreStateReference(namespace: string, workspaceDir: string): string {
+  return `plugin-state:${MEMORY_CORE_PLUGIN_ID}/${namespace}/${memoryCoreWorkspaceStateKey(workspaceDir)}`;
+}
+
+function openWorkspaceStore<T>(namespace: string): PluginStateKeyedStore<WorkspaceValue<T>> {
+  return openMemoryCoreStateStore<WorkspaceValue<T>>({
+    namespace,
+    maxEntries: DREAMING_WORKSPACE_STATE_MAX_ENTRIES,
+  });
+}
+
+export async function readMemoryCoreWorkspaceEntries<T>(params: {
+  namespace: string;
+  workspaceDir: string;
+}): Promise<Array<{ key: string; value: T }>> {
+  const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
+  const prefix = `${workspaceKey}:`;
+  const entries = await openWorkspaceStore<T>(params.namespace).entries();
+  return entries
+    .filter((entry) => entry.key.startsWith(prefix) && entry.value.workspaceKey === workspaceKey)
+    .map((entry) => ({ key: entry.value.key, value: entry.value.value }));
+}
+
+export async function writeMemoryCoreWorkspaceEntries<T>(params: {
+  namespace: string;
+  workspaceDir: string;
+  entries: Array<{ key: string; value: T }>;
+}): Promise<void> {
+  const store = openWorkspaceStore<T>(params.namespace);
+  const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
+  const prefix = `${workspaceKey}:`;
+  const replacementKeys = new Set<string>();
+  for (const entry of params.entries) {
+    const stateKey = memoryCoreWorkspaceEntryKey(params.workspaceDir, entry.key);
+    replacementKeys.add(stateKey);
+    await store.register(stateKey, {
+      version: 1,
+      workspaceKey,
+      workspaceDir: path.resolve(params.workspaceDir),
+      key: entry.key,
+      value: entry.value,
+    });
+  }
+  for (const entry of await store.entries()) {
+    if (entry.key.startsWith(prefix) && !replacementKeys.has(entry.key)) {
+      await store.delete(entry.key);
+    }
+  }
+}
+
+export async function writeMemoryCoreWorkspaceEntry<T>(params: {
+  namespace: string;
+  workspaceDir: string;
+  key: string;
+  value: T;
+}): Promise<void> {
+  const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
+  await openWorkspaceStore<T>(params.namespace).register(
+    memoryCoreWorkspaceEntryKey(params.workspaceDir, params.key),
+    {
+      version: 1,
+      workspaceKey,
+      workspaceDir: path.resolve(params.workspaceDir),
+      key: params.key,
+      value: params.value,
+    },
+  );
+}
+
+export async function deleteMemoryCoreWorkspaceEntry(params: {
+  namespace: string;
+  workspaceDir: string;
+  key: string;
+}): Promise<boolean> {
+  return await openWorkspaceStore(params.namespace).delete(
+    memoryCoreWorkspaceEntryKey(params.workspaceDir, params.key),
+  );
+}
+
+export async function clearMemoryCoreWorkspaceNamespace(params: {
+  namespace: string;
+  workspaceDir: string;
+}): Promise<void> {
+  const store = openWorkspaceStore(params.namespace);
+  const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
+  const prefix = `${workspaceKey}:`;
+  for (const entry of await store.entries()) {
+    if (entry.key.startsWith(prefix)) {
+      await store.delete(entry.key);
+    }
+  }
+}

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -14,7 +14,7 @@ import {
   resolveShortTermPromotionDreamingConfig,
   runShortTermDreamingPromotionIfTriggered,
 } from "./dreaming.js";
-import { recordShortTermRecalls } from "./short-term-promotion.js";
+import { recordShortTermRecalls, testing as shortTermTesting } from "./short-term-promotion.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
 const constants = testing.constants;
@@ -2562,38 +2562,28 @@ describe("short-term dreaming trigger", () => {
       "Move backups to S3 Glacier and sync router failover notes.",
       "Keep router recovery docs current.",
     ]);
-    const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
-    await fs.mkdir(path.dirname(storePath), { recursive: true });
-    await fs.writeFile(
-      storePath,
-      `${JSON.stringify(
-        {
-          version: 1,
-          updatedAt: "2026-04-01T00:00:00.000Z",
-          entries: {
-            "memory:memory/2026-04-03.md:1:2": {
-              key: "memory:memory/2026-04-03.md:1:2",
-              path: "memory/2026-04-03.md",
-              startLine: 1,
-              endLine: 2,
-              source: "memory",
-              snippet: "Move backups to S3 Glacier and sync router failover notes.",
-              recallCount: 3,
-              totalScore: 2.7,
-              maxScore: 0.95,
-              firstRecalledAt: "2026-04-01T00:00:00.000Z",
-              lastRecalledAt: "2026-04-03T00:00:00.000Z",
-              queryHashes: ["abc", "abc", "def"],
-              recallDays: ["2026-04-01", "2026-04-01", "2026-04-03"],
-              conceptTags: [],
-            },
-          },
+    await shortTermTesting.writeRawRecallStore(workspaceDir, {
+      version: 1,
+      updatedAt: "2026-04-01T00:00:00.000Z",
+      entries: {
+        "memory:memory/2026-04-03.md:1:2": {
+          key: "memory:memory/2026-04-03.md:1:2",
+          path: "memory/2026-04-03.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "Move backups to S3 Glacier and sync router failover notes.",
+          recallCount: 3,
+          totalScore: 2.7,
+          maxScore: 0.95,
+          firstRecalledAt: "2026-04-01T00:00:00.000Z",
+          lastRecalledAt: "2026-04-03T00:00:00.000Z",
+          queryHashes: ["abc", "abc", "def"],
+          recallDays: ["2026-04-01", "2026-04-01", "2026-04-03"],
+          conceptTags: [],
         },
-        null,
-        2,
-      )}\n`,
-      "utf-8",
-    );
+      },
+    });
 
     const result = await runShortTermDreamingPromotionIfTriggered({
       cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
@@ -2614,12 +2604,7 @@ describe("short-term dreaming trigger", () => {
 
     expect(result?.handled).toBe(true);
     expectLogContains(logger.info, "normalized recall artifacts before dreaming");
-    const repaired = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
-      entries: Record<
-        string,
-        { queryHashes?: string[]; recallDays?: string[]; conceptTags?: string[] }
-      >;
-    };
+    const repaired = await shortTermTesting.readRecallStore(workspaceDir, new Date().toISOString());
     expect(repaired.entries["memory:memory/2026-04-03.md:1:2"]?.queryHashes).toEqual([
       "abc",
       "def",

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2,27 +2,25 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { createPluginStateKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk/memory-host-events", () => ({
   appendMemoryHostEvent: vi.fn(async () => {}),
 }));
 
-vi.mock("openclaw/plugin-sdk/security-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/security-runtime")>(
-    "openclaw/plugin-sdk/security-runtime",
-  );
-  return {
-    ...actual,
-    privateFileStore: vi.fn((rootDir: string) => actual.privateFileStore(rootDir)),
-  };
-});
-
-import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
+import {
+  configureMemoryCoreDreamingState,
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+  SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
+} from "./dreaming-state.js";
 import {
   applyShortTermPromotions,
   auditShortTermPromotionArtifacts,
   isShortTermMemoryPath,
+  loadShortTermPromotionDreamingStats,
   recordGroundedShortTermCandidates,
   rankShortTermPromotionCandidates,
   recordDreamingPhaseSignals,
@@ -31,9 +29,6 @@ import {
   readLightStagedKeys,
   removeGroundedShortTermCandidates,
   repairShortTermPromotionArtifacts,
-  resolveShortTermRecallLockPath,
-  resolveShortTermPhaseSignalStorePath,
-  resolveShortTermRecallStorePath,
   testing,
 } from "./short-term-promotion.js";
 
@@ -42,6 +37,7 @@ describe("short-term promotion", () => {
   let caseId = 0;
 
   beforeAll(async () => {
+    await configureMemoryCoreDreamingStateForTests();
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-promote-"));
   });
 
@@ -50,6 +46,7 @@ describe("short-term promotion", () => {
       return;
     }
     await fs.rm(fixtureRoot, { recursive: true, force: true });
+    resetMemoryCoreDreamingStateForTests();
   });
 
   afterEach(() => {
@@ -118,21 +115,9 @@ describe("short-term promotion", () => {
       }
     >
   > {
-    const raw = await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8");
-    const store = JSON.parse(raw) as {
-      entries?: Record<
-        string,
-        {
-          claimHash?: unknown;
-          firstRecalledAt?: unknown;
-          lastRecalledAt?: unknown;
-          recallCount?: unknown;
-          snippet?: unknown;
-          totalScore?: unknown;
-        }
-      >;
-    };
-    return store.entries ?? {};
+    return await testing
+      .readRecallStore(workspaceDir, new Date().toISOString())
+      .then((store) => store.entries);
   }
 
   function readEntrySnippet(entry: { snippet?: unknown }): string {
@@ -181,10 +166,8 @@ describe("short-term promotion", () => {
           },
         ],
       });
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      const raw = await fs.readFile(storePath, "utf-8");
-      const store = JSON.parse(raw) as Record<string, unknown>;
-      expect(Object.keys(store).length).toBeGreaterThan(0);
+      const store = await testing.readRecallStore(workspaceDir, new Date().toISOString());
+      expect(Object.keys(store.entries).length).toBeGreaterThan(0);
     });
   });
 
@@ -252,7 +235,9 @@ describe("short-term promotion", () => {
         ],
       });
 
-      const raw = await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8");
+      const raw = JSON.stringify(
+        await testing.readRecallStore(workspaceDir, new Date().toISOString()),
+      );
       expect(raw).toContain("memory/daily notes/2026-04-03.md");
       expect(raw).toContain("memory/日记/2026-04-04.md");
     });
@@ -358,7 +343,7 @@ describe("short-term promotion", () => {
         ],
       });
 
-      await expectEnoent(fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8"));
+      expect(await readRecallStoreEntries(workspaceDir)).toEqual({});
     });
   });
 
@@ -379,7 +364,7 @@ describe("short-term promotion", () => {
         ],
       });
 
-      await expectEnoent(fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8"));
+      expect(await readRecallStoreEntries(workspaceDir)).toEqual({});
     });
   });
 
@@ -401,9 +386,7 @@ describe("short-term promotion", () => {
         ],
       });
 
-      const store = JSON.parse(
-        await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8"),
-      ) as { version?: number; entries?: unknown };
+      const store = await testing.readRecallStore(workspaceDir, new Date().toISOString());
       expect(store.version).toBe(1);
       expect(store.entries).toEqual({});
     });
@@ -432,9 +415,7 @@ describe("short-term promotion", () => {
         ],
       });
 
-      const store = JSON.parse(
-        await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8"),
-      ) as { version?: number; entries?: unknown };
+      const store = await testing.readRecallStore(workspaceDir, new Date().toISOString());
       expect(store.version).toBe(1);
       expect(store.entries).toEqual({});
     });
@@ -458,9 +439,7 @@ describe("short-term promotion", () => {
         ],
       });
 
-      const store = JSON.parse(
-        await fs.readFile(resolveShortTermRecallStorePath(workspaceDir), "utf-8"),
-      ) as { entries: Record<string, { snippet: string }> };
+      const store = await testing.readRecallStore(workspaceDir, new Date().toISOString());
       const entries = Object.values(store.entries);
       expect(entries).toHaveLength(1);
       expect(entries[0]?.snippet).toBe(
@@ -523,8 +502,9 @@ describe("short-term promotion", () => {
       expect(ranked[0]?.conceptTags).toContain("router");
       expect(ranked[0]?.components.conceptual).toBeGreaterThan(0);
 
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      const raw = await fs.readFile(storePath, "utf-8");
+      const raw = JSON.stringify(
+        await testing.readRecallStore(workspaceDir, new Date().toISOString()),
+      );
       expect(raw).toContain("memory/2026-04-02.md");
       expect(raw).not.toContain("Long-term note");
     });
@@ -1032,10 +1012,10 @@ describe("short-term promotion", () => {
       expect(ranked[0]?.path).toBe("memory/2026-04-02.md");
       expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
 
-      const phaseStorePath = resolveShortTermPhaseSignalStorePath(workspaceDir);
-      const phaseStore = JSON.parse(await fs.readFile(phaseStorePath, "utf-8")) as {
-        entries: Record<string, { lightHits: number; remHits: number }>;
-      };
+      const phaseStore = await testing.readPhaseSignalStore(
+        workspaceDir,
+        new Date(nowMs).toISOString(),
+      );
       expect(phaseStore.entries[boostedKey]?.lightHits).toBe(1);
       expect(phaseStore.entries[boostedKey]?.remHits).toBe(1);
     });
@@ -1116,7 +1096,7 @@ describe("short-term promotion", () => {
     });
   });
 
-  it("propagates unreadable phase-signal store errors without overwriting existing signals", async () => {
+  it("updates existing phase-signal rows without dropping prior signal counts", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({
         workspaceDir,
@@ -1147,66 +1127,71 @@ describe("short-term promotion", () => {
         throw new Error("expected ranked candidate key");
       }
 
-      const phaseStorePath = resolveShortTermPhaseSignalStorePath(workspaceDir);
-      const existingRaw = `${JSON.stringify(
-        {
-          version: 1,
-          updatedAt: "2026-04-01T10:00:00.000Z",
-          entries: {
-            [key]: {
-              key,
-              lightHits: 2,
-              remHits: 1,
-              lastLightAt: "2026-04-01T10:00:00.000Z",
-              lastRemAt: "2026-04-02T10:00:00.000Z",
-            },
+      await testing.writeRawPhaseSignalStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-01T10:00:00.000Z",
+        entries: {
+          [key]: {
+            key,
+            lightHits: 2,
+            remHits: 1,
+            lastLightAt: "2026-04-01T10:00:00.000Z",
+            lastRemAt: "2026-04-02T10:00:00.000Z",
           },
         },
-        null,
-        2,
-      )}\n`;
-      await fs.writeFile(phaseStorePath, existingRaw, "utf-8");
-
-      const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/security-runtime")>(
-        "openclaw/plugin-sdk/security-runtime",
-      );
-      const mockedPrivateFileStore = vi.mocked(privateFileStore);
-      mockedPrivateFileStore.mockImplementation((rootDir: string) => {
-        const store = actual.privateFileStore(rootDir);
-        return {
-          ...store,
-          readJsonIfExists: (async <T = unknown>(
-            relativePath: string,
-            options?: Parameters<typeof store.readJsonIfExists>[1],
-          ): Promise<T | null> => {
-            if (rootDir === workspaceDir && store.path(relativePath) === phaseStorePath) {
-              const err = new Error("permission denied") as NodeJS.ErrnoException;
-              err.code = "EACCES";
-              throw err;
-            }
-            return store.readJsonIfExists<T>(relativePath, options);
-          }) as typeof store.readJsonIfExists,
-        };
       });
 
-      try {
-        await expect(
-          recordDreamingPhaseSignals({
-            workspaceDir,
-            phase: "rem",
-            keys: [key],
-            nowMs: Date.parse("2026-04-05T10:00:00.000Z"),
-          }),
-        ).rejects.toMatchObject({
-          code: "EACCES",
-        });
-      } finally {
-        mockedPrivateFileStore.mockImplementation((rootDir: string) =>
-          actual.privateFileStore(rootDir),
-        );
-      }
+      await recordDreamingPhaseSignals({
+        workspaceDir,
+        phase: "rem",
+        keys: [key],
+        nowMs: Date.parse("2026-04-05T10:00:00.000Z"),
+      });
 
-      expect(await fs.readFile(phaseStorePath, "utf-8")).toBe(existingRaw);
+      const phaseStore = await testing.readPhaseSignalStore(
+        workspaceDir,
+        "2026-04-05T10:00:00.000Z",
+      );
+      expect(phaseStore.entries[key]?.lightHits).toBe(2);
+      expect(phaseStore.entries[key]?.remHits).toBe(2);
+    });
+  });
+
+  it("keeps recall stats when phase-signal state cannot be read", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const nowMs = Date.parse("2026-04-05T10:00:00.000Z");
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "glacier cadence",
+        nowMs,
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet: "Move backups to S3 Glacier.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const env = { ...process.env };
+      configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) => {
+        if (options.namespace === SHORT_TERM_PHASE_SIGNAL_NAMESPACE) {
+          throw new Error("phase state unavailable");
+        }
+        return createPluginStateKeyedStoreForTests<T>("memory-core", { ...options, env });
+      });
+      try {
+        const stats = await loadShortTermPromotionDreamingStats({ workspaceDir, nowMs });
+        expect(stats.shortTermCount).toBe(1);
+        expect(stats.recallSignalCount).toBe(1);
+        expect(stats.phaseSignalCount).toBe(0);
+        expect(stats.phaseSignalError).toContain("phase state unavailable");
+      } finally {
+        await configureMemoryCoreDreamingStateForTests();
+      }
     });
   });
 
@@ -1249,14 +1234,11 @@ describe("short-term promotion", () => {
       expect(firstApply.appended).toBe(1);
       expect(firstApply.reconciledExisting).toBe(0);
 
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      const rawStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
-        entries: Record<string, { promotedAt?: string }>;
-      };
+      const rawStore = await testing.readRecallStore(workspaceDir, new Date().toISOString());
       for (const entry of Object.values(rawStore.entries)) {
         delete entry.promotedAt;
       }
-      await fs.writeFile(storePath, `${JSON.stringify(rawStore, null, 2)}\n`, "utf-8");
+      await testing.writeRawRecallStore(workspaceDir, rawStore);
 
       const secondApply = await applyShortTermPromotions({
         workspaceDir,
@@ -1318,14 +1300,11 @@ describe("short-term promotion", () => {
       expect(firstApply.applied).toBe(1);
       expect(firstApply.appended).toBe(1);
 
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      const rawStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
-        entries: Record<string, { promotedAt?: string }>;
-      };
+      const rawStore = await testing.readRecallStore(workspaceDir, new Date().toISOString());
       for (const entry of Object.values(rawStore.entries)) {
         delete entry.promotedAt;
       }
-      await fs.writeFile(storePath, `${JSON.stringify(rawStore, null, 2)}\n`, "utf-8");
+      await testing.writeRawRecallStore(workspaceDir, rawStore);
 
       const secondApply = await applyShortTermPromotions({
         workspaceDir,
@@ -1448,40 +1427,31 @@ describe("short-term promotion", () => {
 
   it("does not rank contaminated dreaming snippets from an existing short-term store", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      await fs.writeFile(
-        storePath,
-        JSON.stringify(
-          {
-            version: 1,
-            updatedAt: "2026-04-04T00:00:00.000Z",
-            entries: {
-              contaminated: {
-                key: "contaminated",
-                path: "memory/2026-04-03.md",
-                startLine: 1,
-                endLine: 1,
-                source: "memory",
-                snippet:
-                  "Reflections: Theme: assistant. confidence: 1.00 evidence: memory/.dreams/session-corpus/2026-04-08.txt:2-2 recalls: 4 status: staged",
-                recallCount: 4,
-                dailyCount: 0,
-                groundedCount: 0,
-                totalScore: 3.6,
-                maxScore: 0.95,
-                firstRecalledAt: "2026-04-03T00:00:00.000Z",
-                lastRecalledAt: "2026-04-04T00:00:00.000Z",
-                queryHashes: ["a", "b"],
-                recallDays: ["2026-04-03", "2026-04-04"],
-                conceptTags: ["assistant"],
-              },
-            },
+      await testing.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: {
+          contaminated: {
+            key: "contaminated",
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            source: "memory",
+            snippet:
+              "Reflections: Theme: assistant. confidence: 1.00 evidence: memory/.dreams/session-corpus/2026-04-08.txt:2-2 recalls: 4 status: staged",
+            recallCount: 4,
+            dailyCount: 0,
+            groundedCount: 0,
+            totalScore: 3.6,
+            maxScore: 0.95,
+            firstRecalledAt: "2026-04-03T00:00:00.000Z",
+            lastRecalledAt: "2026-04-04T00:00:00.000Z",
+            queryHashes: ["a", "b"],
+            recallDays: ["2026-04-03", "2026-04-04"],
+            conceptTags: ["assistant"],
           },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
+        },
+      });
 
       const ranked = await rankShortTermPromotionCandidates({
         workspaceDir,
@@ -2844,43 +2814,33 @@ describe("short-term promotion", () => {
 
   it("audits and repairs invalid store metadata plus stale locks", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      await fs.writeFile(
-        storePath,
-        JSON.stringify(
-          {
-            version: 1,
-            updatedAt: "2026-04-04T00:00:00.000Z",
-            entries: {
-              good: {
-                key: "good",
-                path: "memory/2026-04-01.md",
-                startLine: 1,
-                endLine: 2,
-                source: "memory",
-                snippet: "Gateway host uses qmd vector search for router notes.",
-                recallCount: 2,
-                totalScore: 1.8,
-                maxScore: 0.95,
-                firstRecalledAt: "2026-04-01T00:00:00.000Z",
-                lastRecalledAt: "2026-04-04T00:00:00.000Z",
-                queryHashes: ["a", "b"],
-              },
-              bad: {
-                path: "",
-              },
-            },
+      await testing.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: {
+          good: {
+            key: "good",
+            path: "memory/2026-04-01.md",
+            startLine: 1,
+            endLine: 2,
+            source: "memory",
+            snippet: "Gateway host uses qmd vector search for router notes.",
+            recallCount: 2,
+            totalScore: 1.8,
+            maxScore: 0.95,
+            firstRecalledAt: "2026-04-01T00:00:00.000Z",
+            lastRecalledAt: "2026-04-04T00:00:00.000Z",
+            queryHashes: ["a", "b"],
           },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
-
-      const lockPath = path.join(workspaceDir, "memory", ".dreams", "short-term-promotion.lock");
-      await fs.writeFile(lockPath, "999999:0\n", "utf-8");
-      const staleMtime = new Date(Date.now() - 120_000);
-      await fs.utimes(lockPath, staleMtime, staleMtime);
+          bad: {
+            path: "",
+          },
+        },
+      });
+      await testing.writeShortTermLock(workspaceDir, {
+        owner: "999999:0",
+        acquiredAt: Date.now() - 120_000,
+      });
 
       const auditBefore = await auditShortTermPromotionArtifacts({ workspaceDir });
       expect(auditBefore.invalidEntryCount).toBe(1);
@@ -2898,9 +2858,7 @@ describe("short-term promotion", () => {
       expect(auditAfter.invalidEntryCount).toBe(0);
       expect(auditAfter.issues.map((issue) => issue.code)).not.toContain("recall-lock-stale");
 
-      const repairedRaw = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
-        entries: Record<string, { conceptTags?: string[]; recallDays?: string[] }>;
-      };
+      const repairedRaw = await testing.readRecallStore(workspaceDir, new Date().toISOString());
       expect(repairedRaw.entries.good?.conceptTags).toContain("router");
       expect(repairedRaw.entries.good?.recallDays).toEqual(["2026-04-04"]);
     });
@@ -2910,44 +2868,35 @@ describe("short-term promotion", () => {
     await withTempWorkspace(async (workspaceDir) => {
       const maxEntries = testing.SHORT_TERM_RECALL_MAX_ENTRIES;
       const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      await fs.writeFile(
-        storePath,
-        `${JSON.stringify(
-          {
-            version: 1,
-            updatedAt: "2026-04-04T00:00:00.000Z",
-            entries: Object.fromEntries(
-              Array.from({ length: maxEntries + 3 }, (_, index) => [
-                `entry-${index}`,
-                {
-                  key: `entry-${index}`,
-                  path: "memory/2026-04-01.md",
-                  startLine: index + 1,
-                  endLine: index + 1,
-                  source: "memory",
-                  snippet: `Oversized recall ${index} ${"x".repeat(maxSnippetChars + 100)}`,
-                  recallCount: 1,
-                  dailyCount: 0,
-                  groundedCount: 0,
-                  totalScore: index,
-                  maxScore: 0.75,
-                  firstRecalledAt: "2026-04-01T00:00:00.000Z",
-                  lastRecalledAt: new Date(
-                    Date.parse("2026-04-01T00:00:00.000Z") + index,
-                  ).toISOString(),
-                  queryHashes: [`q-${index}`],
-                  recallDays: ["2026-04-01"],
-                  conceptTags: [],
-                },
-              ]),
-            ),
-          },
-          null,
-          2,
-        )}\n`,
-        "utf-8",
-      );
+      await testing.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: Object.fromEntries(
+          Array.from({ length: maxEntries + 3 }, (_, index) => [
+            `entry-${index}`,
+            {
+              key: `entry-${index}`,
+              path: "memory/2026-04-01.md",
+              startLine: index + 1,
+              endLine: index + 1,
+              source: "memory",
+              snippet: `Oversized recall ${index} ${"x".repeat(maxSnippetChars + 100)}`,
+              recallCount: 1,
+              dailyCount: 0,
+              groundedCount: 0,
+              totalScore: index,
+              maxScore: 0.75,
+              firstRecalledAt: "2026-04-01T00:00:00.000Z",
+              lastRecalledAt: new Date(
+                Date.parse("2026-04-01T00:00:00.000Z") + index,
+              ).toISOString(),
+              queryHashes: [`q-${index}`],
+              recallDays: ["2026-04-01"],
+              conceptTags: [],
+            },
+          ]),
+        ),
+      });
 
       const auditBefore = await auditShortTermPromotionArtifacts({ workspaceDir });
       expect(auditBefore.entryCount).toBe(maxEntries + 3);
@@ -2973,42 +2922,33 @@ describe("short-term promotion", () => {
   it("uses score tie-breakers when capping stores with invalid timestamps", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const maxEntries = testing.SHORT_TERM_RECALL_MAX_ENTRIES;
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      await fs.writeFile(
-        storePath,
-        `${JSON.stringify(
-          {
-            version: 1,
-            updatedAt: "2026-04-04T00:00:00.000Z",
-            entries: Object.fromEntries(
-              Array.from({ length: maxEntries + 3 }, (_, index) => [
-                `entry-${index}`,
-                {
-                  key: `entry-${index}`,
-                  path: "memory/2026-04-01.md",
-                  startLine: index + 1,
-                  endLine: index + 1,
-                  source: "memory",
-                  snippet: `Invalid timestamp recall ${index}`,
-                  recallCount: 1,
-                  dailyCount: 0,
-                  groundedCount: 0,
-                  totalScore: index,
-                  maxScore: 0.75,
-                  firstRecalledAt: "not-a-date",
-                  lastRecalledAt: "not-a-date",
-                  queryHashes: [`q-${index}`],
-                  recallDays: ["2026-04-01"],
-                  conceptTags: [],
-                },
-              ]),
-            ),
-          },
-          null,
-          2,
-        )}\n`,
-        "utf-8",
-      );
+      await testing.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: Object.fromEntries(
+          Array.from({ length: maxEntries + 3 }, (_, index) => [
+            `entry-${index}`,
+            {
+              key: `entry-${index}`,
+              path: "memory/2026-04-01.md",
+              startLine: index + 1,
+              endLine: index + 1,
+              source: "memory",
+              snippet: `Invalid timestamp recall ${index}`,
+              recallCount: 1,
+              dailyCount: 0,
+              groundedCount: 0,
+              totalScore: index,
+              maxScore: 0.75,
+              firstRecalledAt: "not-a-date",
+              lastRecalledAt: "not-a-date",
+              queryHashes: [`q-${index}`],
+              recallDays: ["2026-04-01"],
+              conceptTags: [],
+            },
+          ]),
+        ),
+      });
 
       const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
 
@@ -3023,39 +2963,30 @@ describe("short-term promotion", () => {
   it("rejects long contaminated legacy recall entries before truncating snippets", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const maxSnippetChars = testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS;
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      await fs.writeFile(
-        storePath,
-        `${JSON.stringify(
-          {
-            version: 1,
-            updatedAt: "2026-04-04T00:00:00.000Z",
-            entries: {
-              contaminated: {
-                key: "contaminated",
-                path: "memory/2026-04-01.md",
-                startLine: 1,
-                endLine: 1,
-                source: "memory",
-                snippet: `Candidate: ${"x".repeat(maxSnippetChars + 100)} confidence: 9 evidence: memory/.dreams/session-corpus/2026-04-01.txt status: staged recalls: 1`,
-                recallCount: 1,
-                dailyCount: 0,
-                groundedCount: 0,
-                totalScore: 1,
-                maxScore: 0.75,
-                firstRecalledAt: "2026-04-01T00:00:00.000Z",
-                lastRecalledAt: "2026-04-01T00:00:00.000Z",
-                queryHashes: ["q"],
-                recallDays: ["2026-04-01"],
-                conceptTags: [],
-              },
-            },
+      await testing.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: {
+          contaminated: {
+            key: "contaminated",
+            path: "memory/2026-04-01.md",
+            startLine: 1,
+            endLine: 1,
+            source: "memory",
+            snippet: `Candidate: ${"x".repeat(maxSnippetChars + 100)} confidence: 9 evidence: memory/.dreams/session-corpus/2026-04-01.txt status: staged recalls: 1`,
+            recallCount: 1,
+            dailyCount: 0,
+            groundedCount: 0,
+            totalScore: 1,
+            maxScore: 0.75,
+            firstRecalledAt: "2026-04-01T00:00:00.000Z",
+            lastRecalledAt: "2026-04-01T00:00:00.000Z",
+            queryHashes: ["q"],
+            recallDays: ["2026-04-01"],
+            conceptTags: [],
           },
-          null,
-          2,
-        )}\n`,
-        "utf-8",
-      );
+        },
+      });
 
       const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
 
@@ -3065,19 +2996,13 @@ describe("short-term promotion", () => {
     });
   });
 
-  it("repairs empty recall-store files without throwing", async () => {
+  it("leaves empty recall stores normalized without rewriting", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      await fs.writeFile(storePath, "   \n", "utf-8");
-
       const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
 
-      expect(repair.changed).toBe(true);
-      expect(repair.rewroteStore).toBe(true);
-      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
-        version?: number;
-        entries?: unknown;
-      };
+      expect(repair.changed).toBe(false);
+      expect(repair.rewroteStore).toBe(false);
+      const store = await testing.readRecallStore(workspaceDir, new Date().toISOString());
       expect(store.version).toBe(1);
       expect(store.entries).toEqual({});
     });
@@ -3085,72 +3010,59 @@ describe("short-term promotion", () => {
 
   it("does not rewrite an already normalized healthy recall store", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
       const snippet = "Gateway host uses qmd vector search for router notes.";
-      const raw = `${JSON.stringify(
-        {
-          version: 1,
-          updatedAt: "2026-04-04T00:00:00.000Z",
-          entries: {
-            good: {
-              key: "good",
+      const raw = {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: {
+          good: {
+            key: "good",
+            path: "memory/2026-04-01.md",
+            startLine: 1,
+            endLine: 2,
+            source: "memory",
+            snippet,
+            recallCount: 2,
+            dailyCount: 0,
+            groundedCount: 0,
+            totalScore: 1.8,
+            maxScore: 0.95,
+            firstRecalledAt: "2026-04-01T00:00:00.000Z",
+            lastRecalledAt: "2026-04-04T00:00:00.000Z",
+            queryHashes: ["a", "b"],
+            recallDays: ["2026-04-04"],
+            conceptTags: testing.deriveConceptTags({
               path: "memory/2026-04-01.md",
-              startLine: 1,
-              endLine: 2,
-              source: "memory",
               snippet,
-              recallCount: 2,
-              dailyCount: 0,
-              groundedCount: 0,
-              totalScore: 1.8,
-              maxScore: 0.95,
-              firstRecalledAt: "2026-04-01T00:00:00.000Z",
-              lastRecalledAt: "2026-04-04T00:00:00.000Z",
-              queryHashes: ["a", "b"],
-              recallDays: ["2026-04-04"],
-              conceptTags: testing.deriveConceptTags({
-                path: "memory/2026-04-01.md",
-                snippet,
-              }),
-            },
+            }),
           },
         },
-        null,
-        2,
-      )}\n`;
-      await fs.writeFile(storePath, raw, "utf-8");
+      };
+      await testing.writeRawRecallStore(workspaceDir, raw);
 
       const repair = await repairShortTermPromotionArtifacts({ workspaceDir });
 
       expect(repair.changed).toBe(false);
       expect(repair.rewroteStore).toBe(false);
-      const nextRaw = await fs.readFile(storePath, "utf-8");
-      expect(nextRaw).toBe(raw);
+      expect(await testing.readRecallStore(workspaceDir, new Date().toISOString())).toEqual(raw);
     });
   });
 
   it("waits for an active short-term lock before repairing", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const storePath = resolveShortTermRecallStorePath(workspaceDir);
-      const lockPath = resolveShortTermRecallLockPath(workspaceDir);
-      await fs.writeFile(
-        storePath,
-        JSON.stringify(
-          {
-            version: 1,
-            updatedAt: "2026-04-04T00:00:00.000Z",
-            entries: {
-              bad: {
-                path: "",
-              },
-            },
+      await testing.writeRawRecallStore(workspaceDir, {
+        version: 1,
+        updatedAt: "2026-04-04T00:00:00.000Z",
+        entries: {
+          bad: {
+            path: "",
           },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
-      await fs.writeFile(lockPath, `${process.pid}:${Date.now()}\n`, "utf-8");
+        },
+      });
+      await testing.writeShortTermLock(workspaceDir, {
+        owner: `${process.pid}:${Date.now()}`,
+        acquiredAt: Date.now(),
+      });
 
       vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
       try {
@@ -3163,7 +3075,7 @@ describe("short-term promotion", () => {
         await vi.advanceTimersByTimeAsync(41);
         expect(settled).toBe(false);
 
-        await fs.unlink(lockPath);
+        await testing.deleteShortTermLock(workspaceDir);
         await vi.advanceTimersByTimeAsync(40);
         const repair = await repairPromise;
 
@@ -3176,30 +3088,19 @@ describe("short-term promotion", () => {
     });
   });
 
-  it("downgrades lock inspection failures into audit issues", async () => {
+  it("reports stale sqlite locks as repairable audit issues", async () => {
     await withTempWorkspace(async (workspaceDir) => {
-      const lockPath = path.join(workspaceDir, "memory", ".dreams", "short-term-promotion.lock");
-      const stat = vi.spyOn(fs, "stat").mockImplementation(async (target) => {
-        if (String(target) === lockPath) {
-          const error = Object.assign(new Error("no access"), { code: "EACCES" });
-          throw error;
-        }
-        return await vi
-          .importActual<typeof import("node:fs/promises")>("node:fs/promises")
-          .then((actual) => actual.stat(target));
+      await testing.writeShortTermLock(workspaceDir, {
+        owner: "999999:0",
+        acquiredAt: Date.now() - 120_000,
       });
-      try {
-        const audit = await auditShortTermPromotionArtifacts({ workspaceDir });
-        const lockIssue = audit.issues.find((issue) => issue.code === "recall-lock-unreadable");
-        expect(lockIssue).toStrictEqual({
-          severity: "warn",
-          code: "recall-lock-unreadable",
-          message: "Short-term promotion lock could not be inspected: EACCES.",
-          fixable: false,
-        });
-      } finally {
-        stat.mockRestore();
-      }
+      const audit = await auditShortTermPromotionArtifacts({ workspaceDir });
+      expect(audit.issues.find((issue) => issue.code === "recall-lock-stale")).toStrictEqual({
+        severity: "warn",
+        code: "recall-lock-stale",
+        message: "Short-term promotion lock appears stale.",
+        fixable: true,
+      });
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -6,9 +6,9 @@ import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-ru
 import {
   DEFAULT_MEMORY_DEEP_DREAMING_MAX_PROMOTED_SNIPPET_TOKENS,
   formatMemoryDreamingDay,
+  isSameMemoryDreamingDay,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
-import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringEntries,
@@ -20,7 +20,20 @@ import {
   summarizeConceptTagScriptCoverage,
   type ConceptTagScriptCoverage,
 } from "./concept-vocabulary.js";
-import { asRecord } from "./dreaming-shared.js";
+import { asRecord, formatErrorMessage } from "./dreaming-shared.js";
+import {
+  SHORT_TERM_LOCK_MAX_ENTRIES,
+  SHORT_TERM_LOCK_NAMESPACE,
+  SHORT_TERM_META_NAMESPACE,
+  SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
+  SHORT_TERM_RECALL_NAMESPACE,
+  memoryCoreStateReference,
+  memoryCoreWorkspaceStateKey,
+  openMemoryCoreStateStore,
+  readMemoryCoreWorkspaceEntries,
+  writeMemoryCoreWorkspaceEntries,
+  writeMemoryCoreWorkspaceEntry,
+} from "./dreaming-state.js";
 import { compactMemoryForBudget, DEFAULT_MEMORY_FILE_MAX_CHARS } from "./memory-budget.js";
 import { resolveMemoryCoreNowMs, resolveMemoryCoreTimestamp } from "./time.js";
 
@@ -40,12 +53,25 @@ const MAX_QUERY_HASHES = 32;
 const MAX_RECALL_DAYS = 16;
 const SHORT_TERM_RECALL_MAX_ENTRIES = 512;
 const SHORT_TERM_RECALL_MAX_SNIPPET_CHARS = 800;
-const SHORT_TERM_STORE_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-recall.json");
-const SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH = path.join("memory", ".dreams", "phase-signals.json");
-const SHORT_TERM_LOCK_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-promotion.lock");
+export const SHORT_TERM_STORE_RELATIVE_PATH = path.join(
+  "memory",
+  ".dreams",
+  "short-term-recall.json",
+);
+export const SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH = path.join(
+  "memory",
+  ".dreams",
+  "phase-signals.json",
+);
+export const SHORT_TERM_LOCK_RELATIVE_PATH = path.join(
+  "memory",
+  ".dreams",
+  "short-term-promotion.lock",
+);
 const SHORT_TERM_LOCK_WAIT_TIMEOUT_MS = 10_000;
 const SHORT_TERM_LOCK_STALE_MS = 60_000;
 const SHORT_TERM_LOCK_RETRY_DELAY_MS = 40;
+const DREAMING_ENTRY_LIST_LIMIT = 8;
 // Repeated dreaming revisits should be able to clear the default promotion gate
 // without requiring separate organic recall traffic for the same snippet.
 const PHASE_SIGNAL_LIGHT_BOOST_MAX = 0.06;
@@ -59,7 +85,6 @@ const GENERIC_DAY_HEADING_RE =
 const PROMOTION_LIST_MARKER_RE = /^(?:\d+\.\s+|[-*+]\s+)/;
 const MANAGED_DREAMING_HEADINGS = new Set(["light sleep", "rem sleep"]);
 const inProcessShortTermLocks = new Map<string, Promise<void>>();
-const ensuredShortTermDirs = new Map<string, Promise<void>>();
 
 type PromotionWeights = {
   frequency: number;
@@ -100,7 +125,7 @@ export type ShortTermRecallEntry = {
   promotedAt?: string;
 };
 
-type ShortTermRecallStore = {
+export type ShortTermRecallStore = {
   version: 1;
   updatedAt: string;
   entries: Record<string, ShortTermRecallEntry>;
@@ -115,10 +140,19 @@ type ShortTermPhaseSignalEntry = {
   lastRemConsideredAt?: string;
 };
 
-type ShortTermPhaseSignalStore = {
+export type ShortTermPhaseSignalStore = {
   version: 1;
   updatedAt: string;
   entries: Record<string, ShortTermPhaseSignalEntry>;
+};
+
+type ShortTermStoreMeta = {
+  updatedAt: string;
+};
+
+type ShortTermLockEntry = {
+  owner: string;
+  acquiredAt: number;
 };
 
 type PromotionComponents = {
@@ -251,6 +285,43 @@ type ApplyShortTermPromotionsResult = {
   compactedSections: number;
   /** Dates of the compacted promotion sections, oldest first. */
   compactedDates: string[];
+};
+
+export type ShortTermDreamingStatsEntry = {
+  key: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  snippet: string;
+  recallCount: number;
+  dailyCount: number;
+  groundedCount: number;
+  totalSignalCount: number;
+  lightHits: number;
+  remHits: number;
+  phaseHitCount: number;
+  promotedAt?: string;
+  lastRecalledAt?: string;
+};
+
+export type ShortTermDreamingStats = {
+  shortTermCount: number;
+  recallSignalCount: number;
+  dailySignalCount: number;
+  groundedSignalCount: number;
+  totalSignalCount: number;
+  phaseSignalCount: number;
+  lightPhaseHitCount: number;
+  remPhaseHitCount: number;
+  promotedTotal: number;
+  promotedToday: number;
+  storePath: string;
+  phaseSignalPath: string;
+  phaseSignalError?: string;
+  lastPromotedAt?: string;
+  shortTermEntries: ShortTermDreamingStatsEntry[];
+  signalEntries: ShortTermDreamingStatsEntry[];
+  promotedEntries: ShortTermDreamingStatsEntry[];
 };
 
 function clampScore(value: number): number {
@@ -495,7 +566,7 @@ function emptyStore(nowIso: string): ShortTermRecallStore {
   };
 }
 
-function normalizeStore(raw: unknown, nowIso: string): ShortTermRecallStore {
+export function normalizeShortTermRecallStore(raw: unknown, nowIso: string): ShortTermRecallStore {
   if (!raw || typeof raw !== "object") {
     return emptyStore(nowIso);
   }
@@ -731,37 +802,15 @@ function calculatePhaseSignalBoost(
 }
 
 function resolveStorePath(workspaceDir: string): string {
-  return path.join(workspaceDir, SHORT_TERM_STORE_RELATIVE_PATH);
+  return memoryCoreStateReference(SHORT_TERM_RECALL_NAMESPACE, workspaceDir);
 }
 
 function resolvePhaseSignalPath(workspaceDir: string): string {
-  return path.join(workspaceDir, SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH);
+  return memoryCoreStateReference(SHORT_TERM_PHASE_SIGNAL_NAMESPACE, workspaceDir);
 }
 
 function resolveLockPath(workspaceDir: string): string {
-  return path.join(workspaceDir, SHORT_TERM_LOCK_RELATIVE_PATH);
-}
-
-function resolveShortTermArtifactsDir(workspaceDir: string): string {
-  return path.dirname(resolveLockPath(workspaceDir));
-}
-
-async function ensureShortTermArtifactsDir(workspaceDir: string): Promise<void> {
-  const artifactsDir = resolveShortTermArtifactsDir(workspaceDir);
-  const existing = ensuredShortTermDirs.get(artifactsDir);
-  if (existing) {
-    await existing;
-    return;
-  }
-  const ensuring = fs
-    .mkdir(artifactsDir, { recursive: true })
-    .then(() => undefined)
-    .catch((err: unknown) => {
-      ensuredShortTermDirs.delete(artifactsDir);
-      throw err;
-    });
-  ensuredShortTermDirs.set(artifactsDir, ensuring);
-  await ensuring;
+  return memoryCoreStateReference(SHORT_TERM_LOCK_NAMESPACE, workspaceDir);
 }
 
 function parseLockOwnerPid(raw: string): number | null {
@@ -828,65 +877,72 @@ async function withInProcessShortTermLock<T>(lockPath: string, task: () => Promi
 }
 
 async function withShortTermLock<T>(workspaceDir: string, task: () => Promise<T>): Promise<T> {
-  const lockPath = resolveLockPath(workspaceDir);
-  return withInProcessShortTermLock(lockPath, async () => {
-    await ensureShortTermArtifactsDir(workspaceDir);
+  const lockKey = memoryCoreWorkspaceStateKey(workspaceDir);
+  const lockRef = resolveLockPath(workspaceDir);
+  const lockStore = openMemoryCoreStateStore<ShortTermLockEntry>({
+    namespace: SHORT_TERM_LOCK_NAMESPACE,
+    maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+  });
+  return withInProcessShortTermLock(lockKey, async () => {
     const startedAt = Date.now();
 
     while (true) {
-      try {
-        const lockHandle = await fs.open(lockPath, "wx");
-        await lockHandle
-          .writeFile(`${process.pid}:${Date.now()}\n`, "utf-8")
-          .catch(() => undefined);
+      const owner = `${process.pid}:${Date.now()}`;
+      const acquired = await lockStore.registerIfAbsent(lockKey, {
+        owner,
+        acquiredAt: Date.now(),
+      });
+      if (acquired) {
         try {
           return await task();
         } finally {
-          await lockHandle.close().catch(() => undefined);
-          await fs.unlink(lockPath).catch(() => undefined);
-        }
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") {
-          throw err;
-        }
-
-        const ageMs = await fs
-          .stat(lockPath)
-          .then((stats) => Date.now() - stats.mtimeMs)
-          .catch(() => 0);
-        if (ageMs > SHORT_TERM_LOCK_STALE_MS) {
-          if (await canStealStaleLock(lockPath)) {
-            await fs.unlink(lockPath).catch(() => undefined);
-            continue;
+          const current = await lockStore.lookup(lockKey).catch(() => undefined);
+          if (current?.owner === owner) {
+            await lockStore.delete(lockKey).catch(() => false);
           }
         }
-
-        if (Date.now() - startedAt >= SHORT_TERM_LOCK_WAIT_TIMEOUT_MS) {
-          throw new Error(`Timed out waiting for short-term promotion lock at ${lockPath}`, {
-            cause: err,
-          });
-        }
-
-        await sleep(SHORT_TERM_LOCK_RETRY_DELAY_MS);
       }
+
+      const existing = await lockStore.lookup(lockKey);
+      if (existing && Date.now() - existing.acquiredAt > SHORT_TERM_LOCK_STALE_MS) {
+        const ownerPid = parseLockOwnerPid(existing.owner);
+        if (ownerPid === null || !isProcessLikelyAlive(ownerPid)) {
+          await lockStore.delete(lockKey);
+          continue;
+        }
+      }
+
+      if (Date.now() - startedAt >= SHORT_TERM_LOCK_WAIT_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for short-term promotion lock at ${lockRef}`);
+      }
+
+      await sleep(SHORT_TERM_LOCK_RETRY_DELAY_MS);
     }
   });
 }
 
 async function readStore(workspaceDir: string, nowIso: string): Promise<ShortTermRecallStore> {
-  try {
-    const store = normalizeStore(
-      await privateFileStore(workspaceDir).readJsonIfExists(SHORT_TERM_STORE_RELATIVE_PATH),
-      nowIso,
-    );
-    enforceShortTermRecallStoreRetention(store);
-    return store;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
-      return emptyStore(nowIso);
-    }
-    throw err;
-  }
+  const [entryRows, metaRows] = await Promise.all([
+    readMemoryCoreWorkspaceEntries<ShortTermRecallEntry>({
+      namespace: SHORT_TERM_RECALL_NAMESPACE,
+      workspaceDir,
+    }),
+    readMemoryCoreWorkspaceEntries<ShortTermStoreMeta>({
+      namespace: SHORT_TERM_META_NAMESPACE,
+      workspaceDir,
+    }),
+  ]);
+  const meta = metaRows.find((entry) => entry.key === "recall")?.value;
+  const store = normalizeShortTermRecallStore(
+    {
+      version: 1,
+      updatedAt: meta?.updatedAt ?? nowIso,
+      entries: Object.fromEntries(entryRows.map((entry) => [entry.key, entry.value])),
+    },
+    nowIso,
+  );
+  enforceShortTermRecallStoreRetention(store);
+  return store;
 }
 
 function emptyPhaseSignalStore(nowIso: string): ShortTermPhaseSignalStore {
@@ -897,7 +953,10 @@ function emptyPhaseSignalStore(nowIso: string): ShortTermPhaseSignalStore {
   };
 }
 
-function normalizePhaseSignalStore(raw: unknown, nowIso: string): ShortTermPhaseSignalStore {
+export function normalizeShortTermPhaseSignalStore(
+  raw: unknown,
+  nowIso: string,
+): ShortTermPhaseSignalStore {
   const record = asRecord(raw);
   if (!record) {
     return emptyPhaseSignalStore(nowIso);
@@ -953,36 +1012,62 @@ async function readPhaseSignalStore(
   workspaceDir: string,
   nowIso: string,
 ): Promise<ShortTermPhaseSignalStore> {
-  try {
-    return normalizePhaseSignalStore(
-      await privateFileStore(workspaceDir).readJsonIfExists(SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH),
-      nowIso,
-    );
-  } catch (err) {
-    if (err instanceof SyntaxError) {
-      return emptyPhaseSignalStore(nowIso);
-    }
-    throw err;
-  }
+  const [entryRows, metaRows] = await Promise.all([
+    readMemoryCoreWorkspaceEntries<ShortTermPhaseSignalEntry>({
+      namespace: SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
+      workspaceDir,
+    }),
+    readMemoryCoreWorkspaceEntries<ShortTermStoreMeta>({
+      namespace: SHORT_TERM_META_NAMESPACE,
+      workspaceDir,
+    }),
+  ]);
+  const meta = metaRows.find((entry) => entry.key === "phase")?.value;
+  return normalizeShortTermPhaseSignalStore(
+    {
+      version: 1,
+      updatedAt: meta?.updatedAt ?? nowIso,
+      entries: Object.fromEntries(entryRows.map((entry) => [entry.key, entry.value])),
+    },
+    nowIso,
+  );
 }
 
 async function writePhaseSignalStore(
   workspaceDir: string,
   store: ShortTermPhaseSignalStore,
 ): Promise<void> {
-  await ensureShortTermArtifactsDir(workspaceDir);
-  await privateFileStore(workspaceDir).writeJson(SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH, store, {
-    trailingNewline: true,
-  });
+  await Promise.all([
+    writeMemoryCoreWorkspaceEntries({
+      namespace: SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
+      workspaceDir,
+      entries: Object.entries(store.entries).map(([key, value]) => ({ key, value })),
+    }),
+    writeMemoryCoreWorkspaceEntry({
+      namespace: SHORT_TERM_META_NAMESPACE,
+      workspaceDir,
+      key: "phase",
+      value: { updatedAt: store.updatedAt },
+    }),
+  ]);
 }
 
 async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
   enforceShortTermRecallSnippetCap(store);
   enforceShortTermRecallStoreRetention(store);
-  await ensureShortTermArtifactsDir(workspaceDir);
-  await privateFileStore(workspaceDir).writeJson(SHORT_TERM_STORE_RELATIVE_PATH, store, {
-    trailingNewline: true,
-  });
+  await Promise.all([
+    writeMemoryCoreWorkspaceEntries({
+      namespace: SHORT_TERM_RECALL_NAMESPACE,
+      workspaceDir,
+      entries: Object.entries(store.entries).map(([key, value]) => ({ key, value })),
+    }),
+    writeMemoryCoreWorkspaceEntry({
+      namespace: SHORT_TERM_META_NAMESPACE,
+      workspaceDir,
+      key: "recall",
+      value: { updatedAt: store.updatedAt },
+    }),
+  ]);
 }
 
 export function isShortTermMemoryPath(filePath: string): boolean {
@@ -997,6 +1082,240 @@ export function isShortTermMemoryPath(filePath: string): boolean {
     return true;
   }
   return SHORT_TERM_BASENAME_RE.test(normalized);
+}
+
+function normalizeMemoryPathForWorkspace(workspaceDir: string, rawPath: string): string {
+  const normalized = normalizeMemoryPath(rawPath);
+  const workspaceNormalized = normalizeMemoryPath(workspaceDir);
+  if (path.isAbsolute(rawPath) && normalized.startsWith(`${workspaceNormalized}/`)) {
+    return normalized.slice(workspaceNormalized.length + 1);
+  }
+  return normalized;
+}
+
+function toNonNegativeInt(value: unknown): number {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(num));
+}
+
+function parseEntryRangeFromKey(
+  key: string,
+  fallbackStartLine: unknown,
+  fallbackEndLine: unknown,
+): { startLine: number; endLine: number } {
+  const startLine = toNonNegativeInt(fallbackStartLine);
+  const endLine = toNonNegativeInt(fallbackEndLine);
+  if (startLine > 0 && endLine > 0) {
+    return { startLine, endLine };
+  }
+  const match = key.match(/:(\d+):(\d+)$/);
+  if (match) {
+    return {
+      startLine: Math.max(1, toNonNegativeInt(match[1])),
+      endLine: Math.max(1, toNonNegativeInt(match[2])),
+    };
+  }
+  return { startLine: 1, endLine: 1 };
+}
+
+function compareDreamingStatsEntryByRecency(
+  a: ShortTermDreamingStatsEntry,
+  b: ShortTermDreamingStatsEntry,
+): number {
+  const aMs = a.lastRecalledAt ? Date.parse(a.lastRecalledAt) : Number.NEGATIVE_INFINITY;
+  const bMs = b.lastRecalledAt ? Date.parse(b.lastRecalledAt) : Number.NEGATIVE_INFINITY;
+  if (Number.isFinite(aMs) || Number.isFinite(bMs)) {
+    if (bMs !== aMs) {
+      return bMs - aMs;
+    }
+  }
+  if (b.totalSignalCount !== a.totalSignalCount) {
+    return b.totalSignalCount - a.totalSignalCount;
+  }
+  return a.path.localeCompare(b.path);
+}
+
+function compareDreamingStatsEntryBySignals(
+  a: ShortTermDreamingStatsEntry,
+  b: ShortTermDreamingStatsEntry,
+): number {
+  if (b.totalSignalCount !== a.totalSignalCount) {
+    return b.totalSignalCount - a.totalSignalCount;
+  }
+  if (b.phaseHitCount !== a.phaseHitCount) {
+    return b.phaseHitCount - a.phaseHitCount;
+  }
+  return compareDreamingStatsEntryByRecency(a, b);
+}
+
+function compareDreamingStatsEntryByPromotion(
+  a: ShortTermDreamingStatsEntry,
+  b: ShortTermDreamingStatsEntry,
+): number {
+  const aMs = a.promotedAt ? Date.parse(a.promotedAt) : Number.NEGATIVE_INFINITY;
+  const bMs = b.promotedAt ? Date.parse(b.promotedAt) : Number.NEGATIVE_INFINITY;
+  if (Number.isFinite(aMs) || Number.isFinite(bMs)) {
+    if (bMs !== aMs) {
+      return bMs - aMs;
+    }
+  }
+  return compareDreamingStatsEntryBySignals(a, b);
+}
+
+function trimDreamingStatsEntries(
+  entries: ShortTermDreamingStatsEntry[],
+  compare: (a: ShortTermDreamingStatsEntry, b: ShortTermDreamingStatsEntry) => number,
+): ShortTermDreamingStatsEntry[] {
+  const selected: ShortTermDreamingStatsEntry[] = [];
+  for (const entry of entries) {
+    let insertAt = selected.length;
+    for (let index = 0; index < selected.length; index += 1) {
+      if (compare(entry, selected[index]) < 0) {
+        insertAt = index;
+        break;
+      }
+    }
+    if (insertAt < DREAMING_ENTRY_LIST_LIMIT) {
+      selected.splice(insertAt, 0, entry);
+      if (selected.length > DREAMING_ENTRY_LIST_LIMIT) {
+        selected.pop();
+      }
+    } else if (selected.length < DREAMING_ENTRY_LIST_LIMIT) {
+      selected.push(entry);
+    }
+  }
+  return selected;
+}
+
+export async function loadShortTermPromotionDreamingStats(params: {
+  workspaceDir: string;
+  nowMs: number;
+  timezone?: string;
+}): Promise<ShortTermDreamingStats> {
+  const workspaceDir = params.workspaceDir.trim();
+  const nowIso = new Date(params.nowMs).toISOString();
+  const store = await readStore(workspaceDir, nowIso);
+  let phaseSignalError: string | undefined;
+  let phaseStore: ShortTermPhaseSignalStore;
+  try {
+    phaseStore = await readPhaseSignalStore(workspaceDir, nowIso);
+  } catch (err) {
+    phaseSignalError = formatErrorMessage(err);
+    phaseStore = emptyPhaseSignalStore(nowIso);
+  }
+  let shortTermCount = 0;
+  let recallSignalCount = 0;
+  let dailySignalCount = 0;
+  let groundedSignalCount = 0;
+  let totalSignalCount = 0;
+  let phaseSignalCount = 0;
+  let lightPhaseHitCount = 0;
+  let remPhaseHitCount = 0;
+  let promotedTotal = 0;
+  let promotedToday = 0;
+  let latestPromotedAtMs = Number.NEGATIVE_INFINITY;
+  let latestPromotedAt: string | undefined;
+  const activeKeys = new Set<string>();
+  const activeEntries = new Map<string, ShortTermDreamingStatsEntry>();
+  const shortTermEntries: ShortTermDreamingStatsEntry[] = [];
+  const promotedEntries: ShortTermDreamingStatsEntry[] = [];
+
+  for (const [entryKey, entry] of Object.entries(store.entries)) {
+    if (entry.source !== "memory" || !entry.path || !isShortTermMemoryPath(entry.path)) {
+      continue;
+    }
+    const range = parseEntryRangeFromKey(entryKey, entry.startLine, entry.endLine);
+    const recallCount = toNonNegativeInt(entry.recallCount);
+    const dailyCount = toNonNegativeInt(entry.dailyCount);
+    const groundedCount = toNonNegativeInt(entry.groundedCount);
+    const totalEntrySignalCount = recallCount + dailyCount + groundedCount;
+    const normalizedEntryPath = normalizeMemoryPathForWorkspace(workspaceDir, entry.path);
+    const detail: ShortTermDreamingStatsEntry = {
+      key: entryKey,
+      path: normalizedEntryPath,
+      startLine: range.startLine,
+      endLine: Math.max(range.startLine, range.endLine),
+      snippet: normalizeSnippet(entry.snippet) || normalizedEntryPath,
+      recallCount,
+      dailyCount,
+      groundedCount,
+      totalSignalCount: totalEntrySignalCount,
+      lightHits: 0,
+      remHits: 0,
+      phaseHitCount: 0,
+      ...(entry.lastRecalledAt ? { lastRecalledAt: entry.lastRecalledAt } : {}),
+    };
+    if (!entry.promotedAt) {
+      shortTermCount += 1;
+      activeKeys.add(entryKey);
+      recallSignalCount += recallCount;
+      dailySignalCount += dailyCount;
+      groundedSignalCount += groundedCount;
+      totalSignalCount += totalEntrySignalCount;
+      shortTermEntries.push(detail);
+      activeEntries.set(entryKey, detail);
+      continue;
+    }
+    promotedTotal += 1;
+    promotedEntries.push({ ...detail, promotedAt: entry.promotedAt });
+    const promotedAtMs = Date.parse(entry.promotedAt);
+    if (
+      Number.isFinite(promotedAtMs) &&
+      isSameMemoryDreamingDay(promotedAtMs, params.nowMs, params.timezone)
+    ) {
+      promotedToday += 1;
+    }
+    if (Number.isFinite(promotedAtMs) && promotedAtMs > latestPromotedAtMs) {
+      latestPromotedAtMs = promotedAtMs;
+      latestPromotedAt = entry.promotedAt;
+    }
+  }
+
+  for (const [key, phaseEntry] of Object.entries(phaseStore.entries)) {
+    if (!activeKeys.has(key)) {
+      continue;
+    }
+    const lightHits = toNonNegativeInt(phaseEntry.lightHits);
+    const remHits = toNonNegativeInt(phaseEntry.remHits);
+    lightPhaseHitCount += lightHits;
+    remPhaseHitCount += remHits;
+    phaseSignalCount += lightHits + remHits;
+    const detail = activeEntries.get(key);
+    if (detail) {
+      detail.lightHits = lightHits;
+      detail.remHits = remHits;
+      detail.phaseHitCount = lightHits + remHits;
+    }
+  }
+
+  return {
+    shortTermCount,
+    recallSignalCount,
+    dailySignalCount,
+    groundedSignalCount,
+    totalSignalCount,
+    phaseSignalCount,
+    lightPhaseHitCount,
+    remPhaseHitCount,
+    promotedTotal,
+    promotedToday,
+    storePath: resolveStorePath(workspaceDir),
+    phaseSignalPath: resolvePhaseSignalPath(workspaceDir),
+    shortTermEntries: trimDreamingStatsEntries(
+      shortTermEntries,
+      compareDreamingStatsEntryByRecency,
+    ),
+    signalEntries: trimDreamingStatsEntries(shortTermEntries, compareDreamingStatsEntryBySignals),
+    promotedEntries: trimDreamingStatsEntries(
+      promotedEntries,
+      compareDreamingStatsEntryByPromotion,
+    ),
+    ...(phaseSignalError ? { phaseSignalError } : {}),
+    ...(latestPromotedAt ? { lastPromotedAt: latestPromotedAt } : {}),
+  };
 }
 
 async function shortTermRecallSourceExists(params: {
@@ -2189,86 +2508,73 @@ export async function auditShortTermPromotionArtifacts(params: {
   let invalidEntryCount = 0;
   let updatedAt: string | undefined;
 
-  try {
-    const raw = await fs.readFile(storePath, "utf-8");
-    exists = true;
-    if (raw.trim().length === 0) {
+  const nowIso = new Date().toISOString();
+  const rawEntries = await readMemoryCoreWorkspaceEntries<unknown>({
+    namespace: SHORT_TERM_RECALL_NAMESPACE,
+    workspaceDir,
+  });
+  exists = rawEntries.length > 0;
+  if (exists) {
+    const parsed = {
+      version: 1,
+      updatedAt: nowIso,
+      entries: Object.fromEntries(rawEntries.map((entry) => [entry.key, entry.value])),
+    };
+    const store = normalizeShortTermRecallStore(parsed, nowIso);
+    const normalizedEntryCount = Object.keys(store.entries).length;
+    updatedAt = store.updatedAt;
+    entryCount = normalizedEntryCount;
+    promotedCount = Object.values(store.entries).filter((entry) =>
+      Boolean(entry.promotedAt),
+    ).length;
+    spacedEntryCount = Object.values(store.entries).filter(
+      (entry) => (entry.recallDays?.length ?? 0) > 1,
+    ).length;
+    conceptTaggedEntryCount = Object.values(store.entries).filter(
+      (entry) => (entry.conceptTags?.length ?? 0) > 0,
+    ).length;
+    conceptTagScripts = summarizeConceptTagScriptCoverage(
+      Object.values(store.entries)
+        .filter((entry) => (entry.conceptTags?.length ?? 0) > 0)
+        .map((entry) => entry.conceptTags ?? []),
+    );
+    invalidEntryCount = rawEntries.length - entryCount;
+    if (invalidEntryCount > 0) {
       issues.push({
         severity: "warn",
-        code: "recall-store-empty",
-        message: "Short-term recall store is empty.",
+        code: "recall-store-invalid",
+        message: `Short-term recall store contains ${invalidEntryCount} invalid entr${invalidEntryCount === 1 ? "y" : "ies"}.`,
         fixable: true,
       });
-    } else {
-      const nowIso = new Date().toISOString();
-      const parsed = JSON.parse(raw) as unknown;
-      const store = normalizeStore(parsed, nowIso);
-      const normalizedEntryCount = Object.keys(store.entries).length;
-      updatedAt = store.updatedAt;
-      entryCount = normalizedEntryCount;
-      promotedCount = Object.values(store.entries).filter((entry) =>
-        Boolean(entry.promotedAt),
-      ).length;
-      spacedEntryCount = Object.values(store.entries).filter(
-        (entry) => (entry.recallDays?.length ?? 0) > 1,
-      ).length;
-      conceptTaggedEntryCount = Object.values(store.entries).filter(
-        (entry) => (entry.conceptTags?.length ?? 0) > 0,
-      ).length;
-      conceptTagScripts = summarizeConceptTagScriptCoverage(
-        Object.values(store.entries)
-          .filter((entry) => (entry.conceptTags?.length ?? 0) > 0)
-          .map((entry) => entry.conceptTags ?? []),
-      );
-      invalidEntryCount = Object.keys(asRecord(parsed)?.entries ?? {}).length - entryCount;
-      if (invalidEntryCount > 0) {
-        issues.push({
-          severity: "warn",
-          code: "recall-store-invalid",
-          message: `Short-term recall store contains ${invalidEntryCount} invalid entr${invalidEntryCount === 1 ? "y" : "ies"}.`,
-          fixable: true,
-        });
-      }
-      if (normalizedEntryCount > SHORT_TERM_RECALL_MAX_ENTRIES) {
-        issues.push({
-          severity: "warn",
-          code: "recall-store-over-limit",
-          message: `Short-term recall store contains ${normalizedEntryCount} entries; only the newest ${SHORT_TERM_RECALL_MAX_ENTRIES} are kept at runtime.`,
-          fixable: true,
-        });
-      }
     }
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code !== "ENOENT") {
+    if (normalizedEntryCount > SHORT_TERM_RECALL_MAX_ENTRIES) {
       issues.push({
-        severity: "error",
-        code: "recall-store-unreadable",
-        message: `Short-term recall store is unreadable: ${code ?? "error"}.`,
-        fixable: false,
+        severity: "warn",
+        code: "recall-store-over-limit",
+        message: `Short-term recall store contains ${normalizedEntryCount} entries; only the newest ${SHORT_TERM_RECALL_MAX_ENTRIES} are kept at runtime.`,
+        fixable: true,
       });
     }
   }
 
-  try {
-    const stat = await fs.stat(lockPath);
-    const ageMs = Date.now() - stat.mtimeMs;
-    if (ageMs > SHORT_TERM_LOCK_STALE_MS && (await canStealStaleLock(lockPath))) {
+  const lockKey = memoryCoreWorkspaceStateKey(workspaceDir);
+  const lockStore = openMemoryCoreStateStore<ShortTermLockEntry>({
+    namespace: SHORT_TERM_LOCK_NAMESPACE,
+    maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+  });
+  const lockEntry = await lockStore.lookup(lockKey);
+  if (lockEntry) {
+    const ageMs = Date.now() - lockEntry.acquiredAt;
+    const ownerPid = parseLockOwnerPid(lockEntry.owner);
+    if (
+      ageMs > SHORT_TERM_LOCK_STALE_MS &&
+      (ownerPid === null || !isProcessLikelyAlive(ownerPid))
+    ) {
       issues.push({
         severity: "warn",
         code: "recall-lock-stale",
         message: "Short-term promotion lock appears stale.",
         fixable: true,
-      });
-    }
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code !== "ENOENT") {
-      issues.push({
-        severity: "warn",
-        code: "recall-lock-unreadable",
-        message: `Short-term promotion lock could not be inspected: ${code ?? "error"}.`,
-        fixable: false,
       });
     }
   }
@@ -2342,28 +2648,37 @@ export async function repairShortTermPromotionArtifacts(params: {
   let removedOverflowEntries = 0;
   let removedStaleLock = false;
 
-  try {
-    const lockPath = resolveLockPath(workspaceDir);
-    const stat = await fs.stat(lockPath);
-    const ageMs = Date.now() - stat.mtimeMs;
-    if (ageMs > SHORT_TERM_LOCK_STALE_MS && (await canStealStaleLock(lockPath))) {
-      await fs.unlink(lockPath).catch(() => undefined);
-      removedStaleLock = true;
-    }
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw err;
+  const lockKey = memoryCoreWorkspaceStateKey(workspaceDir);
+  const lockStore = openMemoryCoreStateStore<ShortTermLockEntry>({
+    namespace: SHORT_TERM_LOCK_NAMESPACE,
+    maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+  });
+  const lockEntry = await lockStore.lookup(lockKey);
+  if (lockEntry && Date.now() - lockEntry.acquiredAt > SHORT_TERM_LOCK_STALE_MS) {
+    const ownerPid = parseLockOwnerPid(lockEntry.owner);
+    if (ownerPid === null || !isProcessLikelyAlive(ownerPid)) {
+      removedStaleLock = await lockStore.delete(lockKey);
     }
   }
 
   await withShortTermLock(workspaceDir, async () => {
-    const storePath = resolveStorePath(workspaceDir);
-    try {
-      const raw = await fs.readFile(storePath, "utf-8");
-      const parsed = raw.trim().length > 0 ? (JSON.parse(raw) as unknown) : emptyStore(nowIso);
-      const rawEntries = Object.keys(asRecord(parsed)?.entries ?? {}).length;
-      const normalized = normalizeStore(parsed, nowIso);
-      removedInvalidEntries = Math.max(0, rawEntries - Object.keys(normalized.entries).length);
+    const rawEntries = await readMemoryCoreWorkspaceEntries<unknown>({
+      namespace: SHORT_TERM_RECALL_NAMESPACE,
+      workspaceDir,
+    });
+    if (rawEntries.length > 0) {
+      const normalized = normalizeShortTermRecallStore(
+        {
+          version: 1,
+          updatedAt: nowIso,
+          entries: Object.fromEntries(rawEntries.map((entry) => [entry.key, entry.value])),
+        },
+        nowIso,
+      );
+      removedInvalidEntries = Math.max(
+        0,
+        rawEntries.length - Object.keys(normalized.entries).length,
+      );
       const nextEntries = Object.fromEntries(
         Object.entries(normalized.entries).map(([key, entry]) => {
           const conceptTags = deriveConceptTags({ path: entry.path, snippet: entry.snippet });
@@ -2393,17 +2708,16 @@ export async function repairShortTermPromotionArtifacts(params: {
         entries: nextEntries,
       };
       removedOverflowEntries = enforceShortTermRecallStoreRetention(comparableStore);
-      const comparableRaw = `${JSON.stringify(comparableStore, null, 2)}\n`;
-      if (comparableRaw !== `${raw.trimEnd()}\n`) {
+      const needsRewrite =
+        removedInvalidEntries > 0 ||
+        removedOverflowEntries > 0 ||
+        JSON.stringify(normalized.entries) !== JSON.stringify(comparableStore.entries);
+      if (needsRewrite) {
         await writeStore(workspaceDir, {
           ...comparableStore,
           updatedAt: nowIso,
         });
         rewroteStore = true;
-      }
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw err;
       }
     }
   });
@@ -2465,6 +2779,68 @@ export const testing = {
   parseLockOwnerPid,
   canStealStaleLock,
   isProcessLikelyAlive,
+  readRecallStore: readStore,
+  readPhaseSignalStore,
+  writeRawRecallStore: async (workspaceDir: string, raw: unknown) => {
+    const record = asRecord(raw);
+    const entries = asRecord(record?.entries);
+    await Promise.all([
+      writeMemoryCoreWorkspaceEntries({
+        namespace: SHORT_TERM_RECALL_NAMESPACE,
+        workspaceDir,
+        entries: entries
+          ? Object.entries(entries).map(([key, value]) => ({ key, value: value as unknown }))
+          : [],
+      }),
+      writeMemoryCoreWorkspaceEntry({
+        namespace: SHORT_TERM_META_NAMESPACE,
+        workspaceDir,
+        key: "recall",
+        value: {
+          updatedAt:
+            typeof record?.updatedAt === "string" && record.updatedAt.trim()
+              ? record.updatedAt
+              : new Date().toISOString(),
+        },
+      }),
+    ]);
+  },
+  writeRawPhaseSignalStore: async (workspaceDir: string, raw: unknown) => {
+    const record = asRecord(raw);
+    const entries = asRecord(record?.entries);
+    await Promise.all([
+      writeMemoryCoreWorkspaceEntries({
+        namespace: SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
+        workspaceDir,
+        entries: entries
+          ? Object.entries(entries).map(([key, value]) => ({ key, value: value as unknown }))
+          : [],
+      }),
+      writeMemoryCoreWorkspaceEntry({
+        namespace: SHORT_TERM_META_NAMESPACE,
+        workspaceDir,
+        key: "phase",
+        value: {
+          updatedAt:
+            typeof record?.updatedAt === "string" && record.updatedAt.trim()
+              ? record.updatedAt
+              : new Date().toISOString(),
+        },
+      }),
+    ]);
+  },
+  writeShortTermLock: async (workspaceDir: string, entry: ShortTermLockEntry) => {
+    await openMemoryCoreStateStore<ShortTermLockEntry>({
+      namespace: SHORT_TERM_LOCK_NAMESPACE,
+      maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+    }).register(memoryCoreWorkspaceStateKey(workspaceDir), entry);
+  },
+  deleteShortTermLock: async (workspaceDir: string) => {
+    await openMemoryCoreStateStore<ShortTermLockEntry>({
+      namespace: SHORT_TERM_LOCK_NAMESPACE,
+      maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
+    }).delete(memoryCoreWorkspaceStateKey(workspaceDir));
+  },
   deriveConceptTags,
   calculateConsolidationComponent,
   calculatePhaseSignalBoost,

--- a/extensions/memory-core/src/test-helpers.ts
+++ b/extensions/memory-core/src/test-helpers.ts
@@ -3,12 +3,17 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterAll, beforeAll } from "vitest";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+} from "./dreaming-state.js";
 
 export function createMemoryCoreTestHarness() {
   let fixtureRoot = "";
   let caseId = 0;
 
   beforeAll(async () => {
+    await configureMemoryCoreDreamingStateForTests();
     fixtureRoot = await fs.mkdtemp(
       path.join(resolvePreferredOpenClawTmpDir(), "memory-core-test-fixtures-"),
     );
@@ -19,6 +24,7 @@ export function createMemoryCoreTestHarness() {
       return;
     }
     await fs.rm(fixtureRoot, { recursive: true, force: true });
+    resetMemoryCoreDreamingStateForTests();
   });
 
   async function createTempWorkspace(prefix: string): Promise<string> {

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -1,6 +1,5 @@
 // Memory Core tests cover tools.citations plugin behavior.
 import fs from "node:fs/promises";
-import path from "node:path";
 import {
   clearMemoryPluginState,
   registerMemoryCorpusSupplement,
@@ -17,6 +16,7 @@ import {
   setMemoryWorkspaceDir,
   type MemoryReadParams,
 } from "./memory-tool-manager-mock.js";
+import { testing as shortTermPromotionTesting } from "./short-term-promotion.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
 import { testing as memoryToolsTesting } from "./tools.js";
 import {
@@ -283,13 +283,15 @@ describe("memory tools", () => {
       });
       await tool.execute("call_recall_persist", { query: "glacier backup" });
 
-      const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");
-      const storeRaw = await waitFor(async () => await fs.readFile(storePath, "utf-8"));
-      const store = JSON.parse(storeRaw) as {
-        entries?: Record<string, { path: string; recallCount: number }>;
-      };
-      const entries = Object.values(store.entries ?? {});
-      expect(entries).toHaveLength(1);
+      const entries = await waitFor(async () => {
+        const store = await shortTermPromotionTesting.readRecallStore(
+          workspaceDir,
+          new Date().toISOString(),
+        );
+        const values = Object.values(store.entries);
+        expect(values).toHaveLength(1);
+        return values;
+      });
       const entry = entries[0];
       expect(entry?.path).toBe("memory/2026-04-03.md");
       expect(entry?.recallCount).toBe(1);

--- a/extensions/parallel/index.ts
+++ b/extensions/parallel/index.ts
@@ -1,4 +1,5 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createParallelFreeWebSearchProvider } from "./src/parallel-free-web-search-provider.js";
 import { createParallelWebSearchProvider } from "./src/parallel-web-search-provider.js";
 
 export default definePluginEntry({
@@ -6,6 +7,9 @@ export default definePluginEntry({
   name: "Parallel Plugin",
   description: "Bundled Parallel web search plugin",
   register(api) {
+    // Free hosted Search MCP (keyless, zero-config default) and the paid v1 REST
+    // API (requires PARALLEL_API_KEY) are registered as two distinct providers.
+    api.registerWebSearchProvider(createParallelFreeWebSearchProvider());
     api.registerWebSearchProvider(createParallelWebSearchProvider());
   },
 });

--- a/extensions/parallel/openclaw.plugin.json
+++ b/extensions/parallel/openclaw.plugin.json
@@ -24,7 +24,7 @@
     }
   },
   "contracts": {
-    "webSearchProviders": ["parallel"]
+    "webSearchProviders": ["parallel", "parallel-free"]
   },
   "configContracts": {
     "compatibilityRuntimePaths": ["tools.web.search.apiKey"]

--- a/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
@@ -1,0 +1,114 @@
+import {
+  DEFAULT_SEARCH_COUNT,
+  mergeScopedSearchConfig,
+  readCachedSearchPayload,
+  readNumberParam,
+  readStringArrayParam,
+  readStringParam,
+  resolveProviderWebSearchPluginConfig,
+  resolveSearchCacheTtlMs,
+  resolveSearchTimeoutSeconds,
+  type SearchConfigRecord,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { PARALLEL_MCP_SEARCH_URL, runParallelMcpSearch } from "./parallel-mcp-search.runtime.js";
+import {
+  buildParallelCacheKey,
+  invalidSearchQueriesPayload,
+  mapParallelResults,
+  normalizeParallelClientModel,
+  normalizeParallelObjective,
+  normalizeParallelSearchQueries,
+  normalizeParallelSessionId,
+  PARALLEL_FREE_SESSION_ID_MAX_LENGTH,
+  resolveParallelSearchCount,
+  stripParallelGeneratedSessionId,
+} from "./parallel-search-normalize.js";
+
+export async function executeParallelFreeWebSearchProviderTool(
+  ctx: { config?: Record<string, unknown>; searchConfig?: SearchConfigRecord },
+  args: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+  const searchConfig = mergeScopedSearchConfig(
+    ctx.searchConfig,
+    "parallel-free",
+    resolveProviderWebSearchPluginConfig(ctx.config, "parallel-free"),
+  ) as SearchConfigRecord | undefined;
+
+  // Mirror the paid provider's generic `query` fallback (the operator CLI passes
+  // `{ query, count }`); agent callers supply the native objective/search_queries.
+  const objective = normalizeParallelObjective(readStringParam(args, "objective"));
+  const cliQuery = normalizeParallelObjective(readStringParam(args, "query"));
+  let searchQueries = normalizeParallelSearchQueries(readStringArrayParam(args, "search_queries"));
+  if (searchQueries.length === 0 && cliQuery) {
+    searchQueries = normalizeParallelSearchQueries([cliQuery]);
+  }
+  if (searchQueries.length === 0) {
+    return invalidSearchQueriesPayload();
+  }
+  const requestedCount =
+    readNumberParam(args, "count", { integer: true }) ??
+    (typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined);
+  const count = resolveParallelSearchCount(requestedCount ?? DEFAULT_SEARCH_COUNT);
+  const sessionId = normalizeParallelSessionId(
+    readStringParam(args, "session_id"),
+    PARALLEL_FREE_SESSION_ID_MAX_LENGTH,
+  );
+  const clientModel = normalizeParallelClientModel(readStringParam(args, "client_model"));
+  const cacheKey = buildParallelCacheKey({
+    endpoint: PARALLEL_MCP_SEARCH_URL,
+    objective,
+    searchQueries,
+    count,
+    sessionId,
+    clientModel,
+  });
+  const cached = readCachedSearchPayload(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const start = Date.now();
+  const response = await runParallelMcpSearch({
+    objective,
+    searchQueries,
+    maxResults: count,
+    sessionId,
+    modelName: clientModel,
+    timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
+    signal,
+  });
+  const results = mapParallelResults(response);
+
+  const payload: Record<string, unknown> = {
+    ...(objective ? { objective } : {}),
+    searchQueries,
+    provider: "parallel-free",
+    count: results.length,
+    tookMs: Date.now() - start,
+    externalContent: {
+      untrusted: true,
+      source: "web_search",
+      provider: "parallel-free",
+      wrapped: true,
+    },
+    results,
+  };
+  if (typeof response.search_id === "string") {
+    payload.searchId = response.search_id;
+  }
+  if (typeof response.session_id === "string") {
+    payload.sessionId = response.session_id;
+  }
+  if (Array.isArray(response.warnings) && response.warnings.length > 0) {
+    payload.warnings = response.warnings;
+  }
+  if (Array.isArray(response.usage) && response.usage.length > 0) {
+    payload.usage = response.usage;
+  }
+
+  const cachePayload = sessionId ? payload : stripParallelGeneratedSessionId(payload);
+  writeCachedSearchPayload(cacheKey, cachePayload, resolveSearchCacheTtlMs(searchConfig));
+  return payload;
+}

--- a/extensions/parallel/src/parallel-free-web-search-provider.shared.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.shared.ts
@@ -1,0 +1,29 @@
+import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provider-web-search-contract";
+
+const PARALLEL_FREE_ONBOARDING_SCOPES: Array<"text-inference"> = ["text-inference"];
+
+export function createParallelFreeWebSearchProviderBase() {
+  return {
+    id: "parallel-free",
+    label: "Parallel Search (Free)",
+    hint: "Free web search via Parallel's hosted Search MCP — no API key required",
+    onboardingScopes: [...PARALLEL_FREE_ONBOARDING_SCOPES],
+    // Keyless: always uses Parallel's free hosted Search MCP. This is the
+    // zero-config default web_search provider (autoDetectOrder 76 keeps it ahead
+    // of the other key-free fallbacks: duckduckgo 100, ollama 110). The paid
+    // `parallel` provider (v1 REST, requires a key) is a separate entry.
+    requiresCredential: false,
+    envVars: [],
+    placeholder: "(no key needed)",
+    signupUrl: "https://parallel.ai",
+    docsUrl: "https://docs.openclaw.ai/tools/parallel-search",
+    autoDetectOrder: 76,
+    credentialPath: "",
+    ...createWebSearchProviderContractFields({
+      credentialPath: "",
+      searchCredential: { type: "scoped", scopeId: "parallel-free" },
+      // Both Parallel providers live in the `parallel` plugin.
+      selectionPluginId: "parallel",
+    }),
+  };
+}

--- a/extensions/parallel/src/parallel-free-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type EndpointCall = {
+  url: string;
+  timeoutSeconds: number;
+  init: RequestInit;
+};
+
+const endpointMockState = vi.hoisted(() => ({
+  calls: [] as EndpointCall[],
+  responses: [] as Response[],
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>();
+  const runEndpoint = async (
+    params: EndpointCall,
+    run: (response: Response) => Promise<unknown>,
+  ) => {
+    endpointMockState.calls.push(params);
+    const response = endpointMockState.responses.shift();
+    if (!response) {
+      throw new Error("Missing mocked Parallel MCP response.");
+    }
+    return await run(response);
+  };
+  return {
+    ...actual,
+    withTrustedWebSearchEndpoint: vi.fn(runEndpoint),
+  };
+});
+
+import { createParallelFreeWebSearchProvider } from "./parallel-free-web-search-provider.js";
+
+function jsonResponse(body: unknown, headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+function pushHandshake(toolPayload: unknown): void {
+  endpointMockState.responses.push(
+    jsonResponse(
+      { jsonrpc: "2.0", id: "i", result: { protocolVersion: "2025-06-18" } },
+      {
+        "mcp-session-id": "sess-1",
+      },
+    ),
+    jsonResponse({ jsonrpc: "2.0" }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: "c",
+      result: { content: [{ type: "text", text: JSON.stringify(toolPayload) }] },
+    }),
+  );
+}
+
+describe("parallel-free web search provider", () => {
+  beforeEach(() => {
+    endpointMockState.calls = [];
+    endpointMockState.responses = [];
+  });
+
+  it("exposes keyless metadata as the zero-config default", () => {
+    const provider = createParallelFreeWebSearchProvider();
+    expect(provider.id).toBe("parallel-free");
+    expect(provider.label).toBe("Parallel Search (Free)");
+    expect(provider.requiresCredential).toBe(false);
+    expect(provider.envVars).toEqual([]);
+    expect(provider.autoDetectOrder).toBe(76);
+  });
+
+  it("advertises the free MCP's tighter 100-char session_id cap in its tool schema", () => {
+    const provider = createParallelFreeWebSearchProvider();
+    const tool = provider.createTool({ config: {}, searchConfig: {} });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const sessionIdParam = (
+      tool.parameters as { properties: Record<string, { maxLength?: number }> }
+    ).properties.session_id;
+    expect(sessionIdParam.maxLength).toBe(100);
+  });
+
+  it("searches via the free MCP and brands the result, with no API key", async () => {
+    // No PARALLEL_API_KEY needed — the free path ignores keys entirely.
+    vi.stubEnv("PARALLEL_API_KEY", "par-should-be-ignored"); // pragma: allowlist secret
+    pushHandshake({
+      search_id: "s1",
+      results: [
+        {
+          url: "https://example.com",
+          title: "Example",
+          publish_date: "2024-01-01",
+          excerpts: ["hi"],
+        },
+      ],
+    });
+    const provider = createParallelFreeWebSearchProvider();
+    const tool = provider.createTool({ config: {}, searchConfig: {} });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const result = await tool.execute({
+      objective: "find examples",
+      search_queries: ["example"],
+    });
+
+    // Three MCP calls (initialize -> notifications -> tools/call) to the free MCP.
+    expect(endpointMockState.calls).toHaveLength(3);
+    expect(endpointMockState.calls[0].url).toBe("https://search.parallel.ai/mcp");
+    // No bearer token on the anonymous free path.
+    expect(
+      (endpointMockState.calls[0].init.headers as Record<string, string>).Authorization,
+    ).toBeUndefined();
+    expect(result).toMatchObject({ provider: "parallel-free" });
+    expect(Array.isArray(result.results)).toBe(true);
+    expect((result.results as unknown[]).length).toBe(1);
+    vi.unstubAllEnvs();
+  });
+
+  it("drops an over-limit caller session id and mints one within the free MCP's 100-char cap", async () => {
+    pushHandshake({ search_id: "s1", results: [] });
+    const provider = createParallelFreeWebSearchProvider();
+    const tool = provider.createTool({ config: {}, searchConfig: {} });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    await tool.execute({
+      objective: "session cap check",
+      search_queries: ["session cap"],
+      session_id: "x".repeat(150),
+    });
+
+    const toolsCallArgs = (
+      JSON.parse(endpointMockState.calls[2].init.body as string).params as Record<string, unknown>
+    ).arguments as Record<string, unknown>;
+    const sentSessionId = toolsCallArgs.session_id as string;
+    // The 150-char caller id is out-of-contract for the free MCP; it is dropped
+    // and replaced by a generated id that stays within the advertised 100-char cap.
+    expect(sentSessionId).not.toBe("x".repeat(150));
+    expect(sentSessionId.length).toBeLessThanOrEqual(100);
+  });
+
+  it("returns a structured error when search_queries is missing", async () => {
+    const provider = createParallelFreeWebSearchProvider();
+    const tool = provider.createTool({ config: {}, searchConfig: {} });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+    const result = await tool.execute({ objective: "x" });
+    expect(result.error).toBe("invalid_search_queries");
+    expect(endpointMockState.calls).toHaveLength(0);
+  });
+});

--- a/extensions/parallel/src/parallel-free-web-search-provider.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.ts
@@ -1,0 +1,44 @@
+import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
+import { createParallelFreeWebSearchProviderBase } from "./parallel-free-web-search-provider.shared.js";
+import { PARALLEL_FREE_SESSION_ID_MAX_LENGTH } from "./parallel-search-normalize.js";
+// Reuse the paid provider's tool schema — both transports accept the same
+// objective + search_queries shape — but the free Search MCP caps session_id at
+// 100 chars (its `tools/list` schema), tighter than the paid v1 REST limit, so
+// the free model-facing schema advertises that tighter bound.
+import { ParallelSearchSchema } from "./parallel-web-search-provider.js";
+
+const ParallelFreeSearchSchema = {
+  ...ParallelSearchSchema,
+  properties: {
+    ...ParallelSearchSchema.properties,
+    session_id: {
+      ...ParallelSearchSchema.properties.session_id,
+      maxLength: PARALLEL_FREE_SESSION_ID_MAX_LENGTH,
+    },
+  },
+} satisfies Record<string, unknown>;
+
+type ParallelFreeWebSearchRuntime = typeof import("./parallel-free-web-search-provider.runtime.js");
+
+let parallelFreeWebSearchRuntimePromise: Promise<ParallelFreeWebSearchRuntime> | undefined;
+
+function loadParallelFreeWebSearchRuntime(): Promise<ParallelFreeWebSearchRuntime> {
+  parallelFreeWebSearchRuntimePromise ??= import("./parallel-free-web-search-provider.runtime.js");
+  return parallelFreeWebSearchRuntimePromise;
+}
+
+export function createParallelFreeWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...createParallelFreeWebSearchProviderBase(),
+    createTool: (ctx) => ({
+      description:
+        "Search the web using Parallel's free Search MCP (no API key). Returns ranked, LLM-optimized dense excerpts from web sources. Pass an `objective` describing the underlying question along with 2-3 short keyword `search_queries` (Parallel's recommended pairing). For multi-step research, thread the prior result's `sessionId` back in as `session_id` to keep Parallel's context grouped.",
+      parameters: ParallelFreeSearchSchema,
+      execute: async (args, context) => {
+        const { executeParallelFreeWebSearchProviderTool } =
+          await loadParallelFreeWebSearchRuntime();
+        return await executeParallelFreeWebSearchProviderTool(ctx, args, context?.signal);
+      },
+    }),
+  };
+}

--- a/extensions/parallel/src/parallel-mcp-search.runtime.test.ts
+++ b/extensions/parallel/src/parallel-mcp-search.runtime.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type EndpointCall = {
+  url: string;
+  timeoutSeconds: number;
+  init: RequestInit;
+};
+
+const endpointMockState = vi.hoisted(() => ({
+  calls: [] as EndpointCall[],
+  responses: [] as Response[],
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>();
+  const runEndpoint = async (
+    params: EndpointCall,
+    run: (response: Response) => Promise<unknown>,
+  ) => {
+    endpointMockState.calls.push(params);
+    const response = endpointMockState.responses.shift();
+    if (!response) {
+      throw new Error("Missing mocked Parallel MCP response.");
+    }
+    return await run(response);
+  };
+  return {
+    ...actual,
+    withTrustedWebSearchEndpoint: vi.fn(runEndpoint),
+  };
+});
+
+import {
+  extractMcpToolPayload,
+  iterMcpMessages,
+  runParallelMcpSearch,
+  selectMcpEnvelope,
+} from "./parallel-mcp-search.runtime.js";
+
+function jsonResponse(body: unknown, headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+function readBody(call: EndpointCall): Record<string, unknown> {
+  if (typeof call.init.body !== "string") {
+    throw new Error("Expected a JSON string body.");
+  }
+  return JSON.parse(call.init.body) as Record<string, unknown>;
+}
+
+function headerOf(call: EndpointCall, name: string): string | undefined {
+  return (call.init.headers as Record<string, string>)[name];
+}
+
+describe("iterMcpMessages", () => {
+  it("parses a single JSON object body", () => {
+    expect(iterMcpMessages('{"id":"a","result":{}}')).toEqual([{ id: "a", result: {} }]);
+  });
+
+  it("flattens a JSON array batch", () => {
+    expect(iterMcpMessages('[{"id":"a"},{"id":"b"}]')).toEqual([{ id: "a" }, { id: "b" }]);
+  });
+
+  it("parses SSE events with concatenated data lines", () => {
+    const sse = [
+      "event: message",
+      'data: {"id":"a",',
+      'data: "result":{}}',
+      "",
+      'data: {"id":"b"}',
+      "",
+    ].join("\n");
+    expect(iterMcpMessages(sse)).toEqual([{ id: "a", result: {} }, { id: "b" }]);
+  });
+
+  it("skips unparseable chunks and empty bodies", () => {
+    expect(iterMcpMessages("")).toEqual([]);
+    expect(iterMcpMessages("not json")).toEqual([]);
+    expect(iterMcpMessages("data: {bad json}\n\n")).toEqual([]);
+  });
+});
+
+describe("selectMcpEnvelope", () => {
+  it("returns the message whose id matches, skipping notifications", () => {
+    const body = [
+      '{"jsonrpc":"2.0","method":"notifications/progress"}',
+      '{"jsonrpc":"2.0","id":"other","result":{"n":1}}',
+      '{"jsonrpc":"2.0","id":"want","result":{"n":2}}',
+    ]
+      .map((line) => `data: ${line}`)
+      .join("\n\n");
+    expect(selectMcpEnvelope(body, "want")).toMatchObject({ id: "want", result: { n: 2 } });
+  });
+
+  it("falls back to the last result-bearing message when no id matches", () => {
+    const body = '{"id":"x","result":{"first":true}}\n';
+    expect(selectMcpEnvelope(body, "missing")).toMatchObject({ result: { first: true } });
+  });
+
+  it("returns {} when there is no result or error message", () => {
+    expect(selectMcpEnvelope('{"method":"notifications/initialized"}', "any")).toEqual({});
+  });
+});
+
+describe("extractMcpToolPayload", () => {
+  it("prefers structuredContent", () => {
+    expect(extractMcpToolPayload({ result: { structuredContent: { results: [1] } } })).toEqual({
+      results: [1],
+    });
+  });
+
+  it("parses the first JSON-parseable text block", () => {
+    expect(
+      extractMcpToolPayload({
+        result: {
+          content: [
+            { type: "text", text: "not json" },
+            { type: "text", text: '{"ok":true}' },
+          ],
+        },
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("throws on a JSON-RPC error", () => {
+    expect(() => extractMcpToolPayload({ error: { code: -1, message: "boom" } })).toThrow(
+      /Parallel MCP error/,
+    );
+  });
+
+  it("throws on a tool-level isError", () => {
+    expect(() =>
+      extractMcpToolPayload({ result: { isError: true, content: [{ type: "text", text: "{}" }] } }),
+    ).toThrow(/Parallel MCP tool error/);
+  });
+
+  it("throws when there is no parseable content", () => {
+    expect(() => extractMcpToolPayload({ result: { content: [] } })).toThrow(
+      /no parseable content/,
+    );
+  });
+});
+
+describe("runParallelMcpSearch", () => {
+  beforeEach(() => {
+    endpointMockState.calls = [];
+    endpointMockState.responses = [];
+  });
+
+  it("runs the 3-step handshake and maps results into the REST-compatible shape", async () => {
+    endpointMockState.responses.push(
+      jsonResponse(
+        { jsonrpc: "2.0", id: "ignored", result: { protocolVersion: "2025-06-18" } },
+        { "mcp-session-id": "server-session-1" },
+      ),
+      jsonResponse({ jsonrpc: "2.0" }), // notifications/initialized ack
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: "ignored",
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                search_id: "search_abc",
+                results: [
+                  {
+                    url: "https://example.com",
+                    title: "Example",
+                    publish_date: "2024-01-01",
+                    excerpts: ["hi"],
+                  },
+                  { url: "https://second.com", title: "Second", excerpts: ["yo"] },
+                ],
+              }),
+            },
+          ],
+        },
+      }),
+    );
+
+    const response = await runParallelMcpSearch({
+      objective: "find examples",
+      searchQueries: ["example query"],
+      maxResults: 1,
+      modelName: "claude-opus-4-8",
+    });
+
+    // 3 HTTP calls: initialize, notifications/initialized, tools/call.
+    expect(endpointMockState.calls.map((c) => readBody(c).method)).toEqual([
+      "initialize",
+      "notifications/initialized",
+      "tools/call",
+    ]);
+    // Server session id + a negotiated protocol version are echoed post-init.
+    expect(headerOf(endpointMockState.calls[1], "Mcp-Session-Id")).toBe("server-session-1");
+    expect(headerOf(endpointMockState.calls[2], "Mcp-Session-Id")).toBe("server-session-1");
+    expect(headerOf(endpointMockState.calls[2], "MCP-Protocol-Version")).toBe("2025-06-18");
+    // No bearer token on the anonymous free path.
+    expect(headerOf(endpointMockState.calls[0], "Authorization")).toBeUndefined();
+    // tools/call carries the documented web_search args.
+    const callArgs = (readBody(endpointMockState.calls[2]).params as Record<string, unknown>)
+      .arguments as Record<string, unknown>;
+    expect(callArgs).toMatchObject({
+      objective: "find examples",
+      search_queries: ["example query"],
+      model_name: "claude-opus-4-8",
+    });
+    expect(typeof callArgs.session_id).toBe("string");
+
+    // maxResults applied client-side; mapped to the REST-compatible response.
+    expect(response.search_id).toBe("search_abc");
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0]).toMatchObject({ url: "https://example.com", title: "Example" });
+  });
+
+  it("uses the search queries as the objective when none was supplied", async () => {
+    endpointMockState.responses.push(
+      jsonResponse({ jsonrpc: "2.0", id: "i", result: {} }, { "mcp-session-id": "s" }),
+      jsonResponse({ jsonrpc: "2.0" }),
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: "c",
+        result: { content: [{ type: "text", text: JSON.stringify({ results: [] }) }] },
+      }),
+    );
+
+    await runParallelMcpSearch({ searchQueries: ["alpha", "beta"], maxResults: 5 });
+
+    const callArgs = (readBody(endpointMockState.calls[2]).params as Record<string, unknown>)
+      .arguments as Record<string, unknown>;
+    expect(callArgs.objective).toBe("alpha beta");
+  });
+
+  it("forwards a caller-supplied session id verbatim (no re-minting)", async () => {
+    endpointMockState.responses.push(
+      jsonResponse({ jsonrpc: "2.0", id: "i", result: {} }, { "mcp-session-id": "s" }),
+      jsonResponse({ jsonrpc: "2.0" }),
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: "c",
+        result: { content: [{ type: "text", text: JSON.stringify({ results: [] }) }] },
+      }),
+    );
+    // The MCP client is a dumb transport: an already-normalized caller id (the
+    // provider runtime caps it at the free MCP's 100-char limit) is forwarded as
+    // sent, so the MCP session, cache key, and reported id stay in agreement.
+    const callerSessionId = `sess-${"a".repeat(40)}`;
+    const response = await runParallelMcpSearch({
+      searchQueries: ["x"],
+      maxResults: 5,
+      sessionId: callerSessionId,
+    });
+    const callArgs = (readBody(endpointMockState.calls[2]).params as Record<string, unknown>)
+      .arguments as Record<string, unknown>;
+    expect(callArgs.session_id).toBe(callerSessionId);
+    expect(response.session_id).toBe(callerSessionId);
+  });
+
+  it("throws when initialize fails", async () => {
+    endpointMockState.responses.push(new Response("nope", { status: 500 }));
+    await expect(runParallelMcpSearch({ searchQueries: ["x"], maxResults: 5 })).rejects.toThrow(
+      /initialize failed \(500\)/,
+    );
+  });
+});

--- a/extensions/parallel/src/parallel-mcp-search.runtime.ts
+++ b/extensions/parallel/src/parallel-mcp-search.runtime.ts
@@ -1,0 +1,346 @@
+import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import { readPluginPackageVersion } from "openclaw/plugin-sdk/extension-shared";
+import { withTrustedWebSearchEndpoint } from "openclaw/plugin-sdk/provider-web-search";
+
+// Free hosted Search MCP — anonymous-friendly, used when no PARALLEL_API_KEY is
+// configured. This is the zero-config default web_search transport. Docs:
+// https://docs.parallel.ai/integrations/mcp/search-mcp
+export const PARALLEL_MCP_SEARCH_URL = "https://search.parallel.ai/mcp";
+// Initial protocol version we advertise on `initialize`; we then echo whatever
+// the server negotiates back on every follow-up request.
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+const MCP_TIMEOUT_SECONDS = 30;
+
+const require = createRequire(import.meta.url);
+const PLUGIN_VERSION = readPluginPackageVersion({ require });
+
+type JsonRpcMessage = Record<string, unknown>;
+
+type McpToolPayload = Record<string, unknown>;
+
+/** ParallelSearchResponse-compatible shape consumed by the runtime normalizer. */
+export type ParallelMcpSearchResponse = {
+  search_id?: unknown;
+  session_id?: unknown;
+  results: unknown[];
+  warnings?: unknown;
+  usage?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mcpHeaders(params: {
+  sessionId?: string;
+  protocolVersion?: string;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    // The Search MCP may answer either as a single JSON object or as an SSE
+    // stream; advertise both so the server can pick.
+    Accept: "application/json, text/event-stream",
+  };
+  // After `initialize` the Streamable-HTTP spec expects the negotiated session
+  // id and protocol version echoed on every follow-up request.
+  if (params.sessionId) {
+    headers["Mcp-Session-Id"] = params.sessionId;
+  }
+  if (params.protocolVersion) {
+    headers["MCP-Protocol-Version"] = params.protocolVersion;
+  }
+  // No Authorization header: the free tier is anonymous, and sending an
+  // empty/garbage bearer would flip the server to a 401 instead of serving it.
+  return headers;
+}
+
+/**
+ * Yield JSON-RPC message objects from a plain-JSON or SSE response body.
+ *
+ * Handles `application/json` (a single object) and `text/event-stream` (SSE:
+ * events separated by blank lines; an event's one-or-more `data:` lines
+ * concatenate into a single JSON payload). Streamable HTTP also allows batching
+ * responses into a JSON array, so arrays are flattened. Unparseable chunks and
+ * non-`data` SSE fields (`event:`/`id:`/comments) are skipped.
+ */
+export function iterMcpMessages(text: string): JsonRpcMessage[] {
+  const out: JsonRpcMessage[] = [];
+  const emit = (payload: unknown): void => {
+    if (Array.isArray(payload)) {
+      for (const entry of payload) {
+        if (isRecord(entry)) {
+          out.push(entry);
+        }
+      }
+    } else if (isRecord(payload)) {
+      out.push(payload);
+    }
+  };
+
+  const body = (text ?? "").trim();
+  if (!body) {
+    return out;
+  }
+  if (body.startsWith("{") || body.startsWith("[")) {
+    try {
+      emit(JSON.parse(body));
+    } catch {
+      // Non-JSON body: nothing to emit.
+    }
+    return out;
+  }
+
+  let dataLines: string[] = [];
+  const flush = (): void => {
+    if (dataLines.length === 0) {
+      return;
+    }
+    try {
+      emit(JSON.parse(dataLines.join("\n")));
+    } catch {
+      // Skip an unparseable SSE event rather than failing the whole stream.
+    }
+    dataLines = [];
+  };
+
+  for (const raw of body.split("\n")) {
+    const line = raw.replace(/\r$/, "");
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).replace(/^ /, ""));
+    } else if (line.trim() === "") {
+      flush();
+    }
+  }
+  flush();
+  return out;
+}
+
+/**
+ * Select the JSON-RPC response for `requestId` from an MCP response body.
+ *
+ * Streamable-HTTP servers may emit progress/log notifications before the final
+ * result, so scan the whole stream and return the result/error message whose
+ * `id` matches. Falls back to the last result/error-bearing message if no id
+ * matches; `{}` if none is present.
+ */
+export function selectMcpEnvelope(text: string, requestId: string): JsonRpcMessage {
+  let fallback: JsonRpcMessage = {};
+  for (const msg of iterMcpMessages(text)) {
+    if (!("result" in msg || "error" in msg)) {
+      continue;
+    }
+    if (msg.id === requestId) {
+      return msg;
+    }
+    fallback = msg;
+  }
+  return fallback;
+}
+
+/**
+ * Extract the tool result payload from a `tools/call` envelope.
+ *
+ * Prefers `structuredContent` (authoritative machine-readable form); otherwise
+ * scans text blocks for the first JSON-parseable one. Throws on a JSON-RPC
+ * error or a tool-level `isError`.
+ */
+export function extractMcpToolPayload(envelope: JsonRpcMessage): McpToolPayload {
+  if ("error" in envelope) {
+    throw new Error(`Parallel MCP error: ${JSON.stringify(envelope.error).slice(0, 500)}`);
+  }
+  const result = isRecord(envelope.result) ? envelope.result : {};
+  if (result.isError) {
+    throw new Error(`Parallel MCP tool error: ${JSON.stringify(result).slice(0, 500)}`);
+  }
+  if (isRecord(result.structuredContent)) {
+    return result.structuredContent;
+  }
+  const content = Array.isArray(result.content) ? result.content : [];
+  for (const block of content) {
+    if (isRecord(block) && block.type === "text" && typeof block.text === "string" && block.text) {
+      try {
+        const parsed: unknown = JSON.parse(block.text);
+        if (isRecord(parsed)) {
+          return parsed;
+        }
+      } catch {
+        // Try the next text block.
+      }
+    }
+  }
+  throw new Error(
+    `Parallel MCP returned no parseable content: ${JSON.stringify(result).slice(0, 500)}`,
+  );
+}
+
+type McpHttpResult = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  text: string;
+  sessionIdHeader: string | null;
+};
+
+async function postMcp(params: {
+  body: JsonRpcMessage;
+  sessionId?: string;
+  protocolVersion?: string;
+  timeoutSeconds: number;
+  signal?: AbortSignal;
+}): Promise<McpHttpResult> {
+  return withTrustedWebSearchEndpoint(
+    {
+      url: PARALLEL_MCP_SEARCH_URL,
+      timeoutSeconds: params.timeoutSeconds,
+      signal: params.signal,
+      init: {
+        method: "POST",
+        headers: mcpHeaders({
+          sessionId: params.sessionId,
+          protocolVersion: params.protocolVersion,
+        }),
+        body: JSON.stringify(params.body),
+      },
+    },
+    // Read the body inside the callback: the trusted-endpoint wrapper ties the
+    // request's abort/timeout lifecycle to this scope (same pattern as the REST
+    // path), so the Response must be consumed here, not returned and read later.
+    async (response) => ({
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      text: await response.text(),
+      sessionIdHeader: response.headers.get("mcp-session-id"),
+    }),
+  );
+}
+
+/**
+ * Run the MCP handshake then a single `tools/call`, returning the tool payload.
+ *
+ * initialize -> (capture `Mcp-Session-Id` header + negotiated protocolVersion)
+ * -> notifications/initialized -> tools/call. Anonymous (no bearer token).
+ */
+async function mcpCall(
+  toolName: string,
+  args: Record<string, unknown>,
+  timeoutSeconds: number,
+  signal?: AbortSignal,
+): Promise<McpToolPayload> {
+  // 1. initialize — capture the server-assigned session id + negotiated version.
+  const initId = randomUUID();
+  const init = await postMcp({
+    timeoutSeconds,
+    signal,
+    body: {
+      jsonrpc: "2.0",
+      id: initId,
+      method: "initialize",
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "openclaw-parallel", version: PLUGIN_VERSION },
+      },
+    },
+  });
+  if (!init.ok) {
+    throw new Error(
+      `Parallel MCP initialize failed (${init.status}): ${init.text || init.statusText}`,
+    );
+  }
+  // Only echo a server-assigned session id. Stateless Streamable HTTP servers
+  // omit Mcp-Session-Id; inventing one can make such servers reject follow-ups.
+  const sessionId = init.sessionIdHeader ?? undefined;
+  const initEnvelope = selectMcpEnvelope(init.text, initId);
+  const negotiatedVersion =
+    (isRecord(initEnvelope.result) && typeof initEnvelope.result.protocolVersion === "string"
+      ? initEnvelope.result.protocolVersion
+      : undefined) ?? MCP_PROTOCOL_VERSION;
+
+  // 2. notifications/initialized — required handshake ack (no response body).
+  await postMcp({
+    body: { jsonrpc: "2.0", method: "notifications/initialized" },
+    sessionId,
+    protocolVersion: negotiatedVersion,
+    timeoutSeconds,
+    signal,
+  });
+
+  // 3. tools/call.
+  const callId = randomUUID();
+  const call = await postMcp({
+    body: {
+      jsonrpc: "2.0",
+      id: callId,
+      method: "tools/call",
+      params: { name: toolName, arguments: args },
+    },
+    sessionId,
+    protocolVersion: negotiatedVersion,
+    timeoutSeconds,
+    signal,
+  });
+  if (!call.ok) {
+    throw new Error(
+      `Parallel MCP tools/call failed (${call.status}): ${call.text || call.statusText}`,
+    );
+  }
+  return extractMcpToolPayload(selectMcpEnvelope(call.text, callId));
+}
+
+function normalizeMcpSessionId(value: string | undefined): string {
+  // Use the caller-supplied id verbatim — the runtime already applies the
+  // shared session-id contract before building the cache key, so reusing it
+  // here keeps the MCP session, cache key, and reported sessionId in agreement
+  // (re-minting a valid id would silently break session grouping). The Search
+  // MCP requires a session_id, so mint a per-call uuid only when none was given.
+  return value?.trim() || randomUUID();
+}
+
+/**
+ * Run a `web_search` tool call against the free hosted Search MCP and return a
+ * `ParallelSearchResponse`-compatible object so the runtime's existing result
+ * normalization (`normalizeParallelResults`) is reused verbatim.
+ */
+export async function runParallelMcpSearch(params: {
+  objective?: string;
+  searchQueries: readonly string[];
+  maxResults: number;
+  sessionId?: string;
+  modelName?: string;
+  timeoutSeconds?: number;
+  signal?: AbortSignal;
+}): Promise<ParallelMcpSearchResponse> {
+  const sessionId = normalizeMcpSessionId(params.sessionId);
+  const args: Record<string, unknown> = {
+    // MCP requires a non-empty objective (REST treats it as optional); when the
+    // caller only supplied keyword queries, use them as the objective rather
+    // than failing the call.
+    objective: params.objective ?? params.searchQueries.join(" "),
+    search_queries: [...params.searchQueries],
+    session_id: sessionId,
+  };
+  if (params.modelName) {
+    args.model_name = params.modelName;
+  }
+
+  const payload = await mcpCall(
+    "web_search",
+    args,
+    params.timeoutSeconds ?? MCP_TIMEOUT_SECONDS,
+    params.signal,
+  );
+  const allResults = Array.isArray(payload.results) ? payload.results : [];
+  // The MCP serves a fixed result count, so apply the caller's count client-side
+  // to match the REST path's max_results behavior.
+  const results = allResults.slice(0, Math.max(params.maxResults, 1));
+
+  return {
+    search_id: typeof payload.search_id === "string" ? payload.search_id : undefined,
+    session_id: sessionId,
+    results,
+    warnings: payload.warnings,
+    usage: payload.usage,
+  };
+}

--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -1,0 +1,197 @@
+// Transport-agnostic Parallel search normalization shared by the paid REST
+// provider (`parallel`) and the free Search MCP provider (`parallel-free`).
+// Both transports return the same v1 result shape, so query/result handling
+// lives here instead of being copied into each runtime.
+import {
+  buildSearchCacheKey,
+  resolveSiteName,
+  wrapWebContent,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+// Internal-only bounds (the model-facing tool schema declares its own copies).
+const PARALLEL_MAX_SEARCH_COUNT = 40;
+// Parallel v1 Search caps each search_queries entry at 200 chars, the objective
+// field at 5000, and accepts up to 5 search queries. See
+// https://docs.parallel.ai/search/best-practices.
+const PARALLEL_MAX_SEARCH_QUERY_CHARS = 200;
+const PARALLEL_MAX_OBJECTIVE_CHARS = 5000;
+const PARALLEL_MAX_SEARCH_QUERIES = 5;
+// Paid v1 REST accepts session ids up to 1000 chars, but the free Search MCP
+// `tools/list` schema caps session_id at 100. Each runtime passes its own limit
+// (and advertises it in the tool schema) so callers never send an out-of-contract id.
+export const PARALLEL_SESSION_ID_MAX_LENGTH = 1000;
+export const PARALLEL_FREE_SESSION_ID_MAX_LENGTH = 100;
+const PARALLEL_CLIENT_MODEL_MAX_LENGTH = 100;
+
+export type ParallelSearchResult = {
+  title?: unknown;
+  url?: unknown;
+  publish_date?: unknown;
+  excerpts?: unknown;
+};
+
+export type ParallelSearchResponse = {
+  search_id?: unknown;
+  session_id?: unknown;
+  results?: unknown;
+  warnings?: unknown;
+  usage?: unknown;
+};
+
+export function resolveParallelSearchCount(value: number): number {
+  return Math.max(1, Math.min(PARALLEL_MAX_SEARCH_COUNT, Math.floor(value)));
+}
+
+export function normalizeParallelSessionId(
+  value: string | undefined,
+  maxLength: number,
+): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  return trimmed && trimmed.length <= maxLength ? trimmed : undefined;
+}
+
+export function normalizeParallelObjective(value: string | undefined): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.length <= PARALLEL_MAX_OBJECTIVE_CHARS
+    ? trimmed
+    : trimmed.slice(0, PARALLEL_MAX_OBJECTIVE_CHARS);
+}
+
+export function normalizeParallelClientModel(value: string | undefined): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.length <= PARALLEL_CLIENT_MODEL_MAX_LENGTH
+    ? trimmed
+    : trimmed.slice(0, PARALLEL_CLIENT_MODEL_MAX_LENGTH);
+}
+
+// Parallel's API caps each entry at 200 chars and accepts up to 5 queries. We
+// trim, drop empties/duplicates, truncate over-long entries to the API's hard
+// limit, and cap to the API's maximum so a malformed call from the model
+// doesn't 422 the request. See https://docs.parallel.ai/search/best-practices.
+export function normalizeParallelSearchQueries(value: unknown): string[] {
+  const candidates = Array.isArray(value) ? value : [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of candidates) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const capped =
+      trimmed.length <= PARALLEL_MAX_SEARCH_QUERY_CHARS
+        ? trimmed
+        : trimmed.slice(0, PARALLEL_MAX_SEARCH_QUERY_CHARS);
+    if (seen.has(capped)) {
+      continue;
+    }
+    seen.add(capped);
+    out.push(capped);
+    if (out.length === PARALLEL_MAX_SEARCH_QUERIES) {
+      break;
+    }
+  }
+  return out;
+}
+
+export function invalidSearchQueriesPayload() {
+  return {
+    error: "invalid_search_queries",
+    message:
+      "search_queries must be a non-empty array of keyword strings (max 5, max 200 chars each). See https://docs.parallel.ai/search/best-practices.",
+    docs: "https://docs.openclaw.ai/tools/parallel-search",
+  };
+}
+
+export function normalizeParallelResults(payload: unknown): ParallelSearchResult[] {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+  const results = (payload as ParallelSearchResponse).results;
+  if (!Array.isArray(results)) {
+    return [];
+  }
+  return results.filter((entry): entry is ParallelSearchResult =>
+    Boolean(entry && typeof entry === "object" && !Array.isArray(entry)),
+  );
+}
+
+/** Maps a Parallel v1 response into wrapped `web_search` result entries. */
+export function mapParallelResults(response: ParallelSearchResponse): Record<string, unknown>[] {
+  return normalizeParallelResults(response).map((entry) => {
+    const title = typeof entry.title === "string" ? entry.title : "";
+    const url = typeof entry.url === "string" ? entry.url : "";
+    const published =
+      typeof entry.publish_date === "string" && entry.publish_date ? entry.publish_date : undefined;
+    const excerpts = Array.isArray(entry.excerpts)
+      ? entry.excerpts
+          .filter((e): e is string => typeof e === "string")
+          .map((e) => wrapWebContent(e, "web_search"))
+      : [];
+    const description = excerpts.join("\n\n");
+    return Object.assign(
+      {
+        title: title ? wrapWebContent(title, "web_search") : "",
+        url,
+        description,
+        siteName: resolveSiteName(url) || undefined,
+      },
+      published ? { published } : {},
+      excerpts.length > 0 ? { excerpts } : {},
+    );
+  });
+}
+
+/**
+ * Drops a Parallel-generated `sessionId` before caching. Identical queries from
+ * unrelated tasks would otherwise share that id; caller-supplied session ids are
+ * part of the cache key, so a cache hit only ever returns the matching id.
+ */
+export function stripParallelGeneratedSessionId(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!("sessionId" in payload)) {
+    return payload;
+  }
+  const { sessionId: _omitted, ...rest } = payload;
+  void _omitted;
+  return rest;
+}
+
+export function buildParallelCacheKey(params: {
+  endpoint: string;
+  objective?: string;
+  searchQueries: readonly string[];
+  count: number;
+  sessionId?: string;
+  clientModel?: string;
+}): string {
+  return buildSearchCacheKey([
+    "parallel",
+    // The transport endpoint (REST URL or the free MCP URL) partitions paid-REST
+    // vs free-MCP and REST endpoint overrides so transports never share cached
+    // payloads.
+    params.endpoint,
+    params.objective,
+    // Join with a NUL delimiter (can't appear in normalized queries) so distinct
+    // arrays like ["ab","c"] and ["a","bc"] don't collide on the same cache key.
+    params.searchQueries.join("\u0000"),
+    params.count,
+    // Different Parallel sessions can return different ranked excerpts for the
+    // same query set, so partition cached payloads by caller-provided session.
+    params.sessionId,
+    // Parallel tailors defaults/optimizations to client_model per its docs, so
+    // partition cached payloads by it; otherwise two models hitting the same
+    // query inside the cache TTL would silently share ranked excerpts.
+    params.clientModel,
+  ]);
+}

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -1,7 +1,6 @@
 import { createRequire } from "node:module";
 import { readPluginPackageVersion } from "openclaw/plugin-sdk/extension-shared";
 import {
-  buildSearchCacheKey,
   DEFAULT_SEARCH_COUNT,
   mergeScopedSearchConfig,
   readCachedSearchPayload,
@@ -13,25 +12,28 @@ import {
   resolveProviderWebSearchPluginConfig,
   resolveSearchCacheTtlMs,
   resolveSearchTimeoutSeconds,
-  resolveSiteName,
   type SearchConfigRecord,
   withTrustedWebSearchEndpoint,
-  wrapWebContent,
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  buildParallelCacheKey,
+  invalidSearchQueriesPayload,
+  mapParallelResults,
+  normalizeParallelClientModel,
+  normalizeParallelObjective,
+  normalizeParallelResults,
+  normalizeParallelSearchQueries,
+  normalizeParallelSessionId,
+  PARALLEL_SESSION_ID_MAX_LENGTH,
+  type ParallelSearchResponse,
+  resolveParallelSearchCount,
+  stripParallelGeneratedSessionId,
+} from "./parallel-search-normalize.js";
 
 const PARALLEL_BASE_URL = "https://api.parallel.ai";
 const PARALLEL_SEARCH_PATHNAME = "/v1/search";
-const PARALLEL_MAX_SEARCH_COUNT = 40;
-// Parallel v1 Search caps each search_queries entry at 200 chars, the
-// objective field at 5000, and accepts up to 5 search queries. See
-// https://docs.parallel.ai/search/best-practices.
-const PARALLEL_MAX_SEARCH_QUERY_CHARS = 200;
-const PARALLEL_MAX_OBJECTIVE_CHARS = 5000;
-const PARALLEL_MAX_SEARCH_QUERIES = 5;
-const PARALLEL_SESSION_ID_MAX_LENGTH = 1000;
-const PARALLEL_CLIENT_MODEL_MAX_LENGTH = 100;
 
 const require = createRequire(import.meta.url);
 const PLUGIN_VERSION = readPluginPackageVersion({ require });
@@ -40,21 +42,6 @@ const USER_AGENT = `openclaw-parallel/${PLUGIN_VERSION} (${process.platform})`;
 type ParallelConfig = {
   apiKey?: string;
   baseUrl?: string;
-};
-
-type ParallelSearchResult = {
-  title?: unknown;
-  url?: unknown;
-  publish_date?: unknown;
-  excerpts?: unknown;
-};
-
-type ParallelSearchResponse = {
-  search_id?: unknown;
-  session_id?: unknown;
-  results?: unknown;
-  warnings?: unknown;
-  usage?: unknown;
 };
 
 function resolveParallelConfig(searchConfig?: SearchConfigRecord): ParallelConfig {
@@ -105,116 +92,6 @@ function resolveParallelSearchEndpoint(
     : `${pathname === "" ? "" : pathname}${PARALLEL_SEARCH_PATHNAME}`;
   parsed.hash = "";
   return { endpoint: parsed.toString() };
-}
-
-function resolveParallelSearchCount(value: number): number {
-  return Math.max(1, Math.min(PARALLEL_MAX_SEARCH_COUNT, Math.floor(value)));
-}
-
-function normalizeParallelSessionId(value: string | undefined): string | undefined {
-  const trimmed = normalizeOptionalString(value);
-  return trimmed && trimmed.length <= PARALLEL_SESSION_ID_MAX_LENGTH ? trimmed : undefined;
-}
-
-function normalizeParallelObjective(value: string | undefined): string | undefined {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed) {
-    return undefined;
-  }
-  return trimmed.length <= PARALLEL_MAX_OBJECTIVE_CHARS
-    ? trimmed
-    : trimmed.slice(0, PARALLEL_MAX_OBJECTIVE_CHARS);
-}
-
-function normalizeParallelClientModel(value: string | undefined): string | undefined {
-  const trimmed = normalizeOptionalString(value);
-  if (!trimmed) {
-    return undefined;
-  }
-  return trimmed.length <= PARALLEL_CLIENT_MODEL_MAX_LENGTH
-    ? trimmed
-    : trimmed.slice(0, PARALLEL_CLIENT_MODEL_MAX_LENGTH);
-}
-
-// Parallel's API caps each entry at 200 chars and accepts up to 5 queries.
-// We trim, drop empties/duplicates, truncate over-long entries to the API's
-// hard limit, and cap to the API's maximum so a malformed call from the
-// model doesn't 422 the request. See https://docs.parallel.ai/search/best-practices.
-function normalizeParallelSearchQueries(value: unknown): string[] {
-  const candidates = Array.isArray(value) ? value : [];
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const entry of candidates) {
-    if (typeof entry !== "string") {
-      continue;
-    }
-    const trimmed = entry.trim();
-    if (!trimmed) {
-      continue;
-    }
-    const capped =
-      trimmed.length <= PARALLEL_MAX_SEARCH_QUERY_CHARS
-        ? trimmed
-        : trimmed.slice(0, PARALLEL_MAX_SEARCH_QUERY_CHARS);
-    if (seen.has(capped)) {
-      continue;
-    }
-    seen.add(capped);
-    out.push(capped);
-    if (out.length === PARALLEL_MAX_SEARCH_QUERIES) {
-      break;
-    }
-  }
-  return out;
-}
-
-function invalidSearchQueriesPayload() {
-  return {
-    error: "invalid_search_queries",
-    message:
-      "search_queries must be a non-empty array of keyword strings (max 5, max 200 chars each). See https://docs.parallel.ai/search/best-practices.",
-    docs: "https://docs.openclaw.ai/tools/parallel-search",
-  };
-}
-
-function normalizeParallelResults(payload: unknown): ParallelSearchResult[] {
-  if (!payload || typeof payload !== "object") {
-    return [];
-  }
-  const results = (payload as ParallelSearchResponse).results;
-  if (!Array.isArray(results)) {
-    return [];
-  }
-  return results.filter((entry): entry is ParallelSearchResult =>
-    Boolean(entry && typeof entry === "object" && !Array.isArray(entry)),
-  );
-}
-
-function buildParallelCacheKey(params: {
-  endpoint: string;
-  objective?: string;
-  searchQueries: readonly string[];
-  count: number;
-  sessionId?: string;
-  clientModel?: string;
-}): string {
-  return buildSearchCacheKey([
-    "parallel",
-    params.endpoint,
-    params.objective,
-    // Search queries are already normalized (trimmed, deduped, length-capped,
-    // ≤5) before reaching the cache key so the join is stable.
-    params.searchQueries.join(""),
-    params.count,
-    // Different Parallel sessions can return different ranked excerpts for
-    // the same query set, so partition cached payloads by caller-provided
-    // session.
-    params.sessionId,
-    // Parallel tailors defaults/optimizations to client_model per its docs,
-    // so partition cached payloads by it; otherwise two models hitting the
-    // same query inside the cache TTL would silently share ranked excerpts.
-    params.clientModel,
-  ]);
 }
 
 function missingParallelKeyPayload() {
@@ -305,12 +182,7 @@ export async function executeParallelWebSearchProviderTool(
   // provider is active and doesn't know about Parallel's richer
   // `{ objective, search_queries }` schema. When `search_queries` is absent
   // we promote `query` into the lone search query. `objective` stays unset
-  // in that case rather than being faked from the keyword string — Parallel
-  // documents `objective` as natural-language intent and treats it as
-  // optional, so leaving it absent is more honest than reusing the keyword.
-  // Agent callers that supply `objective`/`search_queries` explicitly take
-  // precedence, and the documented schema still requires the native pair so
-  // the model is encouraged to provide both.
+  // in that case rather than being faked from the keyword string.
   const objective = normalizeParallelObjective(readStringParam(args, "objective"));
   const cliQuery = normalizeParallelObjective(readStringParam(args, "query"));
   let searchQueries = normalizeParallelSearchQueries(readStringArrayParam(args, "search_queries"));
@@ -323,11 +195,13 @@ export async function executeParallelWebSearchProviderTool(
   const requestedCount =
     readNumberParam(args, "count", { integer: true }) ??
     (typeof searchConfig?.maxResults === "number" ? searchConfig.maxResults : undefined);
-  // Always pass max_results so Parallel matches the openclaw web_search
-  // default of 5 instead of falling back to Parallel's own default of 10.
-  // Switching providers should not silently change result volume / token cost.
+  // Always pass max_results so Parallel matches the openclaw web_search default
+  // of 5 instead of Parallel's own default of 10.
   const count = resolveParallelSearchCount(requestedCount ?? DEFAULT_SEARCH_COUNT);
-  const sessionId = normalizeParallelSessionId(readStringParam(args, "session_id"));
+  const sessionId = normalizeParallelSessionId(
+    readStringParam(args, "session_id"),
+    PARALLEL_SESSION_ID_MAX_LENGTH,
+  );
   const clientModel = normalizeParallelClientModel(readStringParam(args, "client_model"));
   const cacheKey = buildParallelCacheKey({
     endpoint,
@@ -353,28 +227,7 @@ export async function executeParallelWebSearchProviderTool(
     clientModel,
     timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
   });
-  const results = normalizeParallelResults(response).map((entry) => {
-    const title = typeof entry.title === "string" ? entry.title : "";
-    const url = typeof entry.url === "string" ? entry.url : "";
-    const published =
-      typeof entry.publish_date === "string" && entry.publish_date ? entry.publish_date : undefined;
-    const excerpts = Array.isArray(entry.excerpts)
-      ? entry.excerpts
-          .filter((e): e is string => typeof e === "string")
-          .map((e) => wrapWebContent(e, "web_search"))
-      : [];
-    const description = excerpts.join("\n\n");
-    return Object.assign(
-      {
-        title: title ? wrapWebContent(title, "web_search") : "",
-        url,
-        description,
-        siteName: resolveSiteName(url) || undefined,
-      },
-      published ? { published } : {},
-      excerpts.length > 0 ? { excerpts } : {},
-    );
-  });
+  const results = mapParallelResults(response);
 
   const payload: Record<string, unknown> = {
     ...(objective ? { objective } : {}),
@@ -404,24 +257,11 @@ export async function executeParallelWebSearchProviderTool(
   }
 
   // Don't persist a Parallel-generated session id into the shared cache:
-  // identical queries from unrelated tasks would otherwise share that id and
-  // an agent threading `sessionId` into follow-ups would group unrelated
-  // tasks on Parallel's side. Caller-supplied session ids are already part
-  // of the cache key, so a cache-hit will only ever return the matching id.
+  // identical queries from unrelated tasks would otherwise share that id.
+  // Caller-supplied session ids are already part of the cache key.
   const cachePayload = sessionId ? payload : stripParallelGeneratedSessionId(payload);
   writeCachedSearchPayload(cacheKey, cachePayload, resolveSearchCacheTtlMs(searchConfig));
   return payload;
-}
-
-function stripParallelGeneratedSessionId(
-  payload: Record<string, unknown>,
-): Record<string, unknown> {
-  if (!("sessionId" in payload)) {
-    return payload;
-  }
-  const { sessionId: _omitted, ...rest } = payload;
-  void _omitted;
-  return rest;
 }
 
 export const testing = {

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -251,11 +251,14 @@ describe("parallel web search provider", () => {
     expect(testing.normalizeParallelSearchQueries(six)).toEqual(["a", "b", "c", "d", "e"]);
   });
 
-  it("normalizes session ids, rejecting blanks and overlong values", () => {
-    expect(testing.normalizeParallelSessionId("session-abc")).toBe("session-abc");
-    expect(testing.normalizeParallelSessionId("  ")).toBeUndefined();
-    expect(testing.normalizeParallelSessionId(undefined)).toBeUndefined();
-    expect(testing.normalizeParallelSessionId("x".repeat(1001))).toBeUndefined();
+  it("normalizes session ids, rejecting blanks and values past the given limit", () => {
+    expect(testing.normalizeParallelSessionId("session-abc", 1000)).toBe("session-abc");
+    expect(testing.normalizeParallelSessionId("  ", 1000)).toBeUndefined();
+    expect(testing.normalizeParallelSessionId(undefined, 1000)).toBeUndefined();
+    expect(testing.normalizeParallelSessionId("x".repeat(1001), 1000)).toBeUndefined();
+    // Free Search MCP caps session_id at 100, so the tighter limit drops longer ids.
+    expect(testing.normalizeParallelSessionId("x".repeat(101), 100)).toBeUndefined();
+    expect(testing.normalizeParallelSessionId("x".repeat(100), 100)).toBe("x".repeat(100));
   });
 
   it("normalizes client_model identifiers", () => {

--- a/extensions/parallel/src/parallel-web-search-provider.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.ts
@@ -19,7 +19,7 @@ function loadParallelWebSearchRuntime(): Promise<ParallelWebSearchRuntime> {
 
 // Mirrors Parallel's recommended search tool schema:
 // https://docs.parallel.ai/search/best-practices#search-tool-definition
-const ParallelSearchSchema = {
+export const ParallelSearchSchema = {
   type: "object",
   properties: {
     objective: {

--- a/extensions/parallel/web-search-contract-api.ts
+++ b/extensions/parallel/web-search-contract-api.ts
@@ -1,9 +1,17 @@
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
+import { createParallelFreeWebSearchProviderBase } from "./src/parallel-free-web-search-provider.shared.js";
 import { createParallelWebSearchProviderBase } from "./src/parallel-web-search-provider.shared.js";
 
 export function createParallelWebSearchProvider(): WebSearchProviderPlugin {
   return {
     ...createParallelWebSearchProviderBase(),
+    createTool: () => null,
+  };
+}
+
+export function createParallelFreeWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...createParallelFreeWebSearchProviderBase(),
     createTool: () => null,
   };
 }

--- a/extensions/parallel/web-search-provider.ts
+++ b/extensions/parallel/web-search-provider.ts
@@ -1,1 +1,2 @@
+export { createParallelFreeWebSearchProvider } from "./src/parallel-free-web-search-provider.js";
 export { createParallelWebSearchProvider } from "./src/parallel-web-search-provider.js";

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -135,6 +135,27 @@ describe("qa agentic parity report", () => {
     });
   });
 
+  it("uses scenario rows rather than stale summary counts for parity metrics", () => {
+    const summary: QaParitySuiteSummary = {
+      counts: {
+        total: 2,
+        passed: 2,
+        failed: 0,
+      },
+      scenarios: [
+        { name: "Approval turn tool followthrough", status: "pass" },
+        { name: "Compaction retry after mutating tool", status: "fail" },
+      ],
+    };
+
+    const metrics = computeQaAgenticParityMetrics(summary);
+
+    expect(metrics.totalScenarios).toBe(2);
+    expect(metrics.passedScenarios).toBe(1);
+    expect(metrics.failedScenarios).toBe(1);
+    expect(metrics.completionRate).toBe(0.5);
+  });
+
   it("keeps non-tool scenarios out of the valid-tool-call metric", () => {
     const summary: QaParitySuiteSummary = {
       scenarios: [

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -177,11 +177,9 @@ export function computeQaAgenticParityMetrics(
   const toolBackedTitleSet: ReadonlySet<string> = new Set(
     QA_AGENTIC_PARITY_TOOL_BACKED_SCENARIO_TITLES,
   );
-  const totalScenarios = summary.counts?.total ?? scenarios.length;
-  const passedScenarios =
-    summary.counts?.passed ?? scenarios.filter((scenario) => scenario.status === "pass").length;
-  const failedScenarios =
-    summary.counts?.failed ?? scenarios.filter((scenario) => scenario.status === "fail").length;
+  const totalScenarios = scenarios.length;
+  const passedScenarios = scenarios.filter((scenario) => scenario.status === "pass").length;
+  const failedScenarios = scenarios.filter((scenario) => scenario.status === "fail").length;
   const unintendedStopCount = scenarios.filter(
     (scenario) =>
       scenario.status !== "pass" && scenarioHasPattern(scenario, UNINTENDED_STOP_PATTERNS),

--- a/extensions/qa-lab/src/character-eval.test.ts
+++ b/extensions/qa-lab/src/character-eval.test.ts
@@ -90,17 +90,51 @@ function createConcurrencyGate(expectedActive: number) {
   };
 }
 
-function makeSuiteResult(params: { outputDir: string; model: string; transcript: string }) {
+async function makeSuiteResult(params: {
+  outputDir: string;
+  model: string;
+  transcript: string;
+  resultStatus?: "pass" | "fail";
+  summaryStatus?: "pass" | "fail";
+  summaryFailedCount?: number;
+}) {
+  const resultStatus = params.resultStatus ?? "pass";
+  const summaryStatus = params.summaryStatus ?? resultStatus;
+  const summaryFailedCount = params.summaryFailedCount ?? (summaryStatus === "fail" ? 1 : 0);
+  const summaryPath = path.join(params.outputDir, "qa-suite-summary.json");
+  await fs.mkdir(params.outputDir, { recursive: true });
+  await fs.writeFile(
+    summaryPath,
+    `${JSON.stringify(
+      {
+        counts: {
+          total: 1,
+          passed: summaryFailedCount > 0 ? 0 : 1,
+          failed: summaryFailedCount,
+        },
+        scenarios: [
+          {
+            name: "Character vibes",
+            status: summaryStatus,
+            steps: [],
+          },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
   return {
     outputDir: params.outputDir,
     reportPath: path.join(params.outputDir, "qa-suite-report.md"),
-    summaryPath: path.join(params.outputDir, "qa-suite-summary.json"),
+    summaryPath,
     report: "# report",
     watchUrl: "http://127.0.0.1:43124",
     scenarios: [
       {
         name: "Character vibes",
-        status: "pass",
+        status: resultStatus,
         steps: [
           {
             name: `transcript for ${params.model}`,
@@ -428,6 +462,33 @@ describe("runQaCharacterEval", () => {
       model: "qwen/qwen3.6-plus",
       error: "model unsupported error leaked into transcript",
     });
+  });
+
+  it("marks candidates failed when the suite summary has failed scenarios", async () => {
+    const runSuite = vi.fn(async (params: CharacterRunSuiteParams) =>
+      makeSuiteResult({
+        outputDir: params.outputDir,
+        model: params.primaryModel,
+        transcript: "USER Alice: hi\n\nASSISTANT openclaw: outwardly fine",
+        summaryStatus: "fail",
+        summaryFailedCount: 1,
+      }),
+    );
+    const runJudge = makeRunJudge([
+      { model: "openai/gpt-5.5", rank: 1, score: 0.5, summary: "failed" },
+    ]);
+
+    const result = await runQaCharacterEval({
+      repoRoot: tempRoot,
+      outputDir: path.join(tempRoot, "character"),
+      models: ["openai/gpt-5.5"],
+      judgeModels: ["openai/gpt-5.5"],
+      runSuite,
+      runJudge,
+    });
+
+    expect(result.runs[0]?.status).toBe("fail");
+    expect(result.runs[0]?.error).toBeUndefined();
   });
 
   it("marks raw tool failure transcripts as failed output", async () => {

--- a/extensions/qa-lab/src/character-eval.ts
+++ b/extensions/qa-lab/src/character-eval.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { runQaManualLane } from "./manual-lane.runtime.js";
 import { isQaFastModeModelRef, type QaProviderMode } from "./model-selection.js";
 import {
   QA_FRONTIER_CHARACTER_EVAL_MODELS,
@@ -13,7 +12,7 @@ import {
 } from "./providers/live-frontier/character-eval.js";
 import type { QaThinkingLevel } from "./qa-gateway-config.js";
 import { extractQaVisibleReplyLeakText } from "./reply-failure.js";
-import { runQaSuiteFromRuntime } from "./suite-launch.runtime.js";
+import { readQaSuiteFailedScenarioCountFromFile } from "./suite-summary.js";
 import type { QaSuiteResult } from "./suite.js";
 
 const DEFAULT_CHARACTER_SCENARIO_ID = "character-vibes-gollum";
@@ -412,6 +411,7 @@ async function defaultRunJudge(params: {
   prompt: string;
   timeoutMs: number;
 }) {
+  const { runQaManualLane } = await import("./manual-lane.runtime.js");
   const result = await runQaManualLane({
     repoRoot: params.repoRoot,
     providerMode: "live-frontier",
@@ -423,6 +423,11 @@ async function defaultRunJudge(params: {
     timeoutMs: params.timeoutMs,
   });
   return result.reply;
+}
+
+async function defaultRunSuite(params: Parameters<RunSuiteFn>[0]) {
+  const { runQaSuiteFromRuntime } = await import("./suite-launch.runtime.js");
+  return await runQaSuiteFromRuntime(params);
 }
 
 function renderCharacterEvalReport(params: {
@@ -519,7 +524,7 @@ export async function runQaCharacterEval(params: QaCharacterEvalParams) {
   const runsDir = path.join(outputDir, "runs");
   await fs.mkdir(runsDir, { recursive: true });
 
-  const runSuite = params.runSuite ?? runQaSuiteFromRuntime;
+  const runSuite = params.runSuite ?? defaultRunSuite;
   const candidateConcurrency = normalizeConcurrency(
     params.candidateConcurrency,
     DEFAULT_CHARACTER_EVAL_CONCURRENCY,
@@ -560,10 +565,8 @@ export async function runQaCharacterEval(params: QaCharacterEvalParams) {
       });
       const transcript = extractTranscript(result);
       const transcriptFailure = detectTranscriptFailure(transcript);
-      const status =
-        result.scenarios.some((scenario) => scenario.status === "fail") || transcriptFailure
-          ? "fail"
-          : "pass";
+      const failedScenarioCount = await readQaSuiteFailedScenarioCountFromFile(result.summaryPath);
+      const status = failedScenarioCount > 0 || transcriptFailure ? "fail" : "pass";
       const run = {
         model,
         status,

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -119,11 +119,15 @@ describe("qa cli runtime", () => {
   let suiteArtifactsDir: string;
   let suiteReportPath: string;
   let suiteSummaryPath: string;
+  let telegramArtifactsDir: string;
+  let telegramSummaryPath: string;
 
   beforeEach(async () => {
     suiteArtifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-runtime-"));
     suiteReportPath = path.join(suiteArtifactsDir, "qa-suite-report.md");
     suiteSummaryPath = path.join(suiteArtifactsDir, "qa-suite-summary.json");
+    telegramArtifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-telegram-runtime-"));
+    telegramSummaryPath = path.join(telegramArtifactsDir, "telegram-qa-summary.json");
     await fs.writeFile(suiteReportPath, "# QA Suite Report\n", "utf8");
     await fs.writeFile(
       suiteSummaryPath,
@@ -131,6 +135,18 @@ describe("qa cli runtime", () => {
         counts: {
           total: 1,
           passed: 1,
+          failed: 0,
+        },
+        scenarios: [],
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      telegramSummaryPath,
+      JSON.stringify({
+        counts: {
+          total: 0,
+          passed: 0,
           failed: 0,
         },
         scenarios: [],
@@ -180,10 +196,10 @@ describe("qa cli runtime", () => {
       scenarioIds: ["channel-chat-baseline"],
     });
     runTelegramQaLive.mockResolvedValue({
-      outputDir: "/tmp/telegram",
-      reportPath: "/tmp/telegram/report.md",
-      summaryPath: "/tmp/telegram/summary.json",
-      observedMessagesPath: "/tmp/telegram/observed.json",
+      outputDir: telegramArtifactsDir,
+      reportPath: path.join(telegramArtifactsDir, "report.md"),
+      summaryPath: telegramSummaryPath,
+      observedMessagesPath: path.join(telegramArtifactsDir, "observed.json"),
       scenarios: [],
     });
     listTelegramQaScenarioCatalog.mockReturnValue([
@@ -221,6 +237,7 @@ describe("qa cli runtime", () => {
     stderrWrite.mockRestore();
     vi.clearAllMocks();
     await fs.rm(suiteArtifactsDir, { recursive: true, force: true });
+    await fs.rm(telegramArtifactsDir, { recursive: true, force: true });
   });
 
   it("resolves suite repo-root-relative paths before dispatching", async () => {
@@ -401,22 +418,23 @@ describe("qa cli runtime", () => {
     );
   });
 
-  it("sets a failing exit code when telegram scenarios fail", async () => {
+  it("sets a failing exit code when the telegram summary reports failures", async () => {
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
+    await fs.writeFile(
+      telegramSummaryPath,
+      JSON.stringify({
+        counts: { total: 1, passed: 1, failed: 0 },
+        scenarios: [{ status: "fail" }],
+      }),
+      "utf8",
+    );
     runTelegramQaLive.mockResolvedValueOnce({
-      outputDir: "/tmp/telegram",
-      reportPath: "/tmp/telegram/report.md",
-      summaryPath: "/tmp/telegram/summary.json",
-      observedMessagesPath: "/tmp/telegram/observed.json",
-      scenarios: [
-        {
-          id: "telegram-help-command",
-          title: "Telegram help command reply",
-          status: "fail",
-          details: "missing expected text",
-        },
-      ],
+      outputDir: telegramArtifactsDir,
+      reportPath: path.join(telegramArtifactsDir, "report.md"),
+      summaryPath: telegramSummaryPath,
+      observedMessagesPath: path.join(telegramArtifactsDir, "observed.json"),
+      scenarios: [],
     });
 
     try {
@@ -433,10 +451,10 @@ describe("qa cli runtime", () => {
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
     runTelegramQaLive.mockResolvedValueOnce({
-      outputDir: "/tmp/telegram",
-      reportPath: "/tmp/telegram/report.md",
-      summaryPath: "/tmp/telegram/summary.json",
-      observedMessagesPath: "/tmp/telegram/observed.json",
+      outputDir: telegramArtifactsDir,
+      reportPath: path.join(telegramArtifactsDir, "report.md"),
+      summaryPath: telegramSummaryPath,
+      observedMessagesPath: path.join(telegramArtifactsDir, "observed.json"),
       scenarios: [
         {
           id: "telegram-help-command",

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -503,13 +503,7 @@ describe("qa cli runtime", () => {
       watchUrl: "http://127.0.0.1:43124",
       reportPath: suiteReportPath,
       summaryPath: suiteSummaryPath,
-      scenarios: [
-        {
-          name: "channel chat baseline",
-          status: "fail",
-          steps: [],
-        },
-      ],
+      scenarios: [],
     });
 
     try {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -68,7 +68,7 @@ import {
 } from "./scenario-catalog.js";
 import { resolveQaScenarioPackScenarioIds } from "./scenario-packs.js";
 import { runQaSuiteFromRuntime } from "./suite-launch.runtime.js";
-import { readQaSuiteFailedScenarioCountFromSummary } from "./suite-summary.js";
+import { readQaSuiteFailedScenarioCountFromFile } from "./suite-summary.js";
 import {
   buildTokenEfficiencyReport,
   renderTokenEfficiencyMarkdownReport,
@@ -243,34 +243,6 @@ function resolveQaRuntimeParityTierScenarioIds(params: {
   return uniqueStrings([...params.scenarioIds, ...matchingScenarioIds]);
 }
 
-async function readQaFailedScenarioCountFromSummary(summaryPath: string) {
-  let summaryText: string;
-  try {
-    summaryText = await fs.readFile(summaryPath, "utf8");
-  } catch (error) {
-    throw new Error(
-      `Could not read QA summary JSON at ${summaryPath}: ${formatErrorMessage(error)}`,
-      { cause: error },
-    );
-  }
-  let payload: unknown;
-  try {
-    payload = JSON.parse(summaryText) as unknown;
-  } catch (error) {
-    throw new Error(
-      `Could not parse QA summary JSON at ${summaryPath}: ${formatErrorMessage(error)}`,
-      { cause: error },
-    );
-  }
-  const failedScenarioCount = readQaSuiteFailedScenarioCountFromSummary(payload);
-  if (failedScenarioCount !== null) {
-    return failedScenarioCount;
-  }
-  throw new Error(
-    `QA summary at ${summaryPath} did not include counts.failed or scenarios[].status.`,
-  );
-}
-
 function isQaSuiteInfraRetryableError(error: unknown) {
   const message = formatErrorMessage(error).toLowerCase();
   return (
@@ -299,7 +271,7 @@ async function assertQaSuiteArtifacts(result: { reportPath: string; summaryPath:
       { cause: error },
     );
   }
-  await readQaFailedScenarioCountFromSummary(result.summaryPath);
+  await readQaSuiteFailedScenarioCountFromFile(result.summaryPath);
 }
 
 async function runQaSuiteFromRuntimeWithInfraRetry(
@@ -352,7 +324,7 @@ async function runQaParityPreflight(params: {
   process.stdout.write(`QA parity preflight watch: ${result.watchUrl}\n`);
   process.stdout.write(`QA parity preflight report: ${result.reportPath}\n`);
   process.stdout.write(`QA parity preflight summary: ${result.summaryPath}\n`);
-  const failedScenarioCount = await readQaFailedScenarioCountFromSummary(result.summaryPath);
+  const failedScenarioCount = await readQaSuiteFailedScenarioCountFromFile(result.summaryPath);
   if (failedScenarioCount > 0) {
     if (params.allowFailures === true) {
       return;
@@ -667,7 +639,7 @@ export async function runQaSuiteCommand(opts: {
     process.stdout.write(`QA Multipass host log: ${result.hostLogPath}\n`);
     process.stdout.write(`QA Multipass bootstrap log: ${result.bootstrapLogPath}\n`);
     if (!allowFailures) {
-      const failedScenarioCount = await readQaFailedScenarioCountFromSummary(result.summaryPath);
+      const failedScenarioCount = await readQaSuiteFailedScenarioCountFromFile(result.summaryPath);
       if (failedScenarioCount > 0) {
         process.exitCode = 1;
       }
@@ -706,8 +678,8 @@ export async function runQaSuiteCommand(opts: {
   process.stdout.write(`QA suite watch: ${result.watchUrl}\n`);
   process.stdout.write(`QA suite report: ${result.reportPath}\n`);
   process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
-  const failedScenarioCount = await readQaFailedScenarioCountFromSummary(result.summaryPath);
-  if (!allowFailures && failedScenarioCount !== null && failedScenarioCount > 0) {
+  const failedScenarioCount = await readQaSuiteFailedScenarioCountFromFile(result.summaryPath);
+  if (!allowFailures && failedScenarioCount > 0) {
     process.exitCode = 1;
   }
 }

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -706,7 +706,7 @@ export async function runQaSuiteCommand(opts: {
   process.stdout.write(`QA suite watch: ${result.watchUrl}\n`);
   process.stdout.write(`QA suite report: ${result.reportPath}\n`);
   process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
-  const failedScenarioCount = readQaSuiteFailedScenarioCountFromSummary(result);
+  const failedScenarioCount = await readQaFailedScenarioCountFromSummary(result.summaryPath);
   if (!allowFailures && failedScenarioCount !== null && failedScenarioCount > 0) {
     process.exitCode = 1;
   }

--- a/extensions/qa-lab/src/gateway-rpc-client.test.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.test.ts
@@ -196,4 +196,34 @@ describe("startQaGatewayRpcClient", () => {
     await expect(secondRequest).resolves.toEqual({ ok: true });
     expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(2);
   });
+
+  it("rejects queued requests that have not started before stop", async () => {
+    let releaseFirst: (() => void) | null = null;
+    gatewayRpcMock.callGatewayFromCli.mockImplementationOnce(
+      async () =>
+        await new Promise<{ ok: boolean }>((resolve) => {
+          releaseFirst = () => resolve({ ok: true });
+        }),
+    );
+
+    const client = await startQaGatewayRpcClient({
+      wsUrl: "ws://127.0.0.1:18789",
+      token: "qa-token",
+      logs: () => "qa logs",
+    });
+
+    const firstRequest = client.request("health");
+    await Promise.resolve();
+    const secondRequest = client.request("status");
+    await Promise.resolve();
+
+    await client.stop();
+    expectReleaseCallback(releaseFirst)();
+
+    await expect(firstRequest).resolves.toEqual({ ok: true });
+    await expect(secondRequest).rejects.toThrow(
+      "gateway rpc client already stopped\nGateway logs:\nqa logs",
+    );
+    expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/qa-lab/src/gateway-rpc-client.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.ts
@@ -35,36 +35,42 @@ export async function startQaGatewayRpcClient(params: {
   const wrapError = (error: unknown) => formatQaGatewayRpcError(error, params.logs);
   let stopped = false;
   let queue = Promise.resolve();
+  const assertNotStopped = () => {
+    if (stopped) {
+      throw new Error("gateway rpc client already stopped");
+    }
+  };
 
   return {
     async request(method, rpcParams, opts) {
-      if (stopped) {
-        throw wrapError(new Error("gateway rpc client already stopped"));
+      try {
+        assertNotStopped();
+      } catch (error) {
+        throw wrapError(error);
       }
       try {
-        const { run, nextQueue } = runQueuedQaGatewayRpc(
-          queue,
-          async () =>
-            await callGatewayFromCli(
-              method,
-              {
-                url: params.wsUrl,
-                token: params.token,
-                timeout: String(opts?.timeoutMs ?? 20_000),
-                expectFinal: opts?.expectFinal,
-                json: true,
-              },
-              rpcParams ?? {},
-              {
-                clientName: "gateway-client",
-                deviceIdentity: null,
-                expectFinal: opts?.expectFinal,
-                mode: "backend",
-                progress: false,
-                scopes: ["operator.admin"],
-              },
-            ),
-        );
+        const { run, nextQueue } = runQueuedQaGatewayRpc(queue, async () => {
+          assertNotStopped();
+          return await callGatewayFromCli(
+            method,
+            {
+              url: params.wsUrl,
+              token: params.token,
+              timeout: String(opts?.timeoutMs ?? 20_000),
+              expectFinal: opts?.expectFinal,
+              json: true,
+            },
+            rpcParams ?? {},
+            {
+              clientName: "gateway-client",
+              deviceIdentity: null,
+              expectFinal: opts?.expectFinal,
+              mode: "backend",
+              progress: false,
+              scopes: ["operator.admin"],
+            },
+          );
+        });
         queue = nextQueue;
         return await run;
       } catch (error) {

--- a/extensions/qa-lab/src/live-transports/discord/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/cli.runtime.ts
@@ -1,3 +1,4 @@
+import { readQaSuiteFailedScenarioCountFromFile } from "../../suite-summary.js";
 // Qa Lab plugin module implements cli behavior.
 import { printLiveTransportQaArtifacts } from "../shared/live-artifacts.js";
 import type { LiveTransportQaCommandOptions } from "../shared/live-transport-cli.js";
@@ -14,10 +15,10 @@ export async function runQaDiscordCommand(opts: LiveTransportQaCommandOptions) {
     ...(result.reactionTimelinesPath ? { "reaction timelines": result.reactionTimelinesPath } : {}),
     ...(result.gatewayDebugDirPath ? { "gateway debug logs": result.gatewayDebugDirPath } : {}),
   });
-  if (
-    !runOptions.allowFailures &&
-    result.scenarios.some((scenario) => scenario.status === "fail")
-  ) {
-    process.exitCode = 1;
+  if (!runOptions.allowFailures) {
+    const failedScenarioCount = await readQaSuiteFailedScenarioCountFromFile(result.summaryPath);
+    if (failedScenarioCount > 0) {
+      process.exitCode = 1;
+    }
   }
 }

--- a/extensions/qa-lab/src/live-transports/slack/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/cli.runtime.ts
@@ -1,3 +1,4 @@
+import { readQaSuiteFailedScenarioCountFromFile } from "../../suite-summary.js";
 // Qa Lab plugin module implements cli behavior.
 import { printLiveTransportQaArtifacts } from "../shared/live-artifacts.js";
 import type { LiveTransportQaCommandOptions } from "../shared/live-transport-cli.js";
@@ -13,10 +14,10 @@ export async function runQaSlackCommand(opts: LiveTransportQaCommandOptions) {
     "observed messages": result.observedMessagesPath,
     ...(result.gatewayDebugDirPath ? { "gateway debug logs": result.gatewayDebugDirPath } : {}),
   });
-  if (
-    !runOptions.allowFailures &&
-    result.scenarios.some((scenario) => scenario.status === "fail")
-  ) {
-    process.exitCode = 1;
+  if (!runOptions.allowFailures) {
+    const failedScenarioCount = await readQaSuiteFailedScenarioCountFromFile(result.summaryPath);
+    if (failedScenarioCount > 0) {
+      process.exitCode = 1;
+    }
   }
 }

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
@@ -1,3 +1,4 @@
+import { readQaSuiteFailedScenarioCountFromFile } from "../../suite-summary.js";
 // Qa Lab plugin module implements cli behavior.
 import { printLiveTransportQaArtifacts } from "../shared/live-artifacts.js";
 import type { LiveTransportQaCommandOptions } from "../shared/live-transport-cli.js";
@@ -23,10 +24,10 @@ export async function runQaTelegramCommand(opts: LiveTransportQaCommandOptions) 
     summary: result.summaryPath,
     "observed messages": result.observedMessagesPath,
   });
-  if (
-    !runOptions.allowFailures &&
-    result.scenarios.some((scenario) => scenario.status === "fail")
-  ) {
-    process.exitCode = 1;
+  if (!runOptions.allowFailures) {
+    const failedScenarioCount = await readQaSuiteFailedScenarioCountFromFile(result.summaryPath);
+    if (failedScenarioCount > 0) {
+      process.exitCode = 1;
+    }
   }
 }

--- a/extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/cli.runtime.ts
@@ -1,3 +1,4 @@
+import { readQaSuiteFailedScenarioCountFromFile } from "../../suite-summary.js";
 // Qa Lab plugin module implements cli behavior.
 import { printLiveTransportQaArtifacts } from "../shared/live-artifacts.js";
 import type { LiveTransportQaCommandOptions } from "../shared/live-transport-cli.js";
@@ -13,10 +14,10 @@ export async function runQaWhatsAppCommand(opts: LiveTransportQaCommandOptions) 
     "observed messages": result.observedMessagesPath,
     ...(result.gatewayDebugDirPath ? { "gateway debug logs": result.gatewayDebugDirPath } : {}),
   });
-  if (
-    !runOptions.allowFailures &&
-    result.scenarios.some((scenario) => scenario.status === "fail")
-  ) {
-    process.exitCode = 1;
+  if (!runOptions.allowFailures) {
+    const failedScenarioCount = await readQaSuiteFailedScenarioCountFromFile(result.summaryPath);
+    if (failedScenarioCount > 0) {
+      process.exitCode = 1;
+    }
   }
 }

--- a/extensions/qa-lab/src/suite-summary.test.ts
+++ b/extensions/qa-lab/src/suite-summary.test.ts
@@ -1,7 +1,11 @@
 // Qa Lab tests cover suite summary plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   countQaSuiteFailedScenarios,
+  readQaSuiteFailedScenarioCountFromFile,
   readQaSuiteFailedScenarioCountFromSummary,
 } from "./suite-summary.js";
 
@@ -40,5 +44,38 @@ describe("qa suite summary helpers", () => {
   it("returns null for unsupported summary shapes", () => {
     expect(readQaSuiteFailedScenarioCountFromSummary({ counts: { total: 2 } })).toBeNull();
     expect(readQaSuiteFailedScenarioCountFromSummary("not-json-object")).toBeNull();
+  });
+
+  it("reads failed scenario counts from summary files", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-summary-"));
+    const summaryPath = path.join(outputDir, "qa-suite-summary.json");
+    await fs.writeFile(
+      summaryPath,
+      JSON.stringify({
+        counts: { failed: 0 },
+        scenarios: [{ status: "fail" }],
+      }),
+      "utf8",
+    );
+
+    try {
+      await expect(readQaSuiteFailedScenarioCountFromFile(summaryPath)).resolves.toBe(1);
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails summary files without a failure signal", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-summary-"));
+    const summaryPath = path.join(outputDir, "qa-suite-summary.json");
+    await fs.writeFile(summaryPath, JSON.stringify({ counts: { total: 1 } }), "utf8");
+
+    try {
+      await expect(readQaSuiteFailedScenarioCountFromFile(summaryPath)).rejects.toThrow(
+        "did not include counts.failed or scenarios[].status",
+      );
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/qa-lab/src/suite-summary.test.ts
+++ b/extensions/qa-lab/src/suite-summary.test.ts
@@ -12,7 +12,14 @@ describe("qa suite summary helpers", () => {
     ).toBe(2);
   });
 
-  it("prefers counts.failed when available", () => {
+  it("uses the larger failure signal when counts and scenarios disagree", () => {
+    expect(
+      readQaSuiteFailedScenarioCountFromSummary({
+        counts: { failed: 0 },
+        scenarios: [{ status: "pass" }, { status: "fail" }],
+      }),
+    ).toBe(1);
+
     expect(
       readQaSuiteFailedScenarioCountFromSummary({
         counts: { failed: 3.8 },

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -1,4 +1,6 @@
 // Qa Lab plugin module implements suite summary behavior.
+import fs from "node:fs/promises";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { QaProviderMode } from "./model-selection.js";
 import type { RuntimeId, RuntimeParityResult } from "./runtime-parity.js";
 
@@ -93,4 +95,32 @@ export function readQaSuiteFailedScenarioCountFromSummary(summary: unknown): num
     return scenarioFailures;
   }
   return countedFailures;
+}
+
+export async function readQaSuiteFailedScenarioCountFromFile(summaryPath: string): Promise<number> {
+  let summaryText: string;
+  try {
+    summaryText = await fs.readFile(summaryPath, "utf8");
+  } catch (error) {
+    throw new Error(
+      `Could not read QA summary JSON at ${summaryPath}: ${formatErrorMessage(error)}`,
+      { cause: error },
+    );
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(summaryText) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Could not parse QA summary JSON at ${summaryPath}: ${formatErrorMessage(error)}`,
+      { cause: error },
+    );
+  }
+  const failedScenarioCount = readQaSuiteFailedScenarioCountFromSummary(payload);
+  if (failedScenarioCount !== null) {
+    return failedScenarioCount;
+  }
+  throw new Error(
+    `QA summary at ${summaryPath} did not include counts.failed or scenarios[].status.`,
+  );
 }

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -79,11 +79,18 @@ export function readQaSuiteFailedScenarioCountFromSummary(summary: unknown): num
     };
     scenarios?: Array<QaSuiteScenarioStatus>;
   };
-  if (typeof payload.counts?.failed === "number" && Number.isFinite(payload.counts.failed)) {
-    return Math.max(0, Math.floor(payload.counts.failed));
+  const countedFailures =
+    typeof payload.counts?.failed === "number" && Number.isFinite(payload.counts.failed)
+      ? Math.max(0, Math.floor(payload.counts.failed))
+      : null;
+  const scenarioFailures = Array.isArray(payload.scenarios)
+    ? countQaSuiteFailedScenarios(payload.scenarios)
+    : null;
+  if (countedFailures !== null && scenarioFailures !== null) {
+    return Math.max(countedFailures, scenarioFailures);
   }
-  if (Array.isArray(payload.scenarios)) {
-    return countQaSuiteFailedScenarios(payload.scenarios);
+  if (scenarioFailures !== null) {
+    return scenarioFailures;
   }
-  return null;
+  return countedFailures;
 }

--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -120,6 +120,7 @@ type StoppableGatewayChild = {
 };
 
 type ClosableLogFile = {
+  appendFile?(data: string | Uint8Array): Promise<void>;
   close(): Promise<void>;
 };
 
@@ -520,11 +521,32 @@ async function startGatewayProcess(params: {
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
-  child.stdout.on("data", (chunk) => void logFile.appendFile(chunk));
-  child.stderr.on("data", (chunk) => void logFile.appendFile(chunk));
+  const pendingLogWrites = new Set<Promise<void>>();
+  const logWriteErrors: unknown[] = [];
+  const trackLogWrite = (chunk: Buffer) => {
+    const write = logFile.appendFile(chunk).catch((error: unknown) => {
+      logWriteErrors.push(error);
+      throw error;
+    });
+    pendingLogWrites.add(write);
+    void write
+      .finally(() => {
+        pendingLogWrites.delete(write);
+      })
+      .catch(() => undefined);
+  };
+  child.stdout.on("data", trackLogWrite);
+  child.stderr.on("data", trackLogWrite);
   return {
     async stop(): Promise<boolean> {
-      return await stopGatewayPromptChild(child, logFile);
+      return await stopGatewayPromptChild(
+        child,
+        logFile,
+        1_500,
+        1_500,
+        pendingLogWrites,
+        logWriteErrors,
+      );
     },
   };
 }
@@ -534,6 +556,8 @@ async function stopGatewayPromptChild(
   logFile: ClosableLogFile,
   sigintTimeoutMs = 1_500,
   sigkillTimeoutMs = 1_500,
+  pendingLogWrites: Iterable<Promise<void>> = [],
+  logWriteErrors: readonly unknown[] = [],
 ): Promise<boolean> {
   let exited = child.exitCode !== null || child.signalCode !== null;
   const exitPromise = exited
@@ -560,7 +584,14 @@ async function stopGatewayPromptChild(
       () => false,
     );
   }
+  const failedLogWrite = (await Promise.allSettled(pendingLogWrites)).find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
   await logFile.close();
+  const logWriteError = failedLogWrite?.reason ?? logWriteErrors[0];
+  if (logWriteError) {
+    throw new Error(`Anthropic prompt gateway log write failed: ${String(logWriteError)}`);
+  }
   return exited;
 }
 

--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -61,6 +61,12 @@ const GATEWAY_TIMEOUT_MS = parseStrictIntegerOption({
   min: 1,
   raw: process.env.OPENCLAW_PROMPT_GATEWAY_TIMEOUT_MS,
 });
+const CAPTURE_PROXY_MAX_BODY_BYTES = parseStrictIntegerOption({
+  fallback: 2 * 1024 * 1024,
+  label: "OPENCLAW_PROMPT_CAPTURE_MAX_BODY_BYTES",
+  min: 1,
+  raw: process.env.OPENCLAW_PROMPT_CAPTURE_MAX_BODY_BYTES,
+});
 const SETUP_TOKEN_RAW = process.env.OPENCLAW_LIVE_SETUP_TOKEN?.trim() ?? "";
 const SETUP_TOKEN_VALUE = process.env.OPENCLAW_LIVE_SETUP_TOKEN_VALUE?.trim() ?? "";
 const SETUP_TOKEN_PROFILE = process.env.OPENCLAW_LIVE_SETUP_TOKEN_PROFILE?.trim() ?? "";
@@ -284,12 +290,22 @@ async function withTimeout<T>(
   return await Promise.race([promise, sleep(timeoutMs).then(() => fallback())]);
 }
 
-async function readRequestBody(req: http.IncomingMessage): Promise<Buffer> {
+async function readRequestBody(
+  req: http.IncomingMessage,
+  maxBytes = CAPTURE_PROXY_MAX_BODY_BYTES,
+): Promise<Buffer> {
   const chunks: Buffer[] = [];
+  let totalBytes = 0;
   for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.length;
+    if (totalBytes > maxBytes) {
+      req.destroy();
+      throw new Error(`Anthropic capture proxy request body exceeded ${maxBytes} bytes`);
+    }
+    chunks.push(buffer);
   }
-  return Buffer.concat(chunks);
+  return Buffer.concat(chunks, totalBytes);
 }
 
 function extractProxyCapture(rawBody: string, req: http.IncomingMessage): ProxyCapture {
@@ -799,6 +815,7 @@ export const testing = {
   cleanupPromptProbeTmpDir,
   matchesExtraUsage400,
   promptProbeTmpResult,
+  readRequestBody,
   resolveAnthropicUpstreamUrl,
   stopGatewayPromptChild,
   summarizeCapture,

--- a/scripts/check-cli-startup-memory.mjs
+++ b/scripts/check-cli-startup-memory.mjs
@@ -20,7 +20,10 @@ let rssHookPath = null;
 
 function readPositiveIntEnv(name, fallback, env = process.env) {
   const value = readPositiveNumberEnv(name, fallback, env);
-  return Number.isInteger(value) ? value : fallback;
+  if (!Number.isInteger(value)) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
 }
 
 function readPositiveNumberEnv(name, fallback, env = process.env) {
@@ -30,10 +33,13 @@ function readPositiveNumberEnv(name, fallback, env = process.env) {
   }
   const text = raw.trim();
   if (!/^(?:\d+(?:\.\d+)?|\.\d+)$/u.test(text)) {
-    return fallback;
+    throw new Error(`${name} must be a positive number`);
   }
   const value = Number(text);
-  return Number.isFinite(value) && value > 0 ? value : fallback;
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+  return value;
 }
 
 function readNonEmptyEnv(name) {

--- a/scripts/e2e/kitchen-sink-rpc-walk.mjs
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mjs
@@ -245,6 +245,7 @@ export function runCommand(command, args, options = {}) {
       resourceSampleIntervalMs = 1000,
       resourceSampleOptions,
       resourceSamples,
+      requireResourceSample = false,
       sampleProcessImpl = sampleProcess,
       timeoutKillGraceMs = 2000,
       timeoutMs = config.commandTimeoutMs,
@@ -262,6 +263,8 @@ export function runCommand(command, args, options = {}) {
     let forceKillTimer;
     let sampleTimer;
     let resourceSampleInFlight = null;
+    let capturedResourceSampleCount = 0;
+    let lastResourceSampleError = null;
     const commandLabel = resourceLabel ?? [command, ...args.slice(0, 2)].join(" ");
     const shouldSampleResources = Array.isArray(resourceSamples);
     const collectResourceSample = () => {
@@ -272,6 +275,7 @@ export function runCommand(command, args, options = {}) {
         .then(() => sampleProcessImpl(child.pid, resourceSampleOptions ?? {}))
         .then((sample) => {
           if (sample) {
+            capturedResourceSampleCount += 1;
             resourceSamples.push({
               ...sample,
               elapsedMs: Date.now() - startedAt,
@@ -279,7 +283,9 @@ export function runCommand(command, args, options = {}) {
             });
           }
         })
-        .catch(() => {})
+        .catch((error) => {
+          lastResourceSampleError = error;
+        })
         .finally(() => {
           resourceSampleInFlight = null;
         });
@@ -288,6 +294,12 @@ export function runCommand(command, args, options = {}) {
     const stopResourceSampling = async () => {
       clearInterval(sampleTimer);
       await resourceSampleInFlight?.catch(() => {});
+      if (requireResourceSample && capturedResourceSampleCount === 0) {
+        const detail =
+          lastResourceSampleError instanceof Error ? `: ${lastResourceSampleError.message}` : "";
+        return new Error(`${commandLabel} RSS sample was not captured${detail}`);
+      }
+      return null;
     };
     if (shouldSampleResources) {
       void collectResourceSample();
@@ -321,8 +333,12 @@ export function runCommand(command, args, options = {}) {
     child.on("close", (status, signal) => {
       clearTimeout(timer);
       clearTimeout(forceKillTimer);
-      void stopResourceSampling().then(() => {
+      void stopResourceSampling().then((resourceSampleFailure) => {
         if (!timedOut && status === 0) {
+          if (resourceSampleFailure) {
+            reject(resourceSampleFailure);
+            return;
+          }
           resolve({
             stdout: stdout.text,
             stderr: stderr.text,
@@ -379,6 +395,7 @@ async function runOpenClaw(runner, args, env, options = {}) {
     resourceSampleIntervalMs: options.resourceSampleIntervalMs,
     resourceSampleOptions: options.resourceSampleOptions,
     resourceSamples: options.resourceSamples,
+    requireResourceSample: options.requireResourceSample,
     timeoutMs: options.timeoutMs ?? config.commandTimeoutMs,
   });
 }
@@ -1775,6 +1792,7 @@ export async function main() {
     console.log(`Kitchen Sink RPC walk using ${PLUGIN_SPEC} via ${runner.label}`);
     await runOpenClaw(runner, ["plugins", "install", PLUGIN_SPEC], env, {
       ...commandResourceOptions,
+      requireResourceSample: true,
       resourceLabel: "plugins install",
       timeoutMs: config.installTimeoutMs,
     });

--- a/scripts/e2e/lib/release-user-journey/assertions.mjs
+++ b/scripts/e2e/lib/release-user-journey/assertions.mjs
@@ -16,13 +16,18 @@ const SCAN_CARRY_CHARS = 256;
 const ERROR_DETAIL_TAIL_BYTES = 16 * 1024;
 
 function clickClackHttpTimeoutMs() {
-  return readPositiveInt(process.env.OPENCLAW_RELEASE_USER_JOURNEY_HTTP_TIMEOUT_MS, 5000);
+  return readPositiveInt(
+    process.env.OPENCLAW_RELEASE_USER_JOURNEY_HTTP_TIMEOUT_MS,
+    5000,
+    "OPENCLAW_RELEASE_USER_JOURNEY_HTTP_TIMEOUT_MS",
+  );
 }
 
 function clickClackHttpBodyMaxBytes() {
   return readPositiveInt(
     process.env.OPENCLAW_RELEASE_USER_JOURNEY_HTTP_BODY_MAX_BYTES,
     1024 * 1024,
+    "OPENCLAW_RELEASE_USER_JOURNEY_HTTP_BODY_MAX_BYTES",
   );
 }
 
@@ -30,13 +35,19 @@ function readJson(file) {
   return JSON.parse(fs.readFileSync(file, "utf8"));
 }
 
-function readPositiveInt(raw, fallback) {
+function readPositiveInt(raw, fallback, label) {
   const text = String(raw ?? "").trim();
-  if (!/^\d+$/u.test(text)) {
+  if (!text) {
     return fallback;
   }
+  if (!/^\d+$/u.test(text)) {
+    throw new Error(`${label} must be a positive integer. Got: ${JSON.stringify(text)}`);
+  }
   const parsed = Number(text);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer. Got: ${JSON.stringify(text)}`);
+  }
+  return parsed;
 }
 
 function fileContainsText(file, needle) {

--- a/scripts/e2e/npm-telegram-live-runner.ts
+++ b/scripts/e2e/npm-telegram-live-runner.ts
@@ -25,6 +25,18 @@ function resolveCredentialRole(env: NodeJS.ProcessEnv) {
   return env.OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE ?? env.OPENCLAW_QA_CREDENTIAL_ROLE;
 }
 
+async function shouldFailPackageTelegramRun(
+  result: { summaryPath: string },
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  if (parseBoolean(env.OPENCLAW_NPM_TELEGRAM_ALLOW_FAILURES)) {
+    return false;
+  }
+  const { readQaSuiteFailedScenarioCountFromFile } =
+    await import("../../extensions/qa-lab/src/suite-summary.ts");
+  return (await readQaSuiteFailedScenarioCountFromFile(result.summaryPath)) > 0;
+}
+
 async function resolveTrustedOpenClawCommand(rawCommand: string) {
   if (!path.isAbsolute(rawCommand)) {
     throw new Error("OPENCLAW_NPM_TELEGRAM_SUT_COMMAND must be an absolute path.");
@@ -80,10 +92,7 @@ async function main() {
   process.stdout.write(`Package Telegram QA report: ${result.reportPath}\n`);
   process.stdout.write(`Package Telegram QA summary: ${result.summaryPath}\n`);
   process.stdout.write(`Package Telegram QA observed messages: ${result.observedMessagesPath}\n`);
-  if (
-    !parseBoolean(process.env.OPENCLAW_NPM_TELEGRAM_ALLOW_FAILURES) &&
-    result.scenarios.some((scenario) => scenario.status === "fail")
-  ) {
+  if (await shouldFailPackageTelegramRun(result)) {
     process.exitCode = 1;
   }
 }
@@ -109,5 +118,6 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 export const testing = {
   resolveCredentialRole,
   resolveCredentialSource,
+  shouldFailPackageTelegramRun,
 };
 export { testing as __testing };

--- a/scripts/lib/channel-contract-test-plan.mjs
+++ b/scripts/lib/channel-contract-test-plan.mjs
@@ -1,29 +1,9 @@
 // Builds balanced Vitest shard plans for channel plugin contract tests.
-import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
-import { join, relative } from "node:path";
+import { relative } from "node:path";
+import { listTrackedTestFiles } from "./list-test-files.mjs";
 
 function listContractTestFiles(rootDir = "src/channels/plugins/contracts") {
-  const result = spawnSync("git", ["ls-files", "--", rootDir], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  if (result.status === 0) {
-    return result.stdout
-      .split("\n")
-      .map((line) => line.trim().replaceAll("\\", "/"))
-      .filter((line) => line.endsWith(".test.ts"))
-      .toSorted((a, b) => a.localeCompare(b));
-  }
-
-  if (!existsSync(rootDir)) {
-    return [];
-  }
-
-  return readdirSync(rootDir, { withFileTypes: true })
-    .filter((entry) => entry.isFile() && entry.name.endsWith(".test.ts"))
-    .map((entry) => join(rootDir, entry.name).replaceAll("\\", "/"))
-    .toSorted((a, b) => a.localeCompare(b));
+  return listTrackedTestFiles(rootDir);
 }
 
 const CONTRACT_FILE_WEIGHTS = new Map([

--- a/scripts/lib/plugin-gateway-gauntlet.mjs
+++ b/scripts/lib/plugin-gateway-gauntlet.mjs
@@ -492,16 +492,51 @@ function validateQaSuiteSummary(summary) {
   if (
     !summary.counts ||
     typeof summary.counts !== "object" ||
-    !Number.isFinite(summary.counts.total) ||
-    !Number.isFinite(summary.counts.passed) ||
-    !Number.isFinite(summary.counts.failed)
+    !isNonNegativeInteger(summary.counts.total) ||
+    !isNonNegativeInteger(summary.counts.passed) ||
+    !isNonNegativeInteger(summary.counts.failed)
   ) {
     return "QA suite summary missing numeric counts";
   }
   if (!summary.run || typeof summary.run !== "object" || Array.isArray(summary.run)) {
     return "QA suite summary missing run metadata";
   }
+  const statusCounts = { failed: 0, passed: 0, skipped: 0 };
+  for (const scenario of summary.scenarios) {
+    if (!scenario || typeof scenario !== "object" || Array.isArray(scenario)) {
+      return "QA suite summary scenario entries must be objects";
+    }
+    if (scenario.status === "pass") {
+      statusCounts.passed += 1;
+    } else if (scenario.status === "fail") {
+      statusCounts.failed += 1;
+    } else if (scenario.status === "skip") {
+      statusCounts.skipped += 1;
+    } else {
+      return `QA suite summary scenario has invalid status: ${String(scenario.status)}`;
+    }
+  }
+  if (summary.counts.total !== summary.scenarios.length) {
+    return `QA suite summary total count mismatch: counts.total=${summary.counts.total}, scenarios=${summary.scenarios.length}`;
+  }
+  if (summary.counts.passed !== statusCounts.passed) {
+    return `QA suite summary passed count mismatch: counts.passed=${summary.counts.passed}, passed scenarios=${statusCounts.passed}`;
+  }
+  if (summary.counts.failed !== statusCounts.failed) {
+    return `QA suite summary failed count mismatch: counts.failed=${summary.counts.failed}, failed scenarios=${statusCounts.failed}`;
+  }
+  if (
+    summary.counts.skipped !== undefined &&
+    (!isNonNegativeInteger(summary.counts.skipped) ||
+      summary.counts.skipped !== statusCounts.skipped)
+  ) {
+    return `QA suite summary skipped count mismatch: counts.skipped=${String(summary.counts.skipped)}, skipped scenarios=${statusCounts.skipped}`;
+  }
   return null;
+}
+
+function isNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0;
 }
 
 export {

--- a/scripts/mcp-code-mode-gateway-e2e.ts
+++ b/scripts/mcp-code-mode-gateway-e2e.ts
@@ -87,6 +87,14 @@ async function readSessionLogMentions(stateDir: string): Promise<Record<string, 
   });
 }
 
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
 async function writeProbeMcpServer(serverPath: string) {
   const sdkMcpServerPath = require.resolve("@modelcontextprotocol/sdk/server/mcp.js");
   const sdkStdioServerPath = require.resolve("@modelcontextprotocol/sdk/server/stdio.js");
@@ -207,6 +215,11 @@ async function writeConfig(params: {
 export async function main() {
   const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mcp-code-mode-"));
   const keep = process.env.OPENCLAW_MCP_CODE_MODE_GATEWAY_E2E_KEEP === "1";
+  const previousEnv = {
+    configPath: process.env.OPENCLAW_CONFIG_PATH,
+    stateDir: process.env.OPENCLAW_STATE_DIR,
+    testFast: process.env.OPENCLAW_TEST_FAST,
+  };
   let provider: Awaited<ReturnType<typeof startQaMockOpenAiServer>> | undefined;
   let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
   try {
@@ -300,9 +313,9 @@ export async function main() {
     await server?.close({ reason: "mcp code-mode gateway e2e complete" });
     await provider?.stop();
     resetConfigRuntimeState();
-    delete process.env.OPENCLAW_STATE_DIR;
-    delete process.env.OPENCLAW_CONFIG_PATH;
-    delete process.env.OPENCLAW_TEST_FAST;
+    restoreEnvValue("OPENCLAW_STATE_DIR", previousEnv.stateDir);
+    restoreEnvValue("OPENCLAW_CONFIG_PATH", previousEnv.configPath);
+    restoreEnvValue("OPENCLAW_TEST_FAST", previousEnv.testFast);
     if (!keep) {
       await fs.rm(rootDir, { recursive: true, force: true });
     }

--- a/scripts/measure-rpc-rtt.mjs
+++ b/scripts/measure-rpc-rtt.mjs
@@ -487,7 +487,7 @@ function toText(data) {
   return Buffer.from(data).toString("utf8");
 }
 
-function createGatewayClient({ WebSocket, url }) {
+export function createGatewayClient({ WebSocket, openTimeoutMs = 8_000, url }) {
   const ws = new WebSocket(url, { handshakeTimeout: 8_000 });
   const pending = new Map();
   const rejectPending = (error) => {
@@ -522,15 +522,28 @@ function createGatewayClient({ WebSocket, url }) {
   });
   const waitOpen = async () =>
     await new Promise((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error("gateway websocket open timeout")), 8_000);
-      ws.once("open", () => {
+      let settled = false;
+      const settle = (callback) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
         clearTimeout(timer);
-        resolve();
-      });
-      ws.once("error", (error) => {
-        clearTimeout(timer);
-        reject(error instanceof Error ? error : new Error(String(error)));
-      });
+        ws.off?.("open", onOpen);
+        ws.off?.("error", onError);
+        callback();
+      };
+      const onOpen = () => settle(resolve);
+      const onError = (error) =>
+        settle(() => reject(error instanceof Error ? error : new Error(String(error))));
+      const timer = setTimeout(() => {
+        settle(() => {
+          ws.close();
+          reject(new Error("gateway websocket open timeout"));
+        });
+      }, openTimeoutMs);
+      ws.once("open", onOpen);
+      ws.once("error", onError);
     });
   const request = async (method, params, timeoutMs = 10_000) =>
     await new Promise((resolve, reject) => {
@@ -622,6 +635,7 @@ async function main() {
   const stdoutPath = path.join(tempRoot, "gateway.stdout.log");
   const stderrPath = path.join(tempRoot, "gateway.stderr.log");
   let gatewayChild;
+  let client;
   let removeGatewayParentCleanup = () => {};
   let status = "fail";
   let details = "";
@@ -663,7 +677,7 @@ async function main() {
     const protocol = await import(
       pathToFileURL(path.join(repoRoot, "packages/gateway-protocol/src/version.ts")).href
     );
-    const client = createGatewayClient({ WebSocket, url: `ws://127.0.0.1:${port}` });
+    client = createGatewayClient({ WebSocket, url: `ws://127.0.0.1:${port}` });
     await client.waitOpen();
     const connectStarted = performance.now();
     const connect = await client.request(
@@ -722,7 +736,6 @@ async function main() {
         });
       }
     }
-    client.close();
     const sampleStats = summarizeRttSamples(samples.map((sample) => sample.durationMs));
     const byMethod = Object.fromEntries(
       args.methods.map((method) => [
@@ -749,6 +762,7 @@ async function main() {
     details = error instanceof Error ? (error.stack ?? error.message) : String(error);
   } finally {
     try {
+      client?.close();
       if (gatewayChild) {
         await stopGateway(gatewayChild).catch(() => {});
       }

--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -3913,11 +3913,16 @@ async function runCommandInvocation(invocation, options) {
 export async function startStaticFileServer(params) {
   mkdirSync(dirname(params.logPath), { recursive: true });
   const logStream = createWriteStream(params.logPath, { flags: "a" });
+  let logStreamError = null;
+  logStream.on("error", (error) => {
+    logStreamError ??= error;
+  });
   const fileName = String(params.filePath.split(/[/\\]/u).at(-1) ?? "artifact");
   const fileStat = statSync(params.filePath);
   const sockets = new Set<Socket>();
   const server = createServer((request, response) => {
     logStream.write(`${new Date().toISOString()} ${request.method} ${request.url}\n`);
+    response.setHeader("connection", "close");
     if (request.url !== `/${fileName}`) {
       response.statusCode = 404;
       response.end("not found");
@@ -3926,7 +3931,6 @@ export async function startStaticFileServer(params) {
     response.statusCode = 200;
     response.setHeader("content-type", resolveStaticFileContentType(params.filePath));
     response.setHeader("content-length", String(fileStat.size));
-    response.setHeader("connection", "close");
     const fileStream = createReadStream(params.filePath);
     fileStream.once("error", (error) => {
       logStream.write(`${new Date().toISOString()} static-file-read-error ${formatError(error)}\n`);
@@ -3955,23 +3959,68 @@ export async function startStaticFileServer(params) {
     throw new Error("Failed to bind static file server.");
   }
   const port = address.port;
+  let closePromise;
   return {
     url: `http://127.0.0.1:${port}/${fileName}`,
-    close: () =>
-      new Promise((resolvePromise, rejectPromise) => {
-        server.close((error) => {
-          logStream.end();
+    close: () => {
+      closePromise ??= new Promise((resolvePromise, rejectPromise) => {
+        closeStaticFileServerConnections(server, sockets);
+        server.close(async (error) => {
+          const closeLogError = await finishStaticFileServerLog(logStream, logStreamError).catch(
+            (logError) => logError,
+          );
           if (error) {
             rejectPromise(error);
             return;
           }
+          if (closeLogError) {
+            rejectPromise(closeLogError);
+            return;
+          }
           resolvePromise();
         });
-        for (const socket of sockets) {
-          socket.destroy();
-        }
-      }),
+        closeStaticFileServerConnections(server, sockets);
+      });
+      return closePromise;
+    },
   };
+}
+
+function closeStaticFileServerConnections(server, sockets) {
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  if (typeof server.closeAllConnections === "function") {
+    server.closeAllConnections();
+  }
+}
+
+function finishStaticFileServerLog(logStream, pendingError) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    if (pendingError) {
+      logStream.destroy();
+      rejectPromise(new Error(`Static file server log write failed: ${formatError(pendingError)}`));
+      return;
+    }
+    let completed = false;
+    const finish = () => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      resolvePromise();
+    };
+    const fail = (error) => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      rejectPromise(new Error(`Static file server log write failed: ${formatError(error)}`));
+    };
+    logStream.once("finish", finish);
+    logStream.once("error", fail);
+    logStream.end();
+  });
 }
 
 export function resolveStaticFileContentType(filePath) {

--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -3785,14 +3785,33 @@ async function runCommandInvocation(invocation, options) {
       }
     };
 
+    const finishLogStream = (callback) => {
+      let completed = false;
+      const finish = (error) => {
+        if (completed) {
+          return;
+        }
+        completed = true;
+        callback(error);
+      };
+      logStream.once("finish", finish);
+      logStream.once("error", finish);
+      logStream.end();
+    };
+
     const finalize = (callback) => {
       if (settled) {
         return;
       }
       settled = true;
       clearTimers();
-      logStream.end();
-      callback();
+      finishLogStream((logError) => {
+        if (logError) {
+          rejectPromise(new Error(`Command log write failed: ${formatError(logError)}`));
+          return;
+        }
+        callback();
+      });
     };
 
     const requestKill = () => {

--- a/scripts/openclaw-performance-source-summary.mjs
+++ b/scripts/openclaw-performance-source-summary.mjs
@@ -145,15 +145,27 @@ function table(headers, rows) {
 
 function validateMockHelloSummary(summary, filePath) {
   const counts = summary?.counts;
+  const scenarios = Array.isArray(summary?.scenarios) ? summary.scenarios : null;
   if (
-    !finiteNumber(counts?.total) ||
-    !finiteNumber(counts?.passed) ||
-    !finiteNumber(counts?.failed) ||
+    !isNonNegativeInteger(counts?.total) ||
+    !isNonNegativeInteger(counts?.passed) ||
+    !isNonNegativeInteger(counts?.failed) ||
     counts.total <= 0 ||
     counts.failed !== 0 ||
     counts.passed !== counts.total
   ) {
     throw new Error(`[source-performance] invalid mock hello summary counts: ${filePath}`);
+  }
+  if (!scenarios || scenarios.length !== counts.total) {
+    throw new Error(`[source-performance] invalid mock hello scenario evidence: ${filePath}`);
+  }
+  const passedScenarios = scenarios.filter((scenario) => scenario?.status === "pass").length;
+  const failedScenarios = scenarios.filter((scenario) => scenario?.status === "fail").length;
+  const invalidScenario = scenarios.find(
+    (scenario) => !["pass", "fail", "skip"].includes(String(scenario?.status)),
+  );
+  if (invalidScenario || passedScenarios !== counts.passed || failedScenarios !== counts.failed) {
+    throw new Error(`[source-performance] invalid mock hello scenario evidence: ${filePath}`);
   }
   const metrics = summary?.metrics;
   const requiredMetrics = [
@@ -167,6 +179,10 @@ function validateMockHelloSummary(summary, filePath) {
   if (missingMetric) {
     throw new Error(`[source-performance] missing mock hello metric ${missingMetric}: ${filePath}`);
   }
+}
+
+function isNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0;
 }
 
 function loadMockHelloSummaries(sourceDir, { required = false } = {}) {

--- a/scripts/qa-otel-smoke.ts
+++ b/scripts/qa-otel-smoke.ts
@@ -705,6 +705,7 @@ function startLocalOtlpReceiver(disallowedBodyNeedlesLocal: string[] = []) {
   const capturedMetrics: CapturedMetric[] = [];
   const capturedLogRecords: CapturedLogRecord[] = [];
   const capturedBodyText: Partial<Record<OtlpSignal, string[]>> = {};
+  const sockets = new Set<Socket>();
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     void (async () => {
       if (req.method !== "POST" || !req.url) {
@@ -803,6 +804,13 @@ function startLocalOtlpReceiver(disallowedBodyNeedlesLocal: string[] = []) {
       res.end();
     })();
   });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => {
+      sockets.delete(socket);
+    });
+  });
+  let closePromise: Promise<void> | undefined;
 
   return {
     capturedRequests,
@@ -821,11 +829,24 @@ function startLocalOtlpReceiver(disallowedBodyNeedlesLocal: string[] = []) {
       return address.port;
     },
     async close(): Promise<void> {
-      await new Promise<void>((resolve, reject) => {
+      closePromise ??= new Promise<void>((resolve, reject) => {
+        closeLocalOtlpReceiverConnections(server, sockets);
         server.close((err) => (err ? reject(err) : resolve()));
+        closeLocalOtlpReceiverConnections(server, sockets);
       });
+      await closePromise;
     },
   };
+}
+
+function closeLocalOtlpReceiverConnections(
+  server: ReturnType<typeof createServer>,
+  sockets: Set<Socket>,
+): void {
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  server.closeAllConnections();
 }
 
 async function reserveLocalPort(): Promise<number> {

--- a/scripts/run-with-env.mjs
+++ b/scripts/run-with-env.mjs
@@ -61,6 +61,25 @@ export function resolveSpawnCommand(command, args, execPath = process.execPath) 
   };
 }
 
+/**
+ * Reads the signal-forwarding force-kill grace period.
+ */
+export function resolveForceKillDelayMs(env = process.env) {
+  const raw = env.OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS;
+  if (raw === undefined || raw === "") {
+    return 5_000;
+  }
+  const text = raw.trim();
+  if (!/^\d+$/u.test(text)) {
+    throw new Error("OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS must be a positive integer");
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error("OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS must be a positive integer");
+  }
+  return parsed;
+}
+
 function main(argv = process.argv.slice(2)) {
   if (isRunWithEnvHelpRequest(argv)) {
     console.log(USAGE);
@@ -70,6 +89,14 @@ function main(argv = process.argv.slice(2)) {
   let parsed;
   try {
     parsed = parseRunWithEnvArgs(argv);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+
+  let forceKillDelayMs;
+  try {
+    forceKillDelayMs = resolveForceKillDelayMs();
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(2);
@@ -85,10 +112,6 @@ function main(argv = process.argv.slice(2)) {
     },
     stdio: "inherit",
   });
-  const forceKillDelayMs = Math.max(
-    1,
-    Number.parseInt(process.env.OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS ?? "5000", 10) || 5_000,
-  );
   let forwardedSignal = null;
   let forceKillTimer = null;
   // Keep the child in the foreground process group so TTY signals such as

--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -358,22 +358,72 @@ function readNonNegativeInt(value, label) {
   return value;
 }
 
+function normalizeReportFilePath(value, repoRoot = process.cwd()) {
+  const text = typeof value === "string" ? value : String(value ?? "");
+  const repoRelative = path.isAbsolute(text) ? path.relative(repoRoot, path.resolve(text)) : text;
+  if (path.isAbsolute(repoRelative) || repoRelative.startsWith("..") || repoRelative === "") {
+    return text.split(path.sep).join("/");
+  }
+  return repoRelative.split(path.sep).join("/");
+}
+
+function collectReportedLiveTestFiles(payload, repoRoot = process.cwd()) {
+  if (!Array.isArray(payload?.testResults)) {
+    return null;
+  }
+  return new Set(
+    payload.testResults
+      .map((result) => normalizeReportFilePath(result?.name, repoRoot))
+      .filter((name) => name.length > 0),
+  );
+}
+
+/**
+ * Removes a previous JSON report before a shard run so stale success cannot be reused.
+ */
+export function removeLiveShardReportFile(reportPath) {
+  fs.rmSync(reportPath, { force: true });
+}
+
 /**
  * Validates a Vitest JSON payload for live-shard proof.
  */
-export function validateLiveShardReportPayload(payload) {
+export function validateLiveShardReportPayload(
+  payload,
+  expectedFiles = [],
+  repoRoot = process.cwd(),
+) {
   if (!payload || typeof payload !== "object") {
     return { ok: false, reason: "Vitest report is not an object." };
   }
   let passed;
+  let total;
   try {
     passed = readNonNegativeInt(payload.numPassedTests, "numPassedTests");
-    readNonNegativeInt(payload.numTotalTests, "numTotalTests");
+    total = readNonNegativeInt(payload.numTotalTests, "numTotalTests");
   } catch (error) {
     return { ok: false, reason: error instanceof Error ? error.message : String(error) };
   }
+  if (passed > total) {
+    return { ok: false, reason: "Vitest report numPassedTests exceeds numTotalTests." };
+  }
   if (passed < 1) {
     return { ok: false, reason: "Vitest report has no passing live tests." };
+  }
+  if (expectedFiles.length > 0) {
+    const reportedFiles = collectReportedLiveTestFiles(payload, repoRoot);
+    if (!reportedFiles) {
+      return { ok: false, reason: "Vitest report is missing testResults file evidence." };
+    }
+    const missingFiles = expectedFiles
+      .map((file) => normalizeReportFilePath(file, repoRoot))
+      .filter((file) => !reportedFiles.has(file));
+    if (missingFiles.length > 0) {
+      return {
+        ok: false,
+        reason: `Vitest report missing selected live test file evidence: ${missingFiles.join(", ")}`,
+      };
+    }
   }
   return { ok: true };
 }
@@ -381,7 +431,7 @@ export function validateLiveShardReportPayload(payload) {
 /**
  * Reads and validates the live-shard Vitest JSON report.
  */
-export function validateLiveShardReport(reportPath) {
+export function validateLiveShardReport(reportPath, expectedFiles = []) {
   let payload;
   try {
     payload = JSON.parse(fs.readFileSync(reportPath, "utf8"));
@@ -389,7 +439,7 @@ export function validateLiveShardReport(reportPath) {
     const message = error instanceof Error ? error.message : String(error);
     return { ok: false, reason: `Unable to read Vitest report ${reportPath}: ${message}` };
   }
-  return validateLiveShardReportPayload(payload);
+  return validateLiveShardReportPayload(payload, expectedFiles);
 }
 
 /**
@@ -449,6 +499,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
   console.log(`[test:live:shard] ${shard}: ${files.length} file(s)`);
   const reportPath = buildLiveShardReportPath(shard, process.env);
   fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  removeLiveShardReportFile(reportPath);
   const child = spawnPnpmRunner({
     pnpmArgs: buildLiveShardPnpmArgs(files, addLiveShardReportArgs(passthroughArgs, reportPath)),
     ...buildLiveShardSpawnParams(process.env),
@@ -471,7 +522,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
       return;
     }
     if ((code ?? 1) === 0) {
-      const validation = validateLiveShardReport(reportPath);
+      const validation = validateLiveShardReport(reportPath, files);
       if (!validation.ok) {
         process.stderr.write(`[test:live:shard] ${validation.reason}\n`);
         process.exit(1);

--- a/scripts/tool-search-gateway-e2e.ts
+++ b/scripts/tool-search-gateway-e2e.ts
@@ -71,6 +71,46 @@ export function readToolSearchGatewayFetchLimits(
 
 const DEFAULT_FETCH_LIMITS = readToolSearchGatewayFetchLimits();
 
+type ToolSearchGatewayEnvSnapshot = {
+  configPath: string | undefined;
+  stateDir: string | undefined;
+  testFast: string | undefined;
+};
+
+export function snapshotToolSearchGatewayEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ToolSearchGatewayEnvSnapshot {
+  return {
+    configPath: env.OPENCLAW_CONFIG_PATH,
+    stateDir: env.OPENCLAW_STATE_DIR,
+    testFast: env.OPENCLAW_TEST_FAST,
+  };
+}
+
+function restoreEnvValue(
+  env: NodeJS.ProcessEnv,
+  key: keyof Pick<
+    NodeJS.ProcessEnv,
+    "OPENCLAW_CONFIG_PATH" | "OPENCLAW_STATE_DIR" | "OPENCLAW_TEST_FAST"
+  >,
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    delete env[key];
+  } else {
+    env[key] = value;
+  }
+}
+
+export function restoreToolSearchGatewayEnv(
+  snapshot: ToolSearchGatewayEnvSnapshot,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  restoreEnvValue(env, "OPENCLAW_CONFIG_PATH", snapshot.configPath);
+  restoreEnvValue(env, "OPENCLAW_STATE_DIR", snapshot.stateDir);
+  restoreEnvValue(env, "OPENCLAW_TEST_FAST", snapshot.testFast);
+}
+
 function timeoutError(message: string) {
   return Object.assign(new Error(message), { code: "ETIMEDOUT" });
 }
@@ -481,11 +521,13 @@ async function runLane(params: {
   const configPath = path.join(stateDir, "openclaw.json");
   const workspaceDir = path.join(params.rootDir, params.lane, "workspace");
   const gatewayPort = await freePort();
+  const previousEnv = snapshotToolSearchGatewayEnv();
   await fs.mkdir(workspaceDir, { recursive: true });
   const [{ resetConfigRuntimeState }, { startGatewayServer }] = await Promise.all([
     import("../src/config/config.js"),
     import("../src/gateway/server.js"),
   ]);
+  let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
   await writeConfig({
     lane: params.lane,
     stateDir,
@@ -501,13 +543,13 @@ async function runLane(params: {
   process.env.OPENCLAW_TEST_FAST = "1";
   resetConfigRuntimeState();
 
-  const server = await startGatewayServer(gatewayPort, {
-    host: "127.0.0.1",
-    auth: { mode: "none" },
-    controlUiEnabled: false,
-    openResponsesEnabled: true,
-  });
   try {
+    server = await startGatewayServer(gatewayPort, {
+      host: "127.0.0.1",
+      auth: { mode: "none" },
+      controlUiEnabled: false,
+      openResponsesEnabled: true,
+    });
     const beforeRequests = (await fetchJson(
       `${params.providerBaseUrl}/debug/requests`,
     )) as unknown[];
@@ -565,8 +607,12 @@ async function runLane(params: {
       }),
     };
   } finally {
-    await server.close({ reason: `${params.lane} lane complete` });
-    resetConfigRuntimeState();
+    try {
+      await server?.close({ reason: `${params.lane} lane complete` });
+      resetConfigRuntimeState();
+    } finally {
+      restoreToolSearchGatewayEnv(previousEnv);
+    }
   }
 }
 

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -38,6 +38,16 @@ const providerEndpointPlugins = vi.hoisted(() => [
       },
       {
         endpointClass: "google-vertex",
+        hosts: ["aiplatform.eu.rep.googleapis.com"],
+        googleVertexRegion: "eu",
+      },
+      {
+        endpointClass: "google-vertex",
+        hosts: ["aiplatform.us.rep.googleapis.com"],
+        googleVertexRegion: "us",
+      },
+      {
+        endpointClass: "google-vertex",
         hostSuffixes: ["-aiplatform.googleapis.com"],
         googleVertexRegionHostSuffix: "-aiplatform.googleapis.com",
       },
@@ -729,6 +739,23 @@ describe("provider attribution", () => {
       endpointClass: "google-vertex",
       hostname: "aiplatform.googleapis.com",
       googleVertexRegion: "global",
+    });
+
+    expectRecordFields(resolveProviderEndpoint("https://aiplatform.eu.rep.googleapis.com"), {
+      endpointClass: "google-vertex",
+      hostname: "aiplatform.eu.rep.googleapis.com",
+      googleVertexRegion: "eu",
+    });
+
+    expectRecordFields(resolveProviderEndpoint("https://aiplatform.us.rep.googleapis.com"), {
+      endpointClass: "google-vertex",
+      hostname: "aiplatform.us.rep.googleapis.com",
+      googleVertexRegion: "us",
+    });
+
+    expectRecordFields(resolveProviderEndpoint("https://discoveryengine.eu.rep.googleapis.com"), {
+      endpointClass: "custom",
+      hostname: "discoveryengine.eu.rep.googleapis.com",
     });
 
     expectRecordFields(resolveProviderEndpoint("https://proxy.example.com/google"), {

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -1,9 +1,10 @@
 // Exec approvals CLI tests cover approval command registration and output handling.
+import { Readable } from "node:stream";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as execApprovals from "../infra/exec-approvals.js";
 import type { ExecApprovalsFile } from "../infra/exec-approvals.js";
-import { registerExecApprovalsCli } from "./exec-approvals-cli.js";
+import { registerExecApprovalsCli, testing } from "./exec-approvals-cli.js";
 
 const mocks = vi.hoisted(() => {
   const runtimeErrors: string[] = [];
@@ -559,5 +560,12 @@ describe("exec approvals CLI", () => {
       agents: undefined,
     });
     expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("bounds approvals JSON read from stdin", async () => {
+    await expect(testing.readStdin(Readable.from(["12345"]), 5)).resolves.toBe("12345");
+    await expect(testing.readStdin(Readable.from(["12345", "6"]), 5)).rejects.toThrow(
+      "Exec approvals stdin exceeds 5 bytes.",
+    );
   });
 });

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -46,6 +46,7 @@ type EffectivePolicyReport = {
   note?: string;
 };
 const APPROVALS_GET_DEFAULT_TIMEOUT_MS = 60_000;
+const EXEC_APPROVALS_STDIN_MAX_BYTES = 1024 * 1024;
 
 type ExecApprovalsCliOpts = NodesRpcOpts & {
   node?: string;
@@ -55,12 +56,21 @@ type ExecApprovalsCliOpts = NodesRpcOpts & {
   agent?: string;
 };
 
-async function readStdin(): Promise<string> {
+async function readStdin(
+  stream: NodeJS.ReadableStream = process.stdin,
+  maxBytes = EXEC_APPROVALS_STDIN_MAX_BYTES,
+): Promise<string> {
   const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  let total = 0;
+  for await (const chunk of stream) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
+    total += buffer.byteLength;
+    if (total > maxBytes) {
+      throw new Error(`Exec approvals stdin exceeds ${maxBytes} bytes.`);
+    }
+    chunks.push(buffer);
   }
-  return Buffer.concat(chunks).toString("utf8");
+  return Buffer.concat(chunks, total).toString("utf8");
 }
 
 async function resolveTargetNodeId(opts: ExecApprovalsCliOpts): Promise<string | null> {
@@ -622,3 +632,7 @@ export function registerExecApprovalsCli(program: Command) {
 
   applyParentDefaultHelpAction(approvals);
 }
+
+export const testing = {
+  readStdin,
+};

--- a/src/commands/doctor/shared/legacy-web-search-migrate.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.ts
@@ -21,14 +21,19 @@ const BUNDLED_LEGACY_WEB_SEARCH_OWNERS = new Map<string, string>([
   ["minimax", "minimax"],
   ["ollama", "ollama"],
   ["parallel", "parallel"],
+  ["parallel-free", "parallel"],
   ["perplexity", "perplexity"],
   ["searxng", "searxng"],
   ["tavily", "tavily"],
 ]);
 
-// Tavily and Parallel only ever used the plugin-owned config path, so there is
-// no legacy `tools.web.search.<id>.*` shape to migrate for them.
-const NON_MIGRATED_LEGACY_WEB_SEARCH_PROVIDER_IDS = new Set(["parallel", "tavily"]);
+// Tavily and Parallel (paid + free) only ever used the plugin-owned config path,
+// so there is no legacy `tools.web.search.<id>.*` shape to migrate for them.
+const NON_MIGRATED_LEGACY_WEB_SEARCH_PROVIDER_IDS = new Set([
+  "parallel",
+  "parallel-free",
+  "tavily",
+]);
 const LEGACY_GLOBAL_WEB_SEARCH_PROVIDER_ID = "brave";
 
 function getBundledLegacyWebSearchOwners(): ReadonlyMap<string, string> {

--- a/src/flows/search-setup.ts
+++ b/src/flows/search-setup.ts
@@ -21,6 +21,7 @@ import {
 import { resolvePluginWebSearchProviders } from "../plugins/web-search-providers.runtime.js";
 import { sortWebSearchProviders } from "../plugins/web-search-providers.shared.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveWebSearchProviderId } from "../web-search/runtime.js";
 import { t } from "../wizard/i18n/index.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { FlowContribution, FlowOption } from "./types.js";
@@ -431,6 +432,42 @@ export async function runSearchSetupFlow(
 
   const existingProvider = config.tools?.web?.search?.provider;
 
+  const defaultProvider: SearchProvider = (() => {
+    if (existingProvider && providerOptions.some((entry) => entry.id === existingProvider)) {
+      return existingProvider;
+    }
+    // Mirror the runtime auto-detect selection (honors autoDetectOrder and
+    // configured credentials, incl. keyless defaults) so accepting the setup
+    // default writes the same provider the gateway would pick — e.g. Parallel
+    // Search (Free), not whichever ready provider happens to sort first
+    // alphabetically. Resolve over the providers actually shown in setup
+    // (`providerOptions`) so the default can't pick an option that isn't listed
+    // or force-load runtime code for an install-catalog-only provider.
+    // Clear any existing provider id before auto-detecting: the valid-existing
+    // case already returned above, so a leftover value here is stale/invalid/
+    // disabled and would otherwise make the resolver short-circuit to
+    // providers[0] (e.g. Brave) instead of the keyless default. Keep the rest of
+    // the search config so configured credentials are still detected.
+    const searchForAutoDetect = {
+      ...config.tools?.web?.search,
+      provider: undefined,
+    } as Parameters<typeof resolveWebSearchProviderId>[0]["search"];
+    const autoDetectedId = resolveWebSearchProviderId({
+      config,
+      search: searchForAutoDetect,
+      providers: [...providerOptions],
+    });
+    const autoDetected = providerOptions.find((entry) => entry.id === autoDetectedId);
+    if (autoDetected) {
+      return autoDetected.id;
+    }
+    const detected = providerOptions.find((entry) => providerIsReady(config, entry));
+    if (detected) {
+      return detected.id;
+    }
+    return providerOptions[0].id;
+  })();
+
   const options = providerOptions.map((entry) => {
     const hint =
       entry.requiresCredential === false
@@ -440,17 +477,6 @@ export async function runSearchSetupFlow(
           : entry.hint;
     return { value: entry.id, label: entry.label, hint };
   });
-
-  const defaultProvider: SearchProvider = (() => {
-    if (existingProvider && providerOptions.some((entry) => entry.id === existingProvider)) {
-      return existingProvider;
-    }
-    const detected = providerOptions.find((entry) => providerIsReady(config, entry));
-    if (detected) {
-      return detected.id;
-    }
-    return providerOptions[0].id;
-  })();
 
   const choice = await prompter.select({
     message: t("wizard.search.providerPrompt"),

--- a/src/gateway/gateway-acp-bind.live.test.ts
+++ b/src/gateway/gateway-acp-bind.live.test.ts
@@ -34,6 +34,7 @@ import {
   runOpenClawCliJson,
   shouldRunLiveImageProbe,
 } from "./live-agent-probes.js";
+import { restoreLiveEnv, snapshotLiveEnv, type LiveEnvSnapshot } from "./live-env-test-helpers.js";
 import { startGatewayServer } from "./server.js";
 
 const LIVE = isLiveTestEnabled();
@@ -51,6 +52,10 @@ const ACP_CRON_MCP_PROBE_VERIFY_POLL_MS = 1_000;
 const DEFAULT_LIVE_CODEX_MODEL = "gpt-5.5";
 const DEFAULT_LIVE_PARENT_MODEL = "openai/gpt-5.4";
 type LiveAcpAgent = "claude" | "codex" | "droid" | "gemini" | "opencode";
+
+function snapshotAcpBindLiveEnv(): LiveEnvSnapshot {
+  return snapshotLiveEnv(["CODEX_HOME", "OPENCLAW_GATEWAY_PORT"]);
+}
 
 function resolveLiveTimeoutMs(raw: string | undefined, fallback: number): number {
   const parsed = raw ? Number(raw) : Number.NaN;
@@ -564,17 +569,7 @@ describeLive("gateway live (ACP bind)", () => {
   it(
     "binds a synthetic Slack DM conversation to a live ACP session and reroutes the next turn",
     async () => {
-      const previous = {
-        configPath: process.env.OPENCLAW_CONFIG_PATH,
-        stateDir: process.env.OPENCLAW_STATE_DIR,
-        token: process.env.OPENCLAW_GATEWAY_TOKEN,
-        port: process.env.OPENCLAW_GATEWAY_PORT,
-        skipChannels: process.env.OPENCLAW_SKIP_CHANNELS,
-        skipGmail: process.env.OPENCLAW_SKIP_GMAIL_WATCHER,
-        skipCron: process.env.OPENCLAW_SKIP_CRON,
-        skipCanvas: process.env.OPENCLAW_SKIP_CANVAS_HOST,
-        codexHome: process.env.CODEX_HOME,
-      };
+      const previousEnv = snapshotAcpBindLiveEnv();
       const liveAgent = normalizeAcpAgent(process.env.OPENCLAW_LIVE_ACP_BIND_AGENT);
       const agentCommandOverride =
         process.env.OPENCLAW_LIVE_ACP_BIND_AGENT_COMMAND?.trim() || undefined;
@@ -591,6 +586,11 @@ describeLive("gateway live (ACP bind)", () => {
       const followupNonce = randomBytes(4).toString("hex").toUpperCase();
       const recallNonce = randomBytes(4).toString("hex").toUpperCase();
       const memoryNonce = randomBytes(4).toString("hex").toUpperCase();
+      let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+      let client: GatewayClient | undefined;
+      let pinnedChannelRegistry:
+        | ReturnType<typeof createSlackCurrentConversationBindingRegistry>
+        | undefined;
 
       clearRuntimeConfigSnapshot();
       process.env.OPENCLAW_STATE_DIR = tempStateDir;
@@ -689,25 +689,26 @@ describeLive("gateway live (ACP bind)", () => {
       clearPluginLoaderCache();
       resetPluginRuntimeStateForTest();
 
-      logLiveStep(`starting gateway on port ${String(port)}`);
-      const server = await startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token },
-        controlUiEnabled: false,
-      });
-      logLiveStep("gateway startup returned");
-      await waitForGatewayPort({ host: "127.0.0.1", port, timeoutMs: CONNECT_TIMEOUT_MS });
-      logLiveStep("gateway port is reachable");
-      const client = await connectClient({
-        url: `ws://127.0.0.1:${port}`,
-        token,
-        timeoutMs: CONNECT_TIMEOUT_MS,
-      });
-      logLiveStep("gateway websocket connected");
-      const channelRegistry = createSlackCurrentConversationBindingRegistry();
-      pinActivePluginChannelRegistry(channelRegistry);
-
       try {
+        logLiveStep(`starting gateway on port ${String(port)}`);
+        server = await startGatewayServer(port, {
+          bind: "loopback",
+          auth: { mode: "token", token },
+          controlUiEnabled: false,
+        });
+        logLiveStep("gateway startup returned");
+        await waitForGatewayPort({ host: "127.0.0.1", port, timeoutMs: CONNECT_TIMEOUT_MS });
+        logLiveStep("gateway port is reachable");
+        client = await connectClient({
+          url: `ws://127.0.0.1:${port}`,
+          token,
+          timeoutMs: CONNECT_TIMEOUT_MS,
+        });
+        logLiveStep("gateway websocket connected");
+        const channelRegistry = createSlackCurrentConversationBindingRegistry();
+        pinActivePluginChannelRegistry(channelRegistry);
+        pinnedChannelRegistry = channelRegistry;
+
         const bindResult = await bindConversationAndWait({
           client,
           sessionKey: originalSessionKey,
@@ -1077,56 +1078,17 @@ describeLive("gateway live (ACP bind)", () => {
         );
         logLiveStep("bound session created cron via MCP and CLI verification passed");
       } finally {
-        releasePinnedPluginChannelRegistry(channelRegistry);
-        clearConfigCache();
-        clearRuntimeConfigSnapshot();
-        await client.stopAndWait({ timeoutMs: 2_000 }).catch(() => {});
-        await server.close();
-        await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-        if (previous.configPath === undefined) {
-          delete process.env.OPENCLAW_CONFIG_PATH;
-        } else {
-          process.env.OPENCLAW_CONFIG_PATH = previous.configPath;
-        }
-        if (previous.stateDir === undefined) {
-          delete process.env.OPENCLAW_STATE_DIR;
-        } else {
-          process.env.OPENCLAW_STATE_DIR = previous.stateDir;
-        }
-        if (previous.token === undefined) {
-          delete process.env.OPENCLAW_GATEWAY_TOKEN;
-        } else {
-          process.env.OPENCLAW_GATEWAY_TOKEN = previous.token;
-        }
-        if (previous.port === undefined) {
-          delete process.env.OPENCLAW_GATEWAY_PORT;
-        } else {
-          process.env.OPENCLAW_GATEWAY_PORT = previous.port;
-        }
-        if (previous.skipChannels === undefined) {
-          delete process.env.OPENCLAW_SKIP_CHANNELS;
-        } else {
-          process.env.OPENCLAW_SKIP_CHANNELS = previous.skipChannels;
-        }
-        if (previous.skipGmail === undefined) {
-          delete process.env.OPENCLAW_SKIP_GMAIL_WATCHER;
-        } else {
-          process.env.OPENCLAW_SKIP_GMAIL_WATCHER = previous.skipGmail;
-        }
-        if (previous.skipCron === undefined) {
-          delete process.env.OPENCLAW_SKIP_CRON;
-        } else {
-          process.env.OPENCLAW_SKIP_CRON = previous.skipCron;
-        }
-        if (previous.skipCanvas === undefined) {
-          delete process.env.OPENCLAW_SKIP_CANVAS_HOST;
-        } else {
-          process.env.OPENCLAW_SKIP_CANVAS_HOST = previous.skipCanvas;
-        }
-        if (previous.codexHome === undefined) {
-          delete process.env.CODEX_HOME;
-        } else {
-          process.env.CODEX_HOME = previous.codexHome;
+        try {
+          if (pinnedChannelRegistry) {
+            releasePinnedPluginChannelRegistry(pinnedChannelRegistry);
+          }
+          clearConfigCache();
+          clearRuntimeConfigSnapshot();
+          await client?.stopAndWait({ timeoutMs: 2_000 }).catch(() => {});
+          await server?.close();
+        } finally {
+          await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+          restoreLiveEnv(previousEnv);
         }
       }
     },

--- a/src/gateway/gateway-acp-spawn-defaults.live.test.ts
+++ b/src/gateway/gateway-acp-spawn-defaults.live.test.ts
@@ -24,6 +24,7 @@ import { isTruthyEnvValue } from "../infra/env.js";
 import { clearPluginLoaderCache } from "../plugins/loader.js";
 import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import { sleep } from "../utils.js";
+import { restoreLiveEnv, snapshotLiveEnv, type LiveEnvSnapshot } from "./live-env-test-helpers.js";
 import { startGatewayServer } from "./server.js";
 
 const LIVE = isLiveTestEnabled();
@@ -37,6 +38,10 @@ const LIVE_TIMEOUT_MS = resolvePositiveInteger(
   process.env.OPENCLAW_LIVE_ACP_SPAWN_DEFAULTS_TIMEOUT_MS,
   240_000,
 );
+
+function snapshotAcpSpawnDefaultsLiveEnv(): LiveEnvSnapshot {
+  return snapshotLiveEnv(["CODEX_HOME", "OPENCLAW_GATEWAY_PORT"]);
+}
 
 function resolvePositiveInteger(raw: string | undefined, fallback: number): number {
   const parsed = raw ? Number(raw) : Number.NaN;
@@ -265,17 +270,7 @@ describeLive("gateway live (ACP spawn defaults)", () => {
   it(
     "applies existing subagent defaults to live ACP spawns without leaking primary agent model",
     async () => {
-      const previous = {
-        configPath: process.env.OPENCLAW_CONFIG_PATH,
-        stateDir: process.env.OPENCLAW_STATE_DIR,
-        token: process.env.OPENCLAW_GATEWAY_TOKEN,
-        port: process.env.OPENCLAW_GATEWAY_PORT,
-        skipChannels: process.env.OPENCLAW_SKIP_CHANNELS,
-        skipGmail: process.env.OPENCLAW_SKIP_GMAIL_WATCHER,
-        skipCron: process.env.OPENCLAW_SKIP_CRON,
-        skipCanvas: process.env.OPENCLAW_SKIP_CANVAS_HOST,
-        codexHome: process.env.CODEX_HOME,
-      };
+      const previousEnv = snapshotAcpSpawnDefaultsLiveEnv();
       const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-acp-spawn-"));
       const tempConfigPath = path.join(tempRoot, "openclaw.json");
       const tempStateDir = path.join(tempRoot, "state");
@@ -285,6 +280,7 @@ describeLive("gateway live (ACP spawn defaults)", () => {
       const subagentModel = resolveSubagentModel();
       const thinking = resolveThinking();
       const sessionKeys: string[] = [];
+      let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
 
       process.env.OPENCLAW_CONFIG_PATH = tempConfigPath;
       process.env.OPENCLAW_STATE_DIR = tempStateDir;
@@ -310,12 +306,12 @@ describeLive("gateway live (ACP spawn defaults)", () => {
       clearPluginLoaderCache();
       resetPluginRuntimeStateForTest();
 
-      const server = await startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token },
-        controlUiEnabled: false,
-      });
       try {
+        server = await startGatewayServer(port, {
+          bind: "loopback",
+          auth: { mode: "token", token },
+          controlUiEnabled: false,
+        });
         await waitForGatewayPort({ host: "127.0.0.1", port, timeoutMs: CONNECT_TIMEOUT_MS });
         await waitForAcpBackendReady();
         const runtimeCfg = getRuntimeConfig();
@@ -368,67 +364,26 @@ describeLive("gateway live (ACP spawn defaults)", () => {
         });
         expect(primaryOnlyEntry.acp?.runtimeOptions?.model).not.toBe("anthropic/claude-sonnet-4-6");
       } finally {
-        const runtimeCfg = getRuntimeConfig();
-        for (const sessionKey of sessionKeys) {
-          await getAcpSessionManager()
-            .closeSession({
-              cfg: runtimeCfg,
-              sessionKey,
-              reason: "live-acp-spawn-defaults-test-cleanup",
-              discardPersistentState: true,
-              clearMeta: true,
-              requireAcpSession: false,
-            })
-            .catch(() => {});
-        }
-        clearConfigCache();
-        clearRuntimeConfigSnapshot();
-        await server.close();
-        await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-        if (previous.configPath === undefined) {
-          delete process.env.OPENCLAW_CONFIG_PATH;
-        } else {
-          process.env.OPENCLAW_CONFIG_PATH = previous.configPath;
-        }
-        if (previous.stateDir === undefined) {
-          delete process.env.OPENCLAW_STATE_DIR;
-        } else {
-          process.env.OPENCLAW_STATE_DIR = previous.stateDir;
-        }
-        if (previous.token === undefined) {
-          delete process.env.OPENCLAW_GATEWAY_TOKEN;
-        } else {
-          process.env.OPENCLAW_GATEWAY_TOKEN = previous.token;
-        }
-        if (previous.port === undefined) {
-          delete process.env.OPENCLAW_GATEWAY_PORT;
-        } else {
-          process.env.OPENCLAW_GATEWAY_PORT = previous.port;
-        }
-        if (previous.skipChannels === undefined) {
-          delete process.env.OPENCLAW_SKIP_CHANNELS;
-        } else {
-          process.env.OPENCLAW_SKIP_CHANNELS = previous.skipChannels;
-        }
-        if (previous.skipGmail === undefined) {
-          delete process.env.OPENCLAW_SKIP_GMAIL_WATCHER;
-        } else {
-          process.env.OPENCLAW_SKIP_GMAIL_WATCHER = previous.skipGmail;
-        }
-        if (previous.skipCron === undefined) {
-          delete process.env.OPENCLAW_SKIP_CRON;
-        } else {
-          process.env.OPENCLAW_SKIP_CRON = previous.skipCron;
-        }
-        if (previous.skipCanvas === undefined) {
-          delete process.env.OPENCLAW_SKIP_CANVAS_HOST;
-        } else {
-          process.env.OPENCLAW_SKIP_CANVAS_HOST = previous.skipCanvas;
-        }
-        if (previous.codexHome === undefined) {
-          delete process.env.CODEX_HOME;
-        } else {
-          process.env.CODEX_HOME = previous.codexHome;
+        try {
+          const runtimeCfg = getRuntimeConfig();
+          for (const sessionKey of sessionKeys) {
+            await getAcpSessionManager()
+              .closeSession({
+                cfg: runtimeCfg,
+                sessionKey,
+                reason: "live-acp-spawn-defaults-test-cleanup",
+                discardPersistentState: true,
+                clearMeta: true,
+                requireAcpSession: false,
+              })
+              .catch(() => {});
+          }
+          clearConfigCache();
+          clearRuntimeConfigSnapshot();
+          await server?.close();
+        } finally {
+          await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+          restoreLiveEnv(previousEnv);
         }
       }
     },

--- a/src/gateway/gateway-cli-backend.live-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.test.ts
@@ -34,6 +34,7 @@ describe("gateway cli backend live helpers", () => {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
     delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
     delete process.env.OPENCLAW_LIVE_CLI_BACKEND_ALLOW_PROVIDER_SKIP;
+    delete process.env.OPENCLAW_LIVE_CLI_BACKEND_ADVISORY;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_API_KEY_OLD;
   });
@@ -155,6 +156,7 @@ describe("gateway cli backend live helpers", () => {
 
   it("requires provider results by default for explicit CLI backend live probes", async () => {
     const {
+      CLI_BACKEND_LIVE_ADVISORY_ENV,
       CLI_BACKEND_LIVE_PROVIDER_SKIP_ENV,
       resolveCliBackendLiveProviderSkipDecision,
       shouldAllowCliBackendLiveProviderSkip,
@@ -171,11 +173,17 @@ describe("gateway cli backend live helpers", () => {
     ).toEqual({
       action: "fail",
       message:
-        'agent request for provider "claude-cli" was blocked by auth drift. Set OPENCLAW_LIVE_CLI_BACKEND_ALLOW_PROVIDER_SKIP=1 only for advisory live probes.',
+        'agent request for provider "claude-cli" was blocked by auth drift. Set OPENCLAW_LIVE_CLI_BACKEND_ADVISORY=1 and OPENCLAW_LIVE_CLI_BACKEND_ALLOW_PROVIDER_SKIP=1 only for advisory live probes.',
     });
 
     expect(
       shouldAllowCliBackendLiveProviderSkip({ [CLI_BACKEND_LIVE_PROVIDER_SKIP_ENV]: "1" }),
+    ).toBe(false);
+    expect(
+      shouldAllowCliBackendLiveProviderSkip({
+        [CLI_BACKEND_LIVE_ADVISORY_ENV]: "1",
+        [CLI_BACKEND_LIVE_PROVIDER_SKIP_ENV]: "1",
+      }),
     ).toBe(true);
     expect(
       resolveCliBackendLiveProviderSkipDecision({

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -65,6 +65,7 @@ export type CliBackendLiveEnvSnapshot = {
 };
 
 export const CLI_BACKEND_LIVE_PROVIDER_SKIP_ENV = "OPENCLAW_LIVE_CLI_BACKEND_ALLOW_PROVIDER_SKIP";
+export const CLI_BACKEND_LIVE_ADVISORY_ENV = "OPENCLAW_LIVE_CLI_BACKEND_ADVISORY";
 
 export type CliBackendLiveProviderSkipDecision = {
   action: "fail" | "skip";
@@ -213,7 +214,10 @@ export function shouldRunCliModelSwitchProbe(providerId: string, modelRef: strin
 export function shouldAllowCliBackendLiveProviderSkip(
   env: Record<string, string | undefined> = process.env,
 ): boolean {
-  return isTruthyEnvValue(env[CLI_BACKEND_LIVE_PROVIDER_SKIP_ENV]);
+  return (
+    isTruthyEnvValue(env[CLI_BACKEND_LIVE_PROVIDER_SKIP_ENV]) &&
+    isTruthyEnvValue(env[CLI_BACKEND_LIVE_ADVISORY_ENV])
+  );
 }
 
 export function resolveCliBackendLiveProviderSkipDecision(params: {
@@ -228,7 +232,9 @@ export function resolveCliBackendLiveProviderSkipDecision(params: {
   }
   return {
     action: "fail",
-    message: `${message} Set ${CLI_BACKEND_LIVE_PROVIDER_SKIP_ENV}=1 only for advisory live probes.`,
+    message:
+      `${message} Set ${CLI_BACKEND_LIVE_ADVISORY_ENV}=1 and ` +
+      `${CLI_BACKEND_LIVE_PROVIDER_SKIP_ENV}=1 only for advisory live probes.`,
   };
 }
 

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -475,6 +475,8 @@ describeLive("gateway live (cli backend)", () => {
       await fs.writeFile(tempConfigPath, `${JSON.stringify(nextCfg, null, 2)}\n`);
       process.env.OPENCLAW_CONFIG_PATH = tempConfigPath;
       const deviceIdentity = await ensurePairedTestGatewayClientIdentity();
+      let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+      let client: Awaited<ReturnType<typeof connectTestGatewayClient>> | undefined;
       logCliBackendLiveStep("config-written", {
         tempConfigPath,
         stateDir,
@@ -482,20 +484,21 @@ describeLive("gateway live (cli backend)", () => {
         cliArgs,
       });
 
-      const server = await startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token },
-        controlUiEnabled: false,
-      });
-      logCliBackendLiveStep("server-started");
-      const client = await connectTestGatewayClient({
-        url: `ws://127.0.0.1:${port}`,
-        token,
-        deviceIdentity,
-      });
-      logCliBackendLiveStep("client-connected");
-
       try {
+        server = await startGatewayServer(port, {
+          bind: "loopback",
+          auth: { mode: "token", token },
+          controlUiEnabled: false,
+        });
+        logCliBackendLiveStep("server-started");
+        client = await connectTestGatewayClient({
+          url: `ws://127.0.0.1:${port}`,
+          token,
+          deviceIdentity,
+        });
+        logCliBackendLiveStep("client-connected");
+        const activeClient = client;
+
         const sessionKey = "agent:dev:live-cli-backend";
         const nonce = randomBytes(3).toString("hex").toUpperCase();
         const memoryNonce = randomBytes(3).toString("hex").toUpperCase();
@@ -505,7 +508,7 @@ describeLive("gateway live (cli backend)", () => {
           providerId,
           "agent request",
           (timeouts) =>
-            client.request(
+            activeClient.request(
               "agent",
               {
                 sessionKey,
@@ -562,7 +565,7 @@ describeLive("gateway live (cli backend)", () => {
             switchNonce,
             memoryToken,
           });
-          const patchPayload = await client.request("sessions.patch", {
+          const patchPayload = await activeClient.request("sessions.patch", {
             key: sessionKey,
             model: modelSwitchTarget,
           });
@@ -575,7 +578,7 @@ describeLive("gateway live (cli backend)", () => {
             providerId,
             "agent model-switch request",
             (timeouts) =>
-              client.request(
+              activeClient.request(
                 "agent",
                 {
                   sessionKey,
@@ -611,7 +614,7 @@ describeLive("gateway live (cli backend)", () => {
             providerId,
             "agent resume request",
             (timeouts) =>
-              client.request(
+              activeClient.request(
                 "agent",
                 {
                   sessionKey,
@@ -650,7 +653,7 @@ describeLive("gateway live (cli backend)", () => {
               : sessionKey;
           logCliBackendLiveStep("image-probe:start", { sessionKey: imageSessionKey });
           await verifyCliBackendImageProbe({
-            client,
+            client: activeClient,
             providerId,
             sessionKey: imageSessionKey,
             tempDir,
@@ -681,7 +684,7 @@ describeLive("gateway live (cli backend)", () => {
           } else {
             logCliBackendLiveStep("cron-mcp-probe:start", { sessionKey });
             await verifyCliCronMcpProbe({
-              client,
+              client: activeClient,
               providerId,
               sessionKey,
               port,
@@ -692,13 +695,19 @@ describeLive("gateway live (cli backend)", () => {
           }
         }
       } finally {
-        logCliBackendLiveStep("cleanup:start");
-        clearRuntimeConfigSnapshot();
-        await client.stopAndWait();
-        await server.close();
-        await fs.rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-        restoreCliBackendLiveEnv(previousEnv);
-        logCliBackendLiveStep("cleanup:done");
+        try {
+          logCliBackendLiveStep("cleanup:start");
+          clearRuntimeConfigSnapshot();
+          try {
+            await client?.stopAndWait();
+          } finally {
+            await server?.close();
+          }
+        } finally {
+          await fs.rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+          restoreCliBackendLiveEnv(previousEnv);
+          logCliBackendLiveStep("cleanup:done");
+        }
       }
     },
     CLI_BACKEND_LIVE_TIMEOUT_MS,

--- a/src/gateway/gateway-codex-bind.live.test.ts
+++ b/src/gateway/gateway-codex-bind.live.test.ts
@@ -467,23 +467,30 @@ describeLive("gateway live (native Codex conversation binding)", () => {
       process.env.OPENCLAW_SKIP_CRON = "1";
       process.env.OPENCLAW_SKIP_GMAIL_WATCHER = "1";
       process.env.OPENCLAW_STATE_DIR = stateDir;
-
-      const server = await startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token },
-        controlUiEnabled: false,
-      });
-      const client = await connectTestGatewayClient({
-        url: `ws://127.0.0.1:${port}`,
-        token,
-        timeoutMs: 90_000,
-        requestTimeoutMs: CODEX_BIND_REQUEST_TIMEOUT_MS,
-        clientDisplayName: "vitest-codex-bind-live",
-      });
-      const channelRegistry = createSlackCurrentConversationBindingRegistry(outboundReplies);
-      pinActivePluginChannelRegistry(channelRegistry);
+      let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+      let client: Awaited<ReturnType<typeof connectTestGatewayClient>> | undefined;
+      let pinnedChannelRegistry:
+        | ReturnType<typeof createSlackCurrentConversationBindingRegistry>
+        | undefined;
 
       try {
+        server = await startGatewayServer(port, {
+          bind: "loopback",
+          auth: { mode: "token", token },
+          controlUiEnabled: false,
+        });
+        client = await connectTestGatewayClient({
+          url: `ws://127.0.0.1:${port}`,
+          token,
+          timeoutMs: 90_000,
+          requestTimeoutMs: CODEX_BIND_REQUEST_TIMEOUT_MS,
+          clientDisplayName: "vitest-codex-bind-live",
+        });
+        const activeClient = client;
+        const channelRegistry = createSlackCurrentConversationBindingRegistry(outboundReplies);
+        pinActivePluginChannelRegistry(channelRegistry);
+        pinnedChannelRegistry = channelRegistry;
+
         await writePluginBindingApproval({
           homeDir: tempHome,
           pluginRoot: resolveCodexPluginRoot(),
@@ -492,7 +499,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
         });
 
         await sendChatAndWait({
-          client,
+          client: activeClient,
           sessionKey,
           idempotencyKey: `idem-codex-bind-${randomUUID()}`,
           context: "bind command",
@@ -520,7 +527,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
 
         const sendCodexCommand = async (message: string, contains: string, timeoutMs = 60_000) => {
           await sendChatAndWait({
-            client,
+            client: activeClient,
             sessionKey,
             idempotencyKey: `idem-codex-command-${randomUUID()}`,
             context: message,
@@ -563,7 +570,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
         const textNonce = randomBytes(4).toString("hex").toUpperCase();
         const textToken = `CODEX-BIND-${textNonce}`;
         await sendChatAndWait({
-          client,
+          client: activeClient,
           sessionKey,
           idempotencyKey: `idem-codex-bound-text-${randomUUID()}`,
           context: "bound text turn",
@@ -573,7 +580,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
           originatingAccountId: accountId,
         });
         const textHistory = await waitForAssistantText({
-          client,
+          client: activeClient,
           sessionKey: boundSessionKey,
           contains: textToken,
           timeoutMs: CODEX_BIND_REQUEST_TIMEOUT_MS,
@@ -581,7 +588,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
         expect(textHistory.matchedAssistantText).toContain(textToken);
 
         await sendChatAndWait({
-          client,
+          client: activeClient,
           sessionKey,
           idempotencyKey: `idem-codex-bound-image-${randomUUID()}`,
           context: "bound image turn",
@@ -599,7 +606,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
           ],
         });
         const imageHistory = await waitForAssistantText({
-          client,
+          client: activeClient,
           sessionKey: boundSessionKey,
           contains: "cat",
           caseInsensitive: true,
@@ -611,21 +618,29 @@ describeLive("gateway live (native Codex conversation binding)", () => {
         await sendCodexCommand("/codex detach", "Detached this conversation from Codex.");
         await sendCodexCommand("/codex binding", "No Codex conversation binding is attached.");
       } finally {
-        releasePinnedPluginChannelRegistry(channelRegistry);
-        clearConfigCache();
-        clearRuntimeConfigSnapshot();
-        await client.stopAndWait({ timeoutMs: 2_000 }).catch(() => {});
-        await server.close();
-        await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-        restoreEnvVar("CODEX_HOME", previous.codexHome);
-        restoreEnvVar("OPENCLAW_CONFIG_PATH", previous.configPath);
-        restoreEnvVar("OPENCLAW_GATEWAY_TOKEN", previous.gatewayToken);
-        restoreEnvVar("HOME", previous.home);
-        restoreEnvVar("OPENCLAW_SKIP_CANVAS_HOST", previous.skipCanvas);
-        restoreEnvVar("OPENCLAW_SKIP_CHANNELS", previous.skipChannels);
-        restoreEnvVar("OPENCLAW_SKIP_CRON", previous.skipCron);
-        restoreEnvVar("OPENCLAW_SKIP_GMAIL_WATCHER", previous.skipGmail);
-        restoreEnvVar("OPENCLAW_STATE_DIR", previous.stateDir);
+        try {
+          if (pinnedChannelRegistry) {
+            releasePinnedPluginChannelRegistry(pinnedChannelRegistry);
+          }
+          clearConfigCache();
+          clearRuntimeConfigSnapshot();
+          try {
+            await client?.stopAndWait({ timeoutMs: 2_000 }).catch(() => {});
+          } finally {
+            await server?.close();
+          }
+        } finally {
+          await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+          restoreEnvVar("CODEX_HOME", previous.codexHome);
+          restoreEnvVar("OPENCLAW_CONFIG_PATH", previous.configPath);
+          restoreEnvVar("OPENCLAW_GATEWAY_TOKEN", previous.gatewayToken);
+          restoreEnvVar("HOME", previous.home);
+          restoreEnvVar("OPENCLAW_SKIP_CANVAS_HOST", previous.skipCanvas);
+          restoreEnvVar("OPENCLAW_SKIP_CHANNELS", previous.skipChannels);
+          restoreEnvVar("OPENCLAW_SKIP_CRON", previous.skipCron);
+          restoreEnvVar("OPENCLAW_SKIP_GMAIL_WATCHER", previous.skipGmail);
+          restoreEnvVar("OPENCLAW_STATE_DIR", previous.stateDir);
+        }
       }
     },
     CODEX_BIND_TIMEOUT_MS,

--- a/src/gateway/gateway-codex-harness.live-helpers.test.ts
+++ b/src/gateway/gateway-codex-harness.live-helpers.test.ts
@@ -8,6 +8,7 @@ import {
   isExpectedCodexModelsCommandText,
   isExpectedCodexStatusCommandText,
   isRetryableCodexHarnessLiveError,
+  isStrictExpectedCodexModelsCommandText,
 } from "./gateway-codex-harness.live-helpers.js";
 
 const includesExpectedCodexModelsCommandText = (text: string) =>
@@ -20,6 +21,11 @@ function expectExpectedCodexModelsCommandText(text: string): void {
 function expectRecognizedCodexModelsCommandText(text: string): void {
   expectExpectedCodexModelsCommandText(text);
   expect(isExpectedCodexModelsCommandText(text)).toBe(true);
+}
+
+function expectStrictCodexModelsCommandText(text: string): void {
+  expectRecognizedCodexModelsCommandText(text);
+  expect(isStrictExpectedCodexModelsCommandText(text)).toBe(true);
 }
 
 describe("gateway codex harness live helpers", () => {
@@ -239,7 +245,7 @@ describe("gateway codex harness live helpers", () => {
       "Current active model is `codex/gpt-5.4`.",
     ].join("\n");
 
-    expectRecognizedCodexModelsCommandText(text);
+    expectStrictCodexModelsCommandText(text);
   });
 
   it("accepts the configured-model fallback summary", () => {
@@ -265,6 +271,7 @@ describe("gateway codex harness live helpers", () => {
     ].join("\n");
 
     expectRecognizedCodexModelsCommandText(text);
+    expect(isStrictExpectedCodexModelsCommandText(text)).toBe(false);
   });
 
   it("accepts the current Codex agent model list from the live harness", () => {
@@ -278,7 +285,31 @@ describe("gateway codex harness live helpers", () => {
       "No other agent models are currently exposed for this session.",
     ].join("\n");
 
-    expectRecognizedCodexModelsCommandText(text);
+    expectStrictCodexModelsCommandText(text);
+  });
+
+  it("accepts healthy literal codex model lists for strict live proof", () => {
+    const texts = [
+      ["Codex models:", "", "- `openai/gpt-5.5`", "- `codex/gpt-5.4`"].join("\n"),
+      ["Available Codex models", "", "- `GPT-5.5`", "- `GPT-5.4-Codex`"].join("\n"),
+      ["Available models:", "", "- `gpt-5.4`", "- `gpt-5.4-mini`"].join("\n"),
+      ["Available model overrides:", "", "- `gpt-5.4`"].join("\n"),
+      ["Available model overrides in this session:", "", "- `codex/gpt-5.4`"].join("\n"),
+      ["Available models in this Codex install", "", "- `gpt-5.4`"].join("\n"),
+      ["Available agent models:", "", "- `codex/gpt-5.4`"].join("\n"),
+    ];
+
+    for (const text of texts) {
+      expectExpectedCodexModelsCommandText(text);
+      expect(isStrictExpectedCodexModelsCommandText(text)).toBe(true);
+    }
+  });
+
+  it("rejects model-list headings without model evidence", () => {
+    const text = "Available models:";
+
+    expectExpectedCodexModelsCommandText(text);
+    expect(isStrictExpectedCodexModelsCommandText(text)).toBe(false);
   });
 
   it("accepts the singular Codex agent model list from the live harness", () => {
@@ -291,7 +322,7 @@ describe("gateway codex harness live helpers", () => {
       "- Configured override: `false`",
     ].join("\n");
 
-    expectRecognizedCodexModelsCommandText(text);
+    expectStrictCodexModelsCommandText(text);
   });
 
   it("accepts sandbox namespace failures with current-session model fallback", () => {
@@ -345,9 +376,25 @@ describe("gateway codex harness live helpers", () => {
 
     for (const text of texts) {
       expectExpectedCodexModelsCommandText(text);
+      expect(isStrictExpectedCodexModelsCommandText(text)).toBe(false);
     }
     expect(isExpectedCodexModelsCommandText(texts[1] ?? "")).toBe(true);
     expect(isExpectedCodexModelsCommandText(texts[2] ?? "")).toBe(true);
+  });
+
+  it("rejects command-unavailable prose for strict live codex models proof", () => {
+    const texts = [
+      "`codex` is not installed on the shell PATH in this environment.",
+      "I couldn’t list them because `codex models` requires running outside the sandbox here, and that approval was rejected.",
+      "`codex models` didn’t return a plain list in this environment; it dropped into the interactive TUI instead.",
+    ];
+
+    for (const text of texts) {
+      expect(
+        includesExpectedCodexModelsCommandText(text) || isExpectedCodexModelsCommandText(text),
+      ).toBe(true);
+      expect(isStrictExpectedCodexModelsCommandText(text)).toBe(false);
+    }
   });
 
   it("accepts current session model summaries from codex models fallback", () => {
@@ -405,6 +452,7 @@ describe("gateway codex harness live helpers", () => {
 
     for (const text of texts) {
       expect(isExpectedCodexModelsCommandText(text)).toBe(true);
+      expect(isStrictExpectedCodexModelsCommandText(text)).toBe(false);
     }
   });
 
@@ -424,6 +472,7 @@ describe("gateway codex harness live helpers", () => {
 
     for (const text of texts) {
       expect(isExpectedCodexModelsCommandText(text)).toBe(true);
+      expect(isStrictExpectedCodexModelsCommandText(text)).toBe(false);
     }
   });
 
@@ -438,6 +487,7 @@ describe("gateway codex harness live helpers", () => {
     ].join("\n");
 
     expectRecognizedCodexModelsCommandText(text);
+    expect(isStrictExpectedCodexModelsCommandText(text)).toBe(false);
   });
 
   it("accepts the local Codex model-cache summary", () => {
@@ -451,8 +501,7 @@ describe("gateway codex harness live helpers", () => {
       "This session is currently running `codex/gpt-5.4` with `low` reasoning according to `/codex status`.",
     ].join("\n");
 
-    expectExpectedCodexModelsCommandText(text);
-    expect(isExpectedCodexModelsCommandText(text)).toBe(false);
+    expectStrictCodexModelsCommandText(text);
   });
 
   it("accepts the sandboxed CLI failure active-model summary", () => {

--- a/src/gateway/gateway-codex-harness.live-helpers.ts
+++ b/src/gateway/gateway-codex-harness.live-helpers.ts
@@ -81,6 +81,66 @@ export const EXPECTED_CODEX_MODELS_COMMAND_TEXT = [
   "Current OpenClaw session status reports the active model as:",
 ] as const;
 
+const HEALTHY_CODEX_MODELS_COMMAND_TEXT = [
+  "Codex models:",
+  "Available Codex models",
+  "Available models:",
+  "Available models, local cache:",
+  "Available agent target:",
+  "Available agent targets:",
+  "Available agent IDs in this session:",
+  "running as Codex on `openai/",
+  "running as Codex on `codex/",
+  "currently running on `openai/",
+  "currently running on `codex/",
+  "I can only see the current session model from this environment",
+  "Available in this session:",
+  "Available here:",
+  "Available models in this session:",
+  "Available models in this environment:",
+  "Available models in this Codex environment:",
+  "Available models in this Codex install",
+  "Available model overrides:",
+  "Available model overrides exposed in this session",
+  "Available model overrides here:",
+  "Available model overrides listed for this session:",
+  "Available model overrides listed in this session:",
+  "Available model overrides shown in this session:",
+  "Available model overrides in this session:",
+  "Available agent models:",
+  "Visible options in this session:",
+  "Current: `openai/",
+  "Current: `codex/",
+  "Current model:",
+  "Current model: `openai/",
+  "Current model: `codex/",
+  "Current model is `openai/",
+  "Current model is `codex/",
+  "Current session model: `openai/",
+  "Current session model: `codex/",
+  "Current session model is `openai/",
+  "Current session model is `codex/",
+  "Visible session model:",
+  "The current session is using `openai/",
+  "The current session is using `codex/",
+  "current session is using `openai/",
+  "current session is using `codex/",
+  "Configured model from `~/.codex/config.toml`:",
+  "Configured models in this session:",
+  "Default model:",
+  "This harness is configured with a single Codex model: `openai/",
+  "This harness is configured with a single Codex model: `codex/",
+  "Primary model: `openai/",
+  "Primary model: `codex/",
+  "Registered models: `openai/",
+  "Registered models: `codex/",
+  "Active model: `openai/",
+  "Active model: `codex/",
+  "Current active model is `openai/",
+  "Current active model is `codex/",
+  "Current OpenClaw session status reports the active model as:",
+] as const;
+
 /** Accepted `/codex status` response fragments for live harness probes. */
 export const EXPECTED_CODEX_STATUS_COMMAND_TEXT = [
   "Codex app-server:",
@@ -169,6 +229,12 @@ export function isExpectedCodexModelsCommandText(text: string): boolean {
   const normalized = text.toLowerCase();
   const mentionsCodexModelsCommand =
     text.includes("`codex models`") || text.includes("`/codex models`");
+  const mentionsModelIdentifier =
+    /(?:^|[\s`])(?:openai|codex)\/[a-z0-9][a-z0-9._-]*/iu.test(text) ||
+    /\b(?:gpt|o[0-9]+|claude|sonnet)-[a-z0-9][a-z0-9._-]*/iu.test(text);
+  const isHealthyExpectedModelEvidence =
+    mentionsModelIdentifier &&
+    HEALTHY_CODEX_MODELS_COMMAND_TEXT.some((expectedText) => text.includes(expectedText));
   const isSandboxFallback =
     mentionsCodexModelsCommand &&
     (normalized.includes("did not run") ||
@@ -223,7 +289,7 @@ export function isExpectedCodexModelsCommandText(text: string): boolean {
     normalized.includes("live openclaw config shows") ||
     normalized.includes("current gateway config");
   const isSessionConfigFallback =
-    (text.includes("`openai/") || text.includes("`codex/")) &&
+    mentionsModelIdentifier &&
     ((mentionsConfiguredModels && mentionsSessionModel) ||
       (mentionsConfigSummary && (mentionsConfiguredModels || mentionsSessionModel)));
 
@@ -255,24 +321,42 @@ export function isExpectedCodexModelsCommandText(text: string): boolean {
     mentionsVisibleOptions &&
     mentionsCurrentActiveModel;
   const isAgentIdModelSummary =
-    normalized.includes("available agent ids in this session:") &&
-    (text.includes("`openai/") || text.includes("`codex/"));
+    normalized.includes("available agent ids in this session:") && mentionsModelIdentifier;
   const isCodexAgentModelSummary =
     (normalized.includes("available codex agent model:") ||
       normalized.includes("available codex agent models:")) &&
-    (text.includes("`openai/") || text.includes("`codex/"));
+    mentionsModelIdentifier;
   const isAvailableHereModelSummary =
     normalized.includes("available here:") &&
     normalized.includes("current session model") &&
-    (text.includes("`openai/") || text.includes("`codex/"));
+    mentionsModelIdentifier;
   const isInteractiveTuiSummary =
     mentionsCodexModelsCommand &&
     mentionsInteractiveSelection &&
     normalized.includes("plain list") &&
     mentionsCurrentSelectedModel;
+  const isLiteralModelList =
+    mentionsModelIdentifier &&
+    (normalized.includes("codex models:") ||
+      normalized.includes("available codex models") ||
+      normalized.includes("available models:") ||
+      normalized.includes("available models, local cache:") ||
+      normalized.includes("available agent target:") ||
+      normalized.includes("available agent targets:"));
+  const isCurrentModelSummary =
+    mentionsModelIdentifier &&
+    (normalized.includes("current:") ||
+      normalized.includes("current model:") ||
+      normalized.includes("current model is") ||
+      normalized.includes("active model:") ||
+      normalized.includes("current active model is") ||
+      normalized.includes("visible session model:"));
 
   return (
     isSandboxFallback ||
+    isHealthyExpectedModelEvidence ||
+    isLiteralModelList ||
+    isCurrentModelSummary ||
     isSessionConfigFallback ||
     isInteractiveSelectionSummary ||
     isAgentIdModelSummary ||
@@ -280,6 +364,52 @@ export function isExpectedCodexModelsCommandText(text: string): boolean {
     isAvailableHereModelSummary ||
     isInteractiveTuiSummary
   );
+}
+
+function isUnavailableCodexModelsCommandText(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return (
+    normalized.includes("did not run") ||
+    normalized.includes("could not run") ||
+    normalized.includes("could not be run") ||
+    normalized.includes("couldn't run") ||
+    normalized.includes("couldn’t run") ||
+    normalized.includes("couldn't get") ||
+    normalized.includes("couldn’t get") ||
+    normalized.includes("couldn't list") ||
+    normalized.includes("couldn’t list") ||
+    normalized.includes("couldn't inspect") ||
+    normalized.includes("couldn’t inspect") ||
+    normalized.includes("didn't return a plain list") ||
+    normalized.includes("didn’t return a plain list") ||
+    normalized.includes("failed in this sandbox") ||
+    normalized.includes("failed because") ||
+    normalized.includes("failed with:") ||
+    normalized.includes("fails to start") ||
+    normalized.includes("sandbox blocks") ||
+    normalized.includes("sandbox blocked") ||
+    normalized.includes("approval review failed") ||
+    normalized.includes("failed before it could be approved") ||
+    normalized.includes("not approved") ||
+    normalized.includes("rejected") ||
+    normalized.includes("interactive in this environment") ||
+    normalized.includes("dropped into the interactive ui") ||
+    normalized.includes("dropped into the interactive tui") ||
+    normalized.includes("does not provide a separate non-interactive") ||
+    normalized.includes("not runnable in this sandboxed session") ||
+    normalized.includes("not installed") ||
+    normalized.includes("not installed on the shell path") ||
+    normalized.includes("command not found") ||
+    normalized.includes("required user namespace") ||
+    normalized.includes("unprivileged user namespaces") ||
+    normalized.includes("user-namespace restriction") ||
+    normalized.includes("bwrap: no permissions to create a new namespace")
+  );
+}
+
+/** Returns true only for live `/codex models` proof that produced usable model evidence. */
+export function isStrictExpectedCodexModelsCommandText(text: string): boolean {
+  return isExpectedCodexModelsCommandText(text) && !isUnavailableCodexModelsCommandText(text);
 }
 
 /** Identifies transient live harness errors that are worth retrying, not skipping. */

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -25,9 +25,9 @@ import {
 import {
   EXPECTED_CODEX_MODELS_COMMAND_TEXT,
   EXPECTED_CODEX_STATUS_COMMAND_TEXT,
-  isExpectedCodexModelsCommandText,
   isExpectedCodexStatusCommandText,
   isRetryableCodexHarnessLiveError,
+  isStrictExpectedCodexModelsCommandText,
 } from "./gateway-codex-harness.live-helpers.js";
 import {
   assertCronJobMatches,
@@ -354,6 +354,7 @@ async function requestCodexCommandText(params: {
   events: EventFrame[];
   expectedText: string | string[];
   isExpectedText?: (text: string) => boolean;
+  predicateOnly?: boolean;
   sessionKey: string;
 }): Promise<string> {
   const runId = `idem-${randomUUID()}-codex-command`;
@@ -381,8 +382,9 @@ async function requestCodexCommandText(params: {
     : [params.expectedText];
   const matchedByText = expectedTexts.some((expectedText) => text.includes(expectedText));
   const matchedByPredicate = params.isExpectedText?.(text) ?? false;
+  const matched = params.predicateOnly ? matchedByPredicate : matchedByText || matchedByPredicate;
   expect(
-    matchedByText || matchedByPredicate,
+    matched,
     `Expected "${params.command}" response to contain one of: ${expectedTexts.join(", ")}\nReceived:\n${text}`,
   ).toBe(true);
   return text;
@@ -1102,7 +1104,8 @@ describeLive("gateway live (Codex harness)", () => {
               sessionKey,
               command: "/codex models",
               expectedText: [...EXPECTED_CODEX_MODELS_COMMAND_TEXT],
-              isExpectedText: isExpectedCodexModelsCommandText,
+              isExpectedText: isStrictExpectedCodexModelsCommandText,
+              predicateOnly: true,
             });
             logCodexLiveStep("codex-models-command", { modelsText });
 

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -1017,28 +1017,31 @@ describeLive("gateway live (Codex harness)", () => {
       const deviceIdentity = await ensurePairedTestGatewayClientIdentity({
         displayName: "vitest-codex-harness-live",
       });
+      let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+      let client: Awaited<ReturnType<typeof connectTestGatewayClient>> | undefined;
       const gatewayEvents: EventFrame[] = [];
       logCodexLiveStep("config-written", { configPath, modelKey, port });
 
-      const server = await startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token },
-        controlUiEnabled: false,
-      });
-      const client = await connectTestGatewayClient({
-        url: `ws://127.0.0.1:${port}`,
-        token,
-        deviceIdentity,
-        timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
-        requestTimeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
-        clientDisplayName: "vitest-codex-harness-live",
-        onEvent: (event) => {
-          gatewayEvents.push(event);
-        },
-      });
-      logCodexLiveStep("client-connected");
-
       try {
+        server = await startGatewayServer(port, {
+          bind: "loopback",
+          auth: { mode: "token", token },
+          controlUiEnabled: false,
+        });
+        client = await connectTestGatewayClient({
+          url: `ws://127.0.0.1:${port}`,
+          token,
+          deviceIdentity,
+          timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
+          requestTimeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
+          clientDisplayName: "vitest-codex-harness-live",
+          onEvent: (event) => {
+            gatewayEvents.push(event);
+          },
+        });
+        logCodexLiveStep("client-connected");
+        const activeClient = client;
+
         const maxAttempts = CODEX_HARNESS_SUBAGENT_PROBE ? 1 : 2;
         for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
           try {
@@ -1046,9 +1049,9 @@ describeLive("gateway live (Codex harness)", () => {
 
             if (CODEX_HARNESS_SUBAGENT_PROBE) {
               logCodexLiveStep("subagent-probe:start", { sessionKey });
-              await verifyCodexSubagentProbe({ client, sessionKey });
+              await verifyCodexSubagentProbe({ client: activeClient, sessionKey });
               logCodexLiveStep("native-subagent-bridge-probe:start", { sessionKey });
-              await verifyCodexNativeSubagentBridgeProbe({ client, sessionKey });
+              await verifyCodexNativeSubagentBridgeProbe({ client: activeClient, sessionKey });
               logCodexLiveStep("subagent-probe:done");
               if (CODEX_HARNESS_SUBAGENT_ONLY) {
                 return;
@@ -1060,7 +1063,7 @@ describeLive("gateway live (Codex harness)", () => {
             try {
               const firstToken = `CODEX-HARNESS-${firstNonce}`;
               const firstText = await requestAgentText({
-                client,
+                client: activeClient,
                 sessionKey,
                 expectedToken: firstToken,
                 message: `Reply with exactly ${firstToken} and nothing else.`,
@@ -1071,7 +1074,7 @@ describeLive("gateway live (Codex harness)", () => {
               const secondNonce = randomBytes(3).toString("hex").toUpperCase();
               const secondToken = `CODEX-HARNESS-RESUME-${secondNonce}`;
               const secondText = await requestAgentText({
-                client,
+                client: activeClient,
                 sessionKey,
                 expectedToken: secondToken,
                 message: `Reply with exactly ${secondToken} and nothing else. Do not repeat ${firstToken}.`,
@@ -1081,7 +1084,10 @@ describeLive("gateway live (Codex harness)", () => {
 
               if (CODEX_HARNESS_CODE_MODE_ONLY) {
                 logCodexLiveStep("code-mode-only-tool-probe:start", { sessionKey });
-                await verifyCodexCodeModeOnlyDynamicToolProbe({ client, sessionKey });
+                await verifyCodexCodeModeOnlyDynamicToolProbe({
+                  client: activeClient,
+                  sessionKey,
+                });
                 logCodexLiveStep("code-mode-only-tool-probe:done");
               }
             } finally {
@@ -1089,7 +1095,7 @@ describeLive("gateway live (Codex harness)", () => {
             }
 
             const statusText = await requestCodexCommandText({
-              client,
+              client: activeClient,
               events: gatewayEvents,
               sessionKey,
               command: "/codex status",
@@ -1099,7 +1105,7 @@ describeLive("gateway live (Codex harness)", () => {
             logCodexLiveStep("codex-status-command", { statusText });
 
             const modelsText = await requestCodexCommandText({
-              client,
+              client: activeClient,
               events: gatewayEvents,
               sessionKey,
               command: "/codex models",
@@ -1111,20 +1117,20 @@ describeLive("gateway live (Codex harness)", () => {
 
             if (CODEX_HARNESS_CHAT_IMAGE_PROBE) {
               logCodexLiveStep("chat-image-probe:start", { sessionKey });
-              await verifyCodexChatImageProbe({ client, sessionKey });
+              await verifyCodexChatImageProbe({ client: activeClient, sessionKey });
               logCodexLiveStep("chat-image-probe:done");
             }
 
             if (CODEX_HARNESS_IMAGE_PROBE) {
               logCodexLiveStep("image-probe:start", { sessionKey });
-              await verifyCodexImageProbe({ client, sessionKey });
+              await verifyCodexImageProbe({ client: activeClient, sessionKey });
               logCodexLiveStep("image-probe:done");
             }
 
             if (CODEX_HARNESS_MCP_PROBE) {
               logCodexLiveStep("cron-mcp-probe:start", { sessionKey });
               await verifyCodexCronMcpProbe({
-                client,
+                client: activeClient,
                 sessionKey,
                 port,
                 token,
@@ -1136,7 +1142,10 @@ describeLive("gateway live (Codex harness)", () => {
             if (CODEX_HARNESS_GUARDIAN_PROBE) {
               const guardianSessionKey = "agent:dev:live-codex-harness-guardian";
               logCodexLiveStep("guardian-probe:start", { sessionKey: guardianSessionKey });
-              await verifyCodexGuardianProbe({ client, sessionKey: guardianSessionKey });
+              await verifyCodexGuardianProbe({
+                client: activeClient,
+                sessionKey: guardianSessionKey,
+              });
               logCodexLiveStep("guardian-probe:done");
             }
             break;
@@ -1166,18 +1175,24 @@ describeLive("gateway live (Codex harness)", () => {
           }
         }
       } finally {
-        clearRuntimeConfigSnapshot();
-        await client.stopAndWait();
-        await server.close();
-        const [{ resetTaskRegistryForTests }, { resetTaskFlowRegistryForTests }] =
-          await Promise.all([
-            import("../tasks/runtime-internal.js"),
-            import("../tasks/task-flow-runtime-internal.js"),
-          ]);
-        resetTaskRegistryForTests({ persist: false });
-        resetTaskFlowRegistryForTests({ persist: false });
-        restoreEnv(previousEnv);
-        await removeLiveTempDir(tempDir);
+        try {
+          clearRuntimeConfigSnapshot();
+          try {
+            await client?.stopAndWait();
+          } finally {
+            await server?.close();
+          }
+          const [{ resetTaskRegistryForTests }, { resetTaskFlowRegistryForTests }] =
+            await Promise.all([
+              import("../tasks/runtime-internal.js"),
+              import("../tasks/task-flow-runtime-internal.js"),
+            ]);
+          resetTaskRegistryForTests({ persist: false });
+          resetTaskFlowRegistryForTests({ persist: false });
+        } finally {
+          restoreEnv(previousEnv);
+          await removeLiveTempDir(tempDir);
+        }
       }
     },
     CODEX_HARNESS_TIMEOUT_MS,

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -434,6 +434,12 @@ function assertGatewayLiveHasRunnableCandidates(params: {
   );
 }
 
+function failGatewayLiveStartupCoverage(params: { label: string; reason: string }): never {
+  throw new Error(
+    `[${params.label}] gateway startup failed before live model coverage: ${params.reason}`,
+  );
+}
+
 async function withGatewayLiveTimeout<T>(params: {
   operation: Promise<T>;
   timeoutMs: number;
@@ -1020,6 +1026,17 @@ describe("assertGatewayLiveHasRunnableCandidates", () => {
         skipped: [],
       }),
     ).not.toThrow();
+  });
+});
+
+describe("failGatewayLiveStartupCoverage", () => {
+  it("fails startup timeouts instead of treating them as skipped live coverage", () => {
+    expect(() =>
+      failGatewayLiveStartupCoverage({
+        label: "all-models",
+        reason: "probe timeout after 90000ms (all-models: gateway-start)",
+      }),
+    ).toThrow(/gateway startup failed before live model coverage/);
   });
 });
 
@@ -2895,41 +2912,41 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
   let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
   let client: GatewayClient | undefined;
   try {
-    const port = await withGatewayLiveProbeTimeout(
-      getFreeGatewayPort(),
-      `${params.label}: gateway-port`,
-    );
-    server = await withGatewayLiveProbeTimeout(
-      startGatewayServer(port, {
-        bind: "loopback",
-        auth: { mode: "token", token },
-        controlUiEnabled: false,
-      }),
-      `${params.label}: gateway-start`,
-    );
+    try {
+      const port = await withGatewayLiveProbeTimeout(
+        getFreeGatewayPort(),
+        `${params.label}: gateway-port`,
+      );
+      server = await withGatewayLiveProbeTimeout(
+        startGatewayServer(port, {
+          bind: "loopback",
+          auth: { mode: "token", token },
+          controlUiEnabled: false,
+        }),
+        `${params.label}: gateway-start`,
+      );
 
-    client = await withGatewayLiveProbeTimeout(
-      connectClient({
-        url: `ws://127.0.0.1:${port}`,
-        token,
-      }),
-      `${params.label}: gateway-connect`,
-    );
-  } catch (error) {
-    const message = String(error);
-    if (isGatewayLiveProbeTimeout(message)) {
-      logProgress(`[${params.label}] skip (gateway startup timeout)`);
-      return;
+      client = await withGatewayLiveProbeTimeout(
+        connectClient({
+          url: `ws://127.0.0.1:${port}`,
+          token,
+        }),
+        `${params.label}: gateway-connect`,
+      );
+    } catch (error) {
+      const message = String(error);
+      if (isGatewayLiveProbeTimeout(message)) {
+        failGatewayLiveStartupCoverage({ label: params.label, reason: message });
+      }
+      throw error;
     }
-    throw error;
-  }
 
-  if (!server || !client) {
-    logProgress(`[${params.label}] skip (gateway startup incomplete)`);
-    return;
-  }
-
-  try {
+    if (!server || !client) {
+      failGatewayLiveStartupCoverage({
+        label: params.label,
+        reason: "gateway server/client did not initialize",
+      });
+    }
     logProgress(
       `[${params.label}] running ${params.candidates.length} models (thinking=${params.thinkingLevel})`,
     );
@@ -3569,8 +3586,10 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
   } finally {
     clearRuntimeConfigSnapshot();
     restoreProductionEnvForLiveRun(runtimeEnv);
-    client.stop();
-    await server.close({ reason: "live test complete" });
+    client?.stop();
+    if (server) {
+      await server.close({ reason: "live test complete" });
+    }
     await fs.rm(toolProbePath, { force: true });
     // Give the filesystem a short retry window while agent/runtime teardown
     // releases handles inside these temporary live-test directories.
@@ -3582,16 +3601,16 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
       await fs.rm(tempStateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
     }
 
-    process.env.OPENCLAW_CONFIG_PATH = previous.configPath;
-    process.env.OPENCLAW_GATEWAY_TOKEN = previous.token;
-    process.env.OPENCLAW_SKIP_CHANNELS = previous.skipChannels;
-    process.env.OPENCLAW_SKIP_GMAIL_WATCHER = previous.skipGmail;
-    process.env.OPENCLAW_SKIP_CRON = previous.skipCron;
-    process.env.OPENCLAW_SKIP_CANVAS_HOST = previous.skipCanvas;
-    process.env.OPENCLAW_DISABLE_BONJOUR = previous.disableBonjour;
-    process.env.OPENCLAW_LOG_LEVEL = previous.logLevel;
-    process.env.OPENCLAW_AGENT_DIR = previous.agentDir;
-    process.env.OPENCLAW_STATE_DIR = previous.stateDir;
+    restoreOptionalEnv("OPENCLAW_CONFIG_PATH", previous.configPath);
+    restoreOptionalEnv("OPENCLAW_GATEWAY_TOKEN", previous.token);
+    restoreOptionalEnv("OPENCLAW_SKIP_CHANNELS", previous.skipChannels);
+    restoreOptionalEnv("OPENCLAW_SKIP_GMAIL_WATCHER", previous.skipGmail);
+    restoreOptionalEnv("OPENCLAW_SKIP_CRON", previous.skipCron);
+    restoreOptionalEnv("OPENCLAW_SKIP_CANVAS_HOST", previous.skipCanvas);
+    restoreOptionalEnv("OPENCLAW_DISABLE_BONJOUR", previous.disableBonjour);
+    restoreOptionalEnv("OPENCLAW_LOG_LEVEL", previous.logLevel);
+    restoreOptionalEnv("OPENCLAW_AGENT_DIR", previous.agentDir);
+    restoreOptionalEnv("OPENCLAW_STATE_DIR", previous.stateDir);
   }
 }
 
@@ -3861,79 +3880,81 @@ describeLive("gateway live (dev agent, profile keys)", () => {
     const token = `test-${randomUUID()}`;
     process.env.OPENCLAW_GATEWAY_TOKEN = token;
 
-    const cfg = getRuntimeConfig();
-    await ensureOpenClawModelsJson(cfg);
-
-    const agentDir = resolveDefaultAgentDir(cfg);
-    const authStorage = discoverAuthStorage(agentDir);
-    const modelRegistry = discoverModels(authStorage, agentDir);
-    const anthropic = modelRegistry.find("anthropic", "claude-opus-4-6") as Model | null;
-    const zai = modelRegistry.find("zai", "glm-5.1") as Model | null;
-
-    if (!anthropic || !zai) {
-      return;
-    }
-    try {
-      await getApiKeyForModel({
-        model: anthropic,
-        cfg,
-        credentialPrecedence: LIVE_CREDENTIAL_PRECEDENCE,
-      });
-      await getApiKeyForModel({
-        model: zai,
-        cfg,
-        credentialPrecedence: LIVE_CREDENTIAL_PRECEDENCE,
-      });
-    } catch {
-      return;
-    }
-
-    const agentId = "dev";
-    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-    await fs.mkdir(workspaceDir, { recursive: true });
-    const nonceA = randomUUID();
-    const nonceB = randomUUID();
-    const toolProbePath = path.join(workspaceDir, `.openclaw-live-zai-fallback.${nonceA}.txt`);
-    await fs.writeFile(toolProbePath, `nonceA=${nonceA}\nnonceB=${nonceB}\n`);
-
     let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
     let client: GatewayClient | undefined;
+    let toolProbePath: string | undefined;
     try {
-      const port = await withGatewayLiveProbeTimeout(
-        getFreeGatewayPort(),
-        "zai-fallback: gateway-port",
-      );
-      server = await withGatewayLiveProbeTimeout(
-        startGatewayServer(port, {
-          bind: "loopback",
-          auth: { mode: "token", token },
-          controlUiEnabled: false,
-        }),
-        "zai-fallback: gateway-start",
-      );
+      const cfg = getRuntimeConfig();
+      await ensureOpenClawModelsJson(cfg);
 
-      client = await withGatewayLiveProbeTimeout(
-        connectClient({
-          url: `ws://127.0.0.1:${port}`,
-          token,
-        }),
-        "zai-fallback: gateway-connect",
-      );
-    } catch (error) {
-      const message = String(error);
-      if (isGatewayLiveProbeTimeout(message)) {
-        logProgress("[zai-fallback] skip (gateway startup timeout)");
+      const agentDir = resolveDefaultAgentDir(cfg);
+      const authStorage = discoverAuthStorage(agentDir);
+      const modelRegistry = discoverModels(authStorage, agentDir);
+      const anthropic = modelRegistry.find("anthropic", "claude-opus-4-6") as Model | null;
+      const zai = modelRegistry.find("zai", "glm-5.1") as Model | null;
+
+      if (!anthropic || !zai) {
         return;
       }
-      throw error;
-    }
+      try {
+        await getApiKeyForModel({
+          model: anthropic,
+          cfg,
+          credentialPrecedence: LIVE_CREDENTIAL_PRECEDENCE,
+        });
+        await getApiKeyForModel({
+          model: zai,
+          cfg,
+          credentialPrecedence: LIVE_CREDENTIAL_PRECEDENCE,
+        });
+      } catch {
+        return;
+      }
 
-    if (!server || !client) {
-      logProgress("[zai-fallback] skip (gateway startup incomplete)");
-      return;
-    }
+      const agentId = "dev";
+      const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+      await fs.mkdir(workspaceDir, { recursive: true });
+      const nonceA = randomUUID();
+      const nonceB = randomUUID();
+      toolProbePath = path.join(workspaceDir, `.openclaw-live-zai-fallback.${nonceA}.txt`);
+      await fs.writeFile(toolProbePath, `nonceA=${nonceA}\nnonceB=${nonceB}\n`);
 
-    try {
+      try {
+        const port = await withGatewayLiveProbeTimeout(
+          getFreeGatewayPort(),
+          "zai-fallback: gateway-port",
+        );
+        server = await withGatewayLiveProbeTimeout(
+          startGatewayServer(port, {
+            bind: "loopback",
+            auth: { mode: "token", token },
+            controlUiEnabled: false,
+          }),
+          "zai-fallback: gateway-start",
+        );
+
+        client = await withGatewayLiveProbeTimeout(
+          connectClient({
+            url: `ws://127.0.0.1:${port}`,
+            token,
+          }),
+          "zai-fallback: gateway-connect",
+        );
+      } catch (error) {
+        const message = String(error);
+        if (isGatewayLiveProbeTimeout(message)) {
+          failGatewayLiveStartupCoverage({ label: "zai-fallback", reason: message });
+        }
+        throw error;
+      }
+
+      if (!server || !client) {
+        failGatewayLiveStartupCoverage({
+          label: "zai-fallback",
+          reason: "gateway server/client did not initialize",
+        });
+      }
+
       const sessionKey = `agent:${agentId}:live-zai-fallback`;
 
       await withGatewayLiveSessionControlTimeout(
@@ -4002,16 +4023,20 @@ describeLive("gateway live (dev agent, profile keys)", () => {
     } finally {
       clearRuntimeConfigSnapshot();
       restoreProductionEnvForLiveRun(runtimeEnv);
-      client.stop();
-      await server.close({ reason: "live test complete" });
-      await fs.rm(toolProbePath, { force: true });
+      client?.stop();
+      if (server) {
+        await server.close({ reason: "live test complete" });
+      }
+      if (toolProbePath) {
+        await fs.rm(toolProbePath, { force: true });
+      }
 
-      process.env.OPENCLAW_CONFIG_PATH = previous.configPath;
-      process.env.OPENCLAW_GATEWAY_TOKEN = previous.token;
-      process.env.OPENCLAW_SKIP_CHANNELS = previous.skipChannels;
-      process.env.OPENCLAW_SKIP_GMAIL_WATCHER = previous.skipGmail;
-      process.env.OPENCLAW_SKIP_CRON = previous.skipCron;
-      process.env.OPENCLAW_SKIP_CANVAS_HOST = previous.skipCanvas;
+      restoreOptionalEnv("OPENCLAW_CONFIG_PATH", previous.configPath);
+      restoreOptionalEnv("OPENCLAW_GATEWAY_TOKEN", previous.token);
+      restoreOptionalEnv("OPENCLAW_SKIP_CHANNELS", previous.skipChannels);
+      restoreOptionalEnv("OPENCLAW_SKIP_GMAIL_WATCHER", previous.skipGmail);
+      restoreOptionalEnv("OPENCLAW_SKIP_CRON", previous.skipCron);
+      restoreOptionalEnv("OPENCLAW_SKIP_CANVAS_HOST", previous.skipCanvas);
     }
   }, 180_000);
 });

--- a/src/gateway/server-methods/doctor.memory-core-runtime.ts
+++ b/src/gateway/server-methods/doctor.memory-core-runtime.ts
@@ -6,6 +6,7 @@
  */
 export {
   dedupeDreamDiaryEntries,
+  loadShortTermPromotionDreamingStats,
   previewGroundedRemMarkdown,
   previewRemHarness,
   removeBackfillDiaryEntries,

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -25,6 +25,7 @@ const writeBackfillDiaryEntries = vi.hoisted(() => vi.fn());
 const removeBackfillDiaryEntries = vi.hoisted(() => vi.fn());
 const removeGroundedShortTermCandidates = vi.hoisted(() => vi.fn());
 const repairDreamingArtifacts = vi.hoisted(() => vi.fn());
+const loadShortTermPromotionDreamingStats = vi.hoisted(() => vi.fn());
 
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig,
@@ -45,6 +46,7 @@ vi.mock("../../plugins/memory-runtime.js", () => ({
 
 vi.mock("./doctor.memory-core-runtime.js", () => ({
   dedupeDreamDiaryEntries,
+  loadShortTermPromotionDreamingStats,
   previewGroundedRemMarkdown,
   previewRemHarness,
   writeBackfillDiaryEntries,
@@ -198,6 +200,27 @@ function findRecordByField(items: unknown, key: string, value: unknown) {
   return (items as Array<Record<string, unknown>>).find((item) => item[key] === value);
 }
 
+function makeDreamingStats(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    shortTermCount: 0,
+    recallSignalCount: 0,
+    dailySignalCount: 0,
+    groundedSignalCount: 0,
+    totalSignalCount: 0,
+    phaseSignalCount: 0,
+    lightPhaseHitCount: 0,
+    remPhaseHitCount: 0,
+    promotedTotal: 0,
+    promotedToday: 0,
+    storePath: "plugin-state:memory-core/short-term-recall/test",
+    phaseSignalPath: "plugin-state:memory-core/short-term-phase-signals/test",
+    shortTermEntries: [],
+    signalEntries: [],
+    promotedEntries: [],
+    ...overrides,
+  };
+}
+
 const expectEmbeddingErrorResponse = (respond: ReturnType<typeof vi.fn>, error: string) => {
   const payload = respondPayload(respond);
   expectRecordFields(payload, {
@@ -222,6 +245,9 @@ describe("doctor.memory.status", () => {
     removeBackfillDiaryEntries.mockReset();
     removeGroundedShortTermCandidates.mockReset();
     repairDreamingArtifacts.mockReset();
+    loadShortTermPromotionDreamingStats
+      .mockReset()
+      .mockImplementation(async () => makeDreamingStats());
   });
 
   it("returns gateway embedding probe status for the default agent", async () => {
@@ -552,6 +578,111 @@ describe("doctor.memory.status", () => {
       }
       return mainWorkspaceDir;
     });
+    loadShortTermPromotionDreamingStats.mockImplementation(
+      async ({ workspaceDir }: { workspaceDir: string }) =>
+        workspaceDir === alphaWorkspaceDir
+          ? makeDreamingStats({
+              shortTermCount: 0,
+              promotedTotal: 2,
+              promotedToday: 1,
+              promotedEntries: [
+                {
+                  key: "memory:memory/2026-04-01.md:1:2",
+                  path: "memory/2026-04-01.md",
+                  startLine: 1,
+                  endLine: 2,
+                  snippet: "Bunji lives in London.",
+                  recallCount: 7,
+                  dailyCount: 4,
+                  groundedCount: 0,
+                  totalSignalCount: 11,
+                  lightHits: 0,
+                  remHits: 0,
+                  phaseHitCount: 0,
+                  promotedAt: olderIso,
+                },
+                {
+                  key: "memory:memory/notes/2026-04-04-0800.md:1:2",
+                  path: "memory/notes/2026-04-04-0800.md",
+                  startLine: 1,
+                  endLine: 2,
+                  snippet: "Always book the covered valet option at Park & Greet BCN.",
+                  recallCount: 8,
+                  dailyCount: 3,
+                  groundedCount: 0,
+                  totalSignalCount: 11,
+                  lightHits: 0,
+                  remHits: 0,
+                  phaseHitCount: 0,
+                  promotedAt: recentIso,
+                },
+              ],
+              lastPromotedAt: recentIso,
+            })
+          : makeDreamingStats({
+              shortTermCount: 1,
+              recallSignalCount: 2,
+              dailySignalCount: 1,
+              totalSignalCount: 3,
+              phaseSignalCount: 5,
+              lightPhaseHitCount: 2,
+              remPhaseHitCount: 3,
+              promotedTotal: 1,
+              promotedToday: 1,
+              shortTermEntries: [
+                {
+                  key: "memory:memory/2026-04-03-1503.md:1:2",
+                  path: "memory/2026-04-03-1503.md",
+                  startLine: 1,
+                  endLine: 2,
+                  snippet: "Emma prefers shorter, lower-pressure check-ins.",
+                  recallCount: 2,
+                  dailyCount: 1,
+                  groundedCount: 0,
+                  totalSignalCount: 3,
+                  lightHits: 2,
+                  remHits: 3,
+                  phaseHitCount: 5,
+                  lastRecalledAt: recentIso,
+                },
+              ],
+              signalEntries: [
+                {
+                  key: "memory:memory/2026-04-03-1503.md:1:2",
+                  path: "memory/2026-04-03-1503.md",
+                  startLine: 1,
+                  endLine: 2,
+                  snippet: "Emma prefers shorter, lower-pressure check-ins.",
+                  recallCount: 2,
+                  dailyCount: 1,
+                  groundedCount: 0,
+                  totalSignalCount: 3,
+                  lightHits: 2,
+                  remHits: 3,
+                  phaseHitCount: 5,
+                  lastRecalledAt: recentIso,
+                },
+              ],
+              promotedEntries: [
+                {
+                  key: "memory:memory/daily/2026-04-02-1015.md:1:2",
+                  path: "memory/daily/2026-04-02-1015.md",
+                  startLine: 1,
+                  endLine: 2,
+                  snippet: "Use the Happy Together calendar for flights.",
+                  recallCount: 9,
+                  dailyCount: 5,
+                  groundedCount: 0,
+                  totalSignalCount: 14,
+                  lightHits: 0,
+                  remHits: 0,
+                  phaseHitCount: 0,
+                  promotedAt: recentIso,
+                },
+              ],
+              lastPromotedAt: recentIso,
+            }),
+    );
 
     const close = vi.fn().mockResolvedValue(undefined);
     getMemorySearchManager.mockResolvedValue({
@@ -667,6 +798,31 @@ describe("doctor.memory.status", () => {
     };
     await writeStore(mainWorkspaceDir, "main agent memory");
     await writeStore(alphaWorkspaceDir, "alpha agent memory");
+    loadShortTermPromotionDreamingStats.mockImplementation(
+      async ({ workspaceDir }: { workspaceDir: string }) =>
+        makeDreamingStats({
+          promotedTotal: 1,
+          promotedEntries: [
+            {
+              key: "memory:memory/2026-04-04.md:1:2",
+              path: "memory/2026-04-04.md",
+              startLine: 1,
+              endLine: 2,
+              snippet:
+                workspaceDir === alphaWorkspaceDir ? "alpha agent memory" : "main agent memory",
+              recallCount: 0,
+              dailyCount: 0,
+              groundedCount: 0,
+              totalSignalCount: 0,
+              lightHits: 0,
+              remHits: 0,
+              phaseHitCount: 0,
+              promotedAt: "2026-04-04T00:00:00.000Z",
+            },
+          ],
+          lastPromotedAt: "2026-04-04T00:00:00.000Z",
+        }),
+    );
     getRuntimeConfig.mockReturnValue({
       agents: {
         list: [{ id: "alpha", workspace: alphaWorkspaceDir }],
@@ -740,6 +896,29 @@ describe("doctor.memory.status", () => {
       "utf-8",
     );
     resolveMemorySearchConfig.mockReturnValue(null);
+    loadShortTermPromotionDreamingStats.mockResolvedValueOnce(
+      makeDreamingStats({
+        promotedTotal: 1,
+        promotedEntries: [
+          {
+            key: "memory:memory/2026-04-03.md:1:2",
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            snippet: "memory/2026-04-03.md",
+            recallCount: 0,
+            dailyCount: 0,
+            groundedCount: 0,
+            totalSignalCount: 0,
+            lightHits: 0,
+            remHits: 0,
+            phaseHitCount: 0,
+            promotedAt: "2026-04-04T00:00:00.000Z",
+          },
+        ],
+        lastPromotedAt: "2026-04-04T00:00:00.000Z",
+      }),
+    );
     getRuntimeConfig.mockReturnValue({
       plugins: {
         entries: {
@@ -879,26 +1058,7 @@ describe("doctor.memory.status", () => {
       agentId === "alpha" ? alphaWorkspaceDir : mainWorkspaceDir,
     );
 
-    const readFileSpy = vi.spyOn(fs, "readFile").mockImplementation(async (target, options) => {
-      const targetPath =
-        typeof target === "string"
-          ? target
-          : Buffer.isBuffer(target)
-            ? target.toString("utf-8")
-            : target instanceof URL
-              ? target.pathname
-              : "";
-      if (
-        targetPath === path.join(mainWorkspaceDir, "memory", ".dreams", "short-term-recall.json") ||
-        targetPath === alphaStorePath
-      ) {
-        const error = Object.assign(new Error("denied"), { code: "EACCES" });
-        throw error;
-      }
-      return await vi
-        .importActual<typeof import("node:fs/promises")>("node:fs/promises")
-        .then((actual) => actual.readFile(target, options as never));
-    });
+    loadShortTermPromotionDreamingStats.mockRejectedValue(new Error("denied"));
 
     const close = vi.fn().mockResolvedValue(undefined);
     getMemorySearchManager.mockResolvedValue({
@@ -919,7 +1079,6 @@ describe("doctor.memory.status", () => {
         storeError: "2 dreaming stores had read errors.",
       });
     } finally {
-      readFileSpy.mockRestore();
       await fs.rm(workspaceRoot, { recursive: true, force: true });
     }
   });

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
-  isSameMemoryDreamingDay,
   resolveMemoryDeepDreamingConfig,
   resolveMemoryLightDreamingConfig,
   resolveMemoryDreamingPluginConfig,
@@ -18,6 +17,7 @@ import { normalizeAgentId } from "../../routing/session-key.js";
 import { formatError } from "../server-utils.js";
 import {
   dedupeDreamDiaryEntries,
+  loadShortTermPromotionDreamingStats,
   previewGroundedRemMarkdown,
   previewRemHarness,
   removeBackfillDiaryEntries,
@@ -28,8 +28,6 @@ import {
 import { asRecord, normalizeTrimmedString } from "./record-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
-const SHORT_TERM_STORE_RELATIVE_PATH = path.join("memory", ".dreams", "short-term-recall.json");
-const SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH = path.join("memory", ".dreams", "phase-signals.json");
 const MANAGED_DEEP_SLEEP_CRON_NAME = "Memory Dreaming Promotion";
 const MANAGED_DEEP_SLEEP_CRON_TAG = "[managed-by=memory-core.short-term-promotion]";
 const DEEP_SLEEP_SYSTEM_EVENT_TEXT = "__openclaw_memory_core_short_term_promotion_dream__";
@@ -334,38 +332,6 @@ function resolveDreamingConfig(
   };
 }
 
-function normalizeMemoryPath(rawPath: string): string {
-  return rawPath.replaceAll("\\", "/").replace(/^\.\//, "");
-}
-
-function normalizeMemoryPathForWorkspace(workspaceDir: string, rawPath: string): string {
-  const normalized = normalizeMemoryPath(rawPath);
-  const workspaceNormalized = normalizeMemoryPath(workspaceDir);
-  if (path.isAbsolute(rawPath) && normalized.startsWith(`${workspaceNormalized}/`)) {
-    return normalized.slice(workspaceNormalized.length + 1);
-  }
-  return normalized;
-}
-
-function isShortTermMemoryPath(filePath: string): boolean {
-  const normalized = normalizeMemoryPath(filePath);
-  // Status only counts short-term source shapes; promoted diary/report files stay out.
-  if (/(?:^|\/)memory\/dreaming\//.test(normalized)) {
-    return false;
-  }
-  if (/(?:^|\/)memory\/(?:[^/]+\/)*(\d{4})-(\d{2})-(\d{2})(?:-[^/]+)?\.md$/.test(normalized)) {
-    return true;
-  }
-  if (
-    /(?:^|\/)memory\/\.dreams\/session-corpus\/(\d{4})-(\d{2})-(\d{2})\.(?:md|txt)$/.test(
-      normalized,
-    )
-  ) {
-    return true;
-  }
-  return /^(\d{4})-(\d{2})-(\d{2})(?:-[^/]+)?\.md$/.test(normalized);
-}
-
 type DreamingStoreStats = Pick<
   DoctorMemoryDreamingPayload,
   | "shortTermCount"
@@ -389,34 +355,6 @@ type DreamingStoreStats = Pick<
 >;
 
 const DREAMING_ENTRY_LIST_LIMIT = 8;
-
-function toNonNegativeInt(value: unknown): number {
-  const num = Number(value);
-  if (!Number.isFinite(num)) {
-    return 0;
-  }
-  return Math.max(0, Math.floor(num));
-}
-
-function parseEntryRangeFromKey(
-  key: string,
-  fallbackStartLine: unknown,
-  fallbackEndLine: unknown,
-): { startLine: number; endLine: number } {
-  const startLine = toNonNegativeInt(fallbackStartLine);
-  const endLine = toNonNegativeInt(fallbackEndLine);
-  if (startLine > 0 && endLine > 0) {
-    return { startLine, endLine };
-  }
-  const match = key.match(/:(\d+):(\d+)$/);
-  if (match) {
-    return {
-      startLine: Math.max(1, toNonNegativeInt(match[1])),
-      endLine: Math.max(1, toNonNegativeInt(match[2])),
-    };
-  }
-  return { startLine: 1, endLine: 1 };
-}
 
 function compareDreamingEntryByRecency(
   a: DoctorMemoryDreamingEntryPayload,
@@ -493,164 +431,9 @@ async function loadDreamingStoreStats(
   nowMs: number,
   timezone?: string,
 ): Promise<DreamingStoreStats> {
-  const storePath = path.join(workspaceDir, SHORT_TERM_STORE_RELATIVE_PATH);
-  const phaseSignalPath = path.join(workspaceDir, SHORT_TERM_PHASE_SIGNAL_RELATIVE_PATH);
   try {
-    const raw = await fs.readFile(storePath, "utf-8");
-    const parsed = JSON.parse(raw) as unknown;
-    const store = asRecord(parsed);
-    const entries = asRecord(store?.entries) ?? {};
-    let shortTermCount = 0;
-    let recallSignalCount = 0;
-    let dailySignalCount = 0;
-    let groundedSignalCount = 0;
-    let totalSignalCount = 0;
-    let phaseSignalCount = 0;
-    let lightPhaseHitCount = 0;
-    let remPhaseHitCount = 0;
-    let promotedTotal = 0;
-    let promotedToday = 0;
-    let latestPromotedAtMs = Number.NEGATIVE_INFINITY;
-    let latestPromotedAt: string | undefined;
-    const activeKeys = new Set<string>();
-    const activeEntries = new Map<string, DoctorMemoryDreamingEntryPayload>();
-    const shortTermEntries: DoctorMemoryDreamingEntryPayload[] = [];
-    const promotedEntries: DoctorMemoryDreamingEntryPayload[] = [];
-
-    for (const [entryKey, value] of Object.entries(entries)) {
-      const entry = asRecord(value);
-      if (!entry) {
-        continue;
-      }
-      const source = normalizeTrimmedString(entry.source);
-      const entryPath = normalizeTrimmedString(entry.path);
-      if (source !== "memory" || !entryPath || !isShortTermMemoryPath(entryPath)) {
-        continue;
-      }
-      const range = parseEntryRangeFromKey(entryKey, entry.startLine, entry.endLine);
-      const recallCount = toNonNegativeInt(entry.recallCount);
-      const dailyCount = toNonNegativeInt(entry.dailyCount);
-      const groundedCount = toNonNegativeInt(entry.groundedCount);
-      const totalEntrySignalCount = recallCount + dailyCount + groundedCount;
-      const normalizedEntryPath = normalizeMemoryPathForWorkspace(workspaceDir, entryPath);
-      const snippet =
-        normalizeTrimmedString(entry.snippet) ??
-        normalizeTrimmedString(entry.summary) ??
-        normalizedEntryPath;
-      const lastRecalledAt = normalizeTrimmedString(entry.lastRecalledAt);
-      const detail: DoctorMemoryDreamingEntryPayload = {
-        key: entryKey,
-        path: normalizedEntryPath,
-        startLine: range.startLine,
-        endLine: Math.max(range.startLine, range.endLine),
-        snippet,
-        recallCount,
-        dailyCount,
-        groundedCount,
-        totalSignalCount: totalEntrySignalCount,
-        lightHits: 0,
-        remHits: 0,
-        phaseHitCount: 0,
-        ...(lastRecalledAt ? { lastRecalledAt } : {}),
-      };
-      const promotedAt = normalizeTrimmedString(entry.promotedAt);
-      if (!promotedAt) {
-        shortTermCount += 1;
-        activeKeys.add(entryKey);
-        recallSignalCount += recallCount;
-        dailySignalCount += dailyCount;
-        groundedSignalCount += groundedCount;
-        totalSignalCount += totalEntrySignalCount;
-        shortTermEntries.push(detail);
-        activeEntries.set(entryKey, detail);
-        continue;
-      }
-      promotedTotal += 1;
-      promotedEntries.push({
-        ...detail,
-        promotedAt,
-      });
-      const promotedAtMs = Date.parse(promotedAt);
-      if (Number.isFinite(promotedAtMs) && isSameMemoryDreamingDay(promotedAtMs, nowMs, timezone)) {
-        promotedToday += 1;
-      }
-      if (Number.isFinite(promotedAtMs) && promotedAtMs > latestPromotedAtMs) {
-        latestPromotedAtMs = promotedAtMs;
-        latestPromotedAt = promotedAt;
-      }
-    }
-
-    let phaseSignalError: string | undefined;
-    try {
-      const phaseRaw = await fs.readFile(phaseSignalPath, "utf-8");
-      const parsedPhase = JSON.parse(phaseRaw) as unknown;
-      const phaseStore = asRecord(parsedPhase);
-      const phaseEntries = asRecord(phaseStore?.entries) ?? {};
-      for (const [key, value] of Object.entries(phaseEntries)) {
-        // Phase signals are joined only to active short-term entries, not archived promotions.
-        if (!activeKeys.has(key)) {
-          continue;
-        }
-        const phaseEntry = asRecord(value);
-        const lightHits = toNonNegativeInt(phaseEntry?.lightHits);
-        const remHits = toNonNegativeInt(phaseEntry?.remHits);
-        lightPhaseHitCount += lightHits;
-        remPhaseHitCount += remHits;
-        phaseSignalCount += lightHits + remHits;
-        const detail = activeEntries.get(key);
-        if (detail) {
-          detail.lightHits = lightHits;
-          detail.remHits = remHits;
-          detail.phaseHitCount = lightHits + remHits;
-        }
-      }
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException | undefined)?.code;
-      if (code !== "ENOENT") {
-        phaseSignalError = formatError(err);
-      }
-    }
-
-    return {
-      shortTermCount,
-      recallSignalCount,
-      dailySignalCount,
-      groundedSignalCount,
-      totalSignalCount,
-      phaseSignalCount,
-      lightPhaseHitCount,
-      remPhaseHitCount,
-      promotedTotal,
-      promotedToday,
-      storePath,
-      phaseSignalPath,
-      shortTermEntries: trimDreamingEntries(shortTermEntries, compareDreamingEntryByRecency),
-      signalEntries: trimDreamingEntries(shortTermEntries, compareDreamingEntryBySignals),
-      promotedEntries: trimDreamingEntries(promotedEntries, compareDreamingEntryByPromotion),
-      ...(latestPromotedAt ? { lastPromotedAt: latestPromotedAt } : {}),
-      ...(phaseSignalError ? { phaseSignalError } : {}),
-    };
+    return await loadShortTermPromotionDreamingStats({ workspaceDir, nowMs, timezone });
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException | undefined)?.code;
-    if (code === "ENOENT") {
-      return {
-        shortTermCount: 0,
-        recallSignalCount: 0,
-        dailySignalCount: 0,
-        groundedSignalCount: 0,
-        totalSignalCount: 0,
-        phaseSignalCount: 0,
-        lightPhaseHitCount: 0,
-        remPhaseHitCount: 0,
-        promotedTotal: 0,
-        promotedToday: 0,
-        storePath,
-        phaseSignalPath,
-        shortTermEntries: [],
-        signalEntries: [],
-        promotedEntries: [],
-      };
-    }
     return {
       shortTermCount: 0,
       recallSignalCount: 0,
@@ -662,8 +445,6 @@ async function loadDreamingStoreStats(
       remPhaseHitCount: 0,
       promotedTotal: 0,
       promotedToday: 0,
-      storePath,
-      phaseSignalPath,
       shortTermEntries: [],
       signalEntries: [],
       promotedEntries: [],

--- a/src/infra/push-apns-http2.ts
+++ b/src/infra/push-apns-http2.ts
@@ -19,7 +19,14 @@ const APNS_AUTHORITIES = new Set([
 type ApnsAuthority = "https://api.push.apple.com" | "https://api.sandbox.push.apple.com";
 
 export const APNS_HTTP2_CANCEL_CODE = http2.constants.NGHTTP2_CANCEL;
+export const APNS_RESPONSE_BODY_MAX_BYTES = 8192;
 const APNS_HTTP2_MIN_TIMEOUT_MS = 1000;
+
+export type ApnsResponseBodyCapture = {
+  text: string;
+  bytes: number;
+  truncated: boolean;
+};
 
 /** Parameters for opening an APNs HTTP/2 client session. */
 export type ConnectApnsHttp2SessionParams = {
@@ -114,6 +121,29 @@ function resolveApnsHttp2TimeoutMs(timeoutMs: number): number {
   return resolveTimerTimeoutMs(timeoutMs, APNS_HTTP2_MIN_TIMEOUT_MS, APNS_HTTP2_MIN_TIMEOUT_MS);
 }
 
+export function createApnsResponseBodyCapture(): ApnsResponseBodyCapture {
+  return { text: "", bytes: 0, truncated: false };
+}
+
+export function appendApnsResponseBodyCapture(
+  capture: ApnsResponseBodyCapture,
+  chunk: unknown,
+  maxBytes = APNS_RESPONSE_BODY_MAX_BYTES,
+): void {
+  const buffer = Buffer.from(String(chunk));
+  capture.bytes += buffer.byteLength;
+  const remaining = maxBytes - Buffer.byteLength(capture.text);
+  if (remaining <= 0) {
+    capture.truncated = capture.truncated || buffer.byteLength > 0;
+    return;
+  }
+  const slice = buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer;
+  capture.text += slice.toString("utf8");
+  if (slice.byteLength < buffer.byteLength) {
+    capture.truncated = true;
+  }
+}
+
 /** Sends an intentionally invalid APNs push through a proxy to prove HTTP/2 reachability. */
 export async function probeApnsHttp2ReachabilityViaProxy(
   params: ProbeApnsHttp2ReachabilityViaProxyParams,
@@ -130,7 +160,7 @@ export async function probeApnsHttp2ReachabilityViaProxy(
   try {
     return await new Promise<ProbeApnsHttp2ReachabilityViaProxyResult>((resolve, reject) => {
       let settled = false;
-      let body = "";
+      const body = createApnsResponseBodyCapture();
       let status: number | undefined;
       let responseHeaders: Record<string, string> = {};
       const timeout = setTimeout(() => {
@@ -176,7 +206,7 @@ export async function probeApnsHttp2ReachabilityViaProxy(
         );
       });
       request.on("data", (chunk) => {
-        body += String(chunk);
+        appendApnsResponseBodyCapture(body, chunk);
       });
       request.once("error", fail);
       request.once("end", () => {
@@ -189,7 +219,7 @@ export async function probeApnsHttp2ReachabilityViaProxy(
           reject(new Error("APNs reachability probe ended without an HTTP/2 status"));
           return;
         }
-        resolve({ status, body, responseHeaders });
+        resolve({ status, body: body.text, responseHeaders });
       });
       request.end(JSON.stringify({ aps: { alert: "OpenClaw APNs proxy validation" } }));
     });

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -6,6 +6,7 @@ import net from "node:net";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { startProxy, stopProxy, type ProxyHandle } from "./net/proxy/proxy-lifecycle.js";
+import { appendApnsResponseBodyCapture, createApnsResponseBodyCapture } from "./push-apns-http2.js";
 import {
   sendApnsAlert,
   sendApnsBackgroundWake,
@@ -198,12 +199,14 @@ function requirePayload(sendRequest: Record<string, unknown>) {
   return requireRecord(sendRequest.payload, "APNs payload");
 }
 
-async function startFakeApnsServer(): Promise<{
+async function startFakeApnsServer(params?: { responseBody?: string; status?: number }): Promise<{
   port: number;
   requests: CapturedApnsRequest[];
   stop: () => Promise<void>;
 }> {
   const requests: CapturedApnsRequest[] = [];
+  const responseBody = params?.responseBody ?? "";
+  const status = params?.status ?? 200;
   const server = http2.createSecureServer({
     key: testApnsServerKeyPem,
     cert: testApnsServerCert,
@@ -217,8 +220,8 @@ async function startFakeApnsServer(): Promise<{
     });
     stream.on("end", () => {
       requests.push({ headers, body });
-      stream.respond({ ":status": 200, "apns-id": "proxied-apns-id" });
-      stream.end();
+      stream.respond({ ":status": status, "apns-id": "proxied-apns-id" });
+      stream.end(responseBody);
     });
   });
   const port = await listen(server);
@@ -279,6 +282,19 @@ afterEach(async () => {
 });
 
 describe("push APNs send semantics", () => {
+  it("bounds APNs response body capture", () => {
+    const capture = createApnsResponseBodyCapture();
+
+    appendApnsResponseBodyCapture(capture, "abc", 5);
+    appendApnsResponseBodyCapture(capture, "def", 5);
+
+    expect(capture).toEqual({
+      text: "abcde",
+      bytes: 6,
+      truncated: true,
+    });
+  });
+
   it("sends alert pushes with alert headers and payload", async () => {
     const { send, registration, auth } = createDirectApnsSendFixture({
       nodeId: "ios-node-alert",
@@ -361,6 +377,56 @@ describe("push APNs send semantics", () => {
       expect(request?.headers["apns-topic"]).toBe("ai.openclaw.ios");
       expect(request?.headers["apns-push-type"]).toBe("alert");
       expect(request?.body).toContain('"nodeId":"ios-node-proxied-alert"');
+    } finally {
+      if (previousTlsRejectUnauthorized === undefined) {
+        delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+      } else {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = previousTlsRejectUnauthorized;
+      }
+      await stopProxy(proxyHandle ?? null);
+      await proxy.stop();
+      await apnsServer.stop();
+    }
+  });
+
+  it("bounds oversized direct APNs error bodies while preserving parseable reasons", async () => {
+    const apnsServer = await startFakeApnsServer({
+      status: 400,
+      responseBody: '{"reason":"BadDeviceToken"}' + " ".repeat(20_000),
+    });
+    const proxy = await startConnectProxy(apnsServer.port);
+    let proxyHandle: ProxyHandle | null | undefined;
+    const previousTlsRejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+    try {
+      proxyHandle = await startProxy({ enabled: true, proxyUrl: proxy.proxyUrl });
+      const { registration, auth } = createDirectApnsSendFixture({
+        nodeId: "ios-node-proxied-error-body",
+        environment: "sandbox",
+        sendResult: {
+          status: 200,
+          apnsId: "unused",
+          body: "",
+        },
+      });
+
+      const result = await sendApnsAlert({
+        registration,
+        nodeId: "ios-node-proxied-error-body",
+        title: "Wake",
+        body: "Ping",
+        auth,
+        timeoutMs: 2_500,
+      });
+
+      expectRecordFields(requireRecord(result, "APNs result"), {
+        ok: false,
+        status: 400,
+        apnsId: "proxied-apns-id",
+        reason: "BadDeviceToken",
+        transport: "direct",
+      });
     } finally {
       if (previousTlsRejectUnauthorized === undefined) {
         delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -11,7 +11,12 @@ import { resolveStateDir } from "../config/paths.js";
 import type { DeviceIdentity } from "./device-identity.js";
 import { formatErrorMessage } from "./errors.js";
 import { createAsyncLock, tryReadJson, writeJson } from "./json-files.js";
-import { APNS_HTTP2_CANCEL_CODE, connectApnsHttp2Session } from "./push-apns-http2.js";
+import {
+  APNS_HTTP2_CANCEL_CODE,
+  appendApnsResponseBodyCapture,
+  connectApnsHttp2Session,
+  createApnsResponseBodyCapture,
+} from "./push-apns-http2.js";
 import {
   type ApnsRelayConfig,
   type ApnsRelayPushResponse,
@@ -753,7 +758,7 @@ async function sendApnsRequest(params: {
 
     let statusCode = 0;
     let apnsId: string | undefined;
-    let responseBody = "";
+    const responseBody = createApnsResponseBodyCapture();
 
     req.setEncoding("utf8");
     req.setTimeout(params.timeoutMs, () => {
@@ -770,11 +775,11 @@ async function sendApnsRequest(params: {
     });
     req.on("data", (chunk) => {
       if (typeof chunk === "string") {
-        responseBody += chunk;
+        appendApnsResponseBodyCapture(responseBody, chunk);
       }
     });
     req.on("end", () => {
-      finish({ status: statusCode, apnsId, body: responseBody });
+      finish({ status: statusCode, apnsId, body: responseBody.text });
     });
     req.on("error", (err) => fail(err));
 

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -152,6 +152,7 @@ export type MemoryDreamingWorkspace = {
 export type MemoryDreamingWorkspaceOptions = {
   primaryWorkspaceDir?: string | null;
   primaryAgentId?: string | null;
+  env?: NodeJS.ProcessEnv;
 };
 
 const DEFAULT_MEMORY_LIGHT_DREAMING_SOURCES: MemoryLightDreamingSource[] = [
@@ -655,7 +656,7 @@ export function resolveMemoryDreamingWorkspaces(
   };
 
   for (const agentId of agentIds) {
-    addWorkspace(resolveAgentWorkspaceDir(cfg, agentId), agentId);
+    addWorkspace(resolveAgentWorkspaceDir(cfg, agentId, options.env), agentId);
   }
   addWorkspace(
     options.primaryWorkspaceDir ?? undefined,

--- a/src/plugin-sdk/memory-core-bundled-runtime.test.ts
+++ b/src/plugin-sdk/memory-core-bundled-runtime.test.ts
@@ -4,9 +4,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const loadBundledPluginPublicSurfaceModuleSync = vi.hoisted(() => vi.fn());
+const configureMemoryCoreDreamingStateImpl = vi.hoisted(() => vi.fn());
 const createEmbeddingProviderImpl = vi.hoisted(() => vi.fn());
 const registerBuiltInMemoryEmbeddingProvidersImpl = vi.hoisted(() => vi.fn());
 const removeGroundedShortTermCandidatesImpl = vi.hoisted(() => vi.fn());
+const loadShortTermPromotionDreamingStatsImpl = vi.hoisted(() => vi.fn());
 const previewGroundedRemMarkdownImpl = vi.hoisted(() => vi.fn());
 const writeBackfillDiaryEntriesImpl = vi.hoisted(() => vi.fn());
 const removeBackfillDiaryEntriesImpl = vi.hoisted(() => vi.fn());
@@ -23,9 +25,11 @@ vi.mock("./facade-loader.js", async () => {
 
 describe("plugin-sdk memory-core bundled runtime", () => {
   beforeEach(() => {
+    configureMemoryCoreDreamingStateImpl.mockReset();
     createEmbeddingProviderImpl.mockReset().mockResolvedValue({ provider: { id: "openai" } });
     registerBuiltInMemoryEmbeddingProvidersImpl.mockReset();
     removeGroundedShortTermCandidatesImpl.mockReset().mockResolvedValue({ removed: 1 });
+    loadShortTermPromotionDreamingStatsImpl.mockReset().mockResolvedValue({ shortTermCount: 0 });
     previewGroundedRemMarkdownImpl.mockReset().mockResolvedValue({ files: [] });
     writeBackfillDiaryEntriesImpl.mockReset().mockResolvedValue({ writtenCount: 1 });
     removeBackfillDiaryEntriesImpl.mockReset().mockResolvedValue({ removedCount: 1 });
@@ -36,13 +40,16 @@ describe("plugin-sdk memory-core bundled runtime", () => {
       .mockImplementation(({ artifactBasename }) => {
         if (artifactBasename === "runtime-api.js") {
           return {
+            configureMemoryCoreDreamingState: configureMemoryCoreDreamingStateImpl,
             createEmbeddingProvider: createEmbeddingProviderImpl,
             registerBuiltInMemoryEmbeddingProviders: registerBuiltInMemoryEmbeddingProvidersImpl,
             removeGroundedShortTermCandidates: removeGroundedShortTermCandidatesImpl,
+            loadShortTermPromotionDreamingStats: loadShortTermPromotionDreamingStatsImpl,
           };
         }
         if (artifactBasename === "api.js") {
           return {
+            configureMemoryCoreDreamingState: configureMemoryCoreDreamingStateImpl,
             previewGroundedRemMarkdown: previewGroundedRemMarkdownImpl,
             writeBackfillDiaryEntries: writeBackfillDiaryEntriesImpl,
             removeBackfillDiaryEntries: removeBackfillDiaryEntriesImpl,
@@ -63,6 +70,7 @@ describe("plugin-sdk memory-core bundled runtime", () => {
       dirName: "memory-core",
       artifactBasename: "runtime-api.js",
     });
+    expect(configureMemoryCoreDreamingStateImpl).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it("delegates doctor and embedding helpers through the bundled public surfaces", async () => {
@@ -70,10 +78,12 @@ describe("plugin-sdk memory-core bundled runtime", () => {
 
     await module.previewGroundedRemMarkdown({} as never);
     await module.removeGroundedShortTermCandidates({} as never);
+    await module.loadShortTermPromotionDreamingStats({} as never);
     module.registerBuiltInMemoryEmbeddingProviders({} as never);
 
     expect(previewGroundedRemMarkdownImpl).toHaveBeenCalledWith({} as never);
     expect(removeGroundedShortTermCandidatesImpl).toHaveBeenCalledWith({} as never);
+    expect(loadShortTermPromotionDreamingStatsImpl).toHaveBeenCalledWith({} as never);
     expect(registerBuiltInMemoryEmbeddingProvidersImpl).toHaveBeenCalledWith({} as never);
     expect(loadBundledPluginPublicSurfaceModuleSync).toHaveBeenCalledWith({
       dirName: "memory-core",
@@ -111,6 +121,7 @@ describe("plugin-sdk memory-core bundled runtime", () => {
 
     expect(result).toBe(preview);
     expect(previewRemHarnessImpl).toHaveBeenCalledWith(params);
+    expect(configureMemoryCoreDreamingStateImpl).toHaveBeenCalledWith(expect.any(Function));
     expect(loadBundledPluginPublicSurfaceModuleSync).toHaveBeenCalledWith({
       dirName: "memory-core",
       artifactBasename: "api.js",

--- a/src/plugin-sdk/memory-core-bundled-runtime.ts
+++ b/src/plugin-sdk/memory-core-bundled-runtime.ts
@@ -1,12 +1,14 @@
+// Manual facade. Keep loader boundary explicit.
+import { createPluginStateKeyedStore } from "../plugin-state/plugin-state-store.js";
 // Memory core bundled runtime helpers load the internal memory plugin through SDK facades.
 import { loadBundledPluginPublicSurfaceModuleSync } from "./facade-loader.js";
-// Manual facade. Keep loader boundary explicit.
 import type {
   MemoryEmbeddingProvider,
   MemoryEmbeddingProviderAdapter,
   MemoryEmbeddingProviderCreateOptions,
   MemoryEmbeddingProviderRuntime,
 } from "./memory-core-host-engine-embeddings.js";
+import type { OpenKeyedStoreOptions, PluginStateKeyedStore } from "./plugin-state-runtime.js";
 
 type EmbeddingProviderResult = {
   provider: MemoryEmbeddingProvider | null;
@@ -18,6 +20,9 @@ type EmbeddingProviderResult = {
 };
 
 type RuntimeFacadeModule = {
+  configureMemoryCoreDreamingState: (
+    openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
+  ) => void;
   createEmbeddingProvider: (
     options: MemoryEmbeddingProviderCreateOptions & {
       provider: string;
@@ -30,6 +35,11 @@ type RuntimeFacadeModule = {
   removeGroundedShortTermCandidates: (params: {
     workspaceDir: string;
   }) => Promise<{ removed: number; storePath: string }>;
+  loadShortTermPromotionDreamingStats: (params: {
+    workspaceDir: string;
+    nowMs: number;
+    timezone?: string;
+  }) => Promise<ShortTermDreamingStats>;
   repairDreamingArtifacts: (params: {
     workspaceDir: string;
     archiveDiary?: boolean;
@@ -89,6 +99,43 @@ type PromotionCandidate = {
   promotedAt?: string;
 };
 
+export type ShortTermDreamingStatsEntry = {
+  key: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  snippet: string;
+  recallCount: number;
+  dailyCount: number;
+  groundedCount: number;
+  totalSignalCount: number;
+  lightHits: number;
+  remHits: number;
+  phaseHitCount: number;
+  promotedAt?: string;
+  lastRecalledAt?: string;
+};
+
+export type ShortTermDreamingStats = {
+  shortTermCount: number;
+  recallSignalCount: number;
+  dailySignalCount: number;
+  groundedSignalCount: number;
+  totalSignalCount: number;
+  phaseSignalCount: number;
+  lightPhaseHitCount: number;
+  remPhaseHitCount: number;
+  promotedTotal: number;
+  promotedToday: number;
+  storePath: string;
+  phaseSignalPath: string;
+  phaseSignalError?: string;
+  lastPromotedAt?: string;
+  shortTermEntries: ShortTermDreamingStatsEntry[];
+  signalEntries: ShortTermDreamingStatsEntry[];
+  promotedEntries: ShortTermDreamingStatsEntry[];
+};
+
 type RemHarnessPreviewResult = {
   workspaceDir: string;
   nowMs: number;
@@ -119,6 +166,9 @@ type RemHarnessPreviewResult = {
 };
 
 type ApiFacadeModule = {
+  configureMemoryCoreDreamingState: (
+    openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
+  ) => void;
   previewGroundedRemMarkdown: (params: {
     workspaceDir: string;
     inputPaths: string[];
@@ -168,17 +218,25 @@ type RepairDreamingArtifactsResult = {
 };
 
 function loadApiFacadeModule(): ApiFacadeModule {
-  return loadBundledPluginPublicSurfaceModuleSync<ApiFacadeModule>({
+  const module = loadBundledPluginPublicSurfaceModuleSync<ApiFacadeModule>({
     dirName: "memory-core",
     artifactBasename: "api.js",
   });
+  module.configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateKeyedStore<T>("memory-core", options),
+  );
+  return module;
 }
 
 function loadRuntimeFacadeModule(): RuntimeFacadeModule {
-  return loadBundledPluginPublicSurfaceModuleSync<RuntimeFacadeModule>({
+  const module = loadBundledPluginPublicSurfaceModuleSync<RuntimeFacadeModule>({
     dirName: "memory-core",
     artifactBasename: "runtime-api.js",
   });
+  module.configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateKeyedStore<T>("memory-core", options),
+  );
+  return module;
 }
 
 /** Create a memory embedding provider with built-in fallback metadata. */
@@ -200,6 +258,12 @@ export const removeGroundedShortTermCandidates: RuntimeFacadeModule["removeGroun
     loadRuntimeFacadeModule().removeGroundedShortTermCandidates(
       ...args,
     )) as RuntimeFacadeModule["removeGroundedShortTermCandidates"];
+/** Load short-term dreaming stats for doctor/control status. */
+export const loadShortTermPromotionDreamingStats: RuntimeFacadeModule["loadShortTermPromotionDreamingStats"] =
+  ((...args) =>
+    loadRuntimeFacadeModule().loadShortTermPromotionDreamingStats(
+      ...args,
+    )) as RuntimeFacadeModule["loadShortTermPromotionDreamingStats"];
 /** Repair or archive problematic dreaming artifacts through the bundled runtime facade. */
 export const repairDreamingArtifacts: RuntimeFacadeModule["repairDreamingArtifacts"] = ((...args) =>
   loadRuntimeFacadeModule().repairDreamingArtifacts(

--- a/src/plugin-sdk/memory-core-engine-runtime.ts
+++ b/src/plugin-sdk/memory-core-engine-runtime.ts
@@ -3,11 +3,13 @@
  * Prefer vendor-neutral memory-host SDK subpaths for new plugin code.
  */
 import type { OpenClawConfig } from "../config/types.js";
+import { createPluginStateKeyedStore } from "../plugin-state/plugin-state-store.js";
 import {
   createLazyFacadeObjectValue,
   loadActivatedBundledPluginPublicSurfaceModuleSync,
 } from "./facade-runtime.js";
 import type { MemorySearchManager } from "./memory-core-host-engine-storage.js";
+import type { OpenKeyedStoreOptions, PluginStateKeyedStore } from "./plugin-state-runtime.js";
 
 /** Doctor metadata for a built-in memory embedding provider. */
 export type BuiltinMemoryEmbeddingProviderDoctorMetadata = {
@@ -110,6 +112,9 @@ type MemoryIndexManagerFacade = {
 };
 
 type FacadeModule = {
+  configureMemoryCoreDreamingState: (
+    openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
+  ) => void;
   auditShortTermPromotionArtifacts: (params: {
     workspaceDir: string;
     qmd?: {
@@ -144,10 +149,14 @@ type FacadeModule = {
 };
 
 function loadFacadeModule(): FacadeModule {
-  return loadActivatedBundledPluginPublicSurfaceModuleSync<FacadeModule>({
+  const module = loadActivatedBundledPluginPublicSurfaceModuleSync<FacadeModule>({
     dirName: "memory-core",
     artifactBasename: "runtime-api.js",
   });
+  module.configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateKeyedStore<T>("memory-core", options),
+  );
+  return module;
 }
 /** Audit short-term promotion artifacts in an agent workspace. */
 export const auditShortTermPromotionArtifacts: FacadeModule["auditShortTermPromotionArtifacts"] = ((

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -187,7 +187,7 @@ export const pluginRegistrationContractCases = {
   },
   parallel: {
     pluginId: "parallel",
-    webSearchProviderIds: ["parallel"],
+    webSearchProviderIds: ["parallel", "parallel-free"],
   },
   perplexity: {
     pluginId: "perplexity",

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -1,6 +1,126 @@
 // Proxy capture server tests cover request recording and response handling.
-import { describe, expect, it } from "vitest";
-import { parseConnectTarget } from "./proxy-server.js";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { request as httpRequest, createServer as createHttpServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DebugProxySettings } from "./env.js";
+import { parseConnectTarget, startDebugProxyServer } from "./proxy-server.js";
+import { closeDebugProxyCaptureStore, getDebugProxyCaptureStore } from "./store.sqlite.js";
+
+let testRoot: string | undefined;
+
+async function cleanupTestRoot(): Promise<void> {
+  closeDebugProxyCaptureStore();
+  if (!testRoot) {
+    return;
+  }
+  const root = testRoot;
+  testRoot = undefined;
+  await rm(root, { recursive: true, force: true });
+}
+
+async function makeSettings(): Promise<DebugProxySettings> {
+  testRoot = await mkdtemp(join(tmpdir(), "openclaw-debug-proxy-server-"));
+  const certDir = join(testRoot, "certs");
+  await mkdir(certDir, { recursive: true });
+  await writeFile(join(certDir, "root-ca.pem"), "test root cert\n", "utf8");
+  await writeFile(join(certDir, "root-ca-key.pem"), "test root key\n", "utf8");
+  return {
+    enabled: true,
+    required: false,
+    dbPath: ":memory:",
+    blobDir: join(testRoot, "blobs"),
+    certDir,
+    sessionId: "debug-proxy-server-test",
+    sourceProcess: "test",
+  };
+}
+
+async function startLargeBodyOrigin(): Promise<{
+  receivedRequestBody: () => string;
+  responseBody: string;
+  stop: () => Promise<void>;
+  url: string;
+}> {
+  let receivedBody = "";
+  const responseBody = "r".repeat(12_000);
+  const server = createHttpServer((req, res) => {
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      receivedBody += chunk;
+    });
+    req.on("end", () => {
+      res.writeHead(200, {
+        "content-length": Buffer.byteLength(responseBody),
+        "content-type": "text/plain; charset=utf-8",
+      });
+      res.end(responseBody);
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    receivedRequestBody: () => receivedBody,
+    responseBody,
+    stop: async () =>
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+    url: `http://127.0.0.1:${address.port}/capture`,
+  };
+}
+
+async function postThroughProxy(params: {
+  body: string;
+  proxyUrl: string;
+  targetUrl: string;
+}): Promise<string> {
+  const proxy = new URL(params.proxyUrl);
+  return await new Promise<string>((resolve, reject) => {
+    const req = httpRequest(
+      {
+        host: proxy.hostname,
+        port: Number(proxy.port),
+        method: "POST",
+        path: params.targetUrl,
+        headers: {
+          connection: "close",
+          "content-length": Buffer.byteLength(params.body),
+          "content-type": "text/plain; charset=utf-8",
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        res.on("end", () => {
+          resolve(Buffer.concat(chunks).toString("utf8"));
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end(params.body);
+  });
+}
+
+afterEach(async () => {
+  await cleanupTestRoot();
+});
 
 describe("parseConnectTarget", () => {
   it("parses bracketed IPv6 CONNECT targets safely", () => {
@@ -21,5 +141,46 @@ describe("parseConnectTarget", () => {
     expect(() => parseConnectTarget("[::1]:99999")).toThrow("Invalid CONNECT target port");
     expect(() => parseConnectTarget("api.openai.com:1e3")).toThrow("Invalid CONNECT target port");
     expect(() => parseConnectTarget("api.openai.com:0x50")).toThrow("Invalid CONNECT target port");
+  });
+});
+
+describe("startDebugProxyServer", () => {
+  it("caps captured body previews while forwarding full request and response bodies", async () => {
+    const settings = await makeSettings();
+    const origin = await startLargeBodyOrigin();
+    const proxy = await startDebugProxyServer({ settings });
+    const requestBody = "q".repeat(12_000);
+
+    try {
+      const responseBody = await postThroughProxy({
+        body: requestBody,
+        proxyUrl: proxy.proxyUrl,
+        targetUrl: origin.url,
+      });
+
+      expect(origin.receivedRequestBody()).toBe(requestBody);
+      expect(responseBody).toBe(origin.responseBody);
+      const events = getDebugProxyCaptureStore(settings.dbPath, settings.blobDir).getSessionEvents(
+        settings.sessionId,
+        10,
+      );
+      const capturedRequest = events.find((event) => event.kind === "request");
+      const capturedResponse = events.find((event) => event.kind === "response");
+      expect(capturedRequest?.dataText).toBe("q".repeat(8192));
+      expect(capturedResponse?.dataText).toBe("r".repeat(8192));
+      expect(JSON.parse(String(capturedRequest?.metaJson))).toMatchObject({
+        bodyBytes: 12_000,
+        capturePreviewBytes: 8192,
+        captureTruncated: true,
+      });
+      expect(JSON.parse(String(capturedResponse?.metaJson))).toMatchObject({
+        bodyBytes: 12_000,
+        capturePreviewBytes: 8192,
+        captureTruncated: true,
+      });
+    } finally {
+      await proxy.stop();
+      await origin.stop();
+    }
   });
 });

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -13,6 +13,14 @@ import type { CaptureEventRecord } from "./types.js";
 const TRUTHY_ENV = new Set(["1", "true", "yes", "on"]);
 const DEBUG_PROXY_DIRECT_CONNECT_OVERRIDE =
   "OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY";
+const CAPTURE_BODY_PREVIEW_BYTES = 8192;
+
+type BodyPreviewCapture = {
+  chunks: Buffer[];
+  previewBytes: number;
+  totalBytes: number;
+  truncated: boolean;
+};
 
 function isTruthyEnvValue(value: string | undefined): boolean {
   return TRUTHY_ENV.has((value ?? "").trim().toLowerCase());
@@ -104,12 +112,40 @@ function normalizeTargetUrl(req: IncomingMessage): URL {
   return new URL(`http://${host}${req.url ?? "/"}`);
 }
 
-async function readBody(req: IncomingMessage): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+function createBodyPreviewCapture(): BodyPreviewCapture {
+  return { chunks: [], previewBytes: 0, totalBytes: 0, truncated: false };
+}
+
+function appendBodyPreviewCapture(capture: BodyPreviewCapture, chunk: Buffer | string): void {
+  const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+  capture.totalBytes += buffer.byteLength;
+  const remaining = CAPTURE_BODY_PREVIEW_BYTES - capture.previewBytes;
+  if (remaining <= 0) {
+    capture.truncated = capture.truncated || buffer.byteLength > 0;
+    return;
   }
-  return Buffer.concat(chunks);
+  const slice = buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer;
+  capture.chunks.push(slice);
+  capture.previewBytes += slice.byteLength;
+  if (slice.byteLength < buffer.byteLength) {
+    capture.truncated = true;
+  }
+}
+
+function finishBodyPreviewCapture(capture: BodyPreviewCapture): {
+  dataText: string;
+  metaJson?: string;
+} {
+  return {
+    dataText: Buffer.concat(capture.chunks, capture.previewBytes).toString("utf8"),
+    metaJson: capture.truncated
+      ? JSON.stringify({
+          bodyBytes: capture.totalBytes,
+          capturePreviewBytes: CAPTURE_BODY_PREVIEW_BYTES,
+          captureTruncated: true,
+        })
+      : undefined,
+  };
 }
 
 export async function startDebugProxyServer(params: {
@@ -180,13 +216,7 @@ export async function startDebugProxyServer(params: {
         res.end(responseBody);
         return;
       }
-      const body = await readBody(req);
-      recordTargetEvent({
-        direction: "outbound",
-        kind: "request",
-        headersJson: JSON.stringify(req.headers),
-        dataText: body.subarray(0, 8192).toString("utf8"),
-      });
+      const requestCapture = createBodyPreviewCapture();
       const upstream = (target.protocol === "https:" ? httpsRequest : httpRequest)(
         target,
         {
@@ -194,26 +224,44 @@ export async function startDebugProxyServer(params: {
           headers: req.headers,
         },
         (upstreamRes) => {
-          const chunks: Buffer[] = [];
+          const responseCapture = createBodyPreviewCapture();
           upstreamRes.on("data", (chunk) => {
             const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-            chunks.push(buffer);
+            appendBodyPreviewCapture(responseCapture, buffer);
             res.write(buffer);
           });
           upstreamRes.on("end", () => {
-            const responseBody = Buffer.concat(chunks);
             recordTargetEvent({
               direction: "inbound",
               kind: "response",
               status: upstreamRes.statusCode ?? undefined,
               headersJson: JSON.stringify(upstreamRes.headers),
-              dataText: responseBody.subarray(0, 8192).toString("utf8"),
+              ...finishBodyPreviewCapture(responseCapture),
             });
             res.end();
           });
           res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
         },
       );
+      req.on("data", (chunk) => {
+        appendBodyPreviewCapture(requestCapture, chunk);
+      });
+      req.on("end", () => {
+        recordTargetEvent({
+          direction: "outbound",
+          kind: "request",
+          headersJson: JSON.stringify(req.headers),
+          ...finishBodyPreviewCapture(requestCapture),
+        });
+      });
+      req.on("error", (error) => {
+        recordTargetEvent({
+          direction: "local",
+          kind: "error",
+          errorText: error.message,
+        });
+        upstream.destroy(error);
+      });
       upstream.on("error", (error) => {
         recordTargetEvent({
           direction: "local",
@@ -223,10 +271,7 @@ export async function startDebugProxyServer(params: {
         res.statusCode = 502;
         res.end(error.message);
       });
-      if (body.byteLength > 0) {
-        upstream.write(body);
-      }
-      upstream.end();
+      req.pipe(upstream);
     })();
   });
 

--- a/test/scripts/check-cli-startup-memory.test.ts
+++ b/test/scripts/check-cli-startup-memory.test.ts
@@ -48,21 +48,26 @@ describe("check-cli-startup-memory", () => {
   });
 
   it("keeps invalid startup memory env values from bypassing budgets", () => {
-    expect(
+    expect(() =>
       testing.readPositiveNumberEnv("OPENCLAW_STARTUP_MEMORY_HELP_MB", 100, {
         OPENCLAW_STARTUP_MEMORY_HELP_MB: "abc",
       }),
-    ).toBe(100);
-    expect(
+    ).toThrow("OPENCLAW_STARTUP_MEMORY_HELP_MB must be a positive number");
+    expect(() =>
       testing.readPositiveNumberEnv("OPENCLAW_STARTUP_MEMORY_HELP_MB", 100, {
         OPENCLAW_STARTUP_MEMORY_HELP_MB: "1e3",
       }),
-    ).toBe(100);
-    expect(
+    ).toThrow("OPENCLAW_STARTUP_MEMORY_HELP_MB must be a positive number");
+    expect(() =>
       testing.readPositiveNumberEnv("OPENCLAW_STARTUP_MEMORY_HELP_MB", 100, {
         OPENCLAW_STARTUP_MEMORY_HELP_MB: "0x10",
       }),
-    ).toBe(100);
+    ).toThrow("OPENCLAW_STARTUP_MEMORY_HELP_MB must be a positive number");
+    expect(() =>
+      testing.readPositiveNumberEnv("OPENCLAW_STARTUP_MEMORY_HELP_MB", 100, {
+        OPENCLAW_STARTUP_MEMORY_HELP_MB: "0",
+      }),
+    ).toThrow("OPENCLAW_STARTUP_MEMORY_HELP_MB must be a positive number");
     expect(
       testing.readPositiveNumberEnv("OPENCLAW_STARTUP_MEMORY_HELP_MB", 100, {
         OPENCLAW_STARTUP_MEMORY_HELP_MB: "125.5",
@@ -71,11 +76,16 @@ describe("check-cli-startup-memory", () => {
   });
 
   it("keeps invalid startup memory timeout env values from parsing loosely", () => {
-    expect(
+    expect(() =>
       testing.readPositiveIntEnv("OPENCLAW_STARTUP_MEMORY_TIMEOUT_MS", 60_000, {
         OPENCLAW_STARTUP_MEMORY_TIMEOUT_MS: "1e3",
       }),
-    ).toBe(60_000);
+    ).toThrow("OPENCLAW_STARTUP_MEMORY_TIMEOUT_MS must be a positive number");
+    expect(() =>
+      testing.readPositiveIntEnv("OPENCLAW_STARTUP_MEMORY_TIMEOUT_MS", 60_000, {
+        OPENCLAW_STARTUP_MEMORY_TIMEOUT_MS: "1000.5",
+      }),
+    ).toThrow("OPENCLAW_STARTUP_MEMORY_TIMEOUT_MS must be a positive integer");
     expect(
       testing.readPositiveIntEnv("OPENCLAW_STARTUP_MEMORY_TIMEOUT_MS", 60_000, {
         OPENCLAW_STARTUP_MEMORY_TIMEOUT_MS: "1000",

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -422,6 +422,42 @@ describe("script-specific dev tooling hardening", () => {
     expect(closeCalls).toBe(1);
   });
 
+  it("waits for Anthropic prompt gateway log writes before closing the log file", async () => {
+    let resolveWrite: (() => void) | undefined;
+    const order: string[] = [];
+    const pendingWrite = new Promise<void>((resolve) => {
+      resolveWrite = () => {
+        order.push("write");
+        resolve();
+      };
+    });
+    const stop = promptProbeTesting.stopGatewayPromptChild(
+      {
+        exitCode: 0,
+        signalCode: null,
+        kill: () => true,
+        once(_event: "exit", _listener: () => void) {},
+      },
+      {
+        close: async () => {
+          order.push("close");
+        },
+      },
+      1,
+      1,
+      [pendingWrite],
+    );
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+    expect(order).toEqual([]);
+
+    resolveWrite?.();
+    await expect(stop).resolves.toBe(true);
+    expect(order).toEqual(["write", "close"]);
+  });
+
   it("uses exact Claude cookie host matchers instead of broad substring matches", () => {
     expect(claudeUsageTesting.CLAUDE_COOKIE_HOST_SQL).toContain("host_key = 'claude.ai'");
     expect(claudeUsageTesting.CLAUDE_COOKIE_HOST_SQL).toContain("LIKE '%.claude.ai'");

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing as promptProbeTesting } from "../../scripts/anthropic-prompt-probe.ts";
 import { testing as claudeUsageTesting } from "../../scripts/debug-claude-usage.ts";
@@ -338,6 +339,16 @@ describe("script-specific dev tooling hardening", () => {
         "https://api.anthropic.com",
       ),
     ).toThrow(/refusing non-origin proxy request URL/u);
+  });
+
+  it("bounds Anthropic capture proxy request bodies", async () => {
+    const request = Readable.from([Buffer.alloc(8), Buffer.alloc(8)]) as never;
+    const destroy = vi.spyOn(request, "destroy");
+
+    await expect(promptProbeTesting.readRequestBody(request, 12)).rejects.toThrow(
+      "Anthropic capture proxy request body exceeded 12 bytes",
+    );
+    expect(destroy).toHaveBeenCalled();
   });
 
   it("cleans Anthropic prompt probe temp dirs unless explicitly kept", async () => {

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -568,6 +568,36 @@ setInterval(() => {}, 1000);
     expect(samples[0]?.elapsedMs).toBeGreaterThanOrEqual(0);
   });
 
+  it("rejects required command resource proof when sampling captures nothing", async () => {
+    const samples: unknown[] = [];
+
+    await expect(
+      runCommand(process.execPath, ["-e", "setTimeout(() => {}, 50);"], {
+        requireResourceSample: true,
+        resourceLabel: "plugins install",
+        resourceSampleIntervalMs: 1,
+        resourceSamples: samples,
+        sampleProcessImpl: async () => null,
+      }),
+    ).rejects.toThrow("plugins install RSS sample was not captured");
+
+    expect(samples).toEqual([]);
+  });
+
+  it("includes sampler errors in required command resource proof failures", async () => {
+    await expect(
+      runCommand(process.execPath, ["-e", "setTimeout(() => {}, 50);"], {
+        requireResourceSample: true,
+        resourceLabel: "plugins install",
+        resourceSampleIntervalMs: 1,
+        resourceSamples: [],
+        sampleProcessImpl: async () => {
+          throw new Error("ps failed");
+        },
+      }),
+    ).rejects.toThrow("plugins install RSS sample was not captured: ps failed");
+  });
+
   it("rejects command spawn failures as Error objects", async () => {
     await expect(runCommand("openclaw-definitely-missing-command", [])).rejects.toMatchObject({
       code: "ENOENT",

--- a/test/scripts/measure-rpc-rtt.test.ts
+++ b/test/scripts/measure-rpc-rtt.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import {
   cleanupTempRoot,
+  createGatewayClient,
   installGatewayParentCleanup,
   isGatewayProcessAlive,
   parseArgs,
@@ -13,7 +14,66 @@ import {
   waitForGatewayReady,
 } from "../../scripts/measure-rpc-rtt.mjs";
 
+class FakeWebSocket extends EventEmitter {
+  static OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+
+  closed = false;
+  readyState = 0;
+  sent: string[] = [];
+
+  constructor(
+    readonly url: string,
+    readonly options: unknown,
+  ) {
+    super();
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(payload: string, callback?: (error?: Error) => void): void {
+    this.sent.push(payload);
+    callback?.();
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = 3;
+    this.emit("close", 1000, "closed");
+  }
+}
+
 describe("scripts/measure-rpc-rtt.mjs", () => {
+  it("closes websocket clients that time out before opening", async () => {
+    FakeWebSocket.instances = [];
+    const client = createGatewayClient({
+      WebSocket: FakeWebSocket,
+      openTimeoutMs: 1,
+      url: "ws://127.0.0.1:12345",
+    });
+
+    await expect(client.waitOpen()).rejects.toThrow("gateway websocket open timeout");
+    expect(FakeWebSocket.instances[0]?.closed).toBe(true);
+  });
+
+  it("rejects pending websocket requests when cleanup closes the client", async () => {
+    FakeWebSocket.instances = [];
+    const client = createGatewayClient({
+      WebSocket: FakeWebSocket,
+      url: "ws://127.0.0.1:12345",
+    });
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("fake websocket was not created");
+    }
+    socket.readyState = FakeWebSocket.OPEN;
+
+    const request = client.request("health", {}, 10_000);
+    client.close();
+
+    await expect(request).rejects.toThrow("gateway websocket client closed");
+    expect(socket.closed).toBe(true);
+  });
+
   it("parses bounded RPC RTT options strictly", () => {
     expect(
       parseArgs([

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -1,8 +1,9 @@
 // Npm Telegram Live tests cover npm telegram live script behavior.
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { testing } from "../../scripts/e2e/npm-telegram-live-runner.ts";
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -11,6 +12,19 @@ const PREPARE_PACKAGE_PATH = path.resolve(
   TEST_DIR,
   "../../scripts/e2e/lib/npm-telegram-live/prepare-package.mjs",
 );
+const tempRoots: string[] = [];
+
+function mkTempRoot() {
+  const root = mkdtempSync(path.join(tmpdir(), "openclaw-npm-telegram-live-"));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
 
 describe("package Telegram live Docker E2E", () => {
   it("supports npm-specific Convex credential aliases", () => {
@@ -172,5 +186,33 @@ describe("package Telegram live Docker E2E", () => {
         OPENCLAW_QA_CREDENTIAL_ROLE: "maintainer",
       }),
     ).toBe("ci");
+  });
+
+  it("gates package Telegram status on the summary artifact", async () => {
+    const summaryPath = path.join(mkTempRoot(), "telegram-qa-summary.json");
+    writeFileSync(
+      summaryPath,
+      JSON.stringify({
+        counts: { total: 1, passed: 1, failed: 0 },
+        scenarios: [{ status: "fail" }],
+      }),
+      "utf8",
+    );
+
+    await expect(
+      testing.shouldFailPackageTelegramRun(
+        { summaryPath },
+        { OPENCLAW_NPM_TELEGRAM_ALLOW_FAILURES: "" },
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("does not read package Telegram summaries when failures are allowed", async () => {
+    await expect(
+      testing.shouldFailPackageTelegramRun(
+        { summaryPath: path.join(mkTempRoot(), "missing-summary.json") },
+        { OPENCLAW_NPM_TELEGRAM_ALLOW_FAILURES: "1" },
+      ),
+    ).resolves.toBe(false);
   });
 });

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -884,6 +884,31 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     }
   });
 
+  it("flushes static release artifact logs before close resolves", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-static-server-log-flush-"));
+    const filePath = join(dir, "openclaw-2026.4.14.tgz");
+    const logPath = join(dir, "server.log");
+    let server: Awaited<ReturnType<typeof startStaticFileServer>> | undefined;
+
+    try {
+      writeFileSync(filePath, Buffer.alloc(128, "x"));
+      server = await startStaticFileServer({ filePath, logPath });
+      const marker = `flush-${"x".repeat(512)}-done`;
+
+      for (let index = 0; index < 8; index += 1) {
+        const response = await fetch(`${server.url}?${marker}-${index}`);
+        await response.text();
+      }
+      await server.close();
+      server = undefined;
+
+      expect(readFileSync(logPath, "utf8")).toContain(`${marker}-7`);
+    } finally {
+      await server?.close().catch(() => {});
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not preload static release artifacts before serving them", () => {
     const source = readFileSync("scripts/openclaw-cross-os-release-checks.ts", "utf8");
     const serverSource = source.slice(

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -1100,6 +1100,35 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     }
   });
 
+  it("flushes command logs before resolving", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-run-command-flush-"));
+    try {
+      const logPath = join(dir, "flush.log");
+      const marker = `flush-start-${"x".repeat(128 * 1024)}-flush-end`;
+
+      await runCommand(
+        process.execPath,
+        [
+          "-e",
+          [
+            "const marker = `flush-start-${'x'.repeat(128 * 1024)}-flush-end`;",
+            "process.stdout.write(marker);",
+          ].join(""),
+        ],
+        {
+          cwd: dir,
+          env: process.env,
+          logPath,
+          maxOutputBytes: 64,
+        },
+      );
+
+      expect(readFileSync(logPath, "utf8")).toContain(marker);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("kills timed-out command process groups", async () => {
     if (process.platform === "win32") {
       return;

--- a/test/scripts/openclaw-performance-source-summary.test.ts
+++ b/test/scripts/openclaw-performance-source-summary.test.ts
@@ -72,6 +72,7 @@ function writeSourceFixture(sourceDir: string) {
       wallMs: 250,
     },
     run: { primaryModel: "mock-openai/perf" },
+    scenarios: [{ id: "mock-hello", status: "pass" }],
   });
 }
 
@@ -140,6 +141,27 @@ describe("buildMarkdown", () => {
 
     expect(() => buildMarkdown(sourceDir, null)).toThrow(
       "[source-performance] invalid mock hello summary counts:",
+    );
+  });
+
+  it("rejects mock hello summaries without matching scenario evidence", () => {
+    const sourceDir = mkTmpRoot();
+    writeSourceFixture(sourceDir);
+    writeJson(path.join(sourceDir, "mock-hello", "run-001", "qa-suite-summary.json"), {
+      counts: { failed: 0, passed: 1, total: 1 },
+      metrics: {
+        gatewayCpuCoreRatio: 0.15,
+        gatewayProcessRssDeltaBytes: 1024 * 1024,
+        gatewayProcessRssEndBytes: 91 * 1024 * 1024,
+        gatewayProcessRssStartBytes: 90 * 1024 * 1024,
+        wallMs: 250,
+      },
+      run: { primaryModel: "mock-openai/perf" },
+      scenarios: [{ id: "mock-hello", status: "fail" }],
+    });
+
+    expect(() => buildMarkdown(sourceDir, null)).toThrow(
+      "[source-performance] invalid mock hello scenario evidence:",
     );
   });
 

--- a/test/scripts/plugin-gateway-gauntlet.test.ts
+++ b/test/scripts/plugin-gateway-gauntlet.test.ts
@@ -1080,6 +1080,86 @@ setInterval(() => {}, 1000);
     await fs.rm(summary.isolatedRunRoot, { recursive: true, force: true });
   });
 
+  it("fails successful QA chunks whose scenario statuses disagree with counts", async () => {
+    const outputDir = path.join(repoRoot, "artifacts");
+    const qaSummaryJson = JSON.stringify({
+      counts: { failed: 0, passed: 1, total: 2 },
+      metrics: { gatewayCpuCoreRatio: 0, wallMs: 1 },
+      run: {
+        concurrency: 1,
+        fastMode: false,
+        finishedAt: "2026-05-30T00:00:01.000Z",
+        primaryModel: "mock-openai/gpt-5.5",
+        primaryModelName: "gpt-5.5",
+        primaryProvider: "mock-openai",
+        providerMode: "mock-openai",
+        scenarioIds: ["channel-chat-baseline", "gateway-restart-inflight-run"],
+        startedAt: "2026-05-30T00:00:00.000Z",
+      },
+      scenarios: [
+        { name: "channel-chat-baseline", status: "pass", steps: [] },
+        { name: "gateway-restart-inflight-run", status: "fail", steps: [] },
+      ],
+    });
+    await writeManifest("alpha", "openclaw.plugin.json", JSON.stringify({ id: "alpha" }));
+    await fs.writeFile(path.join(repoRoot, "extensions", "alpha", "index.ts"), "export {};\n");
+    await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, "scripts", "run-node.mjs"),
+      [
+        'import fs from "node:fs";',
+        'import path from "node:path";',
+        'const outputArgIndex = process.argv.indexOf("--output-dir");',
+        "const outputDir = path.resolve(process.cwd(), process.argv[outputArgIndex + 1]);",
+        "fs.mkdirSync(outputDir, { recursive: true });",
+        `fs.writeFileSync(path.join(outputDir, "qa-suite-summary.json"), ${JSON.stringify(qaSummaryJson)}, "utf8");`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.resolve("scripts/check-plugin-gateway-gauntlet.mjs"),
+        "--repo-root",
+        repoRoot,
+        "--output-dir",
+        outputDir,
+        "--skip-prebuild",
+        "--skip-lifecycle",
+        "--skip-slash-help",
+        "--plugin",
+        "alpha",
+        "--qa-scenario",
+        "channel-chat-baseline",
+        "--qa-scenario",
+        "gateway-restart-inflight-run",
+      ],
+      {
+        cwd: path.resolve("."),
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status, result.stdout).toBe(1);
+    expect(result.stdout).toContain("diagnostic=qa-summary-invalid");
+    const summary = JSON.parse(
+      await fs.readFile(path.join(outputDir, "plugin-gateway-gauntlet-summary.json"), "utf8"),
+    );
+    expect(summary.failures).toEqual([
+      expect.objectContaining({
+        diagnosticDetail:
+          "QA suite summary failed count mismatch: counts.failed=0, failed scenarios=1",
+        diagnosticFailure: "qa-summary-invalid",
+        phase: "qa:rpc",
+        pluginId: "alpha",
+        status: 0,
+      }),
+    ]);
+    expect(summary.isolatedRunRootPreserved).toBe(true);
+    await fs.rm(summary.isolatedRunRoot, { recursive: true, force: true });
+  });
+
   it("fails successful QA chunks that do not write the requested summary", async () => {
     const outputDir = path.join(repoRoot, "artifacts");
     await writeManifest("alpha", "openclaw.plugin.json", JSON.stringify({ id: "alpha" }));

--- a/test/scripts/qa-otel-smoke.test.ts
+++ b/test/scripts/qa-otel-smoke.test.ts
@@ -2,8 +2,10 @@
 import { spawn, spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { createConnection as createNetConnection } from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { gzipSync } from "node:zlib";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { testing } from "../../scripts/qa-otel-smoke.ts";
@@ -158,6 +160,48 @@ describe("qa-otel-smoke receiver bounds", () => {
       ]);
     } finally {
       await receiver.close();
+    }
+  });
+
+  it("closes active local OTLP receiver sockets during cleanup", async () => {
+    const receiver = testing.startLocalOtlpReceiver();
+    const port = await receiver.listen();
+    const socket = createNetConnection(port, "127.0.0.1");
+    const socketClosed = new Promise<void>((resolve) => {
+      socket.once("close", resolve);
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        socket.once("connect", resolve);
+        socket.once("error", reject);
+      });
+      socket.write(
+        [
+          "POST /v1/traces HTTP/1.1",
+          "Host: 127.0.0.1",
+          "Content-Type: application/x-protobuf",
+          "Content-Length: 1048576",
+          "",
+          "x",
+        ].join("\r\n"),
+      );
+
+      await Promise.race([
+        receiver.close(),
+        delay(1_000).then(() => {
+          throw new Error("receiver close timed out");
+        }),
+      ]);
+      await Promise.race([
+        socketClosed,
+        delay(1_000).then(() => {
+          throw new Error("socket close timed out");
+        }),
+      ]);
+    } finally {
+      socket.destroy();
+      await receiver.close().catch(() => {});
     }
   });
 

--- a/test/scripts/release-user-journey-assertions.test.ts
+++ b/test/scripts/release-user-journey-assertions.test.ts
@@ -302,7 +302,9 @@ describe("release user journey assertions", () => {
             "0.2",
           ]),
         ),
-      ).rejects.toThrow("Timed out waiting for ClickClack websocket connection");
+      ).rejects.toThrow(
+        'OPENCLAW_RELEASE_USER_JOURNEY_HTTP_TIMEOUT_MS must be a positive integer. Got: "100ms"',
+      );
     } finally {
       await server.stop();
       rmSync(root, { force: true, recursive: true });
@@ -364,7 +366,9 @@ describe("release user journey assertions", () => {
               "hello",
             ]),
         ),
-      ).rejects.toThrow("fixture inbound failed: 500");
+      ).rejects.toThrow(
+        'OPENCLAW_RELEASE_USER_JOURNEY_HTTP_BODY_MAX_BYTES must be a positive integer. Got: "16bytes"',
+      );
     } finally {
       await server.stop();
       rmSync(root, { force: true, recursive: true });

--- a/test/scripts/run-with-env.test.ts
+++ b/test/scripts/run-with-env.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   isRunWithEnvHelpRequest,
   parseRunWithEnvArgs,
+  resolveForceKillDelayMs,
   resolveSpawnCommand,
 } from "../../scripts/run-with-env.mjs";
 
@@ -122,6 +123,39 @@ describe("run-with-env", () => {
       command: "node.exe",
       args: ["scripts/run-vitest.mjs"],
     });
+  });
+
+  it("rejects malformed force-kill grace configuration before spawning", () => {
+    expect(resolveForceKillDelayMs({})).toBe(5_000);
+    expect(resolveForceKillDelayMs({ OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS: "250" })).toBe(250);
+    for (const value of ["0", "-1", "1e3", "100ms"]) {
+      expect(() => resolveForceKillDelayMs({ OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS: value })).toThrow(
+        "OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS must be a positive integer",
+      );
+    }
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "scripts/run-with-env.mjs",
+        "OPENCLAW_RUN_WITH_ENV_SIGNAL_TEST=1",
+        "--",
+        "node",
+        "-e",
+        "process.stdout.write('spawned')",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS: "100ms" },
+      },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS must be a positive integer",
+    );
   });
 
   it.runIf(process.platform !== "win32").each(["SIGTERM", "SIGHUP", "SIGINT"] as const)(

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -1,6 +1,8 @@
 // Test Live Shard tests cover test live shard script behavior.
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   LIVE_TEST_SHARDS,
@@ -11,6 +13,7 @@ import {
   buildLiveShardSpawnParams,
   collectAllLiveTestFiles,
   parseLiveShardArgs,
+  removeLiveShardReportFile,
   selectLiveShardFiles,
   validateLiveShardReportPayload,
 } from "../../scripts/test-live-shard.mjs";
@@ -195,6 +198,10 @@ describe("scripts/test-live-shard", () => {
     expect(validateLiveShardReportPayload({ numPassedTests: 1, numTotalTests: 3 })).toEqual({
       ok: true,
     });
+    expect(validateLiveShardReportPayload({ numPassedTests: 4, numTotalTests: 3 })).toEqual({
+      ok: false,
+      reason: "Vitest report numPassedTests exceeds numTotalTests.",
+    });
     expect(validateLiveShardReportPayload({ numPassedTests: 0, numTotalTests: 3 })).toEqual({
       ok: false,
       reason: "Vitest report has no passing live tests.",
@@ -207,6 +214,56 @@ describe("scripts/test-live-shard", () => {
       ok: false,
       reason: "Vitest report numTotalTests must be a non-negative integer.",
     });
+  });
+
+  it("requires live shard report evidence for each selected file", () => {
+    const payload = {
+      numPassedTests: 1,
+      numTotalTests: 2,
+      testResults: [
+        {
+          name: path.join(process.cwd(), "src/gateway/gateway-acp-bind.live.test.ts"),
+          assertionResults: [{ status: "passed" }],
+        },
+      ],
+    };
+
+    expect(
+      validateLiveShardReportPayload(payload, ["src/gateway/gateway-acp-bind.live.test.ts"]),
+    ).toEqual({ ok: true });
+    expect(
+      validateLiveShardReportPayload(payload, [
+        "src/gateway/gateway-acp-bind.live.test.ts",
+        "src/gateway/gateway-cli-backend.live.test.ts",
+      ]),
+    ).toEqual({
+      ok: false,
+      reason:
+        "Vitest report missing selected live test file evidence: src/gateway/gateway-cli-backend.live.test.ts",
+    });
+    expect(
+      validateLiveShardReportPayload({ numPassedTests: 1, numTotalTests: 1 }, [
+        "src/gateway/gateway-acp-bind.live.test.ts",
+      ]),
+    ).toEqual({
+      ok: false,
+      reason: "Vitest report is missing testResults file evidence.",
+    });
+  });
+
+  it("removes stale live shard reports before running a shard", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-live-shard-"));
+    const reportPath = path.join(root, "stale.vitest.json");
+    writeFileSync(reportPath, JSON.stringify({ numPassedTests: 1, numTotalTests: 1 }), "utf8");
+
+    try {
+      removeLiveShardReportFile(reportPath);
+
+      expect(existsSync(reportPath)).toBe(false);
+      expect(() => removeLiveShardReportFile(reportPath)).not.toThrow();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 
   it("spawns live shard children in a cleanup-friendly process group", () => {

--- a/test/scripts/tool-search-gateway-e2e.test.ts
+++ b/test/scripts/tool-search-gateway-e2e.test.ts
@@ -4,6 +4,8 @@ import {
   assertToolSearchLaneResults,
   fetchJson,
   readToolSearchGatewayFetchLimits,
+  restoreToolSearchGatewayEnv,
+  snapshotToolSearchGatewayEnv,
 } from "../../scripts/tool-search-gateway-e2e.ts";
 
 describe("tool search gateway e2e fetch helper", () => {
@@ -83,6 +85,27 @@ describe("tool search gateway e2e fetch helper", () => {
     ).rejects.toMatchObject({
       code: "ETOOBIG",
       message: "HTTP response from https://qa.example.invalid/debug/requests exceeded 16 bytes",
+    });
+  });
+});
+
+describe("tool search gateway e2e environment helpers", () => {
+  it("restores mutated gateway environment values", () => {
+    const env: NodeJS.ProcessEnv = {
+      OPENCLAW_CONFIG_PATH: "/before/openclaw.json",
+      OPENCLAW_STATE_DIR: "/before/state",
+    };
+    const snapshot = snapshotToolSearchGatewayEnv(env);
+
+    env.OPENCLAW_CONFIG_PATH = "/after/openclaw.json";
+    env.OPENCLAW_STATE_DIR = "/after/state";
+    env.OPENCLAW_TEST_FAST = "1";
+
+    restoreToolSearchGatewayEnv(snapshot, env);
+
+    expect(env).toEqual({
+      OPENCLAW_CONFIG_PATH: "/before/openclaw.json",
+      OPENCLAW_STATE_DIR: "/before/state",
     });
   });
 });


### PR DESCRIPTION
Incremental back-merge of upstream's **verified-consistent** commit `06e8a74473` (not the floating tip, which could be freshly-broken) onto the assembly. figs's insight: our fork syncs upstream every few min, so the broken-shrinkwrap tip we'd absorbed had **self-healed** upstream.

**Rigor (not hand-wavy):**
- **0 conflicts** (prior absorb resolved the conflict surface; the 36 new commits don't touch our continuation feature)
- **shrinkwrap now self-consistent** (`deps:shrinkwrap:check` exit 0) — deps byte-identical to upstream AND pass the check
- **typecheck green** (tsgo:prod exit 0)
- **drift-cure-gate clean**: 0 FROZEN-STALE / 0 MIXED-CLOBBER (205 GENUINE + 109 SAFE-NEW)
- prior 5 reconcile fixes hold (device-pair .toSorted, etc.)

**Known:** 8 new *stylistic* lint errors in upstream's brand-new code (the new `memory-core` extension + release scripts: no-unnecessary-type-X, use-unknown-in-catch, prefer-promise-reject) — none in our surface, not correctness. These are the recurring 'fork lints upstream stricter than upstream's own CI' pattern → to be addressed by the CI-environment improvement (lint-scoping), not by hand-modifying upstream's code.