### PR TITLE
fix(telegram): isolate session store to end :1403 cross-file test leak

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -559,6 +559,13 @@ beforeEach(() => {
   getRuntimeConfig.mockReset();
   getRuntimeConfig.mockReturnValue(DEFAULT_TELEGRAM_TEST_CONFIG);
   sessionStoreEntries.value = {};
+  // The default session-store path is shared process-wide (pid+pool keyed) and
+  // is read back by the REAL getSessionEntry in handlers that do not set
+  // session.store. Tests that persist a model override to the default path via
+  // the real writer (e.g. the model-select retry test) would otherwise leak a
+  // stale modelOverride into later files in the sequential shard. Delete the
+  // real file too, not just the message sidecar.
+  rmSync(sessionStorePath, { force: true });
   rmSync(`${sessionStorePath}.telegram-messages.json`, { force: true });
   clearTelegramDispatchDedupeFilesForTest();
   loadSessionStoreMock.mockReset();

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -5366,7 +5366,20 @@ describe("createTelegramBot", () => {
   });
 
   it("retries model selection callbacks after a bubbled session-store failure", async () => {
-    createTelegramBot({ token: "tok" });
+    // Isolate this bot's session store: the retry path lets the SECOND middleware
+    // chain run through the REAL patchSessionEntry, persisting modelOverride to disk.
+    // Without an explicit store this resolves to the process-shared default path
+    // (pid+pool keyed) and leaks the override into later files in the sequential
+    // shard (e.g. bot.test.ts "renders model callback lists"). A dedicated temp
+    // store keeps the real write contained to this test. Keep the default DM
+    // policy so the callback stays authorized.
+    const storePath = path.join(createTelegramBotTestStateDir(), "session-store.json");
+    const config = {
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+      session: { store: storePath },
+    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+    loadConfig.mockReturnValue(config);
+    createTelegramBot({ token: "tok", config });
     const callbackHandler = getOnHandler("callback_query");
     const middlewares = middlewareUseSpy.mock.calls
       .map((call) => call[0])


### PR DESCRIPTION
## What

Folds the verified telegram **store-path isolation** fix onto the assembly tip `901fbb3c769`.

**Root (byte-walked, 🌊 Ronan):** on-disk file pollution, not in-memory cache. Polluter `bot.create-telegram-bot.test.ts:5368` (no `session.store`) writes a `modelOverride` to the shared default store file `/tmp/openclaw-telegram-<pid>.json`; victim `bot.test.ts:1407` reads it — a **flaky async-write race** surfaced by the upstream back-merge.

**Fix (A+B):**
- **A** — give the polluter `:5368` an isolated `session.store`.
- **B** — harness deletes the default store file in teardown.

`2 files, +21/−1`. Test-harness isolation only — **zero product change** (full-suite `--maxWorkers=1` reds the test as test-isolation; a real prod-gap would fail standalone — it doesn't).

## Verification

- Verified **3/3 GREEN** (full shard) + mechanism 12/12 by 🌊 Ronan.
- `f70d2522de` cache-clear baseline alone = 2/3 FAIL → proves the cache-fix is insufficient and this store-isolation is the actual cure.

## Gate context

This is the **only** frond-fix blocking CI-green on the assembly tip. Refuted/closed at 06:55 PDT byte-walk (do not block):
- infra-runtime "bypass" — REFUTED (🩸 ~300-subpath audit: zero raw re-exports, force complete).
- Finding-B path-injection — CLOSED (strip in-metal #1019+#1021); residual traceparent fold is cosmetic/non-blocking.
- (e) `System:` regex — upstream-inherited (byte-identical upstream/main = origin/main = 901); figs conscious-call, not a frond-gate.

Merge → re-dispatch `openclaw-ci` → green → deploy.

Co-authored-by: ronan-dandelion-cult
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
