### PR TITLE
fix(continuation): retain delegate subagent for pending continue_work re-entry (#952)

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1005,7 +1005,7 @@ async function scheduleSpawnInitContinueWorkWake(params: {
       unregisterContinuationTimerHandle(sessionKey, timerHandle);
     }
   }, clampedDelay);
-  registerContinuationTimerHandle(sessionKey, timerHandle);
+  registerContinuationTimerHandle(sessionKey, timerHandle, "work-wake");
   timerHandle.unref();
 }
 

--- a/src/agents/subagent-registry-cleanup.test.ts
+++ b/src/agents/subagent-registry-cleanup.test.ts
@@ -1,7 +1,13 @@
 // Subagent registry cleanup tests cover deferred cleanup decisions while
 // completion delivery, descendants, and retry windows are still unresolved.
 import { describe, expect, it } from "vitest";
-import { resolveDeferredCleanupDecision } from "./subagent-registry-cleanup.js";
+import {
+  buildContinuationCleanupDeferralResolver,
+  type ContinuationPendingState,
+  isContinuationPending,
+  resolveContinuationCleanupDeferral,
+  resolveDeferredCleanupDecision,
+} from "./subagent-registry-cleanup.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 function makeEntry(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
@@ -94,5 +100,149 @@ describe("resolveDeferredCleanupDecision", () => {
     });
 
     expect(decision).toEqual({ kind: "retry", retryCount: 2, resumeDelayMs: 2_000 });
+  });
+});
+
+describe("resolveContinuationCleanupDeferral", () => {
+  const now = 1_000_000;
+  const retentionHardExpiryMs = 360_000; // maxDelayMs (300s) + 60s buffer
+  const recheckDelayMs = 5_000;
+
+  function resolve(
+    pending: ContinuationPendingState,
+    entryOverrides: Partial<SubagentRunRecord> = {},
+  ) {
+    return resolveContinuationCleanupDeferral({
+      entry: makeEntry({ expectsCompletionMessage: true, endedAt: now, ...entryOverrides }),
+      now,
+      pending,
+      retentionHardExpiryMs,
+      recheckDelayMs,
+    });
+  }
+
+  const noneState: ContinuationPendingState = {
+    workWakeTimerArmed: false,
+    heartbeatWakePending: false,
+    replyRunActive: false,
+    continuationWakeDispatching: false,
+  };
+
+  it("proceeds (no defer) when nothing is pending", () => {
+    expect(isContinuationPending(noneState)).toBe(false);
+    expect(resolve(noneState)).toBeUndefined();
+  });
+
+  it("defers while a continue_work wake timer is still armed", () => {
+    const decision = resolve({ ...noneState, workWakeTimerArmed: true });
+    expect(decision).toEqual({ kind: "defer-continuation", delayMs: recheckDelayMs });
+  });
+
+  it("still defers after the timer fired but before the wake heartbeat runs (the race)", () => {
+    // The work-wake timer ref releases the instant requestHeartbeatNow fires, so
+    // (a) is false here; the queued wake (b) must keep the session alive until
+    // hop 2 actually starts.
+    const decision = resolve({ ...noneState, heartbeatWakePending: true });
+    expect(decision).toEqual({ kind: "defer-continuation", delayMs: recheckDelayMs });
+  });
+
+  it("still defers while a continuation hop reply run is active", () => {
+    const decision = resolve({ ...noneState, replyRunActive: true });
+    expect(decision).toEqual({ kind: "defer-continuation", delayMs: recheckDelayMs });
+  });
+
+  it("still defers when the wake dispatching marker is the ONLY live signal (the tick gap)", () => {
+    // The real dispatcher window: the continue_work timer already fired (a false),
+    // `pendingWakes.clear()` ran (b false), and the reply run has not registered
+    // yet (c false). Only the synchronously-set dispatching marker (d) keeps the
+    // child alive — without it, a recheck poll here would tear the subagent down
+    // mid-chain (the residual #952 race).
+    expect(isContinuationPending({ ...noneState, continuationWakeDispatching: true })).toBe(true);
+    const decision = resolve({ ...noneState, continuationWakeDispatching: true });
+    expect(decision).toEqual({ kind: "defer-continuation", delayMs: recheckDelayMs });
+  });
+
+  it("gives up the defer once the leak-guard expiry is exceeded with no active hop", () => {
+    // A stuck/leaked timer ref with no progress past the retention window must
+    // not pin the session forever.
+    const decision = resolve(
+      { ...noneState, workWakeTimerArmed: true },
+      { endedAt: now - (retentionHardExpiryMs + 1) },
+    );
+    expect(decision).toBeUndefined();
+  });
+
+  it("bounds a leaked dispatching marker by the hard-expiry leak guard", () => {
+    // The dispatching marker is NOT exempt from the leak guard (only an active
+    // reply run is): a handler that somehow failed to release its marker must
+    // still be reclaimed past the retention window rather than pinning forever.
+    const decision = resolve(
+      { ...noneState, continuationWakeDispatching: true },
+      { endedAt: now - (retentionHardExpiryMs + 1) },
+    );
+    expect(decision).toBeUndefined();
+  });
+
+  it("never trips the leak guard while a hop reply run is still active", () => {
+    // A single hop legitimately running longer than the retention window must
+    // keep deferring; only idle retention counts toward the leak guard.
+    const decision = resolve(
+      { ...noneState, replyRunActive: true },
+      { endedAt: now - (retentionHardExpiryMs + 60_000) },
+    );
+    expect(decision).toEqual({ kind: "defer-continuation", delayMs: recheckDelayMs });
+  });
+
+  it("resets the leak-guard window on observed continuation progress", () => {
+    // refreshFrozenResultFromSession advances completion.capturedAt each hop;
+    // recent progress keeps the defer alive even though endedAt is old.
+    const decision = resolve(
+      { ...noneState, workWakeTimerArmed: true },
+      {
+        endedAt: now - (retentionHardExpiryMs + 60_000),
+        completion: { required: true, capturedAt: now - 1_000 },
+      },
+    );
+    expect(decision).toEqual({ kind: "defer-continuation", delayMs: recheckDelayMs });
+  });
+});
+
+describe("buildContinuationCleanupDeferralResolver", () => {
+  const now = 50_000;
+
+  it("composes per-session signals into a deferral decision", () => {
+    const armed = new Set(["agent:main:subagent:child"]);
+    const resolver = buildContinuationCleanupDeferralResolver({
+      hasLiveWorkWakeTimer: (sessionKey) => armed.has(sessionKey),
+      hasPendingHeartbeatWake: () => false,
+      isReplyRunActive: () => false,
+      hasContinuationWakeDispatching: () => false,
+      resolveRetentionHardExpiryMs: () => 360_000,
+      recheckDelayMs: 5_000,
+    });
+
+    const entry = makeEntry({ endedAt: now });
+    expect(resolver(entry, now)).toEqual({ kind: "defer-continuation", delayMs: 5_000 });
+
+    armed.clear();
+    expect(resolver(entry, now)).toBeUndefined();
+  });
+
+  it("defers when only the dispatching marker query is true", () => {
+    const dispatching = new Set(["agent:main:subagent:child"]);
+    const resolver = buildContinuationCleanupDeferralResolver({
+      hasLiveWorkWakeTimer: () => false,
+      hasPendingHeartbeatWake: () => false,
+      isReplyRunActive: () => false,
+      hasContinuationWakeDispatching: (sessionKey) => dispatching.has(sessionKey),
+      resolveRetentionHardExpiryMs: () => 360_000,
+      recheckDelayMs: 5_000,
+    });
+
+    const entry = makeEntry({ endedAt: now });
+    expect(resolver(entry, now)).toEqual({ kind: "defer-continuation", delayMs: 5_000 });
+
+    dispatching.clear();
+    expect(resolver(entry, now)).toBeUndefined();
   });
 });

--- a/src/agents/subagent-registry-cleanup.ts
+++ b/src/agents/subagent-registry-cleanup.ts
@@ -16,6 +16,14 @@ type DeferredCleanupDecision =
       delayMs: number;
     }
   | {
+      // Same-session continue_work continuation is still pending; keep the run
+      // record AND its session store entry alive so the wake can re-enter as a
+      // heartbeat turn. Distinct from `defer-descendants`, which drives
+      // descendant-wake machinery via `wakeOnDescendantSettle`. Fix #952.
+      kind: "defer-continuation";
+      delayMs: number;
+    }
+  | {
       kind: "give-up";
       reason: "retry-limit" | "expiry";
       retryCount?: number;
@@ -25,6 +33,107 @@ type DeferredCleanupDecision =
       retryCount: number;
       resumeDelayMs?: number;
     };
