### PR TITLE
fix(ci): resolve lint/types/deadcode trivials

### DIFF
--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -11,15 +11,6 @@ export const KNIP_UNUSED_FILE_ALLOWLIST = [
   // releaseQueuedCompactionCompletion implementation. TODO: refactor call-site
   // to use this helper (bigger refactor, not block-CI).
   "src/auto-reply/continuation/post-compaction-release.ts",
-  // Continuation-rail back-pressure cap-on-enqueue (producer-side); declarative
-  // state landed before producer wire. Matches agent-cache-store family.
-  "src/infra/chain-budget.ts",
-  // Substrate-capability registry query-API; scaffold landed before consumers
-  // wired to the routing system.
-  "src/infra/substrate-capability-registry.ts",
-  "src/state/openclaw-agent-db.paths.ts",
-  "src/state/openclaw-agent-db.ts",
-  "src/state/openclaw-agent-schema.generated.ts",
 ];
 
 // Knip can disagree across supported local/CI platforms for files that are

--- a/src/agents/subagent-announce.continuation.test.ts
+++ b/src/agents/subagent-announce.continuation.test.ts
@@ -183,6 +183,7 @@ describe("subagent announce continuation chaining", () => {
       sessionId: `${params.childSessionKey}-session`,
       inputTokens: 0,
       outputTokens: 0,
+      updatedAt: Date.now(),
     };
     await saveSessionStore(storePath, currentStore, { skipMaintenance: true });
     clearSessionStoreCacheForTest();

--- a/src/config/sessions/store.continuation-merge.test.ts
+++ b/src/config/sessions/store.continuation-merge.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import {
   clearSessionStoreCacheForTest,


### PR DESCRIPTION
Trivial CI cleanup on top of `bd4276c813` (PR #965 / assembly-backmerge). Zero behavioral change.

## Fixes

1. **lint** — drop unused `vi` import in `src/config/sessions/store.continuation-merge.test.ts`
2. **test-types** — add missing `updatedAt: Date.now()` to the `SessionEntry` literal in `src/agents/subagent-announce.continuation.test.ts` (~line 184)
3. **deadcode (knip)** — drop 5 stale entries from `scripts/deadcode-unused-files.allowlist.mjs`:
   - `src/infra/chain-budget.ts` (file deleted upstream)
   - `src/infra/substrate-capability-registry.ts` (file deleted upstream)
   - `src/state/openclaw-agent-db.paths.ts` (now imported by `openclaw-agent-db.ts`)
   - `src/state/openclaw-agent-db.ts` (now imported by secrets/state callers)
   - `src/state/openclaw-agent-schema.generated.ts` (now imported by `openclaw-agent-db.ts`)

## Local validation (silas, on this worktree)
- `npx oxlint <touched files>` → 0 warnings, 0 errors
- `pnpm tsgo:test:src` → pass
- `pnpm deadcode:unused-files` → pass (35 intentional entries)

Single commit, clean diff (+2/-10).