### PR TITLE
fix(sdk): Object.assign boundary-force to avoid spread crash on undefined options (Copilot #1010)

### DIFF
--- a/src/plugin-sdk/channel-runtime.ts
+++ b/src/plugin-sdk/channel-runtime.ts
@@ -26,7 +26,7 @@ export function enqueueSystemEvent(
   text: string,
   options: Parameters<typeof enqueueSystemEventInternal>[1],
 ): boolean {
-  return enqueueSystemEventInternal(text, { ...options, trusted: false });
+  return enqueueSystemEventInternal(text, Object.assign({}, options, { trusted: false }));
 }
 export { recordChannelActivity } from "../infra/channel-activity.js";
 export * from "../infra/heartbeat-events.ts";

--- a/src/plugin-sdk/system-event-runtime.ts
+++ b/src/plugin-sdk/system-event-runtime.ts
@@ -2,10 +2,7 @@
 
 import { enqueueSystemEvent as enqueueSystemEventInternal } from "../infra/system-events.js";
 
-export {
-  peekSystemEventEntries,
-  resetSystemEventsForTest,
-} from "../infra/system-events.js";
+export { peekSystemEventEntries, resetSystemEventsForTest } from "../infra/system-events.js";
 
 /**
  * SDK consumers are untrusted by construction — force `trusted: false` so a
@@ -16,5 +13,5 @@ export function enqueueSystemEvent(
   text: string,
   options: Parameters<typeof enqueueSystemEventInternal>[1],
 ): boolean {
-  return enqueueSystemEventInternal(text, { ...options, trusted: false });
+  return enqueueSystemEventInternal(text, Object.assign({}, options, { trusted: false }));
 }

--- a/src/plugins/runtime/runtime-system.ts
+++ b/src/plugins/runtime/runtime-system.ts
@@ -20,7 +20,7 @@ const runHeartbeatOnceInternal = createLazyRuntimeMethod(
 // sanitizer. Trusted-internal producers (continuation/post-compaction) enqueue via the
 // direct `infra/system-events` import, not this plugin runtime facade.
 const enqueueSystemEvent: PluginRuntime["system"]["enqueueSystemEvent"] = (text, options) =>
-  enqueueSystemEventInternal(text, { ...options, trusted: false });
+  enqueueSystemEventInternal(text, Object.assign({}, options, { trusted: false }));
 
 /** Creates the plugin runtime system facade with heartbeat/event/process helpers. */
 export function createRuntimeSystem(): PluginRuntime["system"] {


### PR DESCRIPTION
Addresses the 3 real Copilot findings from #1010 review (r3408888636/647/662).

## What
The SDK/plugin boundary-force wrappers spread `{ ...options, trusted: false }`. If a JS SDK consumer or plugin calls `enqueueSystemEvent(text, undefined)`, the spread throws `Cannot convert undefined or null to object` before the `sessionKey` validation runs.

## Fix
`Object.assign({}, options, { trusted: false })` — undefined-safe, lets `requireSessionKey` surface the intended error.

Sites: `runtime-system.ts:23`, `system-event-runtime.ts:19`, `channel-runtime.ts:29`.

## Security boundary PRESERVED
`{ trusted: false }` is still the last arg → overrides any plugin-set `trusted:true`. Verified: `Object.assign({},{trusted:true},{trusted:false})` === `{trusted:false}`. Anti-spoof force intact.

## Verify
tsgo:core ✓ / tsgo:extensions ✓.

## Note on the rest of #1010
The 4 P1s + P2 (post-compaction-delegate-dispatch.ts) are **scope-artifacts** — the 'missing' continuation modules/types all exist in the assembly, outside the 13-file #999 review-scope; tsgo:core passes on the full assembly. The lastContextKey/traceparent/test-comment findings are also already-correct in the assembly. Only these 3 Object.assign sites were real.