### PR TITLE
fix(continuation): reset chain budget on fresh non-wake turn-entry (#987)

### DIFF
--- a/docs/design/continue-work-signal-v2.md
+++ b/docs/design/continue-work-signal-v2.md
@@ -183,7 +183,7 @@ If `delaySeconds` is 30 and the current turn is still active, the 30-second time
 
 When a `continuation_work` row matures, the dispatcher grants a turn to the **same session** directly through the universal reply executor (`getReplyFromConfig`) with a `[continuation:wake]` system event. It does not call `requestHeartbeatNow()` or `runHeartbeatOnce()`, because heartbeat registration, active-hours, deferral, and busy skip gates are heartbeat policy rather than same-session continuation policy. The session-store entry must still exist when the row matures, so sub-agent cleanup and archive sweeps retain child sessions with live or recently granted continuation work.
 
-**Safety model:** the scheduled continuation remains subject to chain-length and token-budget guards. If the session has already exhausted its configured continuation budget, the call is rejected and the agent may stop, persist state to files, or choose another recovery path.
+**Safety model:** the scheduled continuation remains subject to chain-length and token-budget guards. If the current self-continuation chain has already exhausted its configured `maxChainLength` or `costCapTokens` budget within the unbroken self-chain, the call is rejected and the agent may stop, persist state to files, or choose another recovery path. (A fresh non-continuation turn-entry — genuine user message, heartbeat, or external system event — resets the chain budget per the per-turn chain-reset semantic in §3.3; the budgets bound unattended-loop depth, not session lifetime.)
 
 ### 2.4 `continue_delegate()` semantics and return modes
 
@@ -507,6 +507,11 @@ Session metadata tracks continuation state through:
 - `continuationChainCount`
 - `continuationChainStartedAt`
 - `continuationChainTokens`
+- `continuationChainId`
+
+**Chain-state lifecycle.** These four fields accumulate together within an unbroken self-continuation chain and **reset together** at turn-entry whenever the inbound origin is not a continuation-wake (the `!isContinuationWake` gate evaluated at `get-reply-run.ts` for `work-wake` / `delegate-return` filtering). The reset fires before `loadContinuationChainState` reads the SessionEntry, so a fresh turn opens with `chain 0/maxChainLength` and a freshly minted `continuationChainId`; a fresh turn that itself elects a continuation then advances the new chain from 0 (not from the prior carried count). Continuation-wake turns (`work-wake` / `delegate-return`) preserve the accumulating count so a genuine runaway self-loop still trips the cap.
+
+The full session-rotation reset path (`agent-runner-session-reset.ts`, fired by `/reset`, compaction-failure-recovery, role-ordering-conflict, or ACP-explicit-`resetSession`-flag) clears these fields as part of a broader sessionId-mint and continues to apply for those error-recovery paths; the per-turn chain-reset above is the additive shipped behavior that bounds the leash to _unattended_ self-continuation rather than session lifetime.
 
 Delayed delegates reserve future hop labels before spawn and persist accepted hop state only after acceptance. This keeps planned work distinct from accepted chain state and prevents retries or pre-spawn failures from consuming chain budget.
 
@@ -915,15 +920,25 @@ agents:
 Operational notes:
 
 - `enabled: false` means explicit opt-in is required in `openclaw.json`.
-- `maxChainLength` is a recursion guard.
-- `costCapTokens` is a per-chain budget leash.
+- `maxChainLength` is a recursion guard bounding _unattended self-continuation chain depth_. The chain-count resets to zero on any non-continuation turn-entry (genuine user input, heartbeat, or external system event), so the guard bounds only one unbroken self-driven burst between human (or external) re-engagements, not session-lifetime budget. See §3.3 for the chain-state lifecycle.
+- `costCapTokens` is a per-chain token-cost leash accumulating across `continue_work()` and tool-path delegate hops within a single unbroken self-continuation chain. The accumulated chain tokens reset to zero on the same non-continuation turn-entry trigger as `continuationChainCount`, keeping the cap as a per-burst guard rather than a session-lifetime quota.
 - `crossSessionTargeting: disabled` is the default-deny gate for explicit cross-session delegate return targeting.
 - `contextPressureThreshold` is optional and must be `> 0` and `<= 1` when configured.
 - `earlyWarningBand` is shipped, defaults to `0.3125`, accepts `0` as opt-out, and is schema-validated as a unit-interval value.
 - There is no `generationGuardTolerance` setting. Delayed work is not cancelled by unrelated channel noise.
 - tool-path delegate durability is unconditional; there is no delegate-store switch.
 - all shipped continuation runtime values are read at use time; changes take effect at the next enforcement point.
-- `subagents.maxChildrenPerAgent` (default: 5, schema ceiling: 10000) controls concurrent active children per parent session. This interacts with continuation knobs: `maxDelegatesPerTurn` gates how many delegates a single turn can EMIT; `maxChildrenPerAgent` gates how many can be ACTIVE simultaneously; `maxChainLength` + `costCapTokens` bound the total recursion depth and token budget. For wide-fanout patterns (large-scale fan-out, batch distribution, parallel research), override via `agents.defaults.subagents.maxChildrenPerAgent` in openclaw.json. Hot-reload: config is read at spawn-time (no caching, no restart needed).
+- `subagents.maxChildrenPerAgent` (default: 5, schema ceiling: 10000) controls concurrent active children per parent session. This interacts with continuation knobs: `maxDelegatesPerTurn` gates how many delegates a single turn can EMIT; `maxChildrenPerAgent` gates how many can be ACTIVE simultaneously; `maxChainLength` + `costCapTokens` bound the unattended self-continuation-chain recursion depth and token budget (both reset on fresh non-continuation turn-entry per §3.3). For wide-fanout patterns (large-scale fan-out, batch distribution, parallel research), override via `agents.defaults.subagents.maxChildrenPerAgent` in openclaw.json. Hot-reload: config is read at spawn-time (no caching, no restart needed).
+
+#### Chain budget lifecycle
+
+Both `maxChainLength` and `costCapTokens` budgets accumulate _within an unbroken self-continuation chain_ and reset to zero on the first non-continuation turn-entry (`!isContinuationWake` gate at turn-entry, pre-inference, before `loadContinuationChainState` reads the SessionEntry). A "chain" is the run of self-elected successor turns from `continue_work` / `continue_delegate` between two human (or external) re-engagements; the budgets bound the unattended-loop depth and cost, not the session lifetime.
+
+`/status` displays `chain N/maxChainLength` reflecting current chain depth, which **sawtooths**: climbs within an unbroken self-chain, drops to 0 the moment a fresh chain starts (user message, heartbeat, system event). The default for `maxChainLength` thus reflects "how deep a single unattended self-loop can run before the gateway stops it," not "how many continuations a session gets in its lifetime."
+
+Four fields reset together as a unit at the chain-break: `continuationChainCount`, `continuationChainTokens`, `continuationChainStartedAt`, and a freshly minted `continuationChainId`. The chain-id rotation ensures trace-correlation discriminates one self-continuation arc from the next. Continuation-wake turns (`work-wake` / `delegate-return`) preserve the accumulating chain state so a genuine runaway self-loop still hits the cap; only non-continuation turn-entries trigger the reset.
+
+**Methodological note for source-readers.** Static walks of `loadContinuationChainState`'s `?? 0` default-fallback or the `chainId` mint-ternary (`previousCount > 0 ? sameChain : newChain`) can mistakenly suggest a count-reset active-mechanism on chain-start. They are passive defaults / correlation-id mints — not active count-resets. The actual count-reset sites are the `!isContinuationWake` turn-entry hook (the chain-break reset shipped here) and `agent-runner-session-reset.ts` (the session-rotation reset for error-recovery paths). To find active reset sites, grep for literal `= 0` or `= undefined` assignments rather than reading default-fallback patterns.
 
 ### 5.2 Human-user profiles
 

--- a/src/auto-reply/reply/agent-runner.continuation-span-uniformity.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-span-uniformity.test.ts
@@ -325,6 +325,10 @@ async function runDelegateTurn(
     resolvedBlockStreamingBreak: "message_end",
     shouldInjectGroupIntro: false,
     typingMode: "instant",
+    // These scenarios seed a mid-chain entry (continuationChainCount ≥ 1) and
+    // continue it, so the turn is a continuation WAKE: the #987 chain-break
+    // reset must NOT fire and the parent chain.id / step math carry forward.
+    isContinuationWake: true,
   });
 }
 

