### PR TITLE
security(#999): strip session-delivery ack fields at SDK/plugin boundary (Finding-B)

### DIFF
--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { drainFormattedSystemEvents } from "../auto-reply/reply/session-system-events.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
+import { enqueueSystemEvent as enqueueSystemEventViaSdk } from "../plugin-sdk/system-event-runtime.js";
 import { isCronSystemEvent } from "./heartbeat-events-filter.js";
 import {
   consumeSelectedSystemEventEntries,
@@ -17,7 +18,6 @@ import {
   resetSystemEventsForTest,
   resolveSystemEventDeliveryContext,
 } from "./system-events.js";
-import { enqueueSystemEvent as enqueueSystemEventViaSdk } from "../plugin-sdk/system-event-runtime.js";
 
 type SystemEventsModule = typeof import("./system-events.js");
 
@@ -109,6 +109,24 @@ describe("system events (session routing)", () => {
     expect(peekSystemEvents("agent:sdk:main")).toEqual([
       "System (untrusted): plugin-set trusted spoof",
     ]);
+  });
+
+  it("strips session-delivery ack fields from SDK/plugin producers (blind-delete vector)", () => {
+    // The session-delivery ack fields drive a blind `deleteDeliveryQueueEntry` at a
+    // caller-supplied `sessionDeliveryAckStateDir` on drain. A plugin importing via the
+    // public plugin-SDK subpath must never inject them: the wrapper strips both, so the
+    // queued entry carries no ack metadata even when the plugin passes it. The legitimate
+    // ack producer (continuation-return) sets them via the direct `infra/system-events`
+    // import, not this SDK re-export.
+    enqueueSystemEventViaSdk("plugin ack injection", {
+      sessionKey: "agent:sdk-ack:main",
+      sessionDeliveryAckId: "attacker-ack-id",
+      sessionDeliveryAckStateDir: "/tmp/attacker-controlled-state",
+    });
+    const [entry] = drainSystemEventEntries("agent:sdk-ack:main");
+    expect(entry?.text).toBe("plugin ack injection");
+    expect(entry?.sessionDeliveryAckId).toBeUndefined();
+    expect(entry?.sessionDeliveryAckStateDir).toBeUndefined();
   });
 
   it("requires an explicit session key", () => {

--- a/src/plugin-sdk/channel-runtime.ts
+++ b/src/plugin-sdk/channel-runtime.ts
@@ -21,12 +21,23 @@ export { resetSystemEventsForTest } from "../infra/system-events.js";
  * sanitizer. Force the producer side untrusted regardless of what the plugin
  * passes. Trusted-internal producers use the direct `infra/system-events`
  * import, not this SDK boundary.
+ *
+ * Also strip the session-delivery ack fields: those drive a blind
+ * `deleteDeliveryQueueEntry` at a caller-supplied `sessionDeliveryAckStateDir`
+ * on drain, so a plugin must never inject them via this boundary. Legitimate
+ * ack producers (the continuation-return path) set them through the direct
+ * `infra/system-events` import, not this SDK re-export.
  */
 export function enqueueSystemEvent(
   text: string,
   options: Parameters<typeof enqueueSystemEventInternal>[1],
 ): boolean {
-  return enqueueSystemEventInternal(text, { ...options, trusted: false });
+  const {
+    sessionDeliveryAckId: _ackId,
+    sessionDeliveryAckStateDir: _ackStateDir,
+    ...rest
+  } = options ?? {};
+  return enqueueSystemEventInternal(text, { ...rest, trusted: false });
 }
 export { recordChannelActivity } from "../infra/channel-activity.js";
 export * from "../infra/heartbeat-events.ts";

--- a/src/plugin-sdk/system-event-runtime.ts
+++ b/src/plugin-sdk/system-event-runtime.ts
@@ -2,19 +2,28 @@
 
 import { enqueueSystemEvent as enqueueSystemEventInternal } from "../infra/system-events.js";
 
-export {
-  peekSystemEventEntries,
-  resetSystemEventsForTest,
-} from "../infra/system-events.js";
+export { peekSystemEventEntries, resetSystemEventsForTest } from "../infra/system-events.js";
 
 /**
  * SDK consumers are untrusted by construction — force `trusted: false` so a
  * plugin cannot set `trusted: true` to bypass the inbound anti-spoof sanitizer.
  * Trusted-internal producers use the direct `infra/system-events` import.
+ *
+ * Also strip the session-delivery ack fields (`sessionDeliveryAckId` /
+ * `sessionDeliveryAckStateDir`): on drain they trigger a blind
+ * `deleteDeliveryQueueEntry` at the caller-supplied state dir, so a plugin must
+ * never inject them via this boundary. The legitimate ack producer
+ * (continuation-return) sets them through the direct `infra/system-events`
+ * import, not this SDK re-export.
  */
 export function enqueueSystemEvent(
   text: string,
   options: Parameters<typeof enqueueSystemEventInternal>[1],
 ): boolean {
-  return enqueueSystemEventInternal(text, { ...options, trusted: false });
+  const {
+    sessionDeliveryAckId: _ackId,
+    sessionDeliveryAckStateDir: _ackStateDir,
+    ...rest
+  } = options ?? {};
+  return enqueueSystemEventInternal(text, { ...rest, trusted: false });
 }

--- a/src/plugins/runtime/runtime-system.ts
+++ b/src/plugins/runtime/runtime-system.ts
@@ -19,8 +19,20 @@ const runHeartbeatOnceInternal = createLazyRuntimeMethod(
 // so a channel/plugin cannot set `trusted: true` to bypass the inbound anti-spoof
 // sanitizer. Trusted-internal producers (continuation/post-compaction) enqueue via the
 // direct `infra/system-events` import, not this plugin runtime facade.
-const enqueueSystemEvent: PluginRuntime["system"]["enqueueSystemEvent"] = (text, options) =>
-  enqueueSystemEventInternal(text, { ...options, trusted: false });
+//
+// Also strip the session-delivery ack fields (`sessionDeliveryAckId` /
+// `sessionDeliveryAckStateDir`): on drain they trigger a blind
+// `deleteDeliveryQueueEntry` at the caller-supplied state dir, so a plugin must
+// never inject them through this facade. The legitimate ack producer
+// (continuation-return) sets them via the direct `infra/system-events` import.
+const enqueueSystemEvent: PluginRuntime["system"]["enqueueSystemEvent"] = (text, options) => {
+  const {
+    sessionDeliveryAckId: _ackId,
+    sessionDeliveryAckStateDir: _ackStateDir,
+    ...rest
+  } = options ?? {};
+  return enqueueSystemEventInternal(text, { ...rest, trusted: false });
+};
 
 /** Creates the plugin runtime system facade with heartbeat/event/process helpers. */
 export function createRuntimeSystem(): PluginRuntime["system"] {


### PR DESCRIPTION
## Finding-B fold (figs-delegated)

Closes the **ack-field axis** of the #999 security review — distinct from the trusted-bypass/criterion-5 (which is already green). figs delegated the fold-vs-ship call ("unlimited infer, just do the effort"); the byte said FOLD-is-clean, so this folds it.

### The gap
The three SDK/plugin `enqueueSystemEvent` wrappers force `trusted:false` but passed `sessionDeliveryAckId`/`sessionDeliveryAckStateDir` through **unstripped**:
- `src/plugin-sdk/channel-runtime.ts`
- `src/plugin-sdk/system-event-runtime.ts`
- `src/plugins/runtime/runtime-system.ts` (the PluginRuntime facade)

Chain: wrapper passes ack-fields → `system-events.ts:181-183` puts them on the queued entry → on drain `session-system-events.ts` `ackDrainedSessionDeliveries` calls `ackSessionDelivery(id, stateDir)` (no `trusted` check) → `deleteDeliveryQueueEntry` → `openStateDatabase(stateDir)` + **blind delete, zero validation of stateDir** (`delivery-queue-sqlite.ts`).

A loaded plugin → `enqueueSystemEvent(text, {sessionKey:<victim>, sessionDeliveryAckId, sessionDeliveryAckStateDir:<attacker-dir>})` → blind queue-delete at an attacker-chosen state dir on drain. **Loaded-plugin-class, `trusted`-independent** — the `trusted:false` force does not close it (ack-fields are orthogonal to the trusted gate).

### Why FOLD is clean (loses zero capability)
The **sole** legitimate `sessionDeliveryAckId` producer is the continuation-return (`src/auto-reply/continuation/targeting.ts:118`), and it enqueues via the **direct `infra/system-events` import**, not the SDK re-export. `grep sessionDeliveryAck src/plugin-sdk/** src/plugins/**` = ∅ — no legit ack producer goes through these wrappers. Stripping at the SDK boundary is the exact same shape as the existing `trusted:false` force (legit producers use direct-import; the SDK surface has no legit ack-producer). A future SDK producer needing ack-fields would use the direct import like the continuation machinery does.

### Change
Strip both ack fields in all three wrappers (mirroring the `trusted:false` force) + a guarding test asserting the fields are stripped from SDK producers.

### Verification
- `vitest run src/infra/system-events.test.ts` → **50/50 pass** (incl. the new ack-strip test)
- `tsgo` → the 4 changed files type-clean (pre-existing baseline errors in `config/io.ts`/`secrets/config-io.ts` are unrelated)
- 4 files, surgical

Base = the assembly tip `701c929b59`. Sibling to 🕯's force-untrusted (same boundary, different property). Pairs with the trusted-bypass (#1006) + render-removal (#1005) + the 3-path force-untrusted to complete the #999 security floor.