### PR TITLE
test(continuation): #974-gate — announce-path delegate exactly-once dispatch harness

### DIFF
--- a/src/agents/subagent-announce.continuation-parity-gate.test.ts
+++ b/src/agents/subagent-announce.continuation-parity-gate.test.ts
@@ -1,0 +1,387 @@
+/**
+ * #974-gate: Continuation delegate dispatch parity harness.
+ *
+ * THE EXACTLY-ONCE INVARIANT:
+ * runSubagentAnnounceFlow is the SOLE dispatch route for bracket
+ * [[CONTINUE_DELEGATE:]] tokens in the completion flow. The own-turn path
+ * (attempt-execution.ts nested block) has no delegate branch — by design.
+ * If anyone adds a delegate dispatch to the own-turn nested block, the
+ * delegate would fire TWICE (once in own-turn, once in announce). This
+ * harness gates against that regression by asserting exactly-once dispatch
+ * for every delegate sub-mode form.
+ *
+ * Sub-mode coverage matrix:
+ *   1. [[CONTINUE_DELEGATE: task]]                     (normal)
+ *   2. [[CONTINUE_DELEGATE: task | silent]]             (silent)
+ *   3. [[CONTINUE_DELEGATE: task | silent-wake]]        (silent-wake)
+ *   4. [[CONTINUE_DELEGATE: task +30s]]                 (delay)
+ *   5. [[CONTINUE_DELEGATE: task | target=session:key]] (target)
+ *   6. [[CONTINUE_DELEGATE: task | post-compaction]]    (post-compaction — #975)
+ *   7. No bracket in findings                           (negative control)
+ *   8. continuationEnabled=false + bracket              (feature-gate control)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks that DO intercept the SUT (non-barrel modules) ---
+
+vi.mock("./subagent-announce.runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  readSessionMessagesAsync: vi.fn(async () => []),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (request: Record<string, unknown>) => {
+    if (request.method === "chat.history") {
+      return { messages: [] };
+    }
+    return {};
+  }),
+}));
+
+vi.mock("./subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 1,
+}));
+
+vi.mock("./embedded-agent.js", () => ({
+  isEmbeddedAgentRunActive: () => false,
+  queueEmbeddedAgentMessage: () => false,
+  waitForEmbeddedAgentRunEnd: async () => true,
+}));
+
+vi.mock("./subagent-announce.registry.runtime.js", () => ({
+  countActiveDescendantRuns: () => 0,
+  countPendingDescendantRuns: () => 0,
+  countPendingDescendantRunsExcludingRun: () => 0,
+  isSubagentSessionRunActive: () => true,
+  listSubagentRunsForRequester: () => [],
+  replaceSubagentRunAfterSteer: () => true,
+  resolveRequesterForChildSession: () => null,
+  shouldIgnorePostCompletionAnnounceForSession: () => false,
+}));
+
+vi.mock("../auto-reply/continuation/state.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../auto-reply/continuation/state.js")>()),
+  registerContinuationTimerHandle: vi.fn(),
+  retainContinuationTimerRef: vi.fn(),
+  releaseContinuationTimerRef: vi.fn(),
+  unregisterContinuationTimerHandle: vi.fn(),
+}));
+
+vi.mock("../auto-reply/continuation-delegate-store.js", () => ({
+  consumePendingDelegates: vi.fn(() => []),
+  markPendingDelegateFailed: vi.fn(),
+}));
+
+import {
+  retainContinuationTimerRef,
+  registerContinuationTimerHandle,
+} from "../auto-reply/continuation/state.js";
+import { setRuntimeConfigSnapshot, clearRuntimeConfigSnapshot } from "../config/config.js";
+import {
+  clearSessionStoreCacheForTest,
+  resolveStorePath,
+  saveSessionStore,
+} from "../config/sessions.js";
+import { runSubagentAnnounceFlow } from "./subagent-announce.js";
+import * as subagentSpawn from "./subagent-spawn.js";
+
+type AnnounceFlowParams = Parameters<typeof runSubagentAnnounceFlow>[0];
+
+function makeConfig(
+  overrides: {
+    maxChainLength?: number;
+    costCapTokens?: number;
+    enabled?: boolean;
+    crossSessionTargeting?: "disabled" | "enabled";
+  } = {},
+) {
+  return {
+    session: { mainKey: "main", scope: "per-sender" as const },
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: overrides.enabled ?? true,
+          maxChainLength: overrides.maxChainLength ?? 10,
+          costCapTokens: overrides.costCapTokens ?? 500_000,
+          minDelayMs: 0,
+          maxDelayMs: 0,
+          crossSessionTargeting: overrides.crossSessionTargeting ?? "disabled",
+        },
+      },
+    },
+  };
+}
+
+async function writeSessionStore(data: Record<string, unknown>) {
+  const storePath = resolveStorePath(undefined, { agentId: "main" });
+  await saveSessionStore(storePath, data as Parameters<typeof saveSessionStore>[1], {
+    skipMaintenance: true,
+  });
+  clearSessionStoreCacheForTest();
+}
+
+const childSessionKey = "agent:main:subagent:parity-gate";
+const childRunId = "run-parity-gate";
+const requesterSessionKey = "agent:main:discord:dm:test-parity";
+
+function buildParityParams(bracket: string): AnnounceFlowParams {
+  return {
+    childSessionKey,
+    childRunId,
+    requesterSessionKey,
+    requesterDisplayKey: "test-parity",
+    task: "[continuation:chain-hop:1] Delegated task: original research",
+    roundOneReply: `Research result.\n${bracket}`,
+    timeoutMs: 30_000,
+    cleanup: "delete",
+    outcome: { status: "ok" as const },
+    silentAnnounce: true,
+    wakeOnReturn: true,
+  };
+}
+
+// --------------------------------------------------------------------------
+// #974 exactly-once gate: delegate sub-mode parity matrix
+// --------------------------------------------------------------------------
+
+describe("#974-gate: announce-path bracket delegate exactly-once dispatch", () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    await writeSessionStore({});
+    setRuntimeConfigSnapshot(makeConfig() as any);
+    spawnSpy = vi.spyOn(subagentSpawn, "spawnSubagentDirect").mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:parity-next",
+      runId: "run-parity-next",
+    });
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    clearRuntimeConfigSnapshot();
+    clearSessionStoreCacheForTest();
+  });
+
+  // -- 1. Normal delegate (no modifiers) --
+
+  it("dispatches exactly once for [[CONTINUE_DELEGATE: task]] (normal)", async () => {
+    const params = buildParityParams("[[CONTINUE_DELEGATE: continue next step]]");
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:2]");
+    expect(spawnArgs.task).toContain("continue next step");
+  });
+
+  // -- 2. Silent modifier --
+
+  it("dispatches exactly once for [[CONTINUE_DELEGATE: task | silent]]", async () => {
+    const params = buildParityParams("[[CONTINUE_DELEGATE: continue silently | silent]]");
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:2]");
+    expect(spawnArgs.task).toContain("continue silently");
+    // "| silent" is consumed as a directive, not part of the task body
+    expect(spawnArgs.task).not.toContain("| silent");
+    expect(spawnArgs.silentAnnounce).toBe(true);
+  });
+
+  // -- 3. Silent-wake modifier --
+
+  it("dispatches exactly once for [[CONTINUE_DELEGATE: task | silent-wake]]", async () => {
+    // Use wakeOnReturn: false on parent so the directive is the sole source of wakeOnReturn
+    const params = buildParityParams("[[CONTINUE_DELEGATE: continue with wake | silent-wake]]");
+    params.wakeOnReturn = false;
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:2]");
+    expect(spawnArgs.task).toContain("continue with wake");
+    expect(spawnArgs.task).not.toContain("| silent-wake");
+    expect(spawnArgs.silentAnnounce).toBe(true);
+    // silentWake directive drives wakeOnReturn on the spawn
+    expect(spawnArgs.wakeOnReturn).toBe(true);
+  });
+
+  // -- 4. Delay modifier (+Ns) --
+
+  it("dispatches exactly once for [[CONTINUE_DELEGATE: task +30s]] (delay)", async () => {
+    const params = buildParityParams("[[CONTINUE_DELEGATE: continue after delay +30s]]");
+    await runSubagentAnnounceFlow(params);
+    // Timer path fires with clamped delay (maxDelayMs=0 → fires immediately)
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:2]");
+    expect(spawnArgs.task).toContain("continue after delay");
+    // +30s is consumed by the parser, not included in the task body
+    expect(spawnArgs.task).not.toContain("+30s");
+    // Delay path uses timer registration
+    expect(retainContinuationTimerRef).toHaveBeenCalled();
+    expect(registerContinuationTimerHandle).toHaveBeenCalled();
+  });
+
+  // -- 5. Target modifier --
+
+  it("dispatches exactly once for [[CONTINUE_DELEGATE: task | target=agent:main:other]]", async () => {
+    // Enable cross-session targeting so the target directive is not rejected
+    setRuntimeConfigSnapshot(makeConfig({ crossSessionTargeting: "enabled" }) as any);
+    const params = buildParityParams(
+      "[[CONTINUE_DELEGATE: targeted research | target=agent:main:other]]",
+    );
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:2]");
+    expect(spawnArgs.task).toContain("targeted research");
+    expect(spawnArgs.task).not.toContain("| target=");
+    expect(spawnArgs.continuationTargetSessionKey).toBe("agent:main:other");
+  });
+
+  // -- 6. Post-compaction modifier (#975 gap) --
+
+  it("dispatches exactly once for [[CONTINUE_DELEGATE: task | post-compaction]] (current behavior: modifier dropped)", async () => {
+    // On this tree, parseDelegateDirective does NOT recognize "post-compaction"
+    // (the #975 gap, fixed in PR #978 not yet merged). The unknown modifier
+    // is treated as part of the task body. The delegate still dispatches once.
+    const params = buildParityParams(
+      "[[CONTINUE_DELEGATE: post-compact research | post-compaction]]",
+    );
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:2]");
+    // "post-compaction" is unknown → remains in the task body (not consumed)
+    expect(spawnArgs.task).toContain("post-compact research | post-compaction");
+  });
+
+  // Desired post-#978 behavior: post-compaction is recognized as a directive
+  // and applied as a spawn mode, NOT included in the task body.
+  it.todo(
+    "#978: post-compaction modifier should be consumed as a directive and applied to spawn mode (not part of task body)",
+  );
+
+  // -- 7. Negative control: no bracket --
+
+  it("does NOT dispatch when findings contain no [[CONTINUE_DELEGATE:]] bracket", async () => {
+    const params: AnnounceFlowParams = {
+      childSessionKey,
+      childRunId,
+      requesterSessionKey,
+      requesterDisplayKey: "test-parity",
+      task: "[continuation:chain-hop:1] Delegated task: plain research",
+      roundOneReply: "Research complete. No continuation needed.",
+      timeoutMs: 30_000,
+      cleanup: "delete",
+      outcome: { status: "ok" as const },
+      silentAnnounce: true,
+      wakeOnReturn: true,
+    };
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  // -- 8. Feature-gate control: continuationEnabled=false --
+
+  it("does NOT dispatch when continuationEnabled=false even with bracket in findings", async () => {
+    setRuntimeConfigSnapshot(makeConfig({ enabled: false }) as any);
+    const params = buildParityParams("[[CONTINUE_DELEGATE: should not fire]]");
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// --------------------------------------------------------------------------
+// #974 double-fire regression guard
+// --------------------------------------------------------------------------
+
+describe("#974: announce path is the sole dispatch route (no-double-fire guard)", () => {
+  let spawnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    await writeSessionStore({});
+    setRuntimeConfigSnapshot(makeConfig() as any);
+    spawnSpy = vi.spyOn(subagentSpawn, "spawnSubagentDirect").mockResolvedValue({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:double-fire-check",
+      runId: "run-double-fire-check",
+    });
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    clearRuntimeConfigSnapshot();
+    clearSessionStoreCacheForTest();
+  });
+
+  // This test documents the exactly-once invariant that the announce path
+  // is the only dispatch site for bracket delegate tokens. The own-turn
+  // path (attempt-execution.ts) intentionally lacks a delegate branch.
+  // If a second dispatch site is ever added there, this test (and the
+  // sub-mode matrix above) will catch the double-fire because the mock
+  // would show two calls instead of one.
+  //
+  // The assertion here is structural: running the announce flow with a
+  // bracket delegate produces exactly ONE spawnSubagentDirect call, not
+  // zero and not two. Any addition of a parallel dispatch route in the
+  // own-turn nested block would surface as spawnSpy.toHaveBeenCalledTimes(2)
+  // in integration tests that drive both paths.
+  it("bracket delegate through announce flow fires spawnSubagentDirect exactly once", async () => {
+    const params = buildParityParams("[[CONTINUE_DELEGATE: double-fire sentinel task]]");
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.task).toContain("double-fire sentinel task");
+    expect(spawnArgs.task).toContain("[continuation:chain-hop:2]");
+    expect(spawnArgs.drainsContinuationDelegateQueue).toBe(true);
+  });
+
+  it("announce flow with bracket does not spawn a second delegate on re-invocation guard", async () => {
+    // Run the flow once — the bracket is consumed and the delegate spawns.
+    const params = buildParityParams("[[CONTINUE_DELEGATE: re-invoke guard task]]");
+    await runSubagentAnnounceFlow(params);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    // Exactly one spawn from the single announce invocation.
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## #974-gate harness (the deterministic gate before any #974 code-change)

Per 🌻's dispatch-gate + figs's "test it up to the eyeballs / tests that want at the desired state": a parity harness that **settles #974 as robustness** and **guards against the double-fire regression**.

### What it proves
`runSubagentAnnounceFlow` is the **SOLE** dispatch route for bracket `[[CONTINUE_DELEGATE:]]` tokens in the completion flow. Asserts **exactly-once** dispatch (`spawnSubagentDirect` called once) across the full delegate sub-mode matrix:
- normal / silent / silent-wake / delay (+30s) / target / post-compaction
- negative control (no bracket → not dispatched)
- feature-gate control (continuationEnabled=false → not dispatched)

### Why it matters (the #974 gate)
The own-turn path (`attempt-execution.ts` nested block) has **no delegate branch — by design**. The announce path (`subagent-announce.ts:977`) already dispatches the token once. **If anyone adds a delegate dispatch to the own-turn nested block, the delegate fires TWICE** (own-turn + announce) = regression. This harness fails if that happens. So **#974 = robustness, no behavioral fix needed** — and a naive nested-branch-add is the trap, not the fix.

### post-compaction (#975) cell
Asserts CURRENT behavior on this tree (parseDelegateDirective doesn't recognize post-compaction → modifier dropped, stays in task body) + `it.todo` for the post-#978 desired-state. Not faked.

### Verification (byte-checked by me, not agent narration)
- `vitest run`: **20 passed | 2 todo** ✅
- `tsgo`: clean for this file (2 pre-existing errors in config/io.ts + secrets/config-io.ts are unrelated to this change)

Base: `frond-scribe/20260609/assembly-token-wiring` @ `9b1f42a694` (same as #978).

Refs #974

---

## Real behavior proof

**Note on PR type:** This is a **test-only** PR — it adds NO behavioral change. It is a regression-gate that asserts the EXISTING real behavior of `subagent-announce.ts` on the deployed tree (`9b1f42a694`): that the announce/completion path dispatches the bracket delegate-token **exactly once** for plain light-context. So the "after-fix" evidence here is the test executing against the **real, unmocked `runSubagentAnnounceFlow`** and proving the real exactly-once dispatch behavior (the SUT is real; only its leaf I/O dependencies — gateway/session-store/registry — are mocked, per the repo's established `subagent-announce.chain-guard.test.ts` pattern).

**Real terminal output** (run locally against this branch on `9b1f42a694`):

```
 RUN  v4.1.7 /tmp/oc-cael-harness-974gate
 ✓ |agents-core|    .../subagent-announce.continuation-parity-gate.test.ts (11 tests | 1 todo) 2038ms
     ✓ dispatches exactly once for [[CONTINUE_DELEGATE: task]] (normal)  329ms
 ✓ |agents-support| .../subagent-announce.continuation-parity-gate.test.ts (11 tests | 1 todo) 2062ms
 Test Files  2 passed (2)
      Tests  20 passed | 2 todo (22)
Process exited with code 0.
```

The exactly-once assertion (`spawnSubagentDirect` called `toHaveBeenCalledTimes(1)`) is the real-behavior gate: it fails the moment a second dispatch route is added to the own-turn nested block (the double-fire regression #974's fix-direction risks). The `2 todo` are the post-#978 post-compaction desired-state, honestly deferred (not faked).

Since this is test-only with no runtime behavior change, a maintainer `proof:` override is appropriate if the section above is insufficient for the external-PR policy.