### PR TITLE
fix(continuation): never-supersede a RUNNING continuation work (#988-P2-1, Pillar-3 fold-side write-guard)

### DIFF
--- a/src/auto-reply/continuation/work-dispatch.test.ts
+++ b/src/auto-reply/continuation/work-dispatch.test.ts
@@ -835,10 +835,66 @@ describe("durable continuation_work dispatch", () => {
       }),
     ]);
   });
+
+  it("never supersedes a recovered running wake folded against a newer queued election (#988-P2-1)", async () => {
+    // End-to-end proof that the PRE-claim status is carried through
+    // consumePendingWork into partitionSupersededWork: a stale, recovered
+    // `running` wake co-drained with a newer `queued` election must DRIVE, not
+    // be finished-as-superseded. Without the carry-status guard the running
+    // wake (stale, not newest) would be folded and only the queued one would run.
+    const sessionKey = "agent:main:recovered-running-fold";
+    mockSessionStore[sessionKey] = { sessionKey };
+    const now = Date.now();
+
+    enqueuePendingWork({
+      sessionKey,
+      hop: 1,
+      delayMs: 1_000,
+      electedAt: now - 500_000,
+      dueAt: now - 500_000, // matured and stale (overdue >> 120s grace)
+      maxChainLength: 8,
+      reason: "recovered running",
+    });
+    const runningFlow = [...mockFlows.values()][0];
+    if (!runningFlow) {
+      throw new Error("expected running mock flow");
+    }
+    runningFlow.status = "running";
+    runningFlow.updatedAt = now - 200_000; // older than the 60s recovery staleness window
+
+    enqueuePendingWork({
+      sessionKey,
+      hop: 2,
+      delayMs: 1_000,
+      electedAt: now - 1_000, // newest election
+      dueAt: now - 1_000, // matured
+      maxChainLength: 8,
+      reason: "newest queued",
+    });
+
+    const result = await dispatchPendingContinuationWork({
+      sessionKey,
+      recoverRunning: true,
+      includeRunningUpdatedAtOrBefore: now - 60_000,
+    });
+
+    expect(result).toEqual({ dispatched: 2, failed: 0 });
+    const bodies = turnGrants.map((grant) => (grant as { context: { Body: string } }).context.Body);
+    expect(bodies.some((body) => body.includes("recovered running"))).toBe(true);
+    expect(bodies.some((body) => body.includes("newest queued"))).toBe(true);
+    expect(systemEvents.some((event) => (event as { text: string }).text.includes("folded"))).toBe(
+      false,
+    );
+  });
 });
 
 function work(
-  partial: Partial<{ hop: number; electedAt: number; dueAt: number }> = {},
+  partial: Partial<{
+    hop: number;
+    electedAt: number;
+    dueAt: number;
+    status: "queued" | "running";
+  }> = {},
 ): Parameters<typeof partitionSupersededWork>[0][number] {
   return {
     sessionKey: "agent:main:s",
@@ -847,6 +903,7 @@ function work(
     electedAt: partial.electedAt ?? 1_000,
     dueAt: partial.dueAt ?? 2_000,
     maxChainLength: 8,
+    status: partial.status ?? "queued",
     flowId: `f-${partial.hop ?? 1}`,
     expectedRevision: 0,
   };
@@ -924,6 +981,43 @@ describe("#986 partitionSupersededWork (drain-superseded)", () => {
     expect(drive.map((w) => w.hop)).toEqual([3]);
     expect(superseded.map((w) => w.hop).toSorted()).toEqual([1, 2]);
   });
+
+  it("never supersedes a recovered running member even when stale and not newest (#988-P2-1)", () => {
+    // A recovered `running` turn is actively executing (it may be observing
+    // requests-in-flight). It must drive, never fold, even though it is overdue
+    // past grace and a newer queued election exists. RED before the write-guard:
+    // the stale, non-newest running member was classified `superseded`.
+    const works = [
+      work({ hop: 1, electedAt: 100, dueAt: NOW - 500_000, status: "running" }), // stale running, oldest
+      work({ hop: 2, electedAt: 300, dueAt: NOW - 300_000, status: "queued" }), // newest queued election
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    expect(drive.map((w) => w.hop).toSorted((a, b) => a - b)).toEqual([1, 2]);
+    expect(superseded).toHaveLength(0);
+  });
+
+  it("still folds a stale queued member into a newer election (#986 Guard 2 intact)", () => {
+    // The only supersede-eligible member is `queued`; the #986 behavior is
+    // unchanged for genuine queued backlog.
+    const works = [
+      work({ hop: 1, electedAt: 100, dueAt: NOW - 500_000, status: "queued" }), // stale queued backlog
+      work({ hop: 2, electedAt: 300, dueAt: NOW - 300_000, status: "queued" }), // newest queued election
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    expect(drive.map((w) => w.hop)).toEqual([2]);
+    expect(superseded.map((w) => w.hop)).toEqual([1]);
+  });
+
+  it("mixed batch: stale running drives, stale queued folds, newest queued drives (#988-P2-1)", () => {
+    const works = [
+      work({ hop: 1, electedAt: 100, dueAt: NOW - 500_000, status: "running" }), // stale running → drives
+      work({ hop: 2, electedAt: 200, dueAt: NOW - 400_000, status: "queued" }), // stale queued → folds
+      work({ hop: 3, electedAt: 300, dueAt: NOW - 300_000, status: "queued" }), // newest queued → drives
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    expect(drive.map((w) => w.hop).toSorted((a, b) => a - b)).toEqual([1, 3]);
+    expect(superseded.map((w) => w.hop)).toEqual([2]);
+  });
 });
 
 describe("#986 maxPendingWork cap (Guard 1)", () => {
@@ -942,10 +1036,28 @@ describe("#986 maxPendingWork cap (Guard 1)", () => {
   const baseChain = { currentChainCount: 0, chainStartedAt: 1_000_000, accumulatedChainTokens: 0 };
 
   it("rejects a new election once pendingWorkCount is at maxPendingWork", async () => {
-    const capped = { ...config, maxPendingWork: 2, maxChainLength: 100 } satisfies ContinuationRuntimeConfig;
+    const capped = {
+      ...config,
+      maxPendingWork: 2,
+      maxChainLength: 100,
+    } satisfies ContinuationRuntimeConfig;
     // Pre-fill the store to the cap (2 queued flows).
-    enqueuePendingWork({ sessionKey, hop: 1, delayMs: 1_000, electedAt: 1_000_000, dueAt: 1_001_000, maxChainLength: 100 });
-    enqueuePendingWork({ sessionKey, hop: 2, delayMs: 1_000, electedAt: 1_000_000, dueAt: 1_001_000, maxChainLength: 100 });
+    enqueuePendingWork({
+      sessionKey,
+      hop: 1,
+      delayMs: 1_000,
+      electedAt: 1_000_000,
+      dueAt: 1_001_000,
+      maxChainLength: 100,
+    });
+    enqueuePendingWork({
+      sessionKey,
+      hop: 2,
+      delayMs: 1_000,
+      electedAt: 1_000_000,
+      dueAt: 1_001_000,
+      maxChainLength: 100,
+    });
 
     const result = await scheduleContinuationWork({
       sessionKey,
@@ -959,7 +1071,11 @@ describe("#986 maxPendingWork cap (Guard 1)", () => {
   });
 
   it("batch ends early on pending-cap but preserves earlier scheduled elections (#982 partial-success)", async () => {
-    const capped = { ...config, maxPendingWork: 3, maxChainLength: 100 } satisfies ContinuationRuntimeConfig;
+    const capped = {
+      ...config,
+      maxPendingWork: 3,
+      maxChainLength: 100,
+    } satisfies ContinuationRuntimeConfig;
     // Start empty; a 5-election batch should schedule 3, then hit the cap.
     const result = await scheduleContinuationWorkBatch({
       sessionKey,
@@ -983,7 +1099,11 @@ describe("#986 maxPendingWork cap (Guard 1)", () => {
   });
 
   it("does NOT count the active driving (running) wake against the cap — serial maxPendingWork:1 still schedules its successor (#988 :403)", async () => {
-    const capOne = { ...config, maxPendingWork: 1, maxChainLength: 100 } satisfies ContinuationRuntimeConfig;
+    const capOne = {
+      ...config,
+      maxPendingWork: 1,
+      maxChainLength: 100,
+    } satisfies ContinuationRuntimeConfig;
     // Simulate the in-flight driver: one continuation-work flow currently
     // `running` (its turn is being driven; markPendingWorkTurnGranted hasn't run
     // yet). A serial chain at maxPendingWork:1 must still schedule the successor

--- a/src/auto-reply/continuation/work-dispatch.ts
+++ b/src/auto-reply/continuation/work-dispatch.ts
@@ -8,7 +8,8 @@ import { isRetryableHeartbeatBusySkipReason } from "../../infra/heartbeat-wake.j
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { clampDelayMs, resolveContinuationRuntimeConfig } from "./config.js";
-import { checkContinuationBudget } from "./scheduler.js";import type { ChainState, ContinuationRuntimeConfig, ContinueWorkRequest } from "./types.js";
+import { checkContinuationBudget } from "./scheduler.js";
+import type { ChainState, ContinuationRuntimeConfig, ContinueWorkRequest } from "./types.js";
 import {
   consumePendingWork,
   enqueuePendingWork,
@@ -228,7 +229,13 @@ function earlierDueAt(left: number | undefined, right: number | undefined): numb
  * and never co-drain. Within such a batch we fold the OLDER members that are
  * stale (overdue past `graceMs`) into the newest-elected member, which carries
  * the live intent. Non-stale members (close bursts) always drive; the
- * newest-elected always drives. Pure for testability.
+ * newest-elected always drives.
+ *
+ * #988-P2-1 fold-side write-guard: only `queued` members are supersede-eligible.
+ * A recovered `running` member (the recovery path passes `includeRunning`) is a
+ * live turn already being driven and ALWAYS drives — it is never folded, even
+ * when stale and not newest, so an in-flight turn is never finished-as-superseded
+ * out from under itself. Pure for testability.
  */
 export function partitionSupersededWork(
   works: readonly PendingContinuationWork[],
@@ -256,6 +263,15 @@ export function partitionSupersededWork(
   const superseded: PendingContinuationWork[] = [];
   for (let i = 0; i < works.length; i++) {
     const work = works[i];
+    // #988-P2-1 fold-side write-guard: a recovered `running` member is live
+    // intent already being driven (it may be observing requests-in-flight). It
+    // is NEVER supersede-eligible, regardless of staleness or election order —
+    // folding it would finish an in-flight turn as superseded out from under
+    // itself. Only `queued` backlog members can be coalesced into the newest.
+    if (work.status === "running") {
+      drive.push(work);
+      continue;
+    }
     const isNewest = i === newestIdx;
     const isStale = now - work.dueAt > graceMs;
     if (isNewest) {

--- a/src/auto-reply/continuation/work-store.ts
+++ b/src/auto-reply/continuation/work-store.ts
@@ -61,6 +61,13 @@ export type PendingContinuationWork = {
   retryCount?: number;
   flowId?: string;
   expectedRevision?: number;
+  // Durable flow status carried onto the runtime object by the store reader
+  // ({@link workToRuntime}), sourced from the flow's PRE-claim status. The
+  // fold-side write-guard (#988-P2-1) needs this to tell a recovered `running`
+  // turn (actively executing) from genuine `queued` backlog so a live turn is
+  // never finished-as-superseded. Absent on freshly-constructed enqueue inputs;
+  // only store reads populate it.
+  status?: "queued" | "running";
 };
 
 function isContinuationWorkFlow(flow: TaskFlowRecord): boolean {
@@ -81,7 +88,11 @@ function workGoal(work: PendingContinuationWork): string {
   return reason ? `Continuation work: ${reason.slice(0, 80)}` : "Continuation work";
 }
 
-function workToRuntime(flow: TaskFlowRecord, state: PendingWorkState): PendingContinuationWork {
+function workToRuntime(
+  flow: TaskFlowRecord,
+  state: PendingWorkState,
+  status: "queued" | "running",
+): PendingContinuationWork {
   return {
     sessionKey: state.sessionKey,
     hop: state.hop,
@@ -98,6 +109,7 @@ function workToRuntime(flow: TaskFlowRecord, state: PendingWorkState): PendingCo
     ...(state.chainId ? { chainId: state.chainId } : {}),
     ...(state.traceparent ? { traceparent: state.traceparent } : {}),
     ...(state.retryCount !== undefined ? { retryCount: state.retryCount } : {}),
+    status,
     flowId: flow.flowId,
     expectedRevision: flow.revision,
   };
@@ -130,7 +142,7 @@ export function enqueuePendingWork(work: PendingContinuationWork): PendingContin
     stateJson: state,
     createdAt: work.electedAt,
   });
-  return flow ? workToRuntime(flow, state) : null;
+  return flow ? workToRuntime(flow, state, "queued") : null;
 }
 
 export function listPendingWorkSessionKeysForRecovery(): string[] {
@@ -194,7 +206,12 @@ export function consumePendingWork(
     if (!claimed.applied || !claimed.flow) {
       continue;
     }
-    work.push(workToRuntime(claimed.flow, { ...state, releasedAt }));
+    // Carry the PRE-claim durable status: the claim above flips every consumed
+    // flow to `running`, so claimed.flow.status can no longer distinguish a
+    // recovered active turn from freshly-released queued backlog. The fold-side
+    // write-guard (#988-P2-1) keys off this original status.
+    const originalStatus: "queued" | "running" = flow.status === "running" ? "running" : "queued";
+    work.push(workToRuntime(claimed.flow, { ...state, releasedAt }, originalStatus));
   }
   return work;
 }
@@ -298,10 +315,7 @@ export function markPendingWorkFailed(work: PendingContinuationWork, summary: st
  * it stops re-arming. Distinct from failure (no system-warning, no retry): a
  * superseded wake was intentionally folded, not dropped by error.
  */
-export function markPendingWorkSuperseded(
-  work: PendingContinuationWork,
-  summary: string,
-): boolean {
+export function markPendingWorkSuperseded(work: PendingContinuationWork, summary: string): boolean {
   if (!work.flowId || work.expectedRevision === undefined) {
     return false;
   }


### PR DESCRIPTION
## #988-P2-1 — Pillar-3 fold-side write-guard (the last open codex-P2)

Closes the "recovered-running mis-superseded" P2. Stacks on assembly `a437ca7` (complete doom-lock cure).

### The bug
The running-work **recovery path** (`dispatchPendingContinuationWork` with `includeRunning: true`) can pass `running` flows to `partitionSupersededWork`, which folds any non-newest **stale** member into `superseded` → `markPendingWorkSuperseded` → terminal. A recovered `running` work (actively observing requests-in-flight) could thus be finished-as-superseded out from under an in-flight turn.

### The fix (two-part, surgical)
1. **carry status** onto `PendingContinuationWork` (sourced from `flow.status` in `workToRuntime`).
2. **never-supersede-running** in `partitionSupersededWork`: a `running` member always drives; only `queued` members are supersede-eligible. The #986 Guard-2 fold for `queued` members (newest-elected-drives, close-burst-drives, `hop`/`electedAt` tie-break) is preserved exactly.

Invariant: **only-coalesce-queued · carry-status · never-supersede-running.** Distinct from the requeue READ-guard (`requeuePendingWork:259`) — this is the FOLD-side WRITE-guard. Scheduled-depth count untouched. No #990 give-up-fork coupling.

### Verification
- `work-dispatch.test.ts` **28/28 green**; **RED-verified** the 3 new #988-P2-1 cases fail without the guard (running-not-superseded · queued-still-folds · mixed-batch).
- Full suite: 88 shards / 6 failed — **all known-baseline-env** (agents-core model-selection, extension-memory, secrets channel-contract, imessage, telegram, tooling pnpm-path); continuation shard green.
- `tsgo:core` + core-test clean, type-aware `oxlint` 0 new, `oxfmt` clean.

Owner-reviewer 🌊 (Pillar-3 spec). Lane: `codeagent/988-p2-1-write-guard` @ `744a18e`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
