### PR TITLE
fix(test): add lifecycleGeneration to continue-work + request-compaction opts tests (tsgo:test, #1016 follow-on)

### DIFF
--- a/src/agents/command/attempt-execution.continue-work-opts.test.ts
+++ b/src/agents/command/attempt-execution.continue-work-opts.test.ts
@@ -182,6 +182,7 @@ describe("runAgentAttempt #746 spawn-init continueWorkOpts plumbing (Layer 2 cur
       sessionId: sessionEntry.sessionId,
       sessionKey,
       sessionAgentId: "main",
+      lifecycleGeneration: "test-generation",
       sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
       body: "trap-test prompt",

--- a/src/agents/command/attempt-execution.request-compaction-opts.test.ts
+++ b/src/agents/command/attempt-execution.request-compaction-opts.test.ts
@@ -154,6 +154,7 @@ describe("runAgentAttempt spawn-init requestCompactionOpts plumbing", () => {
       sessionId: sessionEntry.sessionId,
       sessionKey,
       sessionAgentId: "main",
+      lifecycleGeneration: "test-generation",
       sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
       body: "trap-test prompt",


### PR DESCRIPTION
## What

Two `attempt-execution` opts-test files call `runAgentAttempt({...})` without `lifecycleGeneration`, which the opts type now requires (`TS2741`):
- `src/agents/command/attempt-execution.continue-work-opts.test.ts:176`
- `src/agents/command/attempt-execution.request-compaction-opts.test.ts:148`

Same class as #1016, two test instances #1016 didn't cover. Fix matches the canonical `cli.test.ts:36` pattern: `lifecycleGeneration: "test-generation"`.

## Why it's load-bearing for GATES

`tsgo:test` is **RED** on the current assembly head (`04dd727682`) AND on the #1013 back-merge candidate (`370ba80f98`) without this — byte-verified EXIT=2 by running `pnpm tsgo:test` on both. With the fix: `pnpm tsgo:test` → **EXIT=0** (verified, read the exit code). `tsgo:core` was already green; this is the test-typecheck gate specifically.

## Verification

- `pnpm tsgo:test` on the patched worktree → EXIT=0 (read).
- 2-line change, test-typing only, no runtime/source impact.

🌿 — this needs to land on the assembly (or fold into #1013/upstream-sync) before GATES, or the full-tsgo gate REDs. Your integration call: merge this, or cherry-pick the 2 lines into upstream-sync.