### PR TITLE
fix(test): add required lifecycleGeneration to attempt-execution opts tests (canary PROOFS finding)

### DIFF
--- a/src/agents/command/attempt-execution.continue-work-opts.test.ts
+++ b/src/agents/command/attempt-execution.continue-work-opts.test.ts
@@ -182,6 +182,7 @@ describe("runAgentAttempt #746 spawn-init continueWorkOpts plumbing (Layer 2 cur
       sessionId: sessionEntry.sessionId,
       sessionKey,
       sessionAgentId: "main",
+      lifecycleGeneration: "test-generation",
       sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
       body: "trap-test prompt",

--- a/src/agents/command/attempt-execution.request-compaction-opts.test.ts
+++ b/src/agents/command/attempt-execution.request-compaction-opts.test.ts
@@ -154,6 +154,7 @@ describe("runAgentAttempt spawn-init requestCompactionOpts plumbing", () => {
       sessionId: sessionEntry.sessionId,
       sessionKey,
       sessionAgentId: "main",
+      lifecycleGeneration: "test-generation",
       sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
       body: "trap-test prompt",


### PR DESCRIPTION
**Canary PROOFS re-run finding** on the fully-current merged assembly `35116c5ae6` (post-#1009).

## What
`tsgo:test` FAILED (exit 2, TS2741 ×2) on the merged-current assembly — a back-merge integration gap: upstream's `RunAgentAttemptParams` now **requires** `lifecycleGeneration`, but two continuation-feature test files construct the params object without it.

- `src/agents/command/attempt-execution.continue-work-opts.test.ts(176,34)`
- `src/agents/command/attempt-execution.request-compaction-opts.test.ts(148,27)`

## Fix
Add `lifecycleGeneration: "test-generation"` (matching the upstream sibling `attempt-execution.cli.test.ts` default) to both test fixtures. 2 lines.

## Verify
- `tsgo:test` EXIT=0 after fix (was exit 2)
- `tsgo:core` ✅ / `tsgo:extensions` ✅ (unaffected)

Caught by the canary re-run before GATES — the merged-current assembly does not pass `tsgo:test` without this.