--- a/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
+++ b/src/auto-reply/reply/agent-runner.continuation-work-span.test.ts
@@ -305,6 +305,7 @@ async function runWorkTurn(
   run: ReturnType<typeof createContinuationRun>,
   sessionStore: Record<string, SessionEntry>,
   _payloadText: string,
+  isContinuationWake = false,
 ): Promise<unknown> {
   setRuntimeConfigSnapshot(run.followupRun.run.config);
   return runReplyAgent({
@@ -328,6 +329,7 @@ async function runWorkTurn(
     resolvedBlockStreamingBreak: "message_end",
     shouldInjectGroupIntro: false,
     typingMode: "instant",
+    isContinuationWake,
   });
 }
 
@@ -407,9 +409,12 @@ describe("runReplyAgent :: continuation.work span", () => {
 
     // Pre-seed the session entry with an existing chain.id at
     // continuationChainCount=1, simulating a fresh chain that has
-    // already taken its first step. The next accepted WORK should
-    // bump count to 2 and REUSE the same chain.id (mint-or-reuse
-    // contract). chain.step.remaining = max(0, maxChainLength=2 - 2) = 0.
+    // already taken its first step. This step arrives as a continuation
+    // WAKE (work-wake) — a mid-chain step, NOT a fresh entry — so the
+    // #987 chain-break reset must NOT fire and the count carries forward.
+    // The next accepted WORK should bump count to 2 and REUSE the same
+    // chain.id (mint-or-reuse contract). chain.step.remaining =
+    // max(0, maxChainLength=2 - 2) = 0.
     const seededChainId = "019dcf57-b536-77cc-834b-b803d9262032";
     const seededEntry: SessionEntry = {
       sessionId: "session",
@@ -429,7 +434,7 @@ describe("runReplyAgent :: continuation.work span", () => {
       payloads: [{ text: "Step two\nCONTINUE_WORK:1" }],
       meta: { agentMeta: { usage: { input: 1, output: 1 } } },
     });
-    await runWorkTurn(run, sessionStore, "Step two\nCONTINUE_WORK:1");
+    await runWorkTurn(run, sessionStore, "Step two\nCONTINUE_WORK:1", true);
 
     const workSpans = spans.filter((s) => s.name === "continuation.work");
     expect(workSpans).toHaveLength(1);
@@ -450,7 +455,10 @@ describe("runReplyAgent :: continuation.work span", () => {
     setContinuationTracer(tracer);
 
     // Pre-seed at maxChainLength=2 — the next CONTINUE_WORK request
-    // hits chain-cap reject and MUST NOT emit `continuation.work`.
+    // hits chain-cap reject and MUST NOT emit `continuation.work`. This is
+    // a continuation WAKE (mid-runaway chain step), so the #987 chain-break
+    // reset must NOT fire: the runaway leash's whole job is to keep tripping
+    // the cap as long as the chain advances without a fresh re-entry.
     const seededChainId = "019dcf57-aaaa-77cc-834b-b803d9262032";
     const seededEntry: SessionEntry = {
       sessionId: "session",
@@ -470,7 +478,7 @@ describe("runReplyAgent :: continuation.work span", () => {
       payloads: [{ text: "Step 3 attempts\nCONTINUE_WORK:1" }],
       meta: { agentMeta: { usage: { input: 1, output: 1 } } },
     });
-    await runWorkTurn(run, sessionStore, "Step 3 attempts\nCONTINUE_WORK:1");
+    await runWorkTurn(run, sessionStore, "Step 3 attempts\nCONTINUE_WORK:1", true);
 
     // No `continuation.work` span emitted — accept-only contract.
     const workSpans = spans.filter((s) => s.name === "continuation.work");
@@ -489,5 +497,170 @@ describe("runReplyAgent :: continuation.work span", () => {
         "chain.id": seededChainId,
       },
     });
+  });
+});
+
+describe("runReplyAgent :: continuation chain-break reset (#987)", () => {
+  const UNRELEASED_CHAIN_CONFIG = {
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: true,
+          minDelayMs: 0,
+          maxDelayMs: 1_000,
+          defaultDelayMs: 1_000,
+          // High cap so a preserved wake count can still take its next step
+          // (the point under test is preservation, not the cap itself).
+          maxChainLength: 200,
+        },
+      },
+    },
+  } satisfies Record<string, unknown>;
+
+  it("resets the chain budget to 0 on a fresh (non-wake) turn-entry, upstream of inference", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00Z"));
+    const { tracer, spans } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    // A long session has accumulated a stale runaway budget (count=50,
+    // tokens=400k, chain id minted long ago). A genuine fresh inbound turn
+    // (NOT a continuation wake) means the prior chain ended.
+    const seededChainId = "019dcf57-cccc-77cc-834b-b803d9262032";
+    const seededStartedAt = Date.now() - 3_600_000;
+    const seededEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 50,
+      continuationChainStartedAt: seededStartedAt,
+      continuationChainTokens: 400_000,
+      continuationChainId: seededChainId,
+    };
+    const run = createContinuationRun({
+      sessionKey: "continuation-chain-reset-fresh",
+      sessionEntry: seededEntry,
+    });
+    const sessionStore = { [run.sessionKey]: seededEntry };
+
+    // Capture the entry state DURING inference — the reset must already have
+    // landed before the model call, so the resetting turn itself opens at 0.
+    let countDuringInference: number | undefined;
+    let tokensDuringInference: number | undefined;
+    let chainIdDuringInference: string | undefined;
+    let startedAtDuringInference: number | undefined;
+    runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      countDuringInference = run.sessionEntry.continuationChainCount;
+      tokensDuringInference = run.sessionEntry.continuationChainTokens;
+      chainIdDuringInference = run.sessionEntry.continuationChainId;
+      startedAtDuringInference = run.sessionEntry.continuationChainStartedAt;
+      return {
+        payloads: [{ text: "Fresh task\nCONTINUE_WORK:1" }],
+        meta: { agentMeta: { usage: { input: 2, output: 3 } } },
+      };
+    });
+
+    await runWorkTurn(run, sessionStore, "Fresh task\nCONTINUE_WORK:1");
+
+    // Budget zeroed, fresh chain id minted, chainStartedAt advanced — all
+    // visible at inference time (i.e. before the post-inference chain load).
+    expect(countDuringInference).toBe(0);
+    expect(tokensDuringInference).toBe(0);
+    expect(chainIdDuringInference).not.toBe(seededChainId);
+    expect(chainIdDuringInference as string).toMatch(UUID_REGEX);
+    expect(startedAtDuringInference).toBe(Date.now());
+
+    // The fresh chain then took its FIRST work step (0 -> 1) instead of being
+    // rejected against the stale count=50 cap (maxChainLength=2 → remaining=1).
+    const workSpans = spans.filter((s) => s.name === "continuation.work");
+    expect(workSpans).toHaveLength(1);
+    expect(workSpans[0]?.attributes["chain.step.remaining"]).toBe(1);
+    expect(workSpans[0]?.attributes["chain.id"]).toBe(chainIdDuringInference);
+    expect(run.sessionEntry.continuationChainCount).toBe(1);
+    expect(run.sessionEntry.continuationChainStartedAt).toBeGreaterThan(seededStartedAt);
+  });
+
+  it("does NOT reset the chain budget on a continuation-wake turn-entry (count carries forward)", async () => {
+    vi.useFakeTimers();
+    const { tracer, spans } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    // A mid-chain step arriving as a continuation wake: count=50 must be
+    // preserved and advance normally (51), reusing the chain id.
+    const seededChainId = "019dcf57-dddd-77cc-834b-b803d9262032";
+    const seededStartedAt = Date.now() - 3_600_000;
+    const seededEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 50,
+      continuationChainStartedAt: seededStartedAt,
+      continuationChainTokens: 12_345,
+      continuationChainId: seededChainId,
+    };
+    const run = createContinuationRun({
+      sessionKey: "continuation-chain-reset-wake",
+      sessionEntry: seededEntry,
+      config: UNRELEASED_CHAIN_CONFIG,
+    });
+    const sessionStore = { [run.sessionKey]: seededEntry };
+
+    let countDuringInference: number | undefined;
+    let chainIdDuringInference: string | undefined;
+    runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      countDuringInference = run.sessionEntry.continuationChainCount;
+      chainIdDuringInference = run.sessionEntry.continuationChainId;
+      return {
+        payloads: [{ text: "Next step\nCONTINUE_WORK:1" }],
+        meta: { agentMeta: { usage: { input: 2, output: 3 } } },
+      };
+    });
+
+    await runWorkTurn(run, sessionStore, "Next step\nCONTINUE_WORK:1", true);
+
+    // No reset: the wake turn sees the inherited count/chain id unchanged...
+    expect(countDuringInference).toBe(50);
+    expect(chainIdDuringInference).toBe(seededChainId);
+    // ...and the chain advances 50 -> 51, reusing the same chain id.
+    const workSpans = spans.filter((s) => s.name === "continuation.work");
+    expect(workSpans).toHaveLength(1);
+    expect(workSpans[0]?.attributes["chain.id"]).toBe(seededChainId);
+    expect(run.sessionEntry.continuationChainCount).toBe(51);
+    expect(run.sessionEntry.continuationChainStartedAt).toBe(seededStartedAt);
+  });
+
+  it("leaves an already-empty chain budget untouched on a fresh turn (no churn, no spurious mint)", async () => {
+    vi.useFakeTimers();
+    const { tracer, spans } = createRecordingTracer();
+    setContinuationTracer(tracer);
+
+    // count=0 and tokens=0 → nothing to reset; the fresh turn must NOT mint a
+    // spurious chain id or write the entry just to re-zero it.
+    const seededEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      continuationChainCount: 0,
+      continuationChainTokens: 0,
+    };
+    const run = createContinuationRun({
+      sessionKey: "continuation-chain-reset-noop",
+      sessionEntry: seededEntry,
+    });
+    const sessionStore = { [run.sessionKey]: seededEntry };
+
+    let chainIdDuringInference: string | undefined;
+    runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      chainIdDuringInference = run.sessionEntry.continuationChainId;
+      return {
+        payloads: [{ text: "Just a reply" }],
+        meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+      };
+    });
+
+    await runWorkTurn(run, sessionStore, "Just a reply");
+
+    // No CONTINUE signal and nothing to reset: chain id stays absent.
+    expect(chainIdDuringInference).toBeUndefined();
+    expect(spans.filter((s) => s.name === "continuation.work")).toHaveLength(0);
+    expect(run.sessionEntry.continuationChainCount ?? 0).toBe(0);
+    expect(run.sessionEntry.continuationChainId).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1200,6 +1200,7 @@ export async function runReplyAgent(replyParams: {
     typingMode,
     resetTriggered,
     replyThreadingOverride,
+    isContinuationWake,
     replyOperation: providedReplyOperation,
   } = replyParams;
 
@@ -1782,6 +1783,33 @@ export async function runReplyAgent(replyParams: {
           );
         }
       }