+
+/**
+ * Live signals indicating a same-session `continue_work` continuation is still
+ * in flight for a child session. Any one being true must keep the subagent
+ * session alive; together they close the race where the timer ref releases the
+ * instant the wake fires but the heartbeat turn has not run yet. Fix #952.
+ */
+export type ContinuationPendingState = {
+  /** A `continue_work` wake timer is still armed for the child session (a). */
+  workWakeTimerArmed: boolean;
+  /** A heartbeat wake targeting the child session is queued/coalescing (b). */
+  heartbeatWakePending: boolean;
+  /** A reply/heartbeat turn is actively running on the child session (c). */
+  replyRunActive: boolean;
+  /**
+   * The heartbeat wake handler is mid-dispatch for this child's continuation
+   * turn — set synchronously before any await, cleared in finally (d). Covers
+   * the same-tick gap between the timer firing (a → false) plus the dispatcher
+   * clearing its queue (b → false) and the reply run registering active
+   * (c → true): for that window (d) is the only true signal. Fix #952.
+   */
+  continuationWakeDispatching: boolean;
+};
+
+export function isContinuationPending(state: ContinuationPendingState): boolean {
+  return (
+    state.workWakeTimerArmed ||
+    state.heartbeatWakePending ||
+    state.replyRunActive ||
+    state.continuationWakeDispatching
+  );
+}
+
+/** A continuation-deferral decision: defer-with-recheck-delay or proceed. */
+export type ContinuationCleanupDeferralResolver = (
+  entry: SubagentRunRecord,
+  now: number,
+) => { kind: "defer-continuation"; delayMs: number } | undefined;
+
+/**
+ * Decide whether subagent cleanup must defer because a same-session
+ * `continue_work` continuation is still pending.
+ *
+ * Returns `undefined` to proceed with normal cleanup when nothing is pending,
+ * or when the leak guard trips: if no reply run is active and no continuation
+ * progress has been observed for longer than `retentionHardExpiryMs`, a leaked
+ * timer ref OR a leaked dispatching marker must not pin the child session
+ * forever, so we give up the defer and clean up. Only an actively running hop
+ * (`replyRunActive`) is exempt from the guard — the dispatching marker is not,
+ * so it stays bounded by the hard-expiry. Fix #952.
+ */
+export function resolveContinuationCleanupDeferral(params: {
+  entry: SubagentRunRecord;
+  now: number;
+  pending: ContinuationPendingState;
+  retentionHardExpiryMs: number;
+  recheckDelayMs: number;
+}): { kind: "defer-continuation"; delayMs: number } | undefined {
+  if (!isContinuationPending(params.pending)) {
+    return undefined;
+  }
+  if (!params.pending.replyRunActive) {
+    const lastProgressAt = Math.max(
+      params.entry.endedAt ?? 0,
+      params.entry.completion?.capturedAt ?? 0,
+    );
+    const retainedSinceProgressMs = params.now - lastProgressAt;
+    if (retainedSinceProgressMs > params.retentionHardExpiryMs) {
+      return undefined;
+    }
+  }
+  return { kind: "defer-continuation", delayMs: params.recheckDelayMs };
+}
+
+/**
+ * Compose a continuation-deferral resolver from live runtime queries. Kept as a
+ * builder (deps injected) so the predicate sources stay out of this pure module
+ * and so callers/tests can supply real or stubbed signals. Fix #952.
+ */
+export function buildContinuationCleanupDeferralResolver(deps: {
+  hasLiveWorkWakeTimer: (sessionKey: string) => boolean;
+  hasPendingHeartbeatWake: (sessionKey: string) => boolean;
+  isReplyRunActive: (sessionKey: string) => boolean;
+  hasContinuationWakeDispatching: (sessionKey: string) => boolean;
+  resolveRetentionHardExpiryMs: () => number;
+  recheckDelayMs: number;
+}): ContinuationCleanupDeferralResolver {
+  return (entry, now) =>
+    resolveContinuationCleanupDeferral({
+      entry,
+      now,
+      pending: {
+        workWakeTimerArmed: deps.hasLiveWorkWakeTimer(entry.childSessionKey),
+        heartbeatWakePending: deps.hasPendingHeartbeatWake(entry.childSessionKey),
+        replyRunActive: deps.isReplyRunActive(entry.childSessionKey),
+        continuationWakeDispatching: deps.hasContinuationWakeDispatching(entry.childSessionKey),
+      },
+      retentionHardExpiryMs: deps.resolveRetentionHardExpiryMs(),
+      recheckDelayMs: deps.recheckDelayMs,
+    });
+}
 
 /** Resolve the lifecycle ended reason used when cleaning up a subagent run. */
 export function resolveCleanupCompletionReason(

--- a/src/agents/subagent-registry-lifecycle.continuation-cleanup.test.ts
+++ b/src/agents/subagent-registry-lifecycle.continuation-cleanup.test.ts
@@ -1,0 +1,349 @@
+// Continuation-cleanup gate tests cover #952: while a same-session continue_work
+// continuation is pending, subagent cleanup must defer so the child session
+// store entry survives for the continuation wake (hop 2+). Once the chain ends,
+// the normal announce/cleanup runs exactly once.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearContinuationWakeDispatching,
+  hasContinuationWakeDispatching,
+  hasLiveContinuationWorkWakeTimerRefs,
+  markContinuationWakeDispatching,
+  registerContinuationTimerHandle,
+  resetContinuationStateForTests,
+  unregisterContinuationTimerHandle,
+} from "../auto-reply/continuation/state.js";
+import type { CallGatewayOptions } from "../gateway/call.js";
+import { SUBAGENT_ENDED_REASON_COMPLETE } from "./subagent-lifecycle-events.js";
+import { buildContinuationCleanupDeferralResolver } from "./subagent-registry-cleanup.js";
+import { createSubagentRegistryLifecycleController } from "./subagent-registry-lifecycle.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+type LifecycleControllerParams = Parameters<typeof createSubagentRegistryLifecycleController>[0];
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGateway: vi.fn(async (_opts: CallGatewayOptions) => ({})),
+}));
+
+const helperMocks = vi.hoisted(() => ({
+  persistSubagentSessionTiming: vi.fn(async () => {}),
+  safeRemoveAttachmentsDir: vi.fn(async () => {}),
+  logAnnounceGiveUp: vi.fn(),
+}));
+
+const runtimeMocks = vi.hoisted(() => ({
+  log: vi.fn(),
+}));
+
+vi.mock("../tasks/detached-task-runtime.js", () => ({
+  completeTaskRunByRunId: vi.fn(),
+  failTaskRunByRunId: vi.fn(),
+  setDetachedTaskDeliveryStatusByRunId: vi.fn(),
+}));
+
+vi.mock("../sessions/session-lifecycle-events.js", () => ({
+  emitSessionLifecycleEvent: vi.fn(),
+}));
+
+vi.mock("../browser-lifecycle-cleanup.js", () => ({
+  cleanupBrowserSessionsForLifecycleEnd: vi.fn(async () => {}),
+}));
+
+vi.mock("./agent-bundle-mcp-tools.js", () => ({
+  retireSessionMcpRuntimeForSessionKey: vi.fn(async () => true),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    log: runtimeMocks.log,
+  },
+}));
+
+vi.mock("../utils/delivery-context.js", () => ({
+  normalizeDeliveryContext: (origin: unknown) => origin ?? "agent",
+}));
+
+vi.mock("./subagent-announce.js", () => ({
+  captureSubagentCompletionReply: vi.fn(async () => undefined),
+  runSubagentAnnounceFlow: vi.fn(async () => true),
+}));
+
+vi.mock("./subagent-registry-helpers.js", () => ({
+  ANNOUNCE_COMPLETION_HARD_EXPIRY_MS: 30 * 60_000,
+  ANNOUNCE_EXPIRY_MS: 5 * 60_000,
+  MAX_ANNOUNCE_RETRY_COUNT: 3,
+  MIN_ANNOUNCE_RETRY_DELAY_MS: 1_000,
+  capFrozenResultText: (text: string) => text.trim(),
+  logAnnounceGiveUp: helperMocks.logAnnounceGiveUp,
+  persistSubagentSessionTiming: helperMocks.persistSubagentSessionTiming,
+  resolveAnnounceRetryDelayMs: (retryCount: number) =>
+    Math.min(1_000 * 2 ** Math.max(0, retryCount - 1), 8_000),
+  safeRemoveAttachmentsDir: helperMocks.safeRemoveAttachmentsDir,
+}));
+
+const CHILD_SESSION_KEY = "agent:main:subagent:child";
+
+function createRunEntry(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
+  return {
+    runId: "run-1",
+    childSessionKey: CHILD_SESSION_KEY,
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "continue working",
+    cleanup: "keep",
+    createdAt: 1_000,
+    startedAt: 2_000,
+    endedAt: 3_000,
+    endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+    expectsCompletionMessage: true,
+    ...overrides,
+  };
+}
+
+function createController({
+  entry,
+  runs = new Map([[entry.runId, entry]]),
+  ...overrides
+}: {
+  entry: SubagentRunRecord;
+  runs?: Map<string, SubagentRunRecord>;
+} & Partial<LifecycleControllerParams>) {
+  const params: LifecycleControllerParams = {
+    runs,
+    resumedRuns: new Set(),
+    subagentAnnounceTimeoutMs: 1_000,
+    persist: vi.fn(),
+    clearPendingLifecycleError: vi.fn(),
+    countPendingDescendantRuns: () => 0,
+    suppressAnnounceForSteerRestart: () => false,
+    shouldEmitEndedHookForRun: () => false,
+    emitSubagentEndedHookForRun: vi.fn(async () => {}),
+    notifyContextEngineSubagentEnded: vi.fn(async () => {}),
+    resumeSubagentRun: vi.fn(),
+    callGateway: async <T = Record<string, unknown>>(opts: CallGatewayOptions): Promise<T> =>
+      (await gatewayMocks.callGateway(opts)) as T,
+    captureSubagentCompletionReply: vi.fn(async () => "final completion reply"),
+    runSubagentAnnounceFlow: vi.fn(async () => true),
+    warn: vi.fn(),
+  };
+  Object.assign(params, overrides);
+  return { controller: createSubagentRegistryLifecycleController(params), params };
+}
+
+function calledSessionsDelete(): boolean {
+  return gatewayMocks.callGateway.mock.calls.some(([opts]) => opts?.method === "sessions.delete");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetContinuationStateForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetContinuationStateForTests();
+});
+
+describe("startSubagentAnnounceCleanupFlow continuation gate (#952)", () => {
+  it("(a) does not clean up an already-announced run while a continuation is pending", () => {
+    const entry = createRunEntry({
+      delivery: { status: "delivered", announcedAt: 100 },
+    });
+    const { controller } = createController({
+      entry,
+      resolveContinuationCleanupDeferral: () => ({ kind: "defer-continuation", delayMs: 5_000 }),
+    });
+
+    const handled = controller.startSubagentAnnounceCleanupFlow(entry.runId, entry);
+
+    expect(handled).toBe(true);
+    // Gate returns before begin/finalize: the run is neither marked handled nor
+    // completed, and the announced-delivery fast path never fires.
+    expect(entry.cleanupHandled).toBeUndefined();
+    expect(entry.cleanupCompletedAt).toBeUndefined();
+    expect(gatewayMocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it('(b) retains a cleanup:"delete" subagent session while a continuation is pending', () => {
+    const runs = new Map<string, SubagentRunRecord>();
+    const entry = createRunEntry({
+      cleanup: "delete",
+      expectsCompletionMessage: false,
+    });
+    runs.set(entry.runId, entry);
+    const { controller } = createController({
+      entry,
+      runs,
+      resolveContinuationCleanupDeferral: () => ({ kind: "defer-continuation", delayMs: 5_000 }),
+    });
+
+    controller.startSubagentAnnounceCleanupFlow(entry.runId, entry);
+
+    // The session store entry must survive for the continuation wake: no
+    // sessions.delete is issued and the run record stays in the registry.
+    expect(calledSessionsDelete()).toBe(false);
+    expect(runs.has(entry.runId)).toBe(true);
+    expect(entry.cleanupHandled).toBeUndefined();
+    expect(entry.cleanupCompletedAt).toBeUndefined();
+  });
+
+  it("(d) runs cleanup exactly once after the continuation chain ends", async () => {
+    vi.useFakeTimers();
+    const runs = new Map<string, SubagentRunRecord>();
+    const entry = createRunEntry({
+      cleanup: "delete",
+      expectsCompletionMessage: false,
+    });
+    runs.set(entry.runId, entry);
+    let pending = true;
+    const { controller } = createController({
+      entry,
+      runs,
+      resolveContinuationCleanupDeferral: () =>
+        pending ? { kind: "defer-continuation", delayMs: 5_000 } : undefined,
+    });
+
+    controller.startSubagentAnnounceCleanupFlow(entry.runId, entry);
+    expect(calledSessionsDelete()).toBe(false);
+    expect(runs.has(entry.runId)).toBe(true);
+
+    // Chain ends: the recheck timer re-enters the flow, which now proceeds to
+    // delete the session and remove the run record exactly once.
+    pending = false;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const deleteCalls = gatewayMocks.callGateway.mock.calls.filter(
+      ([opts]) => opts?.method === "sessions.delete",
+    );
+    expect(deleteCalls).toHaveLength(1);
+    expect(runs.has(entry.runId)).toBe(false);
+
+    // No further rechecks remain scheduled.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(
+      gatewayMocks.callGateway.mock.calls.filter(([opts]) => opts?.method === "sessions.delete"),
+    ).toHaveLength(1);
+  });
+
+  it("(f) headline: a live continue_work wake ref defers cleanup, and re-entry runs once the ref clears", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const runs = new Map<string, SubagentRunRecord>();
+    const entry = createRunEntry({
+      cleanup: "delete",
+      expectsCompletionMessage: false,
+      endedAt: Date.now(),
+    });
+    runs.set(entry.runId, entry);
+
+    // Hop 1's continue_work arms a real work-wake timer for the child session.
+    const workWakeHandle = setTimeout(() => {}, 5_000);
+    registerContinuationTimerHandle(CHILD_SESSION_KEY, workWakeHandle, "work-wake");
+    expect(hasLiveContinuationWorkWakeTimerRefs(CHILD_SESSION_KEY)).toBe(true);
+
+    // The wake is still in flight (queued, then a hop reply running) after the
+    // timer ref releases — model that via the heartbeat/reply signals.
+    let heartbeatWakePending = false;
+    let replyRunActive = false;
+    const resolver = buildContinuationCleanupDeferralResolver({
+      hasLiveWorkWakeTimer: (sessionKey) => hasLiveContinuationWorkWakeTimerRefs(sessionKey),
+      hasPendingHeartbeatWake: () => heartbeatWakePending,
+      isReplyRunActive: () => replyRunActive,
+      hasContinuationWakeDispatching: (sessionKey) => hasContinuationWakeDispatching(sessionKey),
+      resolveRetentionHardExpiryMs: () => 360_000,
+      recheckDelayMs: 5_000,
+    });
+    const { controller } = createController({
+      entry,
+      runs,
+      resolveContinuationCleanupDeferral: resolver,
+    });
+
+    // Subagent reports done; cleanup must defer because the work-wake ref is live.
+    controller.startSubagentAnnounceCleanupFlow(entry.runId, entry);
+    expect(calledSessionsDelete()).toBe(false);
+    expect(runs.has(entry.runId)).toBe(true);
+
+    // The timer fires: ref releases, but the wake is now queued (race window).
+    unregisterContinuationTimerHandle(CHILD_SESSION_KEY, workWakeHandle);
+    clearTimeout(workWakeHandle);
+    heartbeatWakePending = true;
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(calledSessionsDelete()).toBe(false);
+    expect(runs.has(entry.runId)).toBe(true);
+
+    // Hop 2's heartbeat turn starts running (still defers).
+    heartbeatWakePending = false;
+    replyRunActive = true;
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(calledSessionsDelete()).toBe(false);
+    expect(runs.has(entry.runId)).toBe(true);
+
+    // Chain ends: nothing pending, so cleanup finally proceeds exactly once.
+    replyRunActive = false;
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(
+      gatewayMocks.callGateway.mock.calls.filter(([opts]) => opts?.method === "sessions.delete"),
+    ).toHaveLength(1);
+    expect(runs.has(entry.runId)).toBe(false);
+  });
+
+  it("(g) gap: the dispatching marker alone defers across the real pendingWakes.clear→active window (#952)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const runs = new Map<string, SubagentRunRecord>();
+    const entry = createRunEntry({
+      cleanup: "delete",
+      expectsCompletionMessage: false,
+      endedAt: Date.now(),
+    });
+    runs.set(entry.runId, entry);
+
+    // Wire the resolver to the REAL continuation-state singleton — the exact
+    // predicate the production registry composes. No stubbed booleans and no
+    // manufactured heartbeatWakePending→replyRunActive overlap (the prior
+    // headline masked the gap that way): the only signal exercised here is the
+    // genuine dispatching marker the heartbeat wake handler sets synchronously.
+    const resolver = buildContinuationCleanupDeferralResolver({
+      hasLiveWorkWakeTimer: (sessionKey) => hasLiveContinuationWorkWakeTimerRefs(sessionKey),
+      hasPendingHeartbeatWake: () => false,
+      isReplyRunActive: () => false,
+      hasContinuationWakeDispatching: (sessionKey) => hasContinuationWakeDispatching(sessionKey),
+      resolveRetentionHardExpiryMs: () => 360_000,
+      recheckDelayMs: 5_000,
+    });
+    const { controller } = createController({
+      entry,
+      runs,
+      resolveContinuationCleanupDeferral: resolver,
+    });
+
+    // The exact tick the residual race fires in: the continue_work timer already
+    // fired (no work-wake ref), `pendingWakes.clear()` already ran (no queued
+    // wake), and the reply run is not active yet. The wake handler's first
+    // synchronous statement set the dispatching marker — replicate that here.
+    markContinuationWakeDispatching(CHILD_SESSION_KEY);
+    expect(hasLiveContinuationWorkWakeTimerRefs(CHILD_SESSION_KEY)).toBe(false);
+    expect(hasContinuationWakeDispatching(CHILD_SESSION_KEY)).toBe(true);
+
+    // A recheck poll landing in the gap must STILL defer (pre-fix: deleted the
+    // child session mid-chain, reintroducing #952).
+    controller.startSubagentAnnounceCleanupFlow(entry.runId, entry);
+    expect(calledSessionsDelete()).toBe(false);
+    expect(runs.has(entry.runId)).toBe(true);
+
+    // Still dispatching on the next recheck → still defers.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(calledSessionsDelete()).toBe(false);
+    expect(runs.has(entry.runId)).toBe(true);
+
+    // Handler returns and this turn armed no hop N+1 timer: the marker clears and
+    // every signal is false, so cleanup proceeds exactly once.
+    clearContinuationWakeDispatching(CHILD_SESSION_KEY);
+    expect(hasContinuationWakeDispatching(CHILD_SESSION_KEY)).toBe(false);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(
+      gatewayMocks.callGateway.mock.calls.filter(([opts]) => opts?.method === "sessions.delete"),
+    ).toHaveLength(1);
+    expect(runs.has(entry.runId)).toBe(false);
+  });
+});

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -42,6 +42,7 @@ import {
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
 import {
+  type ContinuationCleanupDeferralResolver,
   resolveCleanupCompletionReason,
   resolveDeferredCleanupDecision,
 } from "./subagent-registry-cleanup.js";
@@ -146,9 +147,21 @@ export function createSubagentRegistryLifecycleController(params: {
   captureSubagentCompletionReply: CaptureSubagentCompletionReply;
   cleanupBrowserSessionsForLifecycleEnd?: typeof cleanupBrowserSessionsForLifecycleEnd;
   runSubagentAnnounceFlow: RunSubagentAnnounceFlow;
+  /**
+   * Returns a `defer-continuation` decision while a same-session `continue_work`
+   * continuation is still pending for the child, otherwise `undefined` to clean
+   * up normally. Optional so tests/non-continuation callers default to no
+   * deferral. Fix #952.
+   */
+  resolveContinuationCleanupDeferral?: ContinuationCleanupDeferralResolver;
   warn(message: string, meta?: Record<string, unknown>): void;
 }) {
   const scheduledResumeTimers = new Set<ReturnType<typeof setTimeout>>();
+  // Per-run recheck timers for continuation-deferred cleanup. Keyed by runId so
+  // a fresh defer replaces (rather than stacks) the pending recheck. Fix #952.
+  const continuationDeferTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const resolveContinuationDeferral: ContinuationCleanupDeferralResolver =
+    params.resolveContinuationCleanupDeferral ?? (() => undefined);
 
   const scheduleResumeSubagentRun = (runId: string, entry: SubagentRunRecord, delayMs: number) => {
     const timer = setTimeout(() => {
@@ -167,6 +180,37 @@ export function createSubagentRegistryLifecycleController(params: {
       clearTimeout(timer);
     }
     scheduledResumeTimers.clear();
+    for (const timer of continuationDeferTimers.values()) {
+      clearTimeout(timer);
+    }
+    continuationDeferTimers.clear();
+  };
+
+  const clearContinuationDeferTimer = (runId: string) => {
+    const timer = continuationDeferTimers.get(runId);
+    if (timer) {
+      clearTimeout(timer);
+      continuationDeferTimers.delete(runId);
+    }
+  };
+
+  // Re-attempt cleanup after a delay while a continuation is still pending.
+  // Replaces any existing recheck for the run so deferrals can't stack timers.
+  const scheduleContinuationDeferRecheck = (
+    runId: string,
+    entry: SubagentRunRecord,
+    delayMs: number,
+  ) => {
+    clearContinuationDeferTimer(runId);
+    const timer = setTimeout(() => {
+      continuationDeferTimers.delete(runId);
+      if (params.runs.get(runId) !== entry || entry.cleanupCompletedAt) {
+        return;
+      }
+      startSubagentAnnounceCleanupFlow(runId, entry);
+    }, delayMs);
+    timer.unref?.();
+    continuationDeferTimers.set(runId, timer);
   };
 
   const maskRunId = (runId: string): string => {
@@ -950,6 +994,12 @@ export function createSubagentRegistryLifecycleController(params: {
       return;
     }
 
+    if (deferredDecision.kind !== "retry") {
+      // `defer-continuation` is produced by the start-flow continuation gate,
+      // never by `resolveDeferredCleanupDecision`; this guard keeps the retry
+      // tail's narrowing exhaustive over the shared decision union. Fix #952.
+      return;
+    }
     markPendingFinalDelivery({
       entry,
       error: didAnnounce ? undefined : "announce deferred or direct delivery failed",
@@ -964,6 +1014,22 @@ export function createSubagentRegistryLifecycleController(params: {
   };
 
   const startSubagentAnnounceCleanupFlow = (runId: string, entry: SubagentRunRecord): boolean => {
+    // Gate BEFORE the announce/delete/didAnnounce fast paths: while a
+    // same-session continue_work continuation is still pending for this child,
+    // tearing the run down now would delete the session store entry that the
+    // continuation wake re-enters as a heartbeat turn (stranding hops 2+).
+    // Keep the run record AND its session alive, then re-check until the chain
+    // settles (or the leak-guard expiry). The deferred announce/cleanup runs
+    // once the chain ends, by which point `refreshFrozenResultFromSession` has
+    // already folded the latest hop's reply into the frozen result. Fix #952.
+    if (!entry.cleanupCompletedAt && !entry.cleanupHandled) {
+      const deferral = resolveContinuationDeferral(entry, Date.now());
+      if (deferral?.kind === "defer-continuation") {
+        scheduleContinuationDeferRecheck(runId, entry, deferral.delayMs);
+        return true;
+      }
+    }
+    clearContinuationDeferTimer(runId);
     if (typeof entry.delivery?.announcedAt === "number" || entry.delivery?.status === "delivered") {
       if (!beginSubagentCleanup(runId)) {
         return false;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -3,6 +3,12 @@
  *
  * Owns registration, lifecycle, delivery retry, steering, orphan recovery, persistence, and cleanup for child runs.
  */
+import { resolveContinuationRuntimeConfig } from "../auto-reply/continuation/config.js";
+import {
+  hasContinuationWakeDispatching,
+  hasLiveContinuationWorkWakeTimerRefs,
+} from "../auto-reply/continuation/state.js";
+import { replyRunRegistry } from "../auto-reply/reply/reply-run-registry.js";
 import type { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -10,6 +16,7 @@ import type { ResolveContextEngineOptions } from "../context-engine/registry.js"
 import type { ContextEngine, SubagentEndReason } from "../context-engine/types.js";
 import { callGateway } from "../gateway/call.js";
 import { getAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
+import { hasPendingHeartbeatWakeForSession } from "../infra/heartbeat-wake.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { formatBlockedLivenessError, isBlockedLivenessState } from "../shared/agent-liveness.js";
 import { createLazyImportLoader, createLazyPromiseLoader } from "../shared/lazy-promise.js";
@@ -40,6 +47,7 @@ import {
   SUBAGENT_ENDED_REASON_KILLED,
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
+import { buildContinuationCleanupDeferralResolver } from "./subagent-registry-cleanup.js";
 import {
   emitSubagentEndedHookOnce,
   resolveLifecycleOutcomeFromRunOutcome,
@@ -208,6 +216,27 @@ let restoreAttempted = false;
 const ORPHAN_RECOVERY_DEBOUNCE_MS = 1_000;
 let lastOrphanRecoveryScheduleAt = 0;
 const SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
+// How often to re-check a continuation-deferred subagent for cleanup. The chain
+// end (last hop arming no new wake) has no completion event for the deferred
+// run, so cleanup polls until the continuation signals clear. Fix #952.
+const CONTINUATION_CLEANUP_RECHECK_MS = 5_000;
+// Leak guard buffer added on top of the configured continuation maxDelayMs: if a
+// continue_work timer ref is somehow stuck (no active hop, no pending wake, no
+// progress) past one max-delay window plus this buffer, give up retaining the
+// session so a leaked ref can't pin it forever. Fix #952.
+const CONTINUATION_RETENTION_BUFFER_MS = 60_000;
+
+// Composed once: the predicate sources are process-global singletons, and the
+// closure defers all reads to cleanup time (safe across bootstrap cycles).
+const resolveContinuationCleanupDeferral = buildContinuationCleanupDeferralResolver({
+  hasLiveWorkWakeTimer: (sessionKey) => hasLiveContinuationWorkWakeTimerRefs(sessionKey),
+  hasPendingHeartbeatWake: (sessionKey) => hasPendingHeartbeatWakeForSession(sessionKey),
+  isReplyRunActive: (sessionKey) => replyRunRegistry.isActive(sessionKey),
+  hasContinuationWakeDispatching: (sessionKey) => hasContinuationWakeDispatching(sessionKey),
+  resolveRetentionHardExpiryMs: () =>
+    resolveContinuationRuntimeConfig().maxDelayMs + CONTINUATION_RETENTION_BUFFER_MS,
+  recheckDelayMs: CONTINUATION_CLEANUP_RECHECK_MS,
+});
 /**
  * Embedded runs can emit transient lifecycle `error` events while provider/model
  * retry is still in progress. Defer terminal error cleanup briefly so a
@@ -601,6 +630,7 @@ const subagentLifecycleController = createSubagentRegistryLifecycleController({
   cleanupBrowserSessionsForLifecycleEnd: (args) =>
     subagentRegistryDeps.cleanupBrowserSessionsForLifecycleEnd(args),
   runSubagentAnnounceFlow: (params) => subagentRegistryDeps.runSubagentAnnounceFlow(params),
+  resolveContinuationCleanupDeferral,
   warn: (message, meta) => log.warn(message, meta),
 });
 

--- a/src/auto-reply/continuation/state.test.ts
+++ b/src/auto-reply/continuation/state.test.ts
@@ -11,10 +11,14 @@ vi.mock("./delegate-store.js", () => ({
 }));
 
 import {
+  clearContinuationWakeDispatching,
   clearTrackedContinuationTimers,
+  hasContinuationWakeDispatching,
   hasDelegatePending,
   hasLiveContinuationTimerRefs,
+  hasLiveContinuationWorkWakeTimerRefs,
   loadContinuationChainState,
+  markContinuationWakeDispatching,
   persistContinuationChainState,
   registerContinuationTimerHandle,
   releaseContinuationTimerRef,
@@ -159,6 +163,69 @@ describe("continuation timer state", () => {
 
     await vi.advanceTimersByTimeAsync(0);
     expect(hasLiveContinuationTimerRefs(sessionKey)).toBe(false);
+  });
+
+  it("tracks work-wake refs separately from delegate refs (#952)", () => {
+    const sessionKey = "typed-refs";
+    const delegateHandle = setTimeout(() => undefined, 1_000);
+
+    // A delegate-hedge timer must NOT register as a continue_work work-wake ref:
+    // cleanup only defers for same-session continue_work, not delegate hedges.
+    retainContinuationTimerRef(sessionKey);
+    registerContinuationTimerHandle(sessionKey, delegateHandle);
+    expect(hasLiveContinuationTimerRefs(sessionKey)).toBe(true);
+    expect(hasLiveContinuationWorkWakeTimerRefs(sessionKey)).toBe(false);
+
+    const workWakeHandle = setTimeout(() => undefined, 1_000);
+    retainContinuationTimerRef(sessionKey);
+    registerContinuationTimerHandle(sessionKey, workWakeHandle, "work-wake");
+    expect(hasLiveContinuationWorkWakeTimerRefs(sessionKey)).toBe(true);
+
+    // Releasing the work-wake handle clears the typed signal while the delegate
+    // ref remains on the shared tracker.
+    expect(unregisterContinuationTimerHandle(sessionKey, workWakeHandle)).toBe(true);
+    expect(hasLiveContinuationWorkWakeTimerRefs(sessionKey)).toBe(false);
+    expect(hasLiveContinuationTimerRefs(sessionKey)).toBe(true);
+
+    expect(unregisterContinuationTimerHandle(sessionKey, delegateHandle)).toBe(true);
+    expect(hasLiveContinuationTimerRefs(sessionKey)).toBe(false);
+    clearTimeout(delegateHandle);
+    clearTimeout(workWakeHandle);
+  });
+
+  it("ref-counts the continuation wake dispatching marker (#952)", () => {
+    const sessionKey = "agent:main:subagent:child";
+    expect(hasContinuationWakeDispatching(sessionKey)).toBe(false);
+
+    // Overlapping dispatch (two handlers for the same child in one batch) must
+    // not let the first finally clear the marker out from under the second.
+    markContinuationWakeDispatching(sessionKey);
+    markContinuationWakeDispatching(sessionKey);
+    expect(hasContinuationWakeDispatching(sessionKey)).toBe(true);
+
+    clearContinuationWakeDispatching(sessionKey);
+    expect(hasContinuationWakeDispatching(sessionKey)).toBe(true);
+
+    clearContinuationWakeDispatching(sessionKey);
+    expect(hasContinuationWakeDispatching(sessionKey)).toBe(false);
+
+    // Over-release is a no-op (stays cleared, never goes negative).
+    clearContinuationWakeDispatching(sessionKey);
+    expect(hasContinuationWakeDispatching(sessionKey)).toBe(false);
+  });
+
+  it("drops the dispatching marker on explicit session reset (#952)", () => {
+    const sessionKey = "agent:main:subagent:child";
+    markContinuationWakeDispatching(sessionKey);
+    expect(hasContinuationWakeDispatching(sessionKey)).toBe(true);
+
+    // /new, /reset abandons the chain — the marker must not pin the new session.
+    clearTrackedContinuationTimers(sessionKey);
+    expect(hasContinuationWakeDispatching(sessionKey)).toBe(false);
+
+    // A late finally from the in-flight handler is a harmless no-op decrement.
+    clearContinuationWakeDispatching(sessionKey);
+    expect(hasContinuationWakeDispatching(sessionKey)).toBe(false);
   });
 });
 

--- a/src/auto-reply/continuation/state.ts
+++ b/src/auto-reply/continuation/state.ts
@@ -10,11 +10,41 @@
 
 type ContinuationTimerHandle = ReturnType<typeof setTimeout>;
 
+/**
+ * Discriminates the two timer families tracked here. `work-wake` is a
+ * same-session `continue_work` heartbeat-wake (turn N -> turn N+1); `delegate`
+ * covers delegate hedge / chain-hop spawn timers. They share the generic
+ * ref/handle bookkeeping, but subagent cleanup must defer ONLY for a live
+ * same-session `continue_work` wake — a delegate hedge must never pin the child
+ * session alive. Fix #952.
+ */
+export type ContinuationTimerKind = "work-wake" | "delegate";
+
 // Per-session timer handles for delayed continuation work.
 const continuationTimerHandles = new Map<string, Set<ContinuationTimerHandle>>();
 // Per-session ref count for outstanding timers (used to determine if
 // continuation state should be kept alive).
 const continuationTimerRefs = new Map<string, number>();
+// Per-session subset of `continuationTimerHandles` holding ONLY `continue_work`
+// wake handles. Tracked apart from delegate timers so subagent cleanup can keep
+// a child session alive while its own continuation wake is still pending,
+// without a delegate hedge (different concern) blocking teardown. Fix #952.
+const continuationWorkWakeTimerHandles = new Map<string, Set<ContinuationTimerHandle>>();
+// Per-session ref count for a continuation wake the heartbeat dispatcher is
+// actively handing off. Set SYNCHRONOUSLY by the batch-dispatch hook the instant
+// the wake dispatcher dequeues a coalesced batch (right after
+// `pendingWakes.clear()`, before any handler runs) and released in each wake's
+// handler finally. Marking the WHOLE batch at dequeue — not each handler's first
+// statement — closes the gap for a continuation wake at batch position >= 2,
+// whose own handler only runs after earlier wakes' multi-second turns await:
+// once the continue_work timer fires it unregisters its work-wake handle AND the
+// dispatcher's `pendingWakes.clear()` empties the queued-wake signal for the
+// whole batch at once. For that window the dispatching marker is the only live
+// continuation signal, so a 5s cleanup recheck poll landing in it still defers
+// instead of deleting the child session mid-chain (reintroducing #952).
+// Ref-counted so overlapping dispatch can't clear it early; bounded by the
+// cleanup leak-guard hard-expiry if a handler somehow fails to release. Fix #952.
+const continuationWakeDispatching = new Map<string, number>();
 // ---------------------------------------------------------------------------
 // Delegate-pending queries — derived from TaskFlow, not a separate Map
 //
@@ -58,23 +88,84 @@ export function hasLiveContinuationTimerRefs(sessionKey: string): boolean {
 }
 
 /**
- * Register a timer handle so it can be cleared on session reset.
+ * True while a same-session `continue_work` wake timer is still armed for this
+ * session. Distinct from `hasLiveContinuationTimerRefs`, which also counts
+ * delegate hedge / chain-hop timers. Subagent cleanup uses this to defer
+ * teardown so the continuation wake can re-enter the (kept-alive) session as a
+ * heartbeat turn. Fix #952.
+ */
+export function hasLiveContinuationWorkWakeTimerRefs(sessionKey: string): boolean {
+  return (continuationWorkWakeTimerHandles.get(sessionKey)?.size ?? 0) > 0;
+}
+
+/**
+ * Mark that the heartbeat dispatcher is synchronously handing off this session's
+ * `continue_work` continuation turn. Called by the heartbeat batch-dispatch hook
+ * for EVERY continuation wake in a coalesced batch the instant the batch is
+ * dequeued (after `pendingWakes.clear()`, before any handler runs) — not per
+ * handler — so a wake at batch position >= 2 is already pending while earlier
+ * wakes' turns await, closing the window where the timer ref released, the
+ * pending wake was cleared, and the reply run has not yet registered active.
+ * Ref-counted so overlapping dispatch never clears the marker early. Pair with
+ * `clearContinuationWakeDispatching` in the handler finally (or the hook's
+ * per-batch release for a wake whose handler never ran). Fix #952.
+ */
+export function markContinuationWakeDispatching(sessionKey: string): void {
+  continuationWakeDispatching.set(
+    sessionKey,
+    (continuationWakeDispatching.get(sessionKey) ?? 0) + 1,
+  );
+}
+
+/** Release one `markContinuationWakeDispatching` ref once the handler returns. */
+export function clearContinuationWakeDispatching(sessionKey: string): void {
+  const current = continuationWakeDispatching.get(sessionKey) ?? 0;
+  if (current <= 1) {
+    continuationWakeDispatching.delete(sessionKey);
+  } else {
+    continuationWakeDispatching.set(sessionKey, current - 1);
+  }
+}
+
+/**
+ * True while a `continue_work` continuation wake is mid-dispatch for this
+ * session. Read by subagent cleanup as the fourth continuation-pending signal,
+ * covering the tick between the timer firing and the reply run going active.
+ * Fix #952.
+ */
+export function hasContinuationWakeDispatching(sessionKey: string): boolean {
+  return (continuationWakeDispatching.get(sessionKey) ?? 0) > 0;
+}
+
+/**
+ * Register a timer handle so it can be cleared on session reset. Pass
+ * `kind: "work-wake"` for `continue_work` wakes so cleanup-deferral tracking
+ * can distinguish them from delegate timers.
  */
 export function registerContinuationTimerHandle(
   sessionKey: string,
   handle: ContinuationTimerHandle,
+  kind: ContinuationTimerKind = "delegate",
 ): void {
   const existing = continuationTimerHandles.get(sessionKey);
   if (existing) {
     existing.add(handle);
-    return;
+  } else {
+    continuationTimerHandles.set(sessionKey, new Set([handle]));
   }
-  continuationTimerHandles.set(sessionKey, new Set([handle]));
+  if (kind === "work-wake") {
+    const workWake = continuationWorkWakeTimerHandles.get(sessionKey);
+    if (workWake) {
+      workWake.add(handle);
+    } else {
+      continuationWorkWakeTimerHandles.set(sessionKey, new Set([handle]));
+    }
+  }
 }
 
 /**
  * Unregister a timer handle after it fires or is cancelled.
- * Also releases the timer ref.
+ * Also releases the timer ref and drops any work-wake tracking for the handle.
  */
 export function unregisterContinuationTimerHandle(
   sessionKey: string,
@@ -87,6 +178,10 @@ export function unregisterContinuationTimerHandle(
   if (existing.size === 0) {
     continuationTimerHandles.delete(sessionKey);
   }
+  const workWake = continuationWorkWakeTimerHandles.get(sessionKey);
+  if (workWake?.delete(handle) && workWake.size === 0) {
+    continuationWorkWakeTimerHandles.delete(sessionKey);
+  }
   releaseContinuationTimerRef(sessionKey);
   return true;
 }
@@ -96,6 +191,11 @@ export function unregisterContinuationTimerHandle(
  * session reset (/new, /reset) — NOT on inbound noise.
  */
 export function clearTrackedContinuationTimers(sessionKey: string): void {
+  continuationWorkWakeTimerHandles.delete(sessionKey);
+  // Drop any in-flight dispatching marker too: an explicit reset (/new, /reset)
+  // abandons the chain, so a leftover marker must not pin the new session. The
+  // handler's finally is a no-op decrement against the cleared entry. Fix #952.
+  continuationWakeDispatching.delete(sessionKey);
   const existing = continuationTimerHandles.get(sessionKey);
   if (!existing || existing.size === 0) {
     return;
@@ -197,5 +297,7 @@ export function persistContinuationChainState(params: {
 export function resetContinuationStateForTests(): void {
   continuationTimerHandles.clear();
   continuationTimerRefs.clear();
+  continuationWorkWakeTimerHandles.clear();
+  continuationWakeDispatching.clear();
   // delegatePendingFlags removed — derived from TaskFlow.
 }

--- a/src/auto-reply/continuation/volatile-map-allowlist.test.ts
+++ b/src/auto-reply/continuation/volatile-map-allowlist.test.ts
@@ -51,6 +51,28 @@ const ALLOWLIST = [
       "Reset to empty on process restart; pending delegate records remain in TaskFlow and rebuild timer state when scheduling resumes.",
   },
   {
+    file: "src/auto-reply/continuation/state.ts",
+    symbol: "continuationWorkWakeTimerHandles",
+    owner: "continuation timer registry",
+    purpose:
+      "Tracks the live setTimeout handles for same-session continue_work wakes only, so subagent cleanup can defer teardown while a continuation wake is still armed (#952) without being tripped by delegate-hedge timers.",
+    safeVolatileClassification:
+      "A per-session subset of continuationTimerHandles holding the same Node timeout handles; persisting it would be meaningless because the handles are process-local.",
+    restartContract:
+      "Lost on process restart; the durable continue_work intent lives in the session store and TaskFlow, and the next scheduling pass re-arms the wake.",
+  },
+  {
+    file: "src/auto-reply/continuation/state.ts",
+    symbol: "continuationWakeDispatching",
+    owner: "continuation timer registry",
+    purpose:
+      "Per-session ref count set synchronously while the heartbeat wake handler dispatches a continue_work turn, so subagent cleanup defers across the same tick the timer ref releases and the dispatcher clears its queued wake but the reply run is not yet active (#952).",
+    safeVolatileClassification:
+      "An in-process ref count tied to the lifetime of a single wake handler invocation; it has no meaning without that live call stack and is bounded by the cleanup leak-guard hard-expiry.",
+    restartContract:
+      "Lost on process restart; the durable continue_work intent lives in the session store and TaskFlow, and the next scheduling pass re-arms the wake.",
+  },
+  {
     file: "src/auto-reply/continuation/delegate-dispatch.ts",
     symbol: "hedgeTimers",
     owner: "continuation delegate dispatcher",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2907,7 +2907,7 @@ export async function runReplyAgent(replyParams: {
                 unregisterContinuationTimerHandle(sessionKey, timerHandle);
               }
             }, clampedDelay);
-            registerContinuationTimerHandle(sessionKey, timerHandle);
+            registerContinuationTimerHandle(sessionKey, timerHandle, "work-wake");
             timerHandle.unref();
           }
         }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1246,7 +1246,7 @@ export function createFollowupRunner(params: {
               unregisterContinuationTimerHandle(sessionKey, timerHandle);
             }
           }, clampedDelay);
-          registerContinuationTimerHandle(sessionKey, timerHandle);
+          registerContinuationTimerHandle(sessionKey, timerHandle, "work-wake");
           timerHandle.unref();
         }
       }

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -1,5 +1,9 @@
 // Tests heartbeat runner scheduling and timer cleanup.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  hasContinuationWakeDispatching,
+  resetContinuationStateForTests,
+} from "../auto-reply/continuation/state.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { startHeartbeatRunner } from "./heartbeat-runner.js";
 import { computeNextHeartbeatPhaseDueMs, resolveHeartbeatPhaseMs } from "./heartbeat-schedule.js";
@@ -165,6 +169,7 @@ describe("startHeartbeatRunner", () => {
 
   afterEach(() => {
     resetHeartbeatWakeStateForTests();
+    resetContinuationStateForTests();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -497,6 +502,146 @@ describe("startHeartbeatRunner", () => {
         sessionKey: "agent:ops:discord:channel:alerts",
       },
     });
+
+    runner.stop();
+  });
+
+  it("sets the continuation wake dispatching marker under the wake's session key for the whole turn (#952)", async () => {
+    useFakeHeartbeatTime();
+    const childSessionKey = "agent:main:subagent:child";
+    // The marker must be live the entire time `run` is executing (the window
+    // that spans pendingWakes.clear → reply-run-active). Capture it from inside
+    // the injected runOnce, which `run` invokes with the routed session key —
+    // the SAME key subagent cleanup queries via entry.childSessionKey.
+    let markerDuringRun: boolean | undefined;
+    let sessionKeyDuringRun: string | undefined;
+    const runSpy = vi.fn().mockImplementation(async (opts: { sessionKey?: string }) => {
+      sessionKeyDuringRun = opts.sessionKey;
+      markerDuringRun = hasContinuationWakeDispatching(childSessionKey);
+      return { status: "ran", durationMs: 1 } as const;
+    });
+
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig([{ id: "main", heartbeat: { every: "30m" } }]),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    // Drive the REAL wake dispatcher → REAL registered wakeHandler (no mirrored
+    // stand-in): a continue_work continuation wake targeting the child session.
+    requestHeartbeat({
+      source: "other",
+      intent: "immediate",
+      reason: "continuation",
+      agentId: "main",
+      sessionKey: childSessionKey,
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(sessionKeyDuringRun).toBe(childSessionKey);
+    // Production wakeHandler set the marker (first synchronous statement) keyed
+    // by the wake's session key, and it was still live while `run` executed.
+    expect(markerDuringRun).toBe(true);
+    // The finally released it once the handler returned — no leaked retention.
+    expect(hasContinuationWakeDispatching(childSessionKey)).toBe(false);
+
+    runner.stop();
+  });
+
+  it("does not set the dispatching marker for a non-continuation targeted wake (#952)", async () => {
+    useFakeHeartbeatTime();
+    const childSessionKey = "agent:main:subagent:child";
+    let markerDuringRun: boolean | undefined;
+    const runSpy = vi.fn().mockImplementation(async () => {
+      markerDuringRun = hasContinuationWakeDispatching(childSessionKey);
+      return { status: "ran", durationMs: 1 } as const;
+    });
+
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig([{ id: "main", heartbeat: { every: "30m" } }]),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    // A plain (non-continuation) wake must not pin the child session.
+    requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: "cron:job-123",
+      agentId: "main",
+      sessionKey: childSessionKey,
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(markerDuringRun).toBe(false);
+    expect(hasContinuationWakeDispatching(childSessionKey)).toBe(false);
+
+    runner.stop();
+  });
+
+  it("keeps a position>=2 continuation wake marked for the whole earlier-wake turn in a coalesced batch (#952)", async () => {
+    useFakeHeartbeatTime();
+    const firstSessionKey = "agent:main:subagent:first";
+    const continuationSessionKey = "agent:main:subagent:second";
+
+    // The race the per-handler mark missed: in a coalesced batch the dispatcher
+    // runs each wake's full turn sequentially, so a continuation wake at batch
+    // position >= 2 has an `await` (every earlier wake's turn) between
+    // `pendingWakes.clear()` and its own handler. The batch-dispatch hook marks
+    // the WHOLE batch at dequeue, so the continuation session reads pending the
+    // entire time the FIRST wake's turn runs. Capture the marker from inside the
+    // first wake's runOnce — exactly when a cleanup recheck poll could observe.
+    let markerDuringFirstTurn: boolean | undefined;
+    let markerDuringContinuationTurn: boolean | undefined;
+    const runSpy = vi.fn().mockImplementation(async (opts: { sessionKey?: string }) => {
+      if (opts.sessionKey === firstSessionKey) {
+        markerDuringFirstTurn = hasContinuationWakeDispatching(continuationSessionKey);
+      } else if (opts.sessionKey === continuationSessionKey) {
+        markerDuringContinuationTurn = hasContinuationWakeDispatching(continuationSessionKey);
+      }
+      return { status: "ran", durationMs: 1 } as const;
+    });
+
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig([{ id: "main", heartbeat: { every: "30m" } }]),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    // Two distinct-session wakes coalesce into ONE batch (same 0ms timer): a
+    // plain manual wake first (never deferred), then the continuation wake at
+    // batch position 2. Drives the REAL dispatcher + REAL registered hook.
+    requestHeartbeat({
+      source: "manual",
+      intent: "manual",
+      reason: "manual",
+      agentId: "main",
+      sessionKey: firstSessionKey,
+      coalesceMs: 0,
+    });
+    requestHeartbeat({
+      source: "other",
+      intent: "immediate",
+      reason: "continuation",
+      agentId: "main",
+      sessionKey: continuationSessionKey,
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).toHaveBeenCalledTimes(2);
+    // The position-2 continuation wake was already pending while the first
+    // wake's turn ran — closing the all-false window. Without the batch hook the
+    // mark would only land when the continuation handler runs (after the first
+    // turn), so this reads false → mutation check.
+    expect(markerDuringFirstTurn).toBe(true);
+    expect(markerDuringContinuationTurn).toBe(true);
+    // The continuation handler's finally released its mark; nothing leaked.
+    expect(hasContinuationWakeDispatching(continuationSessionKey)).toBe(false);
 
     runner.stop();
   });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -25,6 +25,10 @@ import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import { resolveModelRefFromString, type ModelRef } from "../agents/model-selection.js";
 import { resolvePersistedSessionRuntimeId } from "../agents/session-runtime-compat.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
+import {
+  clearContinuationWakeDispatching,
+  markContinuationWakeDispatching,
+} from "../auto-reply/continuation/state.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
   getHeartbeatToolNotificationText,
@@ -128,6 +132,7 @@ import {
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
   HEARTBEAT_SKIP_LANES_BUSY,
   HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+  type HeartbeatBatchWake,
   type HeartbeatRunResult,
   type HeartbeatWakeHandler,
   type HeartbeatWakeIntent,
@@ -135,6 +140,7 @@ import {
   type HeartbeatWakeSource,
   isRetryableHeartbeatBusySkipReason,
   requestHeartbeat,
+  setHeartbeatBatchDispatchHook,
   setHeartbeatsEnabled,
   setHeartbeatWakeHandler,
 } from "./heartbeat-wake.js";
@@ -2623,17 +2629,69 @@ export function startHeartbeatRunner(opts: {
     }
   };
 
-  const wakeHandler: HeartbeatWakeHandler = async (params: HeartbeatWakeRequest) =>
-    run({
-      reason: params.reason,
-      agentId: params.agentId,
-      sessionKey: params.sessionKey,
-      parentRunId: params.parentRunId,
-      heartbeat: params.heartbeat,
-      source: params.source,
-      intent: params.intent,
-    });
+  const wakeHandler: HeartbeatWakeHandler = async (params: HeartbeatWakeRequest) => {
+    // The batch-dispatch hook (registered below) marks this continuation wake
+    // synchronously when the dispatcher dequeues the coalesced batch — before
+    // this handler runs — so even a position >= 2 wake is already pending while
+    // earlier wakes' turns await. Here we only RELEASE this wake's marker once
+    // its own turn finishes; the hook's per-batch release covers a wake whose
+    // handler never ran (an earlier wake threw). Keyed by the wake's target
+    // session — the same forced/routed child session key the cleanup predicate
+    // queries via `entry.childSessionKey`. If this turn arms hop N+1's
+    // continue_work timer, `workWakeTimerArmed` flips true before we release →
+    // continuous coverage. Fix #952.
+    const dispatchingSessionKey = isContinuationHeartbeatWakeReason(params.reason ?? "")
+      ? normalizeOptionalString(params.sessionKey)
+      : undefined;
+    try {
+      return await run({
+        reason: params.reason,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+        parentRunId: params.parentRunId,
+        heartbeat: params.heartbeat,
+        source: params.source,
+        intent: params.intent,
+      });
+    } finally {
+      if (dispatchingSessionKey) {
+        clearContinuationWakeDispatching(dispatchingSessionKey);
+      }
+    }
+  };
   const disposeWakeHandler = setHeartbeatWakeHandler(wakeHandler);
+  // Mark EVERY continuation wake in a coalesced batch the instant the dispatcher
+  // dequeues it (before any handler runs), so a continuation wake at batch
+  // position >= 2 — whose handler only runs after earlier wakes' multi-second
+  // turns await — is never momentarily all-false to a subagent-cleanup recheck.
+  // Each marked wake is released by its own handler's finally above; the returned
+  // release clears any wake whose handler never ran (an earlier wake threw).
+  // Balanced: one mark at dequeue, one clear per continuation wake. Fix #952.
+  const disposeBatchDispatchHook = setHeartbeatBatchDispatchHook((batch) => {
+    const marked: Array<{ wake: HeartbeatBatchWake; sessionKey: string }> = [];
+    for (const wake of batch) {
+      if (!isContinuationHeartbeatWakeReason(wake.reason)) {
+        continue;
+      }
+      const sessionKey = normalizeOptionalString(wake.sessionKey);
+      if (!sessionKey) {
+        continue;
+      }
+      markContinuationWakeDispatching(sessionKey);
+      marked.push({ wake, sessionKey });
+    }
+    // Always hand back the release (no-op over an empty list when nothing was
+    // marked). The dispatcher calls it in finally with the wakes it handed off;
+    // handlers that ran already cleared their own mark, so only wakes the batch
+    // loop never reached are released here.
+    return (handled) => {
+      for (const entry of marked) {
+        if (!handled.has(entry.wake)) {
+          clearContinuationWakeDispatching(entry.sessionKey);
+        }
+      }
+    };
+  });
   updateConfig(state.cfg);
 
   const cleanup = () => {
@@ -2642,6 +2700,7 @@ export function startHeartbeatRunner(opts: {
     }
     state.stopped = true;
     disposeWakeHandler();
+    disposeBatchDispatchHook();
     if (state.timer) {
       clearTimeout(state.timer);
     }

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -1,14 +1,23 @@
 // Exercises heartbeat wake coalescing, retries, and skip handling.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  clearContinuationWakeDispatching,
+  hasContinuationWakeDispatching,
+  markContinuationWakeDispatching,
+  resetContinuationStateForTests,
+} from "../auto-reply/continuation/state.js";
+import {
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
   HEARTBEAT_SKIP_LANES_BUSY,
   HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+  type HeartbeatBatchWake,
   hasHeartbeatWakeHandler,
   hasPendingHeartbeatWake,
+  hasPendingHeartbeatWakeForSession,
   requestHeartbeat,
   requestHeartbeatNow,
   resetHeartbeatWakeStateForTests,
+  setHeartbeatBatchDispatchHook,
   setHeartbeatWakeHandler,
 } from "./heartbeat-wake.js";
 
@@ -467,5 +476,138 @@ describe("heartbeat-wake", () => {
         sessionKey: "agent:main:forum:group:-1001",
       },
     ]);
+  });
+
+  it("reports a pending heartbeat wake targeting a specific session (#952)", () => {
+    vi.useFakeTimers();
+    setHeartbeatWakeHandler(vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" }));
+
+    const childSessionKey = "agent:main:subagent:child";
+    expect(hasPendingHeartbeatWakeForSession(childSessionKey)).toBe(false);
+
+    requestHeartbeatNow({
+      reason: "continuation",
+      agentId: "main",
+      sessionKey: childSessionKey,
+      coalesceMs: 200,
+    });
+
+    expect(hasPendingHeartbeatWakeForSession(childSessionKey)).toBe(true);
+    // A different session's wake must not be confused for this child's.
+    expect(hasPendingHeartbeatWakeForSession("agent:main:subagent:other")).toBe(false);
+  });
+
+  it("a continuation wake handler's dispatching marker spans the pendingWakes.clear→active gap (#952)", async () => {
+    vi.useFakeTimers();
+    resetContinuationStateForTests();
+    const childSessionKey = "agent:main:subagent:child";
+
+    // Mirror heartbeat-runner's wakeHandler contract: set the dispatching marker
+    // as the FIRST synchronous statement (before any await) and clear in finally.
+    // The dispatcher invokes active(wakeOpts) synchronously right after
+    // pendingWakes.clear(), so the marker is already live by the time the handler
+    // body runs — exactly when a continuation-defer recheck poll could observe
+    // state. This drives the REAL dispatcher (not a manufactured overlap).
+    let gapSignals: { queued: boolean; dispatching: boolean } | undefined;
+    setHeartbeatWakeHandler(async (opts) => {
+      const key = opts.sessionKey ?? "";
+      markContinuationWakeDispatching(key);
+      try {
+        await Promise.resolve();
+        // pendingWakes was already cleared by the dispatcher, yet the marker
+        // keeps the continuation pending — closing the all-false race window.
+        gapSignals = {
+          queued: hasPendingHeartbeatWakeForSession(childSessionKey),
+          dispatching: hasContinuationWakeDispatching(childSessionKey),
+        };
+        return { status: "ran", durationMs: 0 };
+      } finally {
+        clearContinuationWakeDispatching(key);
+      }
+    });
+
+    requestHeartbeatNow({
+      reason: "continuation",
+      agentId: "main",
+      sessionKey: childSessionKey,
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(gapSignals).toEqual({ queued: false, dispatching: true });
+    // The marker is released once the handler returns.
+    expect(hasContinuationWakeDispatching(childSessionKey)).toBe(false);
+    resetContinuationStateForTests();
+  });
+
+  it("releases batch-marked continuation marks for wakes whose handler never runs when an earlier wake throws (#952)", async () => {
+    vi.useFakeTimers();
+    resetContinuationStateForTests();
+    const firstSessionKey = "agent:main:subagent:first";
+    const continuationSessionKey = "agent:main:subagent:second";
+
+    // Register the batch-dispatch hook exactly as heartbeat-runner does: mark
+    // every continuation wake at dequeue, and return a release that clears marks
+    // for wakes the batch loop never reached. The dispatcher calls this release
+    // in its finally with the wakes whose handler ran.
+    setHeartbeatBatchDispatchHook((batch) => {
+      const marked: Array<{ wake: HeartbeatBatchWake; sessionKey: string }> = [];
+      for (const batchWake of batch) {
+        if (batchWake.reason !== "continuation") {
+          continue;
+        }
+        const sessionKey = batchWake.sessionKey ?? "";
+        if (!sessionKey) {
+          continue;
+        }
+        markContinuationWakeDispatching(sessionKey);
+        marked.push({ wake: batchWake, sessionKey });
+      }
+      return (handled) => {
+        for (const entry of marked) {
+          if (!handled.has(entry.wake)) {
+            clearContinuationWakeDispatching(entry.sessionKey);
+          }
+        }
+      };
+    });
+
+    // The first wake's handler rejects → the dispatcher's catch re-queues the
+    // batch and the position-2 continuation wake's handler is never invoked this
+    // round, so its mark cannot be cleared by a handler finally.
+    let markerWhileFirstHandlerRan: boolean | undefined;
+    setHeartbeatWakeHandler(async (opts) => {
+      if (opts.sessionKey === firstSessionKey) {
+        markerWhileFirstHandlerRan = hasContinuationWakeDispatching(continuationSessionKey);
+        throw new Error("boom");
+      }
+      return { status: "ran", durationMs: 0 };
+    });
+
+    requestHeartbeat({
+      source: "manual",
+      intent: "manual",
+      reason: "manual",
+      agentId: "main",
+      sessionKey: firstSessionKey,
+      coalesceMs: 0,
+    });
+    requestHeartbeat({
+      source: "other",
+      intent: "immediate",
+      reason: "continuation",
+      agentId: "main",
+      sessionKey: continuationSessionKey,
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    // The continuation wake was marked at dequeue (live while the first handler
+    // ran), and although its own handler never ran, the per-batch release cleared
+    // it — no leaked marker pinning the child session for the leak-guard window.
+    expect(markerWhileFirstHandlerRan).toBe(true);
+    expect(hasContinuationWakeDispatching(continuationSessionKey)).toBe(false);
+
+    resetContinuationStateForTests();
   });
 });

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -61,6 +61,33 @@ export type HeartbeatWakeRequest = {
 
 export type HeartbeatWakeHandler = (opts: HeartbeatWakeRequest) => Promise<HeartbeatRunResult>;
 
+/**
+ * Minimal view of one dequeued wake handed to the batch-dispatch hook. The hook
+ * sees EVERY wake in a coalesced batch the instant `pendingWakes` is cleared,
+ * before any handler runs, so it can synchronously mark cross-cutting per-wake
+ * state (continuation-dispatching) for the whole batch at once. This closes the
+ * window for a wake at batch position >= 2 whose own handler only runs after
+ * earlier wakes' multi-second turns await. Fix #952.
+ */
+export type HeartbeatBatchWake = {
+  reason: string;
+  sessionKey?: string;
+};
+
+/**
+ * Returned by the batch-dispatch hook and called by the dispatcher in its
+ * finally with the wakes whose handler was actually invoked (each such handler
+ * owns clearing its own mark). The hook releases marks for any wake it marked
+ * but whose handler never ran — e.g. an earlier wake rejected and broke the
+ * batch loop — so mark/clear stays balanced without leaning on the cleanup
+ * leak-guard. Fix #952.
+ */
+export type HeartbeatBatchDispatchRelease = (handled: ReadonlySet<HeartbeatBatchWake>) => void;
+
+export type HeartbeatBatchDispatchHook = (
+  batch: ReadonlyArray<HeartbeatBatchWake>,
+) => HeartbeatBatchDispatchRelease | void;
+
 let heartbeatsEnabled = true;
 
 export function setHeartbeatsEnabled(enabled: boolean) {
@@ -86,6 +113,7 @@ type PendingWakeReason = {
 
 let handler: HeartbeatWakeHandler | null = null;
 let handlerGeneration = 0;
+let batchDispatchHook: HeartbeatBatchDispatchHook | null = null;
 const pendingWakes = new Map<string, PendingWakeReason>();
 let scheduled = false;
 let running = false;
@@ -233,7 +261,18 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
 
       const pendingBatch = Array.from(pendingWakes.values());
       pendingWakes.clear();
+      // Mark cross-cutting per-wake state for the WHOLE batch synchronously here
+      // — the same tick `pendingWakes.clear()` drops the queued-wake signal — so
+      // a continuation wake at batch position >= 2 (whose handler only runs after
+      // earlier wakes' multi-second turns await) is never momentarily all-false
+      // to a subagent-cleanup recheck. Marks are released per-handler; the
+      // returned release covers wakes never handled (an earlier wake threw and
+      // broke the loop). Fix #952.
+      const releaseBatchDispatch = batchDispatchHook?.(pendingBatch);
       running = true;
+      // Wakes handed off to a handler — that handler owns clearing its own mark,
+      // so the batch release must skip them and only clear un-run wakes. Fix #952.
+      const handledWakes = new Set<PendingWakeReason>();
       try {
         for (const pendingWake of pendingBatch) {
           const wakeOpts = {
@@ -245,6 +284,7 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
             ...(pendingWake.parentRunId ? { parentRunId: pendingWake.parentRunId } : {}),
             ...(pendingWake.heartbeat ? { heartbeat: pendingWake.heartbeat } : {}),
           };
+          handledWakes.add(pendingWake);
           const res = await active(wakeOpts);
           if (res.status === "skipped" && isRetryableHeartbeatBusySkipReason(res.reason)) {
             // The target runtime is busy; retry this wake target soon.
@@ -276,6 +316,10 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
         schedule(DEFAULT_RETRY_MS, "retry");
       } finally {
         running = false;
+        // Clear marks for any batched wake whose handler never ran (an earlier
+        // wake rejected and broke the loop); their retry re-marks next round.
+        // Fix #952.
+        releaseBatchDispatch?.(handledWakes);
         if (pendingWakes.size > 0 || scheduled) {
           schedule(delay, "normal");
         }
@@ -324,6 +368,24 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
     }
     handlerGeneration += 1;
     handler = null;
+  };
+}
+
+/**
+ * Register (or clear) the batch-dispatch hook invoked synchronously the instant
+ * a coalesced wake batch is dequeued (right after `pendingWakes.clear()`, before
+ * any handler runs). Lets a higher layer mark cross-cutting per-wake state for
+ * EVERY wake in the batch at once, closing the position >= 2 window (Fix #952).
+ * Returns a disposer; like `setHeartbeatWakeHandler`, a stale disposer is a
+ * no-op so an old runner's cleanup cannot clear a newer runner's hook. Default
+ * null = no-op.
+ */
+export function setHeartbeatBatchDispatchHook(next: HeartbeatBatchDispatchHook | null): () => void {
+  batchDispatchHook = next;
+  return () => {
+    if (batchDispatchHook === next) {
+      batchDispatchHook = null;
+    }
   };
 }
 
@@ -379,6 +441,25 @@ export function hasPendingHeartbeatWake() {
   return pendingWakes.size > 0 || Boolean(timer) || scheduled;
 }
 
+/**
+ * True when a heartbeat wake targeting a specific session is still queued
+ * (coalescing, not yet dispatched). Used by subagent cleanup to detect a
+ * `continue_work` continuation wake that has fired its timer but whose
+ * heartbeat turn has not run yet, so teardown can be deferred. Fix #952.
+ */
+export function hasPendingHeartbeatWakeForSession(sessionKey: string): boolean {
+  const normalized = normalizeWakeTarget(sessionKey);
+  if (!normalized) {
+    return false;
+  }
+  for (const pending of pendingWakes.values()) {
+    if (pending.sessionKey === normalized) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function resetHeartbeatWakeStateForTests() {
   if (timer) {
     clearTimeout(timer);
@@ -391,4 +472,5 @@ export function resetHeartbeatWakeStateForTests() {
   running = false;
   handlerGeneration += 1;
   handler = null;
+  batchDispatchHook = null;
 }


### PR DESCRIPTION
## Fixes #952 — continue_work inside a continuation-delegate subagent now chains

### Root
A `continue_delegate` subagent that calls `continue_work` was torn down / its session-store entry deleted before the continuation heartbeat wake fired (the keep-alive that #934's volatile-map elimination removed, with no replacement for the continue_work-nested case). The #746 wake-routing was already correct — the subagent just wasn't there to receive it.

### Fix (current TaskFlow architecture — NOT restoring the volatile `delayedReservations` map)
A `defer-continuation` gate at the single subagent cleanup entry (`startSubagentAnnounceCleanupFlow`) retains the run record **and** its session-store entry while a continuation is pending, then runs the normal announce/cleanup exactly once at chain end. The deferred result stays current via the existing `refreshFrozenResultFromSession`.

**Race-robust pending-continuation predicate** (closed across 3 review passes):
- typed work-wake timer ref (separate from delegate-hedge timers)
- pending heartbeat wake for the child session
- active reply run for the child session
- a **batch-wide** continuation-wake-dispatching marker, set synchronously for every continuation wake in a coalesced batch right after the dispatcher clears its queue — closes both the single-wake gap and the batch-position≥2 gap.
- bounded by an independent hard-expiry leak guard (`maxDelayMs + 60s`).

The gate is a verified **no-op for non-continuation subagents** (resolver returns `undefined` → unchanged path).

### Verification
- ~244 unit/integration tests green incl. **mutation-checked** race coverage (reverting any race fix fails a test); the headline + multi-wake-batch tests drive the **real** dispatcher ordering, not a manufactured overlap.
- `tsgo:core` + `tsgo:core:test` clean; `check:import-cycles` = 0; oxlint + oxfmt clean.
- 3 code-review passes; 3 distinct races found and closed.

### Known follow-up (non-blocking, hardening)
The multi-term signals predicate is inherently gap-prone; a single **continuation-hold** (acquired at `continue_work` arm, released only at re-entry completion) would be structurally race-free. Recommended as a future hardening, not required for this fix.

### Honest residuals (documented, low-risk / out-of-scope for the #952 path)
1. Coalescing-overwrite of a queued continuation reason by a priority≥ACTION wake — pre-existing; child subagent sessions don't receive manual/action wakes.
2. Process-death mid-turn — leak-guard backstop.
3. Live multi-hop end-to-end is unit/integration-proven (retained-session + re-entry path) but the **canary blitz** is the live confirmation.

Base: the assembly `frond-scribe/20260606/assembly-drift-923complete`.
