### PR TITLE
fix(active-memory): drain orphaned recall to end cross-test mock-theft leak (#1028)

### DIFF
--- a/test/setup.extension-active-memory.ts
+++ b/test/setup.extension-active-memory.ts
@@ -1,0 +1,28 @@
+// Active-memory test setup drains background recalls between tests.
+//
+// active-memory's before_prompt_build hook (extensions/active-memory/index.ts)
+// races its recall sub-agent against a deadline and returns on timeout WITHOUT
+// awaiting or hard-cancelling the sub-agent promise. The recall path reaches
+// runEmbeddedAgent only after an `await tempWorkspace(...)` with no abort check
+// in between, and the test double for runEmbeddedAgent ignores the abort
+// signal. So a timed-out test can leave an orphaned recall mid-flight; when it
+// later resolves it calls runEmbeddedAgent inside a SUBSEQUENT test and steals
+// that test's one-shot mock, surfacing as a stale recall leak (openclaw#1028).
+//
+// Flushing a few real-timer macrotasks after each test forces any orphaned
+// recall to finish (consuming its own test's reset mock) before the next test
+// arms a one-shot mock. This is test-harness isolation only; production runs
+// rely on the real runEmbeddedAgent honoring the abort signal.
+import { afterEach, vi } from "vitest";
+
+afterEach(async () => {
+  // Drain on the real clock: a fake-timer test that skipped cleanup would
+  // otherwise leave the loop's setTimeout pending against a stopped clock and
+  // hang teardown until the hook timeout.
+  vi.useRealTimers();
+  for (let tick = 0; tick < 8; tick += 1) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+});

--- a/test/vitest/vitest.extension-active-memory.config.ts
+++ b/test/vitest/vitest.extension-active-memory.config.ts
@@ -20,7 +20,7 @@ export function createExtensionActiveMemoryVitestConfig(
       env,
       name: "extension-active-memory",
       passWithNoTests: true,
-      setupFiles: ["test/setup.extensions.ts"],
+      setupFiles: ["test/setup.extensions.ts", "test/setup.extension-active-memory.ts"],
     },
   );
 }


### PR DESCRIPTION
Closes #1028.

## Summary

`extensions/active-memory/index.test.ts` → "rejects completed output after a memory search returns no recall evidence" fails when the full file runs but passes in isolation — an intra-file test-ordering leak.

The root cause is an **orphaned background recall**, not a stale shared-store value:

- The `before_prompt_build` hook (`extensions/active-memory/index.ts`) races its recall sub-agent against a deadline via `Promise.race` and returns `undefined` on timeout **without awaiting or hard-cancelling** the sub-agent.
- `runRecallSubagent` reaches `runEmbeddedAgent` only after an `await tempWorkspace(...)`, with **no abort check in between**. The test double for `runEmbeddedAgent` ignores the abort signal.
- So a short-timeout test leaves an orphaned recall mid-flight; when it later resolves it calls `runEmbeddedAgent` inside a **subsequent** test and steals that test's `mockImplementationOnce`. The no-recall test then falls through to the default ("lemon pepper") mock and observes a stale recall.

Confirmed empirically: making that test's empty-result mock persistent (`mockImplementation` instead of `mockImplementationOnce`) makes the full file pass 148/148.

## Fix

Add `test/setup.extension-active-memory.ts` — an **active-memory-scoped** vitest setup file whose `afterEach` flushes a few real-timer macrotasks so any orphaned recall settles inside its own test boundary (consuming its own test's reset mock) before the next test arms a one-shot mock. It is wired only into `test/vitest/vitest.extension-active-memory.config.ts`; the shared `test/setup.extensions.ts` and the upstream-identical `index.ts` / `index.test.ts` are untouched.

This is test-harness isolation only — production runs rely on the real `runEmbeddedAgent` honoring the abort signal.

> **Diagnosis correction:** #1028 framed this as a cross-file leak where `qa-lab`'s `server.test.ts` seeds a shared recall-store under `WORKERS=1`. Verification shows the failure reproduces with the active-memory file **alone** (no qa-lab in the process), and the leaked value is active-memory's *own* default mock — i.e. an intra-file orphaned-recall mock-theft. A between-files shared-store reset would not have fixed it, so the fix drains the orphan instead.

## Verification

- `node scripts/run-vitest.mjs extensions/active-memory/index.test.ts` → **148/148**, 3 consecutive runs (deterministic)
- `node scripts/run-vitest.mjs extensions/active-memory/index.test.ts extensions/qa-lab/src/providers/mock-openai/server.test.ts` → active-memory **148/148**, qa-lab **96/96**
- `oxlint` + `oxfmt --check` clean on both changed files
- Before this fix: the active-memory file fails standalone at the no-recall test; the same test passes under `-t` isolation

## Follow-up (not in this PR)

The genuine root-cause fix lives in plugin source: in `runRecallSubagent` add `params.abortSignal?.throwIfAborted()` immediately before the `runEmbeddedAgent` call so a deadline-aborted recall never invokes the sub-agent. Deferred here to keep `extensions/active-memory/**` byte-identical to upstream; worth landing upstream so the harness drain can eventually be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