+    }
+
+    // Continuation chain-break reset (#987). A fresh non-`[continuation:wake]`
+    // turn-entry (inbound user message, plain heartbeat, or outside-machinery
+    // system-event) means the prior auto-continuation chain ended, so the
+    // runaway leashes — chain depth (n/maxChainLength) and accumulated token
+    // cost — must zero here, BEFORE this turn's chain-state load reads the
+    // entry (guard at the post-inference dispatch reads this same
+    // `activeSessionEntry`). Continuation wakes (`work-wake`/`delegate-return`)
+    // are steps INSIDE an active chain and must NOT reset, otherwise the cap
+    // could never bound a runaway. This is the light per-turn complement to the
+    // full session-rotation clear in agent-runner-session-reset.ts: it rewinds
+    // only the chain budget (minting a fresh chain id), not the whole session.
+    if (
+      continuationFeatureEnabled &&
+      sessionKey &&
+      activeSessionEntry &&
+      !isContinuationWake &&
+      ((activeSessionEntry.continuationChainCount ?? 0) > 0 ||
+        (activeSessionEntry.continuationChainTokens ?? 0) > 0)
+    ) {
+      await persistContinuationChainState({
+        count: 0,
+        startedAt: Date.now(),
+        tokens: 0,
+        chainId: generateChainId(),
+      });
     }
 
     const runStartedAt = Date.now();


