### PR TITLE
fix(continuation): fan out multi continue_work() elections (#982)

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -703,11 +703,13 @@ export async function runAgentAttempt(params: {
   // this wiring, createOpenClawTools sees no continueWorkOpts on the spawn-init
   // path, so typed continue_work never registers for turn-1 subagent tool calls.
   const continuationEnabled = params.cfg?.agents?.defaults?.continuation?.enabled === true;
-  let attemptContinueWorkRequest: ContinueWorkRequest | undefined;
+  // Accumulate every continue_work election fired this turn; capturing only the
+  // last one silently drops the rest (#982).
+  const attemptContinueWorkRequests: ContinueWorkRequest[] = [];
   const continueWorkOpts = continuationEnabled
     ? {
         requestContinuation: (request: ContinueWorkRequest) => {
-          attemptContinueWorkRequest = request;
+          attemptContinueWorkRequests.push(request);
         },
       }
     : undefined;
@@ -901,13 +903,30 @@ export async function runAgentAttempt(params: {
         import("../../auto-reply/tokens.js"),
       ]);
       const continuationPayloads = embeddedRunResult.payloads ?? [];
+      const firstWorkRequest = attemptContinueWorkRequests[0];
       const extraction = extractContinuationSignal({
         payloads: continuationPayloads.map((payload) => ({ ...payload })),
-        ...(attemptContinueWorkRequest ? { continueWorkRequest: attemptContinueWorkRequest } : {}),
+        ...(firstWorkRequest ? { continueWorkRequest: firstWorkRequest } : {}),
         enabled: true,
         sessionKey: params.sessionKey,
       });
       if (extraction.signal?.kind === "work") {
+        // Tool elections fan out one wake each; a bracket signal has no per-tool
+        // array, so it schedules a single election from the merged signal.
+        const requests =
+          !extraction.fromBracket && attemptContinueWorkRequests.length > 0
+            ? attemptContinueWorkRequests
+            : [
+                {
+                  reason: extraction.workReason ?? "",
+                  ...(extraction.signal.delayMs !== undefined
+                    ? { delaySeconds: extraction.signal.delayMs / 1000 }
+                    : {}),
+                  ...(extraction.signal.traceparent
+                    ? { traceparent: extraction.signal.traceparent }
+                    : {}),
+                },
+              ];
         if (extraction.fromBracket) {
           for (let i = continuationPayloads.length - 1; i >= 0; i--) {
             const payload = continuationPayloads[i];
@@ -928,17 +947,7 @@ export async function runAgentAttempt(params: {
           sessionStore: params.sessionStore,
           storePath: params.storePath,
           runId: params.runId,
-          request: {
-            reason: extraction.workReason ?? "",
-            ...(extraction.signal.delayMs !== undefined
-              ? { delaySeconds: extraction.signal.delayMs / 1000 }
-              : !extraction.fromBracket && attemptContinueWorkRequest
-                ? { delaySeconds: attemptContinueWorkRequest.delaySeconds }
-                : {}),
-            ...(extraction.signal.traceparent
-              ? { traceparent: extraction.signal.traceparent }
-              : {}),
-          },
+          requests,
           cfg: params.cfg,
           runResult: embeddedRunResult,
         });
@@ -966,14 +975,14 @@ async function scheduleSpawnInitContinueWorkWake(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   runId: string;
-  request: { reason: string; delaySeconds?: number; traceparent?: string };
+  requests: { reason: string; delaySeconds?: number; traceparent?: string }[];
   cfg: OpenClawConfig;
   runResult: EmbeddedAgentRunResult;
 }): Promise<void> {
   const [
     { resolveLiveContinuationRuntimeConfig },
     { loadContinuationChainState, persistContinuationChainState },
-    { scheduleContinuationWork },
+    { scheduleContinuationWorkBatch },
     { resolveSessionStoreEntry, updateSessionStore },
   ] = await Promise.all([
     import("../../auto-reply/continuation/config.js"),
@@ -986,19 +995,19 @@ async function scheduleSpawnInitContinueWorkWake(params: {
   const tailUsage = params.runResult.meta?.agentMeta?.usage;
   const turnTokens = (tailUsage?.input ?? 0) + (tailUsage?.output ?? 0);
   const chainState = loadContinuationChainState(params.sessionEntry, turnTokens);
-  const result = await scheduleContinuationWork({
+  const result = await scheduleContinuationWorkBatch({
     sessionKey: params.sessionKey,
     chainState,
-    request: {
-      reason: params.request.reason,
-      delaySeconds: params.request.delaySeconds ?? continuationConfig.defaultDelayMs / 1000,
-      ...(params.request.traceparent ? { traceparent: params.request.traceparent } : {}),
-    },
+    requests: params.requests.map((request) => ({
+      reason: request.reason,
+      delaySeconds: request.delaySeconds ?? continuationConfig.defaultDelayMs / 1000,
+      ...(request.traceparent ? { traceparent: request.traceparent } : {}),
+    })),
     config: continuationConfig,
     parentRunId: params.runId,
     log: (message) => log.info(message),
   });
-  if (!result.scheduled) {
+  if (result.scheduledCount === 0) {
     return;
   }
   persistContinuationChainState({

--- a/src/auto-reply/continuation/lazy.runtime.ts
+++ b/src/auto-reply/continuation/lazy.runtime.ts
@@ -18,7 +18,7 @@
 export { resolveContinuationRuntimeConfig } from "./config.js";
 export { checkContextPressure, clearContextPressureState } from "./context-pressure.js";
 export { dispatchToolDelegates } from "./delegate-dispatch.js";
-export { scheduleContinuationWork } from "./work-dispatch.js";
+export { scheduleContinuationWork, scheduleContinuationWorkBatch } from "./work-dispatch.js";
 export {
   consumeStagedPostCompactionDelegates,
   pendingDelegateCount,

--- a/src/auto-reply/continuation/work-dispatch.test.ts
+++ b/src/auto-reply/continuation/work-dispatch.test.ts
@@ -231,6 +231,7 @@ import {
   recoverPendingContinuationWork,
   resetContinuationWorkDispatchForTests,
   scheduleContinuationWork,
+  scheduleContinuationWorkBatch,
 } from "./work-dispatch.js";
 import { enqueuePendingWork, hasLiveOrRecentlyDispatchedContinuationWork } from "./work-store.js";
 
@@ -698,6 +699,97 @@ describe("durable continuation_work dispatch", () => {
     expect(systemEvents).toEqual([
       expect.objectContaining({ text: expect.stringContaining("was not granted") }),
     ]);
+  });
+
+  it("delivers a distinct wake for every continue_work election scheduled in one turn (#982)", async () => {
+    // Regression for #982: N continue_work() calls in one model turn must each
+    // deliver their own wake at their own offset. The single-variable capture
+    // dropped all but the last; the batch helper fans out all N, and the
+    // wake-timer re-arms for the soonest pending after each fire.
+    const sessionKey = "agent:main:multi-fanout";
+    mockSessionStore[sessionKey] = { sessionKey };
+
+    const batch = await scheduleContinuationWorkBatch({
+      sessionKey,
+      chainState: {
+        currentChainCount: 0,
+        chainStartedAt: Date.now(),
+        accumulatedChainTokens: 0,
+        chainId: "chain-multi",
+      },
+      requests: [
+        { reason: "work-A", delaySeconds: 1 },
+        { reason: "work-B", delaySeconds: 2 },
+        { reason: "work-C", delaySeconds: 3 },
+      ],
+      config,
+      parentRunId: "run-multi",
+    });
+
+    expect(batch).toMatchObject({ scheduledCount: 3, cappedCount: 0, capped: false });
+    expect(turnGrants).toHaveLength(0);
+
+    // Advance one offset at a time. Each fire delivers exactly one wake and
+    // re-arms for the next pending dueAt — proving distinct delivery, not the
+    // single collapsed wake of the regression. `advanceTimersByTimeAsync` only
+    // runs timers due within the window (unlike `flushTimers`, which drains the
+    // re-armed future timers too).
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(turnGrants).toHaveLength(1);
+    expect(turnGrants[0]).toMatchObject({
+      context: expect.objectContaining({ Body: expect.stringContaining("work-A") }),
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(turnGrants).toHaveLength(2);
+    expect(turnGrants[1]).toMatchObject({
+      context: expect.objectContaining({ Body: expect.stringContaining("work-B") }),
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(turnGrants).toHaveLength(3);
+    expect(turnGrants[2]).toMatchObject({
+      context: expect.objectContaining({ Body: expect.stringContaining("work-C") }),
+    });
+  });
+
+  it("schedules the valid elections and caps the overflow without dropping the earlier ones", async () => {
+    // Partial-success is load-bearing: when the cumulative chain cap rejects a
+    // later election, the earlier valid ones must still schedule and deliver.
+    const sessionKey = "agent:main:partial-cap";
+    mockSessionStore[sessionKey] = { sessionKey };
+    const cappedConfig = { ...config, maxChainLength: 2 } satisfies ContinuationRuntimeConfig;
+
+    const batch = await scheduleContinuationWorkBatch({
+      sessionKey,
+      chainState: {
+        currentChainCount: 0,
+        chainStartedAt: Date.now(),
+        accumulatedChainTokens: 0,
+        chainId: "chain-partial",
+      },
+      requests: [
+        { reason: "fit-1", delaySeconds: 1 },
+        { reason: "fit-2", delaySeconds: 1 },
+        { reason: "over-cap", delaySeconds: 1 },
+      ],
+      config: cappedConfig,
+      parentRunId: "run-partial",
+    });
+
+    expect(batch).toMatchObject({ scheduledCount: 2, cappedCount: 1, capped: true });
+    expect(batch.chainState.currentChainCount).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flushTimers();
+
+    const deliveredReasons = turnGrants.map((grant) =>
+      String((grant as { context: { Body: string } }).context.Body),
+    );
+    expect(deliveredReasons).toHaveLength(2);
+    expect(deliveredReasons.some((body) => body.includes("fit-1"))).toBe(true);
+    expect(deliveredReasons.some((body) => body.includes("fit-2"))).toBe(true);
+    expect(deliveredReasons.some((body) => body.includes("over-cap"))).toBe(false);
   });
 
   it("does not let a hedge reclaim freshly running continuation work", async () => {

--- a/src/auto-reply/continuation/work-dispatch.ts
+++ b/src/auto-reply/continuation/work-dispatch.ts
@@ -9,7 +9,7 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { clampDelayMs, resolveContinuationRuntimeConfig } from "./config.js";
 import { checkContinuationBudget } from "./scheduler.js";
-import type { ChainState, ContinuationRuntimeConfig } from "./types.js";
+import type { ChainState, ContinuationRuntimeConfig, ContinueWorkRequest } from "./types.js";
 import {
   consumePendingWork,
   enqueuePendingWork,
@@ -361,6 +361,63 @@ export async function scheduleContinuationWork(params: {
   // can start the next turn; the timer fires on the next event-loop tick.
   armWorkTimer(params.sessionKey, fireAt);
   return { scheduled: true, capped: false, chainState: nextState };
+}
+
+export type ContinuationWorkBatchResult = {
+  /** Elections that successfully enqueued a durable wake. */
+  scheduledCount: number;
+  /** Elections rejected once the cumulative chain/cost cap was reached. */
+  cappedCount: number;
+  /** True when a cap rejection ended the batch early. */
+  capped: boolean;
+  /** Chain state after the last scheduled election; persist this once. */
+  chainState: ChainState;
+};
+
+/**
+ * Schedule every continue_work election captured in a single model turn.
+ *
+ * A single model response can emit N `continue_work` tool calls; each is its
+ * own flow with its own delay/reason and must deliver its own wake. The chain
+ * state is threaded across elections so chain/cost caps apply cumulatively.
+ *
+ * Partial success is load-bearing (#982): when a later election trips the cap,
+ * the earlier valid elections MUST stay scheduled — silently dropping them is
+ * exactly the regression this batches against. A cap rejection ends the batch
+ * because the cumulative chain count only grows, so every later election would
+ * hit the same cap.
+ */
+export async function scheduleContinuationWorkBatch(params: {
+  sessionKey: string;
+  chainState: ChainState;
+  requests: readonly ContinueWorkRequest[];
+  config: ContinuationRuntimeConfig;
+  parentRunId?: string;
+  log?: (message: string) => void;
+}): Promise<ContinuationWorkBatchResult> {
+  let chainState = params.chainState;
+  let scheduledCount = 0;
+  for (const request of params.requests) {
+    const result = await scheduleContinuationWork({
+      sessionKey: params.sessionKey,
+      chainState,
+      request,
+      config: params.config,
+      ...(params.parentRunId !== undefined ? { parentRunId: params.parentRunId } : {}),
+      ...(params.log ? { log: params.log } : {}),
+    });
+    if (!result.scheduled) {
+      return {
+        scheduledCount,
+        cappedCount: params.requests.length - scheduledCount,
+        capped: result.capped,
+        chainState,
+      };
+    }
+    chainState = result.chainState;
+    scheduledCount += 1;
+  }
+  return { scheduledCount, cappedCount: 0, capped: false, chainState };
 }
 
 export async function recoverPendingContinuationWork(): Promise<{

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -140,14 +140,14 @@ type EmbeddedAgentRunResult = Awaited<ReturnType<typeof runEmbeddedAgent>>;
 /** Type guard for wrapped continuation run results. */
 function isContinuationWrappedRunResult(result: unknown): result is {
   result: EmbeddedAgentRunResult;
-  continueWorkRequest?: ContinueWorkRequest;
+  continueWorkRequests?: ContinueWorkRequest[];
   compactionTraceparent?: string;
 } {
   return (
     typeof result === "object" &&
     result !== null &&
     "result" in result &&
-    "continueWorkRequest" in result
+    "continueWorkRequests" in result
   );
 }
 
@@ -463,7 +463,7 @@ export type AgentRunLoopResult =
       autoCompactionCount: number;
       compactionTraceparent?: string;
       /** Payload keys sent directly (not via pipeline) during tool flush. */
-      continueWorkRequest?: import("../../agents/tools/continue-work-tool.js").ContinueWorkRequest;
+      continueWorkRequests?: import("../../agents/tools/continue-work-tool.js").ContinueWorkRequest[];
       directlySentBlockKeys?: Set<string>;
     }
   | { kind: "final"; payload: ReplyPayload };
@@ -1847,7 +1847,7 @@ export async function runAgentTurnWithFallback(params: {
   let attemptedRuntimeProvider = fallbackProvider;
   let attemptedRuntimeModel = fallbackModel;
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
-  let continueWorkRequest: ContinueWorkRequest | undefined;
+  let continueWorkRequests: ContinueWorkRequest[] = [];
   let compactionTraceparent: string | undefined;
   let didResetAfterCompactionFailure = false;
   let transientHttpRetriesRemaining = 1;
@@ -2163,7 +2163,7 @@ export async function runAgentTurnWithFallback(params: {
           | EmbeddedAgentRunResult
           | {
               result: EmbeddedAgentRunResult;
-              continueWorkRequest?: ContinueWorkRequest;
+              continueWorkRequests?: ContinueWorkRequest[];
               compactionTraceparent?: string;
             }
         >({
@@ -2478,7 +2478,10 @@ export async function runAgentTurnWithFallback(params: {
             return (async () => {
               let attemptCompactionCount = 0;
               let attemptCompactionTraceparent: string | undefined;
-              let attemptContinueWorkRequest: ContinueWorkRequest | undefined;
+              // Accumulate every continue_work election fired this turn. A single
+              // model response can emit N calls; capturing only the last one
+              // silently drops the rest (#982).
+              const attemptContinueWorkRequests: ContinueWorkRequest[] = [];
               const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
                 runId,
                 sessionKey: params.sessionKey,
@@ -2549,7 +2552,7 @@ export async function runAgentTurnWithFallback(params: {
                       runtimeConfig?.agents?.defaults?.continuation?.enabled === true
                         ? {
                             requestContinuation: (request) => {
-                              attemptContinueWorkRequest = request;
+                              attemptContinueWorkRequests.push(request);
                             },
                           }
                         : undefined,
@@ -2948,7 +2951,7 @@ export async function runAgentTurnWithFallback(params: {
                 attemptCompactionCount = Math.max(attemptCompactionCount, resultCompactionCount);
                 return {
                   result: embeddedRunResult,
-                  continueWorkRequest: attemptContinueWorkRequest,
+                  continueWorkRequests: attemptContinueWorkRequests,
                   compactionTraceparent: attemptCompactionTraceparent,
                 };
               } catch (err) {
@@ -2981,16 +2984,16 @@ export async function runAgentTurnWithFallback(params: {
         | EmbeddedAgentRunResult
         | {
             result: EmbeddedAgentRunResult;
-            continueWorkRequest?: ContinueWorkRequest;
+            continueWorkRequests?: ContinueWorkRequest[];
             compactionTraceparent?: string;
           };
       if (isContinuationWrappedRunResult(fallbackRunResult)) {
         runResult = fallbackRunResult.result;
-        continueWorkRequest = fallbackRunResult.continueWorkRequest;
+        continueWorkRequests = fallbackRunResult.continueWorkRequests ?? [];
         compactionTraceparent = fallbackRunResult.compactionTraceparent;
       } else {
         runResult = fallbackRunResult;
-        continueWorkRequest = undefined;
+        continueWorkRequests = [];
         compactionTraceparent = undefined;
       }
       fallbackProvider = fallbackResult.provider;
@@ -3465,6 +3468,6 @@ export async function runAgentTurnWithFallback(params: {
     autoCompactionCount,
     compactionTraceparent,
     directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
-    continueWorkRequest,
+    continueWorkRequests,
   };
 }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -75,7 +75,7 @@ import { resolveLiveContinuationRuntimeConfig } from "../continuation/config.js"
 import { checkContextPressure } from "../continuation/context-pressure.js";
 import { extractContinuationSignal } from "../continuation/signal.js";
 import { hasCrossSessionDelegateTargeting } from "../continuation/targeting-pure.js";
-import type { ChainState } from "../continuation/types.js";
+import type { ChainState, ContinueWorkRequest } from "../continuation/types.js";
 import {
   buildFallbackClearedNotice,
   buildFallbackNotice,
@@ -1876,17 +1876,20 @@ export async function runReplyAgent(replyParams: {
     // --- Continuation signal extraction (docs/design/continue-work-signal-v2.md §3.1) ---
     // Tool-based `continue_work` flows via the closure `requestContinuation`
     // callback in agent-runner-execution.ts and is surfaced on the run outcome
-    // as `runOutcome.continueWorkRequest`. Bracket signals (CONTINUE_WORK,
-    // CONTINUE_DELEGATE) live in the payload text and are parsed here.
-    const continueWorkRequest = runOutcome.continueWorkRequest;
+    // as `runOutcome.continueWorkRequests` (one entry per tool call this turn).
+    // Bracket signals (CONTINUE_WORK, CONTINUE_DELEGATE) live in the payload
+    // text and are parsed here. The merged signal only needs the first request
+    // to decide kind/delay; the full array fans out at the work-schedule site.
+    const continueWorkRequests = runOutcome.continueWorkRequests ?? [];
+    const firstWorkRequest = continueWorkRequests[0];
     const continuationExtraction = extractContinuationSignal({
       payloads: payloadArray,
-      continueWorkRequest: continueWorkRequest
+      continueWorkRequest: firstWorkRequest
         ? {
-            reason: continueWorkRequest.reason,
-            delaySeconds: continueWorkRequest.delaySeconds,
-            ...(continueWorkRequest.traceparent
-              ? { traceparent: continueWorkRequest.traceparent }
+            reason: firstWorkRequest.reason,
+            delaySeconds: firstWorkRequest.delaySeconds,
+            ...(firstWorkRequest.traceparent
+              ? { traceparent: firstWorkRequest.traceparent }
               : {}),
           }
         : undefined,
@@ -2907,11 +2910,28 @@ export async function runReplyAgent(replyParams: {
               });
             }
           } else {
-            const requestedDelaySeconds =
-              (effectiveContinuationSignal.delayMs ?? defaultDelayMs) / 1000;
+            // Fan out every continue_work tool election captured this turn
+            // (#982). A single model response can fire N continue_work calls;
+            // each is its own flow with its own delay/reason. Bracket-sourced
+            // work has no per-tool array, so it schedules one election from the
+            // merged signal.
+            const workRequests: ContinueWorkRequest[] =
+              !continuationExtraction.fromBracket && continueWorkRequests.length > 0
+                ? continueWorkRequests
+                : [
+                    {
+                      reason: continuationWorkReason ?? "",
+                      delaySeconds: (effectiveContinuationSignal.delayMs ?? defaultDelayMs) / 1000,
+                      ...(effectiveContinuationSignal.traceparent
+                        ? { traceparent: effectiveContinuationSignal.traceparent }
+                        : {}),
+                    },
+                  ];
             const workChainId = activeSessionEntry?.continuationChainId ?? generateChainId();
-            const { scheduleContinuationWork } = await import("../continuation/lazy.runtime.js");
-            const scheduleResult = await scheduleContinuationWork({
+            const { scheduleContinuationWorkBatch } = await import(
+              "../continuation/lazy.runtime.js"
+            );
+            const batchResult = await scheduleContinuationWorkBatch({
               sessionKey,
               chainState: {
                 currentChainCount,
@@ -2919,26 +2939,29 @@ export async function runReplyAgent(replyParams: {
                 accumulatedChainTokens,
                 chainId: workChainId,
               },
-              request: {
-                delaySeconds: requestedDelaySeconds,
-                reason: continuationWorkReason ?? "",
-                ...(effectiveContinuationSignal.traceparent
-                  ? { traceparent: effectiveContinuationSignal.traceparent }
-                  : {}),
-              },
+              requests: workRequests,
               config: resolveLiveContinuationRuntimeConfig(cfg),
               parentRunId: runId,
               log: (message) => defaultRuntime.log(message),
             });
-            if (scheduleResult.scheduled) {
+            if (batchResult.scheduledCount > 0) {
               await persistContinuationChainState({
-                count: scheduleResult.chainState.currentChainCount,
-                startedAt: scheduleResult.chainState.chainStartedAt,
-                tokens: scheduleResult.chainState.accumulatedChainTokens,
-                ...(scheduleResult.chainState.chainId
-                  ? { chainId: scheduleResult.chainState.chainId }
+                count: batchResult.chainState.currentChainCount,
+                startedAt: batchResult.chainState.chainStartedAt,
+                tokens: batchResult.chainState.accumulatedChainTokens,
+                ...(batchResult.chainState.chainId
+                  ? { chainId: batchResult.chainState.chainId }
                   : {}),
               });
+            }
+            // Surface cap-dropped elections so a partial fan-out is not silent:
+            // the tool already told the model each call was "scheduled". Only
+            // emit for multi-election turns to keep single-work behavior intact.
+            if (batchResult.cappedCount > 0 && workRequests.length > 1) {
+              enqueueSystemEvent(
+                `[continuation] ${batchResult.cappedCount} of ${workRequests.length} continue_work elections were not scheduled (chain/cost cap).`,
+                { sessionKey, trusted: true },
+              );
             }
           }
         }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -763,7 +763,9 @@ export function createFollowupRunner(params: {
         | undefined;
       let queuedUserMessagePersistedAcrossFallback = false;
       let assistantErrorPersistedAcrossFallback = false;
-      let attemptContinueWorkRequest: ContinueWorkRequest | undefined;
+      // Accumulate every continue_work election fired this turn; capturing only
+      // the last one silently drops the rest (#982).
+      const attemptContinueWorkRequests: ContinueWorkRequest[] = [];
       try {
         const outcomePlan = buildAgentRuntimeOutcomePlan();
         const fallbackResult = await runWithModelFallback<EmbeddedAgentRunResult>({
@@ -1042,7 +1044,7 @@ export function createFollowupRunner(params: {
                   runtimeConfig?.agents?.defaults?.continuation?.enabled === true
                     ? {
                         requestContinuation: (request: ContinueWorkRequest) => {
-                          attemptContinueWorkRequest = request;
+                          attemptContinueWorkRequests.push(request);
                         },
                       }
                     : undefined,
@@ -1262,10 +1264,19 @@ export function createFollowupRunner(params: {
       // The election is durable TaskFlow state; the dispatcher only arms a
       // maturity timer and can replay it after gateway restart.
       const continuationEnabled = runtimeConfig?.agents?.defaults?.continuation?.enabled === true;
-      let effectiveContinueWorkRequest:
-        | { reason: string; delaySeconds?: number; traceparent?: string }
-        | undefined = attemptContinueWorkRequest;
-      if (!effectiveContinueWorkRequest && continuationEnabled && sessionKey) {
+      // One entry per continue_work tool call this turn; each fans out its own
+      // wake. Falls back to a single bracket-derived election when the model
+      // used [[CONTINUE_WORK]] text instead of the tool (subagent leaf path).
+      let effectiveContinueWorkRequests: {
+        reason: string;
+        delaySeconds?: number;
+        traceparent?: string;
+      }[] = attemptContinueWorkRequests;
+      if (
+        effectiveContinueWorkRequests.length === 0 &&
+        continuationEnabled &&
+        sessionKey
+      ) {
         const [{ extractContinuationSignal }, { stripContinuationSignal }] = await Promise.all([
           import("../continuation/signal.js"),
           import("../tokens.js"),
@@ -1291,22 +1302,24 @@ export function createFollowupRunner(params: {
               break;
             }
           }
-          effectiveContinueWorkRequest = {
-            reason: extraction.workReason ?? "",
-            ...(extraction.signal.delayMs !== undefined
-              ? { delaySeconds: extraction.signal.delayMs / 1000 }
-              : {}),
-            ...(extraction.signal.traceparent
-              ? { traceparent: extraction.signal.traceparent }
-              : {}),
-          };
+          effectiveContinueWorkRequests = [
+            {
+              reason: extraction.workReason ?? "",
+              ...(extraction.signal.delayMs !== undefined
+                ? { delaySeconds: extraction.signal.delayMs / 1000 }
+                : {}),
+              ...(extraction.signal.traceparent
+                ? { traceparent: extraction.signal.traceparent }
+                : {}),
+            },
+          ];
         }
       }
-      if (effectiveContinueWorkRequest && continuationEnabled && sessionKey) {
+      if (effectiveContinueWorkRequests.length > 0 && continuationEnabled && sessionKey) {
         const [
           { resolveLiveContinuationRuntimeConfig },
           { loadContinuationChainState, persistContinuationChainState },
-          { scheduleContinuationWork },
+          { scheduleContinuationWorkBatch },
           { updateSessionStore: updateSessionStoreFromStoreModule, resolveSessionStoreEntry },
         ] = await Promise.all([
           import("../continuation/config.js"),
@@ -1321,22 +1334,19 @@ export function createFollowupRunner(params: {
         const chainState =
           continuationChainStateAfterDelegateDispatch ??
           loadContinuationChainState(tailEntry, turnTokens);
-        const scheduleResult = await scheduleContinuationWork({
+        const scheduleResult = await scheduleContinuationWorkBatch({
           sessionKey,
           chainState,
-          request: {
-            reason: effectiveContinueWorkRequest.reason,
-            delaySeconds:
-              effectiveContinueWorkRequest.delaySeconds ?? continuationConfig.defaultDelayMs / 1000,
-            ...(effectiveContinueWorkRequest.traceparent
-              ? { traceparent: effectiveContinueWorkRequest.traceparent }
-              : {}),
-          },
+          requests: effectiveContinueWorkRequests.map((request) => ({
+            reason: request.reason,
+            delaySeconds: request.delaySeconds ?? continuationConfig.defaultDelayMs / 1000,
+            ...(request.traceparent ? { traceparent: request.traceparent } : {}),
+          })),
           config: continuationConfig,
           parentRunId: runId,
           log: (message) => defaultRuntime.log(message),
         });
-        if (scheduleResult.scheduled) {
+        if (scheduleResult.scheduledCount > 0) {
           persistContinuationChainState({
             sessionEntry: tailEntry,
             count: scheduleResult.chainState.currentChainCount,


### PR DESCRIPTION
## #982 — multi `continue_work()` silent-drop

Fixes the silent-drop where **N `continue_work()` elections in one model turn collapse to 1** (only the last survives), so every multi-schedule but the last is lost with a lying `{status: scheduled}`.

### Root cause (one-component, triple-confirmed)
Single-variable **capture-overwrite** at **3 sibling closures** — `attempt-execution.ts` (subagent) · `agent-runner-execution.ts` (main-reply) · `followup-runner.ts` (followup). `let attemptContinueWorkRequest = request` overwrites N→1 **before** `enqueuePendingWork` ever sees the siblings.

The **wake-timer was never broken**: `flows.set` is synchronous (`task-flow-registry.ts:433`), `peekSoonestUnmaturedWorkDueAt` sees all siblings, `consumePendingWork` drains-all-matured + re-arms soonest. The diff touches **zero** timer-arm lines — confirmed by empty grep on `armWorkTimer|clearWorkTimer|peekSoonest|workTimers|setTimeout|Math.min`. Diagnosis triple-confirmed: 🩸 Cael (`1514311525`) + 🌿 diff-byte + 🌫 retraction (#982 comment `4672156214`).

### Fix
- **Array-capture** (`let x` → `const requests[] + .push`) at all 3 closures — half-symmetric-cure-complete (#917/#918/#920-class: all siblings, not a half-cure).
- New **`scheduleContinuationWorkBatch`** helper threads cumulative `ChainState` → **partial-success** (earlier valid elections still schedule when a later one hits the chain-cap) + emits a system-event on cap-drop so partial fan-out is **never silent**.
- Consumer fans out the full `ContinueWorkRequest[]`. Single `continue_work` = 1-element array = no behavior change.
- Stays inside TaskFlow; does **not** touch continue_delegate / request_compaction / work-store / bracket-regex.

### Validation
- **Delivery-test** `work-dispatch.test.ts:704`: 3 elections one turn → **3 distinct delivered wakes** in soonest-first order (work-A@1s → work-B@2s → work-C@3s), via real `advanceTimersByTimeAsync` (not store-count). + partial-cap test (earlier valid ones survive an over-cap election).
- Targeted shard **15/15** (13 pre-existing + 2 new); core + test typecheck **clean**.
- **Second-seat confirmed**: 🌫 ran `:704` on lothric → 15/15 green (`1514309751763374181`).
- **Full suite** (`CI=true node scripts/test-projects.mjs`): EXIT=1 / ~1936s. All ~12 fails are **outside the 7 changed files** and in the documented rotating-baseline-flake set (deadcode-pnpm-env · telegram media-group #55216 · memory-lancedb/memory-core · secrets/runtime-channel · model-selection config). The continuation domain itself is green.

### Pending gates before merge (byte-honest — NOT "all green / tested" yet)
- [ ] 🪨 Rune **half-cure-completeness review** of the diff (all 3 closures + per-lane semantics) — merge-driver.
- [ ] **Per-lane re-prove on the deployed binary** — subagent-fire + main-fire + followup-fire each → distinct wakes (not just the main-session repro). The load-bearing live test; "fixed" is not claimed until this passes.
- [ ] Full pre-push gate-set (`tsgo:core/test/extensions` + `lint` + `package-boundary` + full vitest) + cross-repo CI per CODE_AGENTS runbook.
- [ ] Re-deploy `4bbd3aec096` + this fix → live **6-fire → 6-wakes** confirmation.

Severity: assembly-introduced (capture `8e04d27f1a`, 2026-06-05, fork-lineage; no upstream regression). Separable from #978; presented-cure intact. Base is the **assembly branch** — the pr-presentation gate is held separately for figs.

🌫 #984 is the cross-walk-validation companion (different impl, same bug-shape) — closed as superseded when this merges.

Co-authored-by: Silas <silas-dandelion-cult@users.noreply.github.com>
Co-authored-by: Rune <rune-dandelion-cult@users.noreply.github.com>
Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
