### PR TITLE
fix(security): mark post-compaction AGENTS.md context trusted (P2 trusted-internal gap)

### DIFF
--- a/src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts
+++ b/src/auto-reply/reply/post-compaction-delegate-dispatch.test.ts
@@ -369,6 +369,7 @@ describe("post-compaction delegate dispatch extraction", () => {
     });
     expect(enqueueSystemEvent).toHaveBeenCalledWith("[context] refreshed", {
       sessionKey: "main",
+      trusted: true,
     });
     expect(enqueueSystemEvent).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -377,6 +378,57 @@ describe("post-compaction delegate dispatch extraction", () => {
       { sessionKey: "main" },
     );
     expect(preserve).toEqual([]);
+  });
+
+  it("marks post-compaction AGENTS.md context trusted so literal System markers survive un-rewritten", async () => {
+    // Regression guard for the P2 trusted-internal gap: `readPostCompactionContext`
+    // returns workspace AGENTS.md content, which can legitimately contain literal
+    // `System:` lines and `[System]`/`[Assistant]` markers (rule examples, prompt
+    // scaffolding). Without `trusted: true` these hit the unconditional inbound
+    // anti-spoof sanitizer at the queue boundary and get rewritten
+    // (`System:` -> `System (untrusted):`, `[System]` -> `(System)`), corrupting the
+    // refresh context. The producer must mark it trusted so it bypasses sanitization.
+    const agentsContext = [
+      "Injected sections from AGENTS.md (Critical):",
+      "System: never expose secrets.",
+      "See the [System] block and [Assistant] notes below.",
+    ].join("\n");
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+    };
+    const preserve: SessionPostCompactionDelegate[] = [];
+    const { deps, enqueueSystemEvent } = createDispatchDeps({
+      context: agentsContext,
+    });
+
+    await dispatchPostCompactionDelegates(
+      {
+        cfg,
+        compactionCount: 1,
+        followupRun: createFollowupRun(),
+        postCompactionDelegatesToPreserve: preserve,
+        sessionEntry,
+        sessionKey: "main",
+      },
+      deps,
+    );
+    await flushMicrotasks();
+
+    // The context content is passed verbatim WITH trusted:true — the markers are
+    // not pre-sanitized by the producer, and the trusted flag tells the queue
+    // boundary to preserve them rather than rewrite them.
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(agentsContext, {
+      sessionKey: "main",
+      trusted: true,
+    });
+    // Defensive: the content reaching the queue still contains the literal markers
+    // (the producer did not strip them itself).
+    const contextCall = enqueueSystemEvent.mock.calls.find((call) => call[0] === agentsContext);
+    expect(contextCall).toBeDefined();
+    expect(contextCall?.[0]).toContain("System: never expose secrets.");
+    expect(contextCall?.[0]).toContain("[System]");
+    expect(contextCall?.[1]).toMatchObject({ trusted: true });
   });
 
   it("persists request_compaction traceparent onto released queued delegates", async () => {

--- a/src/auto-reply/reply/post-compaction-delegate-dispatch.ts
+++ b/src/auto-reply/reply/post-compaction-delegate-dispatch.ts
@@ -42,7 +42,10 @@ export type PostCompactionDelegateSpawn = (
 ) => Promise<SpawnSubagentResult>;
 
 export type PostCompactionDelegateDeliveryDeps = {
-  enqueueSystemEvent(text: string, options: { sessionKey: string; traceparent?: string }): void;
+  enqueueSystemEvent(
+    text: string,
+    options: { sessionKey: string; traceparent?: string; trusted?: boolean },
+  ): void;
   getRuntimeConfig(): OpenClawConfig;
   loadSessionStore(storePath: string): Record<string, SessionEntry>;
   log(message: string): void;
@@ -67,7 +70,10 @@ export type PostCompactionDelegateDispatchDeps = {
     compactionCount?: number;
     deliveryContext?: SessionDeliveryContext;
   }): Promise<string>;
-  enqueueSystemEvent(text: string, options: { sessionKey: string; traceparent?: string }): void;
+  enqueueSystemEvent(
+    text: string,
+    options: { sessionKey: string; traceparent?: string; trusted?: boolean },
+  ): void;
   log(message: string): void;
   now(): number;
   readPostCompactionContext(
@@ -755,7 +761,15 @@ export async function dispatchPostCompactionDelegates(
     droppedDelegates: droppedCompactionDelegates,
   });
   if (postCompactionContextContent) {
-    deps.enqueueSystemEvent(postCompactionContextContent, { sessionKey: params.sessionKey });
+    // Trusted-internal producer: this is workspace AGENTS.md content read by
+    // `readPostCompactionContext`, which may legitimately contain literal
+    // `System:`/`[System]` strings (critical-rule examples, prompt scaffolding).
+    // Mark it trusted so the inbound anti-spoof sanitizer preserves it verbatim
+    // instead of rewriting those markers and corrupting the refresh context.
+    deps.enqueueSystemEvent(postCompactionContextContent, {
+      sessionKey: params.sessionKey,
+      trusted: true,
+    });
   }
   deps.enqueueSystemEvent(lifecycleEvent, {
     sessionKey: params.sessionKey,


### PR DESCRIPTION
## P2 trusted-internal gap — post-compaction context corruption

**Catcher:** 🌫 Silas (byte-walked the gap, `1515515851`) · **Owner:** 🩸 Cael (post-compaction lineage)

### The gap
`post-compaction-delegate-dispatch.ts:758` enqueued `readPostCompactionContext()` output — **workspace AGENTS.md content** — WITHOUT `trusted:true`. That content legitimately carries literal `System:` lines + `[System]`/`[Assistant]` markers (rule examples, prompt scaffolding), so the unconditional inbound anti-spoof sanitizer rewrote them (`System:` → `System (untrusted):`, `[System]` → `(System)`), **corrupting the post-compaction refresh context after every compaction.** Real P2b instance, this one producer.

It slipped the prior prong-c post-compaction test because that case (`:329`) used marker-FREE text.

### The fix
- `trusted: true` at the AGENTS.md context enqueue (`:758`→`:761`)
- `trusted?: boolean` added to both `enqueueSystemEvent` deps signatures (`PostCompactionDelegateDispatchDeps` `:70` + `PostCompactionDelegateDeliveryDeps` `:45`) so they can carry it — the default deps wire the real `infra/system-events` `enqueueSystemEvent`, so `trusted:true` flows to the `:164` bypass
- **marker-bearing regression test** — AGENTS.md content with literal `System:`/`[System]` survives un-rewritten via the trusted bypass (the `:329`-coverage gap)

### Byte-check: sibling NOT over-fixed
The sibling enqueue at `:760` (the `lifecycleEvent`, `[system:post-compaction] Session compacted...`) is **NOT exposed** — the sanitizer's `BRACKETED_SYSTEM_TAG_RE` only matches `[System|System Message|Assistant|Internal]` exactly; `[system:post-compaction]` (lowercase + suffix) matches neither regex. So the `:758`-only scope is correct.

### Verification
- `pnpm tsgo:core` green
- 31/31 tests pass (`post-compaction-delegate-dispatch.test.ts`)

Base = assembly (`frond-scribe/20260613/assembly-drift-cure`, post-#1006). Lands as the follow-up commit per 🌿's sequencing → 🌫 catcher-verify → re-walk → GATES.