### PR DESCRIPTION
Closes #987.

## What

`continuationChainCount` (the `/status` `n/200`) + `continuationChainTokens` (token-cost cap) accumulate per-session and **never reset on a normal user-turn** — the only reset-site in the tree is `agent-runner-session-reset.ts:88` (full session-rotation: `/new`, `/reset`, compaction-FAILURE-recovery, role-conflict, ACP-reset). So a long-lived session monotonically climbs toward `maxChainLength` (200) with no decline until `/new` — figs's "pool of 195 forever" doom-lock. **This is the bug, byte-confirmed at 6+ source convergence** (figs's intuition + frond-scribe byte-walk + Silas filing + Emeric retraction + Elliott reconciliation + Rune retraction; the recurring `?? 0` LOAD-not-RESET conflation was caught + retracted by 4 princes).

## Fix

Reset all 4 chain-budget fields — `continuationChainCount` + `continuationChainTokens` + `continuationChainStartedAt` + a fresh `continuationChainId` — at turn-entry **before** the runner reads chain-state, gated on **`isContinuationWake === false`** (a genuine external turn: user message / heartbeat / non-continuation system-event). Continuation-wake turns (`work-wake` / `delegate-return`) **preserve** the count, so the 200 leash still bounds an unbroken unattended self-continuation chain — its actual safety intent — not session-lifetime.

Plain-language invariant: *the cap counts how deep a self-scheduled loop runs while you're away; the instant you (or a heartbeat) re-engage, it's not a runaway anymore, so it resets to 0.*

Reuses the local `persistContinuationChainState` (mem + store + disk), zero new imports.

## Diff

3 files, +211/-6:
- `src/auto-reply/reply/agent-runner.ts` (+28) — the gated reset at turn-entry
- `agent-runner.continuation-work-span.test.ts` (+185) — fresh-resets / wake-preserves / `/new`-still-resets / #982-fan-out-intact + 3 new #987 tests
- `agent-runner.continuation-span-uniformity.test.ts` (+4) — wake-semantics alignment

## Gate status

- **Targeted shard `auto-reply-reply` GREEN**: 153 files / 2573 tests (incl 3 new #987 tests; #982 array-capture fan-out intact)
- **tsgo** core + core-test: rc=0
- **Full-suite**: ~76,455 passed / 32 failed — **all 32 are pre-existing baseline/env in UNTOUCHED subsystems** (model-selection [reproduced deterministically in isolation], secrets/slack-contract, imessage-retry, telegram-album, matrix-crypto, memory-lancedb, memory-core, deadcode-pnpm) + 1 gateway-cpu QA. **None in changed files.** Same baseline-flake set as the assembly's standing CI.

## Review

🪨 Rune + 🌻 Elliott on the continuation-lifecycle surface (per cohort review-pairing). Verify: reset fires upstream of `loadContinuationChainState`, all 4 fields as a unit, no phantom-depth on the status-line, runaway-chain still capped on pure self-wakes